### PR TITLE
Replace malloc.h with stdlib.h in mkdfs.

### DIFF
--- a/tools/mkdfs/mkdfs.c
+++ b/tools/mkdfs/mkdfs.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <string.h>


### PR DESCRIPTION
This enables the tool to be used on mac OS.