### PR TITLE
N64tool fixes

### DIFF
--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -70,7 +70,7 @@ uint32_t get_file_size(FILE *fp)
 
 int swap_bytes(uint8_t *buffer, int size)
 {
-	if(size & 1 == 0)
+	if((size & 1) == 0)
 	{
 		/* Invalid, can only byteswap multiples of 2 */
 		return -1;
@@ -159,7 +159,7 @@ int copy_file(FILE *dest, char *file, int byte_swap)
 
 int output_zeros(FILE *dest, int amount)
 {
-	if(amount & 3 != 0)
+	if((amount & 3) != 0)
 	{
 		/* Don't support odd word alignments */
 		return -1;

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -39,6 +39,7 @@
 /* Easier to write from here */
 static int title[TITLE_SIZE];
 static int wrote_title = 0;
+static unsigned char zero[1024] = {0};
 
 void print_usage(char *prog_name)
 {
@@ -165,22 +166,15 @@ int output_zeros(FILE *dest, int amount)
 		return -1;
 	}
 	
-	if(amount <= 0)
-	{
-		/* We are done */
-		return 0;
-	}
-	
 	int i;
-	
-	for(i = 0; i < (amount >> 2); i++)
-	{
-		/* Write out a word at a time */
-		uint32_t byte = 0;
-		
-		fwrite(&byte, 1, 4, dest);
+	while (amount > 0) {
+		int sz = amount;
+		if (sz > sizeof(zero))
+			sz = sizeof(zero);
+		fwrite(zero, 1, sz, dest);
+		amount -= sz;
 	}
-	
+
 	return 0;
 }
 

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define WRITE_SIZE	1024
+#define WRITE_SIZE	(1024*1024)
 
 #define TITLE_LOC	32
 #define TITLE_SIZE	20


### PR DESCRIPTION
This PR contains 3 commits with misc fixes to n64tool:

 * A real bug: the check for odd sizes for byte-swapping or zero-padding was never triggering, because of missing parentheses. LLVM detected this as soon as I first compiled this file, and btw I was looking for this bug as I had hit it: it produced a non-working ROM for my application because the assets where not in the correct position because of missing padding.

 * Two speed fixes, by doing less I/O calls, using larger chunks. This brings the total execution time for a 64Mb ROM through the docker container from 4 seconds to 0.8 seconds. 