### PR TITLE
dfs: fix performance of dfs_seek to be constant-time.

### DIFF
--- a/include/dfsinternal.h
+++ b/include/dfsinternal.h
@@ -12,9 +12,11 @@
  */
 
 /** @brief The special ID value in #directory_entry::flags defining the root sector */
-#define FLAGS_ID        0xFFFFFFFF
+#define ROOT_FLAGS      0xFFFFFFFF
 /** @brief The special ID value in #directory_entry::next_entry defining the root sector */
-#define NEXTENTRY_ID    0xDEADBEEF
+#define ROOT_NEXT_ENTRY 0xDEADBEEF
+/** @brief Special path value in #directory_entry::path defining the root sector */
+#define ROOT_PATH       "DragonFS 2.0"
 
 /** @brief The size of a sector */
 #define SECTOR_SIZE     256
@@ -24,54 +26,41 @@
 /** @brief Representation of a directory entry */
 struct directory_entry
 {
-    /** @brief File size and flags.  See #FLAGS_FILE, #FLAGS_DIR and #FLAGS_EOF */
-    uint32_t flags;
     /** @brief Offset to next directory entry */
     uint32_t next_entry;
+    /** @brief File size and flags.  See #FLAGS_FILE, #FLAGS_DIR and #FLAGS_EOF */
+    uint32_t flags;
     /** @brief The file or directory name */
     char path[MAX_FILENAME_LEN+1];
     /** @brief Offset to start sector of the file */
     uint32_t file_pointer;
 } __attribute__((__packed__));
 
+_Static_assert(sizeof(struct directory_entry) == SECTOR_SIZE, "invalid directory_entry size");
+
 /** @brief Type definition */
 typedef struct directory_entry directory_entry_t;
-
-/** @brief Representation of a file sector */
-struct file_entry
-{
-    /** @brief Offset of next sector of the file */
-    uint32_t next_sector;
-    /** @brief File data */
-    uint8_t data[SECTOR_PAYLOAD];
-} __attribute__((__packed__));
-
-/** @brief Type definition */
-typedef struct file_entry file_entry_t;
 
 /** @brief Open file handle structure */
 typedef struct open_file
 {
-    /** @brief Cached copy of the current sector */
-    file_entry_t cur_sector;
-    /** @brief Pointer to the first sector */
-    file_entry_t *start_sector;
+    /** @brief Cached data to speed up small reads.
+     *
+     *  We want this buffer to be 8-byte aligned for DMA, but also
+     *  16-byte aligned so that it doesn't share cachelines with other
+     *  members of the structure, so it's easier to handle coherency.
+     * */
+    uint8_t cached_data[512] __attribute__((aligned(16)));
+    /** @brief location of the cached data */
+    uint32_t cached_loc;
     /** @brief The unique file handle to refer to this file by */
     uint32_t handle;
     /** @brief The size in bytes of this file */
     uint32_t size;
     /** @brief The offset of the current location in the file */
     uint32_t loc;
-    /** @brief The sector number of the current sector */
-    uint32_t sector_number;
-    /** 
-     * @brief Padding
-     * 
-     * If this isn't here, the second file opened will fail due to cur_sector
-     * not being on a 8 byte aligned boundary, so I just aligned it to 512
-     * bytes. 
-     */
-    uint8_t padding[236];
+    /** @brief The offset within the filesystem where the file is stored */
+    uint32_t cart_start_loc;
 } open_file_t;
 
 /** @} */ /* dfs */


### PR DESCRIPTION
Currently, within DFS, files are laid out as a linked list of sectors.
At runtime, dfs_seek / dfs_read must go through this list in linear
time to access data at a specific offset (see walk_sectors for the
seeking loop). This is very inefficient especially for huge files,
where seeking can take literally seconds.

This PR changes the DFS layout to fix this.

Files are now stored as "raw blobs" within the filesystem. They are
still padded out to be multiple of sectors so that the rest of the code
(directory handling) does not need to change.

Once files are opened, they can be seeked by simply moving the location
pointer, without needing to go through a linked list. This allows for
a true random access, as expected on modern filesystems.

Since I was at it, I also slightly changed the directory layout to
separate the flags and size words, allowing files larger than 2**24.
I also needed this for my experiments with full motion videos.

This is a small benchmark run on a real N64. The benchmark opens
a 16M file, seeks to 6M and read 16K of data:

 * libdragon trunk: 144025 Kcycles
 * this PR, unaligned buffer: 470 Kcycles
 * this PR, aligned buffer: 345 Kcycles

(A "Kcycle" is 1024 cycles as measured by COP0 count register).

Fixes #85