### PR TITLE
Fix delay functions

### DIFF
--- a/files.in
+++ b/files.in
@@ -27,7 +27,7 @@ $(CURDIR)/build/n64sys.o: $(CURDIR)/src/n64sys.c
 $(CURDIR)/build/interrupt.o: $(CURDIR)/src/interrupt.c
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/interrupt.o $(CURDIR)/src/interrupt.c
-$(CURDIR)/build/dma.o: $(CURDIR)/src/dma.c
+$(CURDIR)/build/dma.o: $(CURDIR)/src/dma.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/dma.o $(CURDIR)/src/dma.c
 $(CURDIR)/build/inthandler.o: $(CURDIR)/src/inthandler.S
@@ -38,7 +38,7 @@ $(CURDIR)/build/entrypoint.o: $(CURDIR)/src/entrypoint.S
 	$(CC) -c -o $(CURDIR)/build/entrypoint.o $(CURDIR)/src/entrypoint.S
 
 # Rules for compiling filesystem
-$(CURDIR)/build/dragonfs.o: $(CURDIR)/src/dragonfs.c
+$(CURDIR)/build/dragonfs.o: $(CURDIR)/src/dragonfs.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/dragonfs.o $(CURDIR)/src/dragonfs.c
 
@@ -48,10 +48,10 @@ $(CURDIR)/build/audio.o: $(CURDIR)/src/audio.c
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/audio.o $(CURDIR)/src/audio.c
 
 # Rules for compiling video system
-$(CURDIR)/build/display.o: $(CURDIR)/src/display.c
+$(CURDIR)/build/display.o: $(CURDIR)/src/display.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/display.o $(CURDIR)/src/display.c
-$(CURDIR)/build/console.o: $(CURDIR)/src/console.c
+$(CURDIR)/build/console.o: $(CURDIR)/src/console.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/console.o $(CURDIR)/src/console.c
 $(CURDIR)/build/graphics.o: $(CURDIR)/src/graphics.c
@@ -76,7 +76,7 @@ $(CURDIR)/build/tpak.o: $(CURDIR)/src/tpak.c
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/tpak.o $(CURDIR)/src/tpak.c
 
 # Rules for compiling timer system
-$(CURDIR)/build/timer.o: $(CURDIR)/src/timer.c
+$(CURDIR)/build/timer.o: $(CURDIR)/src/timer.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/timer.o $(CURDIR)/src/timer.c
 
@@ -86,7 +86,7 @@ $(CURDIR)/build/exception.o: $(CURDIR)/src/exception.c
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/exception.o $(CURDIR)/src/exception.c
 
 # Rules for compiling newlib interface
-$(CURDIR)/build/system.o: $(CURDIR)/src/system.c
+$(CURDIR)/build/system.o: $(CURDIR)/src/system.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/system.o $(CURDIR)/src/system.c
 

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -183,8 +183,7 @@ static inline void wait_ticks( unsigned long wait )
  */
 static inline void wait_ms( unsigned long wait_ms )
 {
-    unsigned int wait = wait_ms * (TICKS_PER_SECOND / 1000);
-    wait_ticks(wait);
+    wait_ticks(TICKS_FROM_MS(wait_ms));
 }
 
 void data_cache_hit_invalidate(volatile void *, unsigned long);

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -127,7 +127,7 @@
 /**
  * @brief Returns equivalent count ticks for the given millis.
  */
-#define TICKS_FROM_MS(val) ((uint32_t)(val * (TICKS_PER_SECOND / 1000)))
+#define TICKS_FROM_MS(val) ((uint32_t)((val) * (TICKS_PER_SECOND / 1000)))
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -82,16 +82,105 @@
  */
 #define MEMORY_BARRIER() asm volatile ("" : : : "memory")
 
