### PR TITLE
New release 1.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## [1.3.9] - 2019-27-10
+### Added
+
+- Add texture mirroring. https://github.com/DragonMinded/libdragon/commit/00a6cc8e6d136cf2578a50320f6ff0814dfb6657

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.3.15] - 2019-01-11
+### Changed
+
+- `libdragon install` should skip CI checks.
+
 ## [1.3.14] - 2019-31-10
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.3.14] - 2019-31-10
+### Changed
+
+- Skip make install if no Makefile is found.
+
 ## [1.3.12] - 2019-29-10
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.3.12] - 2019-29-10
+### Changed
+
+- Reduce response time for NPM commands.
+- Remove unnecessary console statements and double logs.
+
+## [1.3.11] - 2019-29-10
+### Fixed
+
+- Fix problem with wait ticks. They do not lock the system now.
+
 ## [1.3.9] - 2019-27-10
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For example this package.json;
         "scripts": {
             "build": "libdragon make",
             "clean": "libdragon make clean",
-            "install": "libdragon install"
+            "prepare": "libdragon install"
         },
         "dependencies": {
             "ed64": [version],
@@ -93,7 +93,7 @@ For example this package.json;
         }
     }
 
-will download the docker image, run it with the name `libdragonDependentProject` and run `make && make install` for ed64 upon running `npm install`. This is an experimental dependency management.
+will download the docker image, run it with the name `libdragonDependentProject` and run `make && make install` for ed64 upon running `npm install`. This is an experimental dependency management. To develop a dependency [this](https://github.com/anacierdem/libdragon-dependency) is a good starting point.
 
 # RSP assembly
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ e.g to run clean all on root;
 
     npm run make clean
 
-The toolchain make command will be only run at the root-level. Use -C flag to make a directory instead;
+The toolchain make command will be only run at the root-level. Additonal parameters are passed down to the make command. Also keep in mind that `--` is necessary for anything more complicated. For example use -C flag to make a directory instead;
 
-    npm run make -C your/path
+    npm run make -- -C your/path
 
 Please note that the path should be unix-compatible, so you should not use auto completion on non-unix systems.
 

--- a/index.js
+++ b/index.js
@@ -16,9 +16,8 @@ const options = {
 
 function runCommand(cmd) {
   return new Promise((resolve, reject) => {
-    const command = exec(cmd, {}, (err, stdout, stderr) => {
+    const command = exec(cmd, {}, (err, stdout) => {
       if (err === null) {
-        console.log('Finished running ' + cmd, stdout);
         resolve(stdout);
       } else {
         reject(err);
@@ -30,7 +29,7 @@ function runCommand(cmd) {
     });
 
     command.stderr.on('data', function (data) {
-      console.log(data.toString());
+      console.error(data.toString());
     });
   })
 }
@@ -173,7 +172,7 @@ const availableActions = {
 }
 
 process.argv.forEach(function (val, index) {
-  if (index < 2) {
+  if (index < 1) {
     return;
   }
 
@@ -197,10 +196,8 @@ process.argv.forEach(function (val, index) {
     const param = params.join(' ');
 
     functionToRun(param).then((r) => {
-      console.log('Completed task: ' + val);
       process.exit(0);
     }).catch((e) => {
-      console.error(e);
       process.exit(1);
     });
   }

--- a/index.js
+++ b/index.js
@@ -112,6 +112,8 @@ const availableActions = {
     await startToolchain();
   },
   install: async function install() {
+    // Override CI checks and start actual version on install
+    options.IS_CI = false;
     await download();
 
     const { dependencies } = require(path.join(process.cwd() + '/package.json'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.10",
+  "version": "1.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.4",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "This is a simple library for N64 that allows one to code using the gcc compiler suite and nothing else.  No proprietary library is needed.  For more information, visit http://www.dragonminded.com/n64dev/",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "This is a simple library for N64 that allows one to code using the gcc compiler suite and nothing else.  No proprietary library is needed.  For more information, visit http://www.dragonminded.com/n64dev/",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "This is a simple library for N64 that allows one to code using the gcc compiler suite and nothing else.  No proprietary library is needed.  For more information, visit http://www.dragonminded.com/n64dev/",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.10",
+  "version": "1.3.12",
   "description": "This is a simple library for N64 that allows one to code using the gcc compiler suite and nothing else.  No proprietary library is needed.  For more information, visit http://www.dragonminded.com/n64dev/",
   "main": "index.js",
   "engines": {
@@ -14,12 +14,12 @@
   },
   "scripts": {
     "tc": "node index.js",
-    "start": "npm run tc -- start",
-    "stop": "npm run tc -- stop",
-    "make": "npm run tc -- make",
-    "download": "npm run tc -- download",
-    "init": "npm run tc -- init",
-    "prepublishOnly": "npm run tc -- update"
+    "start": "node index.js start",
+    "stop": "node index.js stop",
+    "make": "node index.js make",
+    "download": "node index.js download",
+    "init": "node index.js init",
+    "prepublishOnly": "node index.js update"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libdragon",
-  "version": "1.3.12",
+  "version": "1.3.14",
   "description": "This is a simple library for N64 that allows one to code using the gcc compiler suite and nothing else.  No proprietary library is needed.  For more information, visit http://www.dragonminded.com/n64dev/",
   "main": "index.js",
   "engines": {

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -65,7 +65,7 @@ volatile unsigned long get_ticks(void)
 {
     unsigned long count;
     // reg $9 on COP0 is count
-    asm("\tmfc0 %0,$9\n\tnop":"=r"(count));
+    asm volatile("\tmfc0 %0,$9\n\tnop":"=r"(count));
 
     return count;
 }
@@ -79,7 +79,7 @@ volatile unsigned long get_ticks_ms(void)
 {
     unsigned long count;
     // reg $9 on COP0 is count
-    asm("\tmfc0 %0,$9\n\tnop":"=r"(count));
+    asm volatile("\tmfc0 %0,$9\n\tnop":"=r"(count));
 
     return count / (COUNTS_PER_SECOND / 1000);
 }


### PR DESCRIPTION
Bump version
Add changelog
NPM improvements.
`libdragon install` now skips CI shecks.
Fix non-volatile asm - see https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Extended-Asm.html

> An asm instruction without any output operands will be treated identically to a volatile asm instruction.