### PR TITLE
rdp non-shaded triangle

### DIFF
--- a/include/rdp.h
+++ b/include/rdp.h
@@ -64,6 +64,7 @@ void rdp_sync( sync_t sync );
 void rdp_set_clipping( uint32_t tx, uint32_t ty, uint32_t bx, uint32_t by );
 void rdp_set_default_clipping( void );
 void rdp_enable_primitive_fill( void );
+void rdp_enable_blend_fill( void );
 void rdp_enable_texture_copy( void );
 uint32_t rdp_load_texture( uint32_t texslot, uint32_t texloc, mirror_t mirror_enabled, sprite_t *sprite );
 uint32_t rdp_load_texture_stride( uint32_t texslot, uint32_t texloc, mirror_t mirror_enabled, sprite_t *sprite, int offset );
@@ -72,7 +73,9 @@ void rdp_draw_textured_rectangle_scaled( uint32_t texslot, int tx, int ty, int b
 void rdp_draw_sprite( uint32_t texslot, int x, int y );
 void rdp_draw_sprite_scaled( uint32_t texslot, int x, int y, double x_scale, double y_scale );
 void rdp_set_primitive_color( uint32_t color );
+void rdp_set_blend_color( uint32_t color );
 void rdp_draw_filled_rectangle( int tx, int ty, int bx, int by );
+void rdp_draw_filled_triangle( float x1, float y1, float x2, float y2, float x3, float y3 );
 void rdp_set_texture_flush( flush_t flush );
 void rdp_close( void );
 

--- a/src/rdp.c
+++ b/src/rdp.c
@@ -807,12 +807,12 @@ void rdp_draw_filled_triangle( float x1, float y1, float x2, float y2, float x3,
     if( y2 > y3 ) { temp_x = x3, temp_y = y3; y3 = y2; y2 = temp_y; x3 = x2; x2 = temp_x; }
     if( y1 > y2 ) { temp_x = x2, temp_y = y2; y2 = y1; y1 = temp_y; x2 = x1; x1 = temp_x; }
 
-    /* calculate Y edge coeffcients in 11.2 fixed format */
+    /* calculate Y edge coefficients in 11.2 fixed format */
     int yh = y1 * to_fixed_11_2;
     int ym = (int)( y2 * to_fixed_11_2 ) << 16; // high word
     int yl = y3 * to_fixed_11_2;
     
-    /* calculate X edge coeffcients in 16.16 fixed format */
+    /* calculate X edge coefficients in 16.16 fixed format */
     int xh = x1 * to_fixed_16_16;
     int xm = x1 * to_fixed_16_16;
     int xl = x2 * to_fixed_16_16;

--- a/src/rdp.c
+++ b/src/rdp.c
@@ -408,6 +408,18 @@ void rdp_enable_primitive_fill( void )
 }
 
 /**
+ * @brief Enable display of 2D filled (untextured) triangles
+ *
+ * This must be called before using #rdp_draw_filled_triangle.
+ */
+void rdp_enable_blend_fill( void )
+{
+    __rdp_ringbuffer_queue( 0xEF0000FF );
+    __rdp_ringbuffer_queue( 0x80000000 );
+    __rdp_ringbuffer_send();
+}
+
+/**
  * @brief Enable display of 2D sprites
  *
  * This must be called before using #rdp_draw_textured_rectangle_scaled,
@@ -717,6 +729,21 @@ void rdp_set_primitive_color( uint32_t color )
 }
 
 /**
+ * @brief Set the blend draw color for subsequent filled primitive operations
+ *
+ * This function sets the color of all #rdp_draw_filled_triangle operations that follow.
+ *
+ * @param[in] color
+ *            Color to draw primitives in
+ */
+void rdp_set_blend_color( uint32_t color )
+{
+    __rdp_ringbuffer_queue( 0xF9000000 );
+    __rdp_ringbuffer_queue( color );
+    __rdp_ringbuffer_send();
+}
+
+/**
  * @brief Draw a filled rectangle
  *
  * Given a color set with #rdp_set_primitive_color, this will draw a filled rectangle
@@ -744,6 +771,69 @@ void rdp_draw_filled_rectangle( int tx, int ty, int bx, int by )
 
     __rdp_ringbuffer_queue( 0xF6000000 | ( bx << 14 ) | ( by << 2 ) ); 
     __rdp_ringbuffer_queue( ( tx << 14 ) | ( ty << 2 ) );
+    __rdp_ringbuffer_send();
+}
+
+/**
+ * @brief Draw a filled triangle
+ *
+ * Given a color set with #rdp_set_blend_color, this will draw a filled triangle
+ * to the screen. Vertex order is not important.
+ *
+ * Before calling this function, make sure that the RDP is set to blend mode by
+ * calling #rdp_enable_blend_fill.
+ *
+ * @param[in] x1
+ *            Pixel X1 location of triangle
+ * @param[in] y1
+ *            Pixel Y1 location of triangle
+ * @param[in] x2
+ *            Pixel X2 location of triangle
+ * @param[in] y2
+ *            Pixel Y2 location of triangle
+ * @param[in] x3
+ *            Pixel X3 location of triangle
+ * @param[in] y3
+ *            Pixel Y3 location of triangle
+ */
+void rdp_draw_filled_triangle( float x1, float y1, float x2, float y2, float x3, float y3 )
+{
+    float temp_x, temp_y;
+    const float to_fixed_11_2 = 4.0f;
+    const float to_fixed_16_16 = 65536.0f;
+    
+    /* sort vertices by Y ascending to find the major, mid and low edges */
+    if( y1 > y2 ) { temp_x = x2, temp_y = y2; y2 = y1; y1 = temp_y; x2 = x1; x1 = temp_x; }
+    if( y2 > y3 ) { temp_x = x3, temp_y = y3; y3 = y2; y2 = temp_y; x3 = x2; x2 = temp_x; }
+    if( y1 > y2 ) { temp_x = x2, temp_y = y2; y2 = y1; y1 = temp_y; x2 = x1; x1 = temp_x; }
+
+    /* calculate Y edge coeffcients in 11.2 fixed format */
+    int yh = y1 * to_fixed_11_2;
+    int ym = (int)( y2 * to_fixed_11_2 ) << 16; // high word
+    int yl = y3 * to_fixed_11_2;
+    
+    /* calculate X edge coeffcients in 16.16 fixed format */
+    int xh = x1 * to_fixed_16_16;
+    int xm = x1 * to_fixed_16_16;
+    int xl = x2 * to_fixed_16_16;
+    
+    /* calculate inverse slopes in 16.16 fixed format */
+    int dxhdy = ( y3 == y1 ) ? 0 : ( ( x3 - x1 ) / ( y3 - y1 ) ) * to_fixed_16_16;
+    int dxmdy = ( y2 == y1 ) ? 0 : ( ( x2 - x1 ) / ( y2 - y1 ) ) * to_fixed_16_16;
+    int dxldy = ( y3 == y2 ) ? 0 : ( ( x3 - x2 ) / ( y3 - y2 ) ) * to_fixed_16_16;
+    
+    /* determine the winding of the triangle */
+    int winding = ( x1 * y2 - x2 * y1 ) + ( x2 * y3 - x3 * y2 ) + ( x3 * y1 - x1 * y3 );
+    int flip = ( winding > 0 ? 1 : 0 ) << 23;
+    
+    __rdp_ringbuffer_queue( 0xC8000000 | flip | yl );
+    __rdp_ringbuffer_queue( ym | yh );
+    __rdp_ringbuffer_queue( xl );
+    __rdp_ringbuffer_queue( dxldy );
+    __rdp_ringbuffer_queue( xh );
+    __rdp_ringbuffer_queue( dxhdy );
+    __rdp_ringbuffer_queue( xm );
+    __rdp_ringbuffer_queue( dxmdy );
     __rdp_ringbuffer_send();
 }
 


### PR DESCRIPTION
I've tested rendering all sorts of triangles on the n64 hardware and they all appear to look correct. I had to add the blend fill mode since Left Major triangles for some reason wouldn't fill correctly in the primitive fill mode. I might eventually calculate more accurate XH/XM values but setting them both to the highest vertex X value seems to work just fine.