### PR TITLE
n64tool: fix bug in detection of unaligned image sizes

### DIFF
--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -71,7 +71,7 @@ uint32_t get_file_size(FILE *fp)
 
 int swap_bytes(uint8_t *buffer, int size)
 {
-	if((size & 1) == 0)
+	if((size & 1) != 0)
 	{
 		/* Invalid, can only byteswap multiples of 2 */
 		return -1;


### PR DESCRIPTION
The alignment check in swap_bytes() was still incorrect. This should fix it.