### PR TITLE
fixed 16 bit accesses to 8 bit buffer in __validate_header

### DIFF
--- a/src/mempak.c
+++ b/src/mempak.c
@@ -159,16 +159,16 @@ static int __validate_header( uint8_t *sector )
     /* Check 4 checksums of copied header data */
     current_block = 0x20;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) || (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
     current_block = 0x60;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) || (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
     current_block = 0x80;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) || (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
     current_block = 0xC0;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) || (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
 
     return 0;
 }

--- a/src/mempak.c
+++ b/src/mempak.c
@@ -159,16 +159,16 @@ static int __validate_header( uint8_t *sector )
     /* Check 4 checksums of copied header data */
     current_block = 0x20;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != (uint16_t)(sector[current_block + 0x1C])) && (checksum != 0xFFF2 - (uint16_t)(sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
     current_block = 0x60;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != (uint16_t)(sector[current_block + 0x1C])) && (checksum != 0xFFF2 - (uint16_t)(sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
     current_block = 0x80;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != (uint16_t)(sector[current_block + 0x1C])) && (checksum != 0xFFF2 - (uint16_t)(sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
     current_block = 0xC0;
     checksum = __get_header_checksum((uint16_t *)&sector[current_block]);
-    if( (checksum != (uint16_t)(sector[current_block + 0x1C])) && (checksum != 0xFFF2 - (uint16_t)(sector[current_block + 0x1E])) ) { return -1; }
+    if( (checksum != *(uint16_t *)(&sector[current_block + 0x1C])) && (checksum != 0xFFF2 - *(uint16_t *)(&sector[current_block + 0x1E])) ) { return -1; }
 
     return 0;
 }


### PR DESCRIPTION
The mputest-example did't work for me. I've found this to be the reason. 
The base code is accessing the sector pointer as an uint8_t and is then comparing the data to the uint16_t checksum. Don't know how this could have been working.

This could be done nicer but I did a quick fix.

Greetings,
jago85