### PR TITLE
Fix cpptest example

### DIFF
--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -14,7 +14,7 @@ class TestClass
 
     public:
         TestClass() {
-            d = 2;
+            d = 100;
         }
         int f1()
         {

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -10,7 +10,7 @@ static bitdepth_t bit = DEPTH_32_BPP;
 class TestClass
 {
     private:
-        int d;
+        uint32_t d;
 
     public:
         TestClass() {
@@ -18,16 +18,17 @@ class TestClass
         }
         int f1()
         {
+            d = d + 1;
             return d;
         }
 };
 
 // Test global constructor
-TestClass o1;
+TestClass globalClass;
 
 int main(void)
 {
-    int* a = new int(2);
+    TestClass* localClass = new TestClass();
 
     init_interrupts();
 
@@ -41,9 +42,10 @@ int main(void)
     {
         console_clear();
         printf("Libdragon v%d.%d.%d \n", libdragon_version.major, libdragon_version.minor, libdragon_version.revision);
-        printf("Test: %d\n", o1.f1());
+        printf("Global class method: %d\n", globalClass.f1());
+        printf("Local class method: %d\n", localClass->f1());
         console_render();
     }
 
-    delete a;
+    delete localClass;
 }

--- a/n64.ld
+++ b/n64.ld
@@ -66,8 +66,6 @@ SECTIONS {
     . = ALIGN(8);
 
     .ctors : {
-        __CTOR_LIST_SIZE__ = .;
-        LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 1)
         __CTOR_LIST__ = .;
         *(.ctors)
         LONG(0)

--- a/n64.ld
+++ b/n64.ld
@@ -76,16 +76,6 @@ SECTIONS {
 
     . = ALIGN(8);
 
-    .dtors : {
-        __DTOR_LIST__ = .;
-        LONG((__DTOR_END__ - __DTOR_LIST__) / 4 - 2)
-        *(.dtors)
-        LONG(0)
-        __DTOR_END__ = .;
-    } > mem
-
-    . = ALIGN(8);
-
     /* Data section has relocation address at start of RAM in cached,
     * unmapped memory, but is loaded just at the end of the text segment,
     * and must be copied to the correct location at startup

--- a/n64.ld
+++ b/n64.ld
@@ -68,7 +68,6 @@ SECTIONS {
     .ctors : {
         __CTOR_LIST__ = .;
         *(.ctors)
-        LONG(0)
         __CTOR_END__ = .;
     } > mem
 

--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -26,8 +26,8 @@ extern func_ptr __CTOR_END__ __attribute__((section (".data")));
 void __do_global_ctors()
 {
 	func_ptr * ctor_addr = &__CTOR_END__ - 1;
-	func_ptr * ctor_stop = &__CTOR_LIST__;
-	while (ctor_addr > ctor_stop) {
+	func_ptr * ctor_sentinel = &__CTOR_LIST__;
+	while (ctor_addr > ctor_sentinel) {
 		if (*ctor_addr) (*ctor_addr)();
 		ctor_addr--;
 	}

--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -14,20 +14,21 @@
 typedef void (*func_ptr)(void);
 
 /** @brief Pointer to the beginning of the constructor list */
-extern func_ptr __CTOR_LIST__[] __attribute__((section (".data")));
+extern func_ptr __CTOR_LIST__ __attribute__((section (".data")));
 /** @brief Pointer to the end of the constructor list */
-extern func_ptr __CTOR_END__[] __attribute__((section (".data")));
+extern func_ptr __CTOR_END__ __attribute__((section (".data")));
 
 /**
  * @brief Execute global constructors
+ * "Constructors are called in reverse order of the list"
+ * @see https://gcc.gnu.org/onlinedocs/gccint/Initialization.html
  */
 void __do_global_ctors()
 {
-	// "Constructors are called in reverse order of the list"
-	// https://gcc.gnu.org/onlinedocs/gccint/Initialization.html
-	func_ptr *ctor_addr = __CTOR_END__ - 1;
-	while (ctor_addr > __CTOR_LIST__) {
-		if (**ctor_addr) (**ctor_addr)();
+	func_ptr * ctor_addr = &__CTOR_END__ - 1;
+	func_ptr * ctor_stop = &__CTOR_LIST__;
+	while (ctor_addr > ctor_stop) {
+		if (*ctor_addr) (*ctor_addr)();
 		ctor_addr--;
 	}
 }

--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -13,21 +13,23 @@
 /** @brief Function pointer */
 typedef void (*func_ptr)(void);
 
-/** @brief Pointer to the size of the constructor list */
-extern uint32_t __CTOR_LIST_SIZE__  __attribute__((section (".data")));
 /** @brief Pointer to the beginning of the constructor list */
-extern func_ptr __CTOR_LIST__[];
+extern func_ptr __CTOR_LIST__[] __attribute__((section (".data")));
 /** @brief Pointer to the end of the constructor list */
-extern func_ptr __CTOR_END__[];
+extern func_ptr __CTOR_END__[] __attribute__((section (".data")));
 
-/** 
+/**
  * @brief Execute global constructors
  */
-void __do_global_ctors() 
+void __do_global_ctors()
 {
-	unsigned int tot_constructors = __CTOR_LIST_SIZE__;
-	for (void (**f)(void) = (void (**)(void))(__CTOR_LIST__); tot_constructors > 0; tot_constructors--, f++)
-		(**f)();
+	// "Constructors are called in reverse order of the list"
+	// https://gcc.gnu.org/onlinedocs/gccint/Initialization.html
+	func_ptr *ctor_addr = __CTOR_END__ - 1;
+	while (ctor_addr > __CTOR_LIST__) {
+		if (**ctor_addr) (**ctor_addr)();
+		ctor_addr--;
+	}
 }
 
 /** @} */


### PR DESCRIPTION
I have verified that the cpptest example now works correctly in MAME.

Resolves https://github.com/DragonMinded/libdragon/issues/92

* Fix global constructors for C++
* Remove unused global destructors from `ld` script
* Minor improvements to cpptest example

According to https://gcc.gnu.org/onlinedocs/gccint/Initialization.html
>Each list always begins with an ignored function pointer (which may hold 0, -1, or a count of the function pointers after it, depending on the environment).

>This is followed by a series of zero or more function pointers to constructors (or destructors), followed by a function pointer containing zero. 

>Constructors are called in reverse order of the list

Global destructors weren't exactly hurting anything by being included, but they were never being called and there is no logical reason _to_ call them since the system effectively halts after `main` returns (which it should pretty much never do).
