### PR TITLE
Improve error message when using MIPS opcodes not available on RSP

### DIFF
--- a/include/ucode.S
+++ b/include/ucode.S
@@ -1,7 +1,7 @@
 # Not implemented
 .macro makeNotImplemented name
     .macro \name _:vararg
-        \name\()_na
+        .error "\name is not supported by RSP"
     .endm
 .endm
 


### PR DESCRIPTION
When using a MIPS opcode not available on RSP, before the user would get:

 ```Error: unrecognized opcode 'swr_na'```

After this PR, the error is more clear:

```Error: swr is not supported by RSP```