### PR TITLE
Fix bss-related compile error in inthandler.S with newer GAS versions

### DIFF
--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -235,7 +235,6 @@ endint:
 
 	.section .bss
 	.global __baseRegAddr
-	.long __baseRegAddr
 
 	.align 8
 	__baseRegAddr:


### PR DESCRIPTION
Without this fix, newer versions of GAS will abort the compilation with the message `.../src/inthandler.S:238: Error: attempt to store non-zero value in section `.bss'`
