### PR TITLE
Improved directory structure by moving all MIPS libraries/includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ROOTDIR = $(N64_INST)
-CFLAGS = -std=gnu99 -O2 -G0 -Wall -Werror -mtune=vr4300 -march=vr4300 -I$(CURDIR)/include -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+CFLAGS = -std=gnu99 -O2 -G0 -Wall -Werror -mtune=vr4300 -march=vr4300 -I$(CURDIR)/include -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 N64PREFIX = $(N64_INST)/bin/mips64-elf-
 INSTALLDIR = $(N64_INST)
@@ -43,29 +43,29 @@ libdragonpp.a: $(OFILES_LDP)
 	$(AR) -rcs -o libdragonpp.a $(OFILES_LDP)
 
 install: libdragon.a libdragonsys.a libdragonpp.a
-	install -m 0644 libdragon.a $(INSTALLDIR)/lib/libdragon.a
-	install -m 0644 n64ld.x $(INSTALLDIR)/lib/n64ld.x
-	install -m 0644 n64ld_cpp.x $(INSTALLDIR)/lib/n64ld_cpp.x
-	install -m 0644 n64ld_exp_cpp.x $(INSTALLDIR)/lib/n64ld_exp_cpp.x
-	install -m 0644 header $(INSTALLDIR)/lib/header
-	install -m 0644 libdragonsys.a $(INSTALLDIR)/lib/libdragonsys.a
-	install -m 0644 libdragonpp.a $(INSTALLDIR)/lib/libdragonpp.a
-	install -m 0644 include/n64sys.h $(INSTALLDIR)/include/n64sys.h
-	install -m 0644 include/interrupt.h $(INSTALLDIR)/include/interrupt.h
-	install -m 0644 include/dma.h $(INSTALLDIR)/include/dma.h
-	install -m 0644 include/dragonfs.h $(INSTALLDIR)/include/dragonfs.h
-	install -m 0644 include/audio.h $(INSTALLDIR)/include/audio.h
-	install -m 0644 include/display.h $(INSTALLDIR)/include/display.h
-	install -m 0644 include/console.h $(INSTALLDIR)/include/console.h
-	install -m 0644 include/mempak.h $(INSTALLDIR)/include/mempak.h
-	install -m 0644 include/controller.h $(INSTALLDIR)/include/controller.h
-	install -m 0644 include/graphics.h $(INSTALLDIR)/include/graphics.h
-	install -m 0644 include/rdp.h $(INSTALLDIR)/include/rdp.h
-	install -m 0644 include/timer.h $(INSTALLDIR)/include/timer.h
-	install -m 0644 include/exception.h $(INSTALLDIR)/include/exception.h
-	install -m 0644 include/system.h $(INSTALLDIR)/include/system.h
-	install -m 0644 include/dir.h $(INSTALLDIR)/include/dir.h
-	install -m 0644 include/libdragon.h $(INSTALLDIR)/include/libdragon.h
+	install -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a
+	install -m 0644 n64ld.x $(INSTALLDIR)/mips64-elf/lib/n64ld.x
+	install -m 0644 n64ld_cpp.x $(INSTALLDIR)/mips64-elf/lib/n64ld_cpp.x
+	install -m 0644 n64ld_exp_cpp.x $(INSTALLDIR)/mips64-elf/lib/n64ld_exp_cpp.x
+	install -m 0644 header $(INSTALLDIR)/mips64-elf/lib/header
+	install -m 0644 libdragonsys.a $(INSTALLDIR)/mips64-elf/lib/libdragonsys.a
+	install -m 0644 libdragonpp.a $(INSTALLDIR)/mips64-elf/lib/libdragonpp.a
+	install -m 0644 include/n64sys.h $(INSTALLDIR)/mips64-elf/include/n64sys.h
+	install -m 0644 include/interrupt.h $(INSTALLDIR)/mips64-elf/include/interrupt.h
+	install -m 0644 include/dma.h $(INSTALLDIR)/mips64-elf/include/dma.h
+	install -m 0644 include/dragonfs.h $(INSTALLDIR)/mips64-elf/include/dragonfs.h
+	install -m 0644 include/audio.h $(INSTALLDIR)/mips64-elf/include/audio.h
+	install -m 0644 include/display.h $(INSTALLDIR)/mips64-elf/include/display.h
+	install -m 0644 include/console.h $(INSTALLDIR)/mips64-elf/include/console.h
+	install -m 0644 include/mempak.h $(INSTALLDIR)/mips64-elf/include/mempak.h
+	install -m 0644 include/controller.h $(INSTALLDIR)/mips64-elf/include/controller.h
+	install -m 0644 include/graphics.h $(INSTALLDIR)/mips64-elf/include/graphics.h
+	install -m 0644 include/rdp.h $(INSTALLDIR)/mips64-elf/include/rdp.h
+	install -m 0644 include/timer.h $(INSTALLDIR)/mips64-elf/include/timer.h
+	install -m 0644 include/exception.h $(INSTALLDIR)/mips64-elf/include/exception.h
+	install -m 0644 include/system.h $(INSTALLDIR)/mips64-elf/include/system.h
+	install -m 0644 include/dir.h $(INSTALLDIR)/mips64-elf/include/dir.h
+	install -m 0644 include/libdragon.h $(INSTALLDIR)/mips64-elf/include/libdragon.h
 
 clean:
 	rm -f *.o *.a

