### PR TITLE
n64.ld: force padding of text/data/bss/rodata sections

### DIFF
--- a/n64.ld
+++ b/n64.ld
@@ -46,6 +46,7 @@ SECTIONS {
         *(.init)
         *(.fini)
         *(.gnu.linkonce.t.*)
+        . = ALIGN(16);
         __text_end  = .;
     } > mem
 
@@ -59,6 +60,7 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
         *(.gnu.linkonce.r.*)
+        . = ALIGN(8);
     } > mem
 
     . = ALIGN(8);
@@ -99,28 +101,30 @@ SECTIONS {
         *(.data)
         *(.data.*)
         *(.gnu.linkonce.d.*)
+        . = ALIGN(8);
     } > mem
 
     /* Small data START */
 
-    . = ALIGN(8);
     .sdata : {
         _gp = . + 0x8000;
         *(.sdata)
         *(.sdata.*)
         *(.gnu.linkonce.s.*)
+        . = ALIGN(8);
     } > mem
 
     .lit8 : {
         *(.lit8)
+        . = ALIGN(8);
     } > mem
     .lit4 : {
         *(.lit4)
+        . = ALIGN(8);
     } > mem
 
     __data_end = .;
 
-    . = ALIGN(8);
     .sbss (NOLOAD) : {
          __bss_start = .;
         *(.sbss)
@@ -138,7 +142,8 @@ SECTIONS {
         *(.bss*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        __bss_end = .;
+        . = ALIGN(8);
+         __bss_end = .;
     } > mem
 
     . = ALIGN(8);


### PR DESCRIPTION
Currently, it was possible to create data sections whose size were not
a multiple of 4 bytes (for instance, by simply declaring global
variables in the correct order so that the last one was only 1 or 2
bytes long). This produced correct binaries, that were unable to boot
because the libdragon bootloader (entrypoint.S) assumes that the data
section is multiple of 4 bytes, so it would loop forever.

This commit fixes the problem by forcing a padding to all sections.
I used padding to multiple of 16 bytes on text section (because it was already aligned
to 16-bytes, so I assume it might be important), and multiple of 8 bytes
for all the others (4 bytes is possibly enough, but 8 bytes means that
even changing the bootloader to use DMA to copy the sections won't
break it, so I guess it's more future proof and anyway it's just
a few bytes of padding per binary).

Verified on my own application that stopped working because of this bug,
and works again after this fix.