+/**
+ * @brief Number of updates to the count register per second
+ *
+ * The count register updates at "half maximum instruction issue rate".
+ * This appears to be half the CPU clock.  Every second, this many counts
+ * will have passed in the count register
+ */
+#define COUNTS_PER_SECOND (93750000/2)
+
+// Returns the signed difference of time between "from" and "to". If "from"
+// is before "to", the distance in time is positive, otherwise it is
+// negative .
+#define TICKS_DISTANCE(from, to) ((int32_t)((uint32_t)(to) - (uint32_t)(from)))
+
+// Returns true if "t1" is before "t2". This is similar to t1 < t2,
+// but it correctly handles timer overflows which are very frequent.
+//
+// Notice that the N64 counter overflows every 90 seconds, so it's
+// not possible to compare times that are more than 45 seconds apart.
+#define TICKS_BEFORE(t1, t2) ({ TICKS_DISTANCE(t1, t2) > 0; })
+
+// Reads the COP0 register $9 (count) into the provided variable.
+// It will always produce a 32 bit unsigned value.
+#define READ_TICKS(variable) do { \
+    _Static_assert(sizeof(variable) >= 4, "target variable is narrower than 32 bits"); \
+    asm volatile("mfc0 %0,$9":"=r"(variable)); \
+} while(0)
+
+#define WAIT_TICKS(wait) do { \
+    unsigned int initial_tick; \
+    unsigned int current_tick; \
+    READ_TICKS(initial_tick); \
+    READ_TICKS(current_tick); \
+    while( current_tick - initial_tick < wait ) { \
+        READ_TICKS(current_tick); \
+    }; \
+} while(0)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int sys_get_boot_cic();
 void sys_set_boot_cic(int bc);
-volatile unsigned long get_ticks( void );
-volatile unsigned long get_ticks_ms( void );
-void wait_ticks( unsigned long wait );
-void wait_ms( unsigned long wait );
+/**
+ * @brief Read the number of ticks since system startup
+ *
+ * @note This is the clock rate divided by two.
+ * It will wrap back to 0 after about 91.6 seconds
+ * Do not use for comparison without special handling
+ *
+ * @return The number of ticks since system startup
+ */
+static inline volatile unsigned long get_ticks(void)
+{
+    unsigned long count;
+    READ_TICKS(count);
+    return count;
+}
+
+/**
+ * @brief Read the number of millisecounds since system startup
+ *
+ * It will wrap back to 0 after about 91.6 seconds
+ * Do not use for comparison without special handling
+ *
+ * @return The number of millisecounds since system startup
+ */
+static inline volatile unsigned long get_ticks_ms(void)
+{
+    unsigned long count;
+    READ_TICKS(count);
+    return count / (COUNTS_PER_SECOND / 1000);
+}
+
+/**
+ * @brief Spin wait until the number of ticks have elapsed
+ *
+ * @param[in] wait
+ *            Number of ticks to wait
+ *            Maximum accepted value is 0xFFFFFFFF ticks
+ */
+static inline void wait_ticks( unsigned long wait )
+{
+    WAIT_TICKS(wait);
+}
+
+/**
+ * @brief Spin wait until the number of millisecounds have elapsed
+ *
+ * @param[in] wait
+ *            Number of millisecounds to wait
+ *            Maximum accepted value is 91625 ms
+ */
+static inline void wait_ms( unsigned long wait_ms )
+{
+    unsigned int wait = wait_ms * (COUNTS_PER_SECOND / 1000);
+    WAIT_TICKS(wait);
+}
 
 void data_cache_hit_invalidate(volatile void *, unsigned long);
 void data_cache_hit_writeback(volatile void *, unsigned long);
@@ -114,15 +203,6 @@ tv_type_t get_tv_type();
 #ifdef __cplusplus
 }
 #endif