--- a/examples/ctest/Makefile
+++ b/examples/ctest/Makefile
@@ -2,11 +2,11 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x 
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/dfsdemo/Makefile
+++ b/examples/dfsdemo/Makefile
@@ -2,12 +2,12 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lmikmod -lc -lm -ldragonsys -Tn64ld.x 
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lmikmod -lc -lm -ldragonsys -Tn64ld.x
 PROG_NAME = dfsdemo
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/mptest/Makefile
+++ b/examples/mptest/Makefile
@@ -2,11 +2,11 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x 
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/mputest/Makefile
+++ b/examples/mputest/Makefile
@@ -2,11 +2,11 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x 
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/spritemap/Makefile
+++ b/examples/spritemap/Makefile
@@ -2,12 +2,12 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+LINK_FLAGS = -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
 PROG_NAME = spritemap
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/test/Makefile
+++ b/examples/test/Makefile
@@ -2,12 +2,12 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+LINK_FLAGS = -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
 PROG_NAME = test
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/timers/Makefile
+++ b/examples/timers/Makefile
@@ -2,11 +2,11 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/vrutest/Makefile
+++ b/examples/vrutest/Makefile
@@ -2,11 +2,11 @@ ROOTDIR = $(N64_INST)
 GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x 
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/examples/vtest/Makefile
+++ b/examples/vtest/Makefile
@@ -3,12 +3,12 @@ GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
 CHKSUM64PATH = $(ROOTDIR)/bin/chksum64
 MKDFSPATH = $(ROOTDIR)/bin/mkdfs
 MKSPRITEPATH = $(ROOTDIR)/bin/mksprite
-HEADERPATH = $(ROOTDIR)/lib
+HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
+LINK_FLAGS = -G0 -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Tn64ld.x
 PROG_NAME = VidResTest
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -G0 -Wall -Werror -I$(ROOTDIR)/include -I$(ROOTDIR)/mips64-elf/include
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -G0 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as

--- a/tools/build
+++ b/tools/build
@@ -18,7 +18,7 @@
 set -e
 
 # EDIT THIS LINE TO CHANGE YOUR INSTALL PATH!
-export INSTALL_PATH=${N64_INST:-/usr/mips64-elf}
+export INSTALL_PATH=${N64_INST:-/usr/local}
 
 # Set up path for newlib to compile later
 export PATH=$PATH:$INSTALL_PATH/bin


### PR DESCRIPTION
to $N64_INST/mips64-elf/{lib,include}.
Old project Makefiles incompatible, but can be trivially fixed
(see the "examples" folder).

This causes less issues when installing to /usr, since
MIPS/libdragon-related files will be installed in /usr/{lib,include} otherwise, 
where it can conflict with native libraries.