### PR TITLE
n64sys: fix dma cache ops

### DIFF
--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -116,10 +116,14 @@ void wait_ms( unsigned long wait )
  * @param[in] op
  *            Operation to perform
  */
-#define cache_op(op) \
-    addr=(void*)(((unsigned long)addr)&(~3));\
-    for (;length>0;length-=4,addr+=4) \
-	asm ("\tcache %0,(%1)\n"::"i" (op), "r" (addr))
+#define cache_op(op) ({ \
+    if (length) { \
+        void *cur = (void*)((unsigned long)addr & ~15); \
+        int count = (int)length + (addr-cur); \
+        for (int i = 0; i < count; i += 16) \
+            asm ("\tcache %0,(%1)\n"::"i" (op), "r" (cur+i)); \
+    } \
+})
 
 /**
  * @brief Force a data cache writeback over a memory region


### PR DESCRIPTION
The previous implementation had a couple of issues:

* It went into infinite loop if length was not a multiple of 4 (because
length is an unsigned variable that wrapped around).
* It incremented in steps of 4 bytes, even if cachelines are 16 bytes,
causing a 4x increase of execution time in large mostly-flushed buffers
(obviously if the cache is hot, the actual memory access dominates
execution time so the decrease in speed is not so evident).
* It incorrectly handled disalignment of memory addresses, so it was
possible for a cacheline included in the requested range not to be
touched by the cache op. For instance, addr=2 length=16, you need to
touch cachlines 0 (0-15) and 1 (16-31), but the previous code was not
touching cacheline 1. This is a correctness bug that can lead to very
nasty bugs.

The new implementation generates a loop of 4 assembly instructions
(including the delay slot). I've tried a few ways to express the same
loop in C, but this is the best I could come up with. It is possible
to do it with 3 instructions (cache op + compare/branch + increment),
but I couldn't find a way to make GCC generate it.

I have a test for this new implementation, and will submit it as a
separate PR with a new proposed test framework for libdragon. The
test was extensively run on a real N64.