### PR TITLE
Refactor tools Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ To get started from scratch, follow the following steps:
 
 *Below steps can also be executed by running `build.sh` at the top level.*
 
-5. Make libdragon by typing 'make' at the top level.
-6. Install libdragon by typing 'make install' at the top level.
-7. Make the tools by typing 'make tools' at the top level.
-8. Install the tools by typing 'make tools-install' at the top level.
-9.  Install libmikmod for the examples using it. See `build.sh` at the top level for details.
-10. Compile the examples by typing 'make examples' at the top level.
+5. Install libdragon by typing 'make install' at the top level.
+6. Install the tools by typing 'make tools-install' at the top level.
+7. Install libmikmod for the examples using it. See `build.sh` at the top level for details.
+8. Compile the examples by typing 'make examples' at the top level.
 
 You are now ready to run the examples on your N64.
 For more information, visit http://www.dragonminded.com/n64dev/

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,30 @@
-#!/bin/bash
-make -j8 clean && \
-make -j8 && \
-make install && \
-make -j8 tools && \
-make tools-install && \
-git clone https://github.com/networkfusion/libmikmod.git /tmp/libmikmod && \
-pushd /tmp/libmikmod/n64 && \
-git checkout 738b1e8b11b470360b1b919680d1d88429d9d174 && \
-make -j8 && \
-make install && \
-popd && \
-rm -rf /tmp/libmikmod && \
-make -j8 examples
+#!/usr/bin/env bash
+
+# Exit this script if any command fails
+set -e
+
+# Limit the number of make jobs to the number of CPUs
+CPU_COUNT=$(nproc)
+
+# Specify where to get libmikmod from and where to put it
+LIBMIKMOD_REPO=https://github.com/networkfusion/libmikmod.git
+LIBMIKMOD_COMMIT=738b1e8b11b470360b1b919680d1d88429d9d174
+LIBMIKMOD_DIR=/tmp/libmikmod
+
+# Clean, build, and install libdragon + tools
+make -j${CPU_COUNT} clobber
+make -j${CPU_COUNT} install tools-install
+
+# Remove the cloned libmikmod repo if it already exists
+[ -d "$LIBMIKMOD_DIR" ] && rm -Rf $LIBMIKMOD_DIR
+# Clone, compile, and install libmikmod
+git clone $LIBMIKMOD_REPO $LIBMIKMOD_DIR
+pushd $LIBMIKMOD_DIR/n64
+git checkout $LIBMIKMOD_COMMIT
+make -j${CPU_COUNT}
+make install
+popd
+rm -Rf $LIBMIKMOD_DIR
+
+# Build all of the libdragon examples
+make -j${CPU_COUNT} examples

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,16 +1,21 @@
 INSTALLDIR = $(N64_INST)
 
 all: build
-build: dumpdfs mkdfs mksprite chksum64 n64tool
+build: chksum64 n64tool dumpdfs mkdfs mksprite
+install: dumpdfs-install mkdfs-install mksprite-install chksum64-install n64tool-install
 clean: chksum64-clean n64tool-clean dumpdfs-clean mkdfs-clean mksprite-clean
 
 chksum64: chksum64.c
 	gcc -o chksum64 chksum64.c
+chksum64-install: chksum64
+	install -m 0755 chksum64 $(INSTALLDIR)/bin
 chksum64-clean:
 	rm -rf chksum64
 
 n64tool: n64tool.c
 	gcc -o n64tool n64tool.c
+n64tool-install: n64tool
+	install -m 0755 n64tool $(INSTALLDIR)/bin
 n64tool-clean:
 	rm -rf n64tool
 
@@ -35,9 +40,6 @@ mksprite-install:
 mksprite-clean:
 	make -C mksprite clean
 
-install: dumpdfs-install mkdfs-install mksprite-install
-	install -m 0755 chksum64 $(INSTALLDIR)/bin
-	install -m 0755 n64tool $(INSTALLDIR)/bin
-
-.PHONY: dumpdfs mkdfs mksprite dumpdfs-install mkdfs-install mksprite-install chksum64-clean n64tool-clean 
-.PHONY: dumpdfs-clean mkdfs-clean mksprite-clean
+.PHONY: dumpdfs mkdfs mksprite
+.PHONY: chksum64-install n64tool-install dumpdfs-install mkdfs-install mksprite-install
+.PHONY: chksum64-clean n64tool-clean dumpdfs-clean mkdfs-clean mksprite-clean


### PR DESCRIPTION
## `tools/Makefile` changes

Allows running `make tools-install` without first calling `make tools`

Before, `make tools-install` would fail with:
```
install -m 0755 chksum64 ${N64_INST}/bin
install: chksum64: No such file or directory
make[1]: *** [install] Error 71
make: *** [tools-install] Error 2
```

`dumpdfs-install`, `mkdfs-install`, and `mksprite-install` already build if necessary before installing

## README changes

Removed unnecessary steps; `make install` implies `make`