### PR TITLE
Upgrade binutils to fix RSP assembly alignment

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -27,7 +27,7 @@ export FORCE_DEFAULT_GCC=${FORCE_DEFAULT_GCC:-false}
 export PATH=$PATH:$INSTALL_PATH/bin
 
 # Versions
-export BINUTILS_V=2.32
+export BINUTILS_V=2.33.1
 export GCC_V=9.1.0
 export NEWLIB_V=3.1.0
 


### PR DESCRIPTION
Currently, people following the `ucode/Makefile` pattern of using `objcopy` to create sections of RSP binary code can hit an annoying bug in which the RSP symbol is not aligned to a 16-byte boundary, as required by `load_ucode` / `load_data` to operate correctly the DMA engine.

There are many possible workaround for this (including adding one of the many `bin2h` tools to the whole toolchain) but it looks like binutils just added a feature to `objcopy`. This is extracted from the [2.33 release notes](https://sourceware.org/ml/binutils/2019-10/msg00103.html):

> * Add --set-section-alignment &lt;section-name&gt;=&lt;power-of-2-align&gt;
>      option to objcopy to allow the changing of section alignments.

So it seems that makefiles could be adjusted to use that option to force the RSP binary code to always be 16-byte aligned.

This PR upgrades binutils; I don't know how the official docker image is updated, but it would help a lot if it could get updated as well. Meanwhile, I'm also sending another PR to workaround the problem in `load_ucode` / `load_data`.