-
-/**
- * @brief Number of updates to the count register per second
- *
- * The count register updates at "half maximum instruction issue rate".
- * This appears to be half the CPU clock.  Every second, this many counts
- * will have passed in the count register
- */
-#define COUNTS_PER_SECOND (93750000/2)
 
 /** @} */
 

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -57,69 +57,6 @@ void sys_set_boot_cic(int bc)
 }
 
 /**
- * @brief Read the number of ticks since system startup
- *
- * @note This is the clock rate divided by two.
- * It will wrap back to 0 after about 91.6 seconds
- * Do not use for comparison without special handling
- *
- * @return The number of ticks since system startup
- */
-volatile unsigned long get_ticks(void)
-{
-    unsigned long count;
-    // reg $9 on COP0 is count
-    asm volatile("\tmfc0 %0,$9\n\tnop":"=r"(count));
-
-    return count;
-}
-
-/**
- * @brief Read the number of millisecounds since system startup
- *
- * It will wrap back to 0 after about 91.6 seconds
- * Do not use for comparison without special handling
- *
- * @return The number of millisecounds since system startup
- */
-volatile unsigned long get_ticks_ms(void)
-{
-    unsigned long count;
-    // reg $9 on COP0 is count
-    asm volatile("\tmfc0 %0,$9\n\tnop":"=r"(count));
-
-    return count / (COUNTS_PER_SECOND / 1000);
-}
-
-/**
- * @brief Spin wait until the number of ticks have elapsed
- *
- * @param[in] wait
- *            Number of ticks to wait
- *            Maximum accepted value is 0xFFFFFFFF ticks
- */
-void wait_ticks( unsigned long wait )
-{
-    unsigned int tick_value = get_ticks();
-
-    while( get_ticks() - tick_value < wait );
-}
-
-/**
- * @brief Spin wait until the number of millisecounds have elapsed
- *
- * @param[in] wait
- *            Number of millisecounds to wait
- *            Maximum accepted value is 91625 ms
- */
-void wait_ms( unsigned long wait_ms )
-{
-    unsigned int wait = wait_ms * (COUNTS_PER_SECOND / 1000);
-
-    wait_ticks(wait);
-}
-
-/**
  * @brief Helper macro to perform cache refresh operations
  *
  * @param[in] op

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -96,13 +96,13 @@ volatile unsigned long get_ticks_ms(void)
  *
  * @param[in] wait
  *            Number of ticks to wait
- *            Maximum accepted value is 0x7FFFFFFF ticks
+ *            Maximum accepted value is 0xFFFFFFFF ticks
  */
 void wait_ticks( unsigned long wait )
 {
-    unsigned int stop = wait + get_ticks();
+    unsigned int tick_value = get_ticks();
 
-    while( stop - get_ticks() < 0x7FFFFFFF );
+    while( get_ticks() - tick_value < wait );
 }
 
 /**
@@ -110,13 +110,13 @@ void wait_ticks( unsigned long wait )
  *
  * @param[in] wait
  *            Number of millisecounds to wait
- *            Maximum accepted value is 45812 ms
+ *            Maximum accepted value is 91625 ms
  */
-void wait_ms( unsigned long wait )
+void wait_ms( unsigned long wait_ms )
 {
-    unsigned int stop = wait * (COUNTS_PER_SECOND / 1000) + get_ticks();
+    unsigned int wait = wait_ms * (COUNTS_PER_SECOND / 1000);
 
-    while( stop - get_ticks() < 0x7FFFFFFF );
+    wait_ticks(wait);
 }
 
 /**

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -60,6 +60,8 @@ void sys_set_boot_cic(int bc)
  * @brief Read the number of ticks since system startup
  *
  * @note This is the clock rate divided by two.
+ * It will wrap back to 0 after about 91.6 seconds
+ * Do not use for comparison without special handling
  *
  * @return The number of ticks since system startup
  */
@@ -74,6 +76,9 @@ volatile unsigned long get_ticks(void)
 
 /**
  * @brief Read the number of millisecounds since system startup
+ *
+ * It will wrap back to 0 after about 91.6 seconds
+ * Do not use for comparison without special handling
  *
  * @return The number of millisecounds since system startup
  */
@@ -91,12 +96,13 @@ volatile unsigned long get_ticks_ms(void)
  *
  * @param[in] wait
  *            Number of ticks to wait
+ *            Maximum accepted value is 0x7FFFFFFF ticks
  */
 void wait_ticks( unsigned long wait )
 {
     unsigned int stop = wait + get_ticks();
 
-    while( stop > get_ticks() );
+    while( stop - get_ticks() < 0x7FFFFFFF );
 }
 
 /**
@@ -104,12 +110,13 @@ void wait_ticks( unsigned long wait )
  *
  * @param[in] wait
  *            Number of millisecounds to wait
+ *            Maximum accepted value is 45812 ms
  */
 void wait_ms( unsigned long wait )
 {
-    unsigned int stop = wait + get_ticks_ms();
+    unsigned int stop = wait * (COUNTS_PER_SECOND / 1000) + get_ticks();
 
-    while( stop > get_ticks_ms() );
+    while( stop - get_ticks() < 0x7FFFFFFF );
 }
 
 /**

--- a/src/timer.c
+++ b/src/timer.c
@@ -165,7 +165,7 @@ static void timer_callback(void)
  * @brief Initialize the timer subsystem
  *
  * @note This will currently mess with get_ticks, get_ticks_ms and related wait
- * routines return as it is explicitly manipulating the system timer.
+ * routines as it is explicitly manipulating the system timer.
  *
  */
 void timer_init(void)

--- a/src/timer.c
+++ b/src/timer.c
@@ -75,7 +75,7 @@ static int __proc_timers(timer_link_t * head)
     int smallest = 0x3FFFFFFF;			// ~ 22.9 secs
 	int start, now;
 
-	READ_TICKS(start);
+	start = TICKS_READ();
 	total_ticks += start;
 
     while (head)
@@ -119,7 +119,7 @@ static int __proc_timers(timer_link_t * head)
     }
 
 	/* check if shortest time left < 5us */
-	READ_TICKS(now);
+	now = TICKS_READ();
 	if (smallest < (now - start + 234))
 	{
 		total_ticks += (now - start);
@@ -146,8 +146,7 @@ static void timer_callback(void)
 	}
 	else
 	{
-		int now;
-		READ_TICKS(now);
+		int now = TICKS_READ();
 		total_ticks += now;
 		write_count(0);
 		write_compare(0x7FFFFFFF);

--- a/src/timer.c
+++ b/src/timer.c
@@ -37,13 +37,6 @@ static timer_link_t *TI_timers = 0;
 static long long total_ticks;
 
 /**
- * @brief Read the count out of the count register
- *
- * @param[out] x
- *             Variable to place count into
- */
-#define read_count(x) asm volatile("mfc0 %0,$9\n\t nop \n\t" : "=r" (x) : )
-/**
  * @brief Write the count to the count register
  *
  * @param[in] x
@@ -82,7 +75,7 @@ static int __proc_timers(timer_link_t * head)
     int smallest = 0x3FFFFFFF;			// ~ 22.9 secs
 	int start, now;
 
-	read_count(start);
+	READ_TICKS(start);
 	total_ticks += start;
 
     while (head)
@@ -126,7 +119,7 @@ static int __proc_timers(timer_link_t * head)
     }
 
 	/* check if shortest time left < 5us */
-	read_count(now);
+	READ_TICKS(now);
 	if (smallest < (now - start + 234))
 	{
 		total_ticks += (now - start);
@@ -154,7 +147,7 @@ static void timer_callback(void)
 	else
 	{
 		int now;
-		read_count(now);
+		READ_TICKS(now);
 		total_ticks += now;
 		write_count(0);
 		write_compare(0x7FFFFFFF);

--- a/src/timer.c
+++ b/src/timer.c
@@ -163,6 +163,10 @@ static void timer_callback(void)
 
 /**
  * @brief Initialize the timer subsystem
+ *
+ * @note This will currently mess with get_ticks, get_ticks_ms and related wait
+ * routines return as it is explicitly manipulating the system timer.
+ *
  */
 void timer_init(void)
 {

--- a/tests/test_ticks.c
+++ b/tests/test_ticks.c
@@ -1,34 +1,17 @@
 // Writes the 32bit value to COP0 register 9 (count)
 #define WRITE_TICKS(val) do { asm volatile("mtc0 %0,$9"::"r"(val)); } while(0)
 
-#define TEST(name, tests) do { \
-	const int NUM_CASES = sizeof(tests) / sizeof(tests[0]); \
-	for (int i=0; i < NUM_CASES; i++) { \
-		/* move ticks a little before the target to make sure it is actually doing some waiting */ \
-		mock_tick = tests[i][1] - TICKS_FROM_MS(5); \
-		WRITE_TICKS(tests[i][0]); \
-		/* act */ \
-		name(tests[i][2]); \
-		ticks_0 = TICKS_READ(); \
-		ASSERT(state != Timeout, "Case: %u Test timed out. " #name " didn't finish on time (Ticks: %#10lX)", i, ticks_0); \
-		ASSERT(state == Test && ticks_0 >= tests[i][1], "Case: %u " #name " finished too early (Ticks: %#10lX)", i, ticks_0); \
-		ASSERT(state <= Timeout, "Case: %u Unexpected state for " #name " (Ticks: %#10lX)", i, ticks_0); \
-		/* re-sync to frame */ \
-		while (state < Timeout); \
-		/* reset state */ \
-		state = Start; \
-	} \
-} while(0)
-
-static volatile uint32_t mock_tick = 0;
-static volatile enum state_t{ Start = 0, Test = 1, Timeout = 2 } state = -1;
+static volatile uint32_t test_ticks_mock = 0;
+static volatile enum test_ticks_state_t { Start = 0, Test = 1, Timeout = 2 } state = -1;
 
 static void frame_callback() {
 	state++;
 
+	state = state > Timeout ? Timeout : state;
+
 	switch(state) {
 		case Test:
-			WRITE_TICKS(mock_tick);
+			WRITE_TICKS(test_ticks_mock);
 		break;
 		default:
 		break;
@@ -52,7 +35,9 @@ static void frame_callback() {
 // test. Execution times are negligible with this setup.
 // 0x2CB4178 is 1 second
 
-static uint32_t test_cases[][3] = {
+typedef uint32_t test_ticks_cases_t[][3];
+
+static test_ticks_cases_t test_ticks_cases = {
 	// No overflow
 	{0x2CB4178, 0x59682F0, 0x2CB4178},
 	// Wrap towards the end
@@ -63,7 +48,7 @@ static uint32_t test_cases[][3] = {
 	{0xFD34BE87, 0xFA697D0F, 0xFD34BE87},
 };
 
-static uint32_t test_cases_ms[][3] = {
+static test_ticks_cases_t test_ticks_ms_cases = {
 	// No overflow
 	{0x2CB4178, 0x59682F0, 1000},
 	// Wrap towards the end
@@ -73,6 +58,25 @@ static uint32_t test_cases_ms[][3] = {
 	// Long wait, wrapping around - 1 second before the end => 2 second before the end
 	{0xFD34BE87, 0xFA697D0F, 90626},
 };
+
+static void test_ticks_func(TestContext *ctx, void to_test(unsigned long), char name[], test_ticks_cases_t tests, int num_cases) {
+	for (int i=0; i < num_cases; i++) {
+		/* move ticks a little before the target to make sure it is actually doing some waiting */
+		test_ticks_mock = tests[i][1] - TICKS_FROM_MS(5);
+		WRITE_TICKS(tests[i][0]);
+		/* act */
+		(*to_test)(tests[i][2]);
+		uint32_t ticks_0 = TICKS_READ();
+		ASSERT(state <= Timeout, "Case: %u Unexpected state for %s (Ticks: %#10lX)\n", i,name, ticks_0);
+		ASSERT(state != Timeout, "Case: %u Test timed out. %s didn't finish on time (Ticks: %#10lX)\n", i, name, ticks_0);
+		ASSERT(state == Test && ticks_0 >= tests[i][1], "Case: %u %s finished too early (Ticks: %#10lX)\n", i, name, ticks_0);
+		
+		/* re-sync to frame */
+		while (state < Timeout);
+		/* reset state */
+		state = Start;
+	}
+}
 
 void test_ticks(TestContext *ctx) {
 	uint32_t ticks_0;
@@ -115,7 +119,7 @@ void test_ticks(TestContext *ctx) {
 		WRITE_TICKS(0x0);
 		ticks_0 = get_ticks_ms();
 		WRITE_TICKS(0x7FFFFFFF);
-		ticks_1 = get_ticks_ms();	
+		ticks_1 = get_ticks_ms();
 	}
 
 	// Prepare for next test
@@ -127,8 +131,8 @@ void test_ticks(TestContext *ctx) {
 	// Sync to nearest video frame to use as an interval
 	while (state < Start);
 
-	TEST(wait_ticks, test_cases);
-	TEST(wait_ms, test_cases_ms);
+	test_ticks_func(ctx, wait_ticks, "wait_ticks", test_ticks_cases, sizeof(test_ticks_cases) / sizeof(test_ticks_cases[0]));
+	test_ticks_func(ctx, wait_ms, "wait_ms", test_ticks_ms_cases, sizeof(test_ticks_ms_cases) / sizeof(test_ticks_ms_cases[0]));
 
 	// Cleanup
 	unregister_VI_handler(frame_callback);

--- a/tests/test_ticks.c
+++ b/tests/test_ticks.c
@@ -1,0 +1,149 @@
+// Writes the 32bit value to COP0 register 9 (count)
+#define WRITE_TICKS(val) do { asm volatile("mtc0 %0,$9"::"r"(val)); } while(0)
+
+// Writes the 32bit value to COP0 register 11 (compare)
+#define WRITE_COMPARE(val) do { asm volatile("mtc0 %0,$11" ::"r"(val)); } while(0)
+
+#define ARM_INTERRUPT(compare) do { \
+	asm volatile(".align 4"); \
+	WRITE_TICKS(0x0); \
+	WRITE_COMPARE(compare); \
+} while(0)
+
+#define TEST(name, tests) do { \
+	const int NUM_CASES = sizeof(tests) / sizeof(tests[0]); \
+	for (int i=0; i < NUM_CASES; i++) { \
+		mock_tick = tests[i][1]; \
+		WRITE_TICKS(tests[i][0]); \
+		/* act */ \
+		name(tests[i][2]); \
+		READ_TICKS(ticks_0); \
+		ASSERT(state != Timeout, "Case: %u Test timed out. " #name " didn't finish on time (Ticks: %#10lX)", state, ticks_0); \
+		ASSERT(state == Test, "Case: %u " #name " finished too early (Ticks: %#10lX)", state, ticks_0); \
+		ASSERT(state <= Timeout, "Case: %u Unexpected state for " #name " (Ticks: %#10lX)", state, ticks_0); \
+		/* re-sync to frame */ \
+		while (state < Timeout); \
+		/* reset state */ \
+		state = Start; \
+	} \
+} while(0)
+
+static volatile uint32_t mock_tick = 0;
+static volatile enum state_t{ Start = 0, Test = 1, Timeout = 2 } state = -1;
+
+static void frame_callback() {
+	state++;
+
+	switch(state) {
+		case Test:
+			WRITE_TICKS(mock_tick);
+		break;
+		default:
+		break;
+	}
+}
+
+// Array of test cases in the form {initial, mock, wait}
+// We have three phases incremented on every frame (VI used as an interval)
+
+// Start: set the count register to the initial value and enter the wait loop
+// Test: VI interrupt updates the count register to the mock value
+// Timeout: If the wait loop fails to exit upon setting the mock value, the VI
+
+// interrupt will move the state into this phase, which is asserted in the test.
+// So we can test them each of them in three frames, without waiting the full
+// delay. Tested wait should be an order of magnitude longer than the VI interval
+// to prevent the loop from exiting before we are able to update the count reg.
+// If wait calculation is unable to wrap properly, the loop will run for a maximum
+// of 90 secs and endup in Timeout state, failing the tes.
+// Execution times are negligible with this setup.
+// 0x2CB4178 is 1 second
+
+static uint32_t test_cases[][3] = {
+	// No overflow
+	{0x2CB4178, 0x59682F0, 0x2CB4178},
+	// Wrap towards the end
+	{0xFD34BE87, 0x2CB4178, 0x59682F0},
+	// wait a long time - 1 second in the range to 1 second before the end
+	{0x2CB4178, 0xFD34BE87, 0xFA697D0F},
+	 // already fulfilled way past the start tick
+	{0x2CB4178, 0xFD34BE87, 0x59682F0},
+	// TODO: also test unfulfilled cases to make sure we don't exit the loop early.
+};
+
+static uint32_t test_cases_ms[][3] = {
+	// No overflow
+	{0x2CB4178, 0x59682F0, 1000},
+	// Wrap towards the end
+	{0xFD34BE87, 0x2CB4178, 2000},
+	// wait a long time - 1 second in the range to 1 second before the end
+	{0x2CB4178, 0xFD34BE87, 88000},
+	 // already fulfilled way past the start tick
+	{0x2CB4178, 0xFD34BE87, 2000},
+	// TODO: also test unfulfilled cases to make sure we don't exit the loop early.
+};
+
+void test_ticks(TestContext *ctx) {
+	uint32_t ticks_0;
+	uint32_t ticks_1;
+
+	uint32_t continue_ticks;
+	READ_TICKS(continue_ticks);
+
+	disable_interrupts();
+
+	// Put the instructions on the same cacheline
+	asm volatile(".align 4");
+	WRITE_TICKS(0x0);
+	READ_TICKS(ticks_0);
+	WRITE_TICKS(0xFFFFFFFF);
+	READ_TICKS(ticks_1);
+
+	enable_interrupts();
+
+	ASSERT(ticks_0 == 0x0 && ticks_1 == 0xFFFFFFFF, "not reading correct register. Received %#010lX and %#010lX", ticks_0, ticks_1);
+
+	disable_interrupts();
+
+	// Put the instructions on the same cacheline
+	asm volatile(".align 4");
+	WRITE_TICKS(0x0);
+	ticks_0 = get_ticks();
+	WRITE_TICKS(0xFFFFFFFF);
+	ticks_1 = get_ticks();
+
+	enable_interrupts();
+
+	ASSERT(ticks_0 == 0x0 && ticks_1 == 0xFFFFFFFF, "not reading correct register or function not inlined. Received %#010lX and %#010lX", ticks_0, ticks_1);
+
+	disable_interrupts();
+
+	// Put the instructions on the same cacheline
+	asm volatile(".align 4");
+	WRITE_TICKS(0x0);
+	ticks_0 = get_ticks_ms();
+	WRITE_TICKS(0x7FFFFFFF);
+	ticks_1 = get_ticks_ms();
+
+	// Prepare for next test
+	register_VI_handler(frame_callback);
+	enable_interrupts();
+
+	ASSERT(ticks_0 == 0 && ticks_1 == 45812, "not reading correct register or function not inlined. Received %lu and %lu", ticks_0, ticks_1);
+
+	// Sync to nearest video frame to use as an interval
+	while (state < Start);
+
+	TEST(WAIT_TICKS, test_cases);
+	TEST(wait_ticks, test_cases);
+	TEST(wait_ms, test_cases_ms);
+
+	// Cleanup
+	unregister_VI_handler(frame_callback);
+	WRITE_TICKS(continue_ticks);
+}
+
+#undef WRITE_TICKS
+#undef WRITE_COMPARE
+#undef ARM_INTERRUPT
+#undef TEST

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -171,81 +171,81 @@ static const struct Testsuite
 };
 
 int main() {
-    init_interrupts();
+	init_interrupts();
 
-    display_init(RESOLUTION_320x240, DEPTH_32_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
-    console_init();
+	display_init(RESOLUTION_320x240, DEPTH_32_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+	console_init();
 
-    if (dfs_init( DFS_DEFAULT_LOCATION ) != DFS_ESUCCESS) {
-        printf("Invalid ROM: cannot initialize DFS\n");
-        return 0;
-    }
+	if (dfs_init( DFS_DEFAULT_LOCATION ) != DFS_ESUCCESS) {
+		printf("Invalid ROM: cannot initialize DFS\n");
+		return 0;
+	}
 
-    printf("libdragon testsuite\n\n");
-    int failures = 0;
-    int successes = 0;
+	printf("libdragon testsuite\n\n");
+	int failures = 0;
+	int successes = 0;
 
 	const int NUM_TESTS = sizeof(tests) / sizeof(tests[0]);
-    uint32_t start;
+	uint32_t start;
 	READ_TICKS(start);
-    for (int i=0; i < NUM_TESTS; i++) {
-    	static char logbuf[16384];
+	for (int i=0; i < NUM_TESTS; i++) {
+		static char logbuf[16384];
 
-    	// Prepare the test context
-    	TestContext ctx;
-    	ctx.log = logbuf;
-    	ctx.logleft = sizeof(logbuf);
-    	ctx.result = TEST_SUCCESS;
-    	rand_state = 1; // reset to be fully reproducible
+		// Prepare the test context
+		TestContext ctx;
+		ctx.log = logbuf;
+		ctx.logleft = sizeof(logbuf);
+		ctx.result = TEST_SUCCESS;
+		rand_state = 1; // reset to be fully reproducible
 
-    	printf("%-30s", tests[i].name);
-    	fflush(stdout);
+		printf("%-30s", tests[i].name);
+		fflush(stdout);
 
-    	uint32_t test_start;
+		uint32_t test_start;
 		READ_TICKS(test_start);
 
-    	// Run the test!
-    	tests[i].fn(&ctx);
+		// Run the test!
+		tests[i].fn(&ctx);
 
-    	// Compute the test duration
-    	uint32_t test_stop;
+		// Compute the test duration
+		uint32_t test_stop;
 		READ_TICKS(test_stop);
 
-    	int32_t test_duration = (test_stop - test_start) / 1024;
-    	int64_t test_diff = (test_duration - tests[i].duration);
-    	if (test_diff < 0) test_diff = -test_diff;
+		int32_t test_duration = (test_stop - test_start) / 1024;
+		int64_t test_diff = (test_duration - tests[i].duration);
+		if (test_diff < 0) test_diff = -test_diff;
 
-    	if (ctx.result == TEST_FAILED) {
-    		failures++;
-    		printf("FAIL\n\n");
+		if (ctx.result == TEST_FAILED) {
+			failures++;
+			printf("FAIL\n\n");
 
-    		if (ctx.log != logbuf) {			
-	    		printf("%s\n\n", logbuf);
-    		}
-    	}
-    #if BENCHMARK_TESTS
-    	// If there's more than a 10% drift on the running time (/1024) compared to
-    	// the expected one, make the test fail. Something happened and we
-    	// need to double check this.
-    	else if (tests[i].duration > 0 && ((float)test_diff / (float)test_duration > 0.1))
-    	{
-    		failures++;
-    		printf("FAIL\n\n");
+			if (ctx.log != logbuf) {			
+				printf("%s\n\n", logbuf);
+			}
+		}
+	#if BENCHMARK_TESTS
+		// If there's more than a 10% drift on the running time (/1024) compared to
+		// the expected one, make the test fail. Something happened and we
+		// need to double check this.
+		else if (tests[i].duration > 0 && ((float)test_diff / (float)test_duration > 0.1))
+		{
+			failures++;
+			printf("FAIL\n\n");
 
-    		printf("Duration changed by %.1f%%\n", (float)test_diff * 100.0 / (float)test_duration);
-    		printf("(expected: %ldK, measured: %ldK)\n\n", tests[i].duration, test_duration);
-    	}
-    #endif
-    	else {
-    		successes++;
-    		printf("PASS\n");
-    	}
-    }
-    uint32_t stop;
+			printf("Duration changed by %.1f%%\n", (float)test_diff * 100.0 / (float)test_duration);
+			printf("(expected: %ldK, measured: %ldK)\n\n", tests[i].duration, test_duration);
+		}
+	#endif
+		else {
+			successes++;
+			printf("PASS\n");
+		}
+	}
+	uint32_t stop;
 	READ_TICKS(stop);
 
-    int64_t total_time = TIMER_MICROS(stop-start) / 1000000;
+	int64_t total_time = TIMER_MICROS(stop-start) / 1000000;
 
-    printf("\nTestsuite finished in %02lld:%02lld\n", total_time%60, total_time/60);
-    printf("Passed: %d out of %d\n", successes, NUM_TESTS);
+	printf("\nTestsuite finished in %02lld:%02lld\n", total_time%60, total_time/60);
+	printf("Passed: %d out of %d\n", successes, NUM_TESTS);
 }

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -172,7 +172,10 @@ static const struct Testsuite
 } tests[] = {
 	TEST_FUNC(test_dfs_read, 1104, TEST_FLAGS_IO),
 	TEST_FUNC(test_cache_invalidate, 1337, TEST_FLAGS_NONE),
+
+#if BENCHMARK_TESTS
 	TEST_FUNC(test_ticks, 0, TEST_FLAGS_NO_BENCHMARK),
+#endif
 };
 
 int main() {


### PR DESCRIPTION
`wait_ticks` and `wait_ms` functions were not working correctly because of the limited range of the underlying hardware register size (32bits). This gets consumed in about 91 seconds and it is not possible to do a simple comparison to wait for some time.

It is fixed by limiting the wait range to `0x7FFFFFFF` ticks which allows detecting the direction of the current count register with respect to the reference time.