### PR TITLE
Fix icache ops and support GCC nested functions

### DIFF
--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -62,11 +62,11 @@ void sys_set_boot_cic(int bc)
  * @param[in] op
  *            Operation to perform
  */
-#define cache_op(op) ({ \
+#define cache_op(op, linesize) ({ \
     if (length) { \
-        void *cur = (void*)((unsigned long)addr & ~15); \
+        void *cur = (void*)((unsigned long)addr & ~(linesize-1)); \
         int count = (int)length + (addr-cur); \
-        for (int i = 0; i < count; i += 16) \
+        for (int i = 0; i < count; i += linesize) \
             asm ("\tcache %0,(%1)\n"::"i" (op), "r" (cur+i)); \
     } \
 })
@@ -83,7 +83,7 @@ void sys_set_boot_cic(int bc)
  */
 void data_cache_hit_writeback(volatile void * addr, unsigned long length)
 {
-    cache_op(0x19);
+    cache_op(0x19, 16);
 }
 
 /**
@@ -98,7 +98,7 @@ void data_cache_hit_writeback(volatile void * addr, unsigned long length)
  */
 void data_cache_hit_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x11);
+    cache_op(0x11, 16);
 }
 
 /**
@@ -113,7 +113,7 @@ void data_cache_hit_invalidate(volatile void * addr, unsigned long length)
  */
 void data_cache_hit_writeback_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x15);
+    cache_op(0x15, 16);
 }
 
 /**
@@ -126,7 +126,7 @@ void data_cache_hit_writeback_invalidate(volatile void * addr, unsigned long len
  */
 void data_cache_index_writeback_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x01);
+    cache_op(0x01, 16);
 }
 
 /**
@@ -141,7 +141,7 @@ void data_cache_index_writeback_invalidate(volatile void * addr, unsigned long l
  */
 void inst_cache_hit_writeback(volatile void * addr, unsigned long length)
 {
-    cache_op(0x18);
+    cache_op(0x18, 32);
 }
 
 /**
@@ -156,7 +156,7 @@ void inst_cache_hit_writeback(volatile void * addr, unsigned long length)
  */
 void inst_cache_hit_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x10);
+    cache_op(0x10, 32);
 }
 
 /**
@@ -169,7 +169,7 @@ void inst_cache_hit_invalidate(volatile void * addr, unsigned long length)
  */
 void inst_cache_index_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x00);
+    cache_op(0x00, 32);
 }
 
 /**

--- a/src/system.c
+++ b/src/system.c
@@ -1295,4 +1295,16 @@ int unhook_stdio_calls()
     return 0;
 }
 
+/**
+ * @brief Implement _flush_cache as required by GCC for nested functions.
+ *
+ * When using the nested function extensions of GCC, a call to _flush_cache
+ * is generated which must be supplied by the operating system or runtime
+ * to allow flushing the instruction cache for the generated trampoline.
+ */
+void _flush_cache(uint8_t* addr, unsigned long bytes) {
+    data_cache_hit_writeback(addr, bytes);
+    inst_cache_hit_invalidate(addr, bytes);
+}
+
 /** @} */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,7 +49,7 @@ test.dfs:
 	$(MKDFSPATH) test.dfs ./filesystem/
 
 clean:
-	rm -f *.v64 *.z64 *.elf *.o *.bin *.dfs
+	rm -f *.v64 *.z64 *.elf *.o *.bin *.dfs *.d
 
 -include testrom.d testrom_emu.d
 

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -7,9 +7,10 @@ void test_cache_invalidate(TestContext *ctx) {
 	for (int i=0;i<32;i++) {
 		for (int j=0;j<32;j++) {
 
-			// Write the whole buffer through cache,
+			// Read/write the whole buffer through cache,
 			// so it's all populated in D-Cache.
-			memset(buf, 0xAA, sizeof(buf));
+			memset(buf, 0xA0, sizeof(buf));
+			for (int i=0;i<sizeof(buf);i++) buf[i] += 0xA;
 
 			// Writeback+Invalidate buf[i..i+j]. Now only
 			// those lines should be invalidated.

--- a/tests/test_irq.c
+++ b/tests/test_irq.c
@@ -1,0 +1,45 @@
+
+void test_irq_reentrancy(TestContext *ctx) {
+	// Make sure that enable_interrupts() does not cause an interrupt
+	// to trigger if called under interrupt.
+	volatile bool cb1_called = false;
+	volatile bool cb2_called = false;
+	bool cb1_running = false;
+	bool fail_reentrant = false;
+	bool fail_order = false;
+
+	void cb1(int ovlf) {
+		cb1_called = true;
+		cb1_running = true;
+		disable_interrupts();
+
+		// Wait for the other timer interrupt to trigger
+		wait_ms(30);
+
+		// This enable_interrupts should not trigger the other
+		// interrupt, otherwise the test will fail.
+		enable_interrupts();
+		cb1_running = false;
+	}
+
+	void cb2(int ovlf) {
+		cb2_called = true;
+		if (!cb1_called)
+			fail_order = true;
+		if (cb1_running)
+			fail_reentrant = true;
+	}
+
+	timer_init();
+	DEFER(timer_close());
+
+	timer_link_t *t1 = new_timer(TICKS_FROM_MS(10), TF_ONE_SHOT, cb1);
+	DEFER(delete_timer(t1));
+	timer_link_t *t2 = new_timer(TICKS_FROM_MS(30), TF_ONE_SHOT, cb2);
+	DEFER(delete_timer(t2));
+
+	while (!cb2_called) {}
+
+	ASSERT(!fail_order, "invalid order of call of callbacks");
+	ASSERT(!fail_reentrant, "interrupt called while another interrupt was in progress");
+}

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -171,7 +171,7 @@ static const struct Testsuite
 	uint32_t flags;
 } tests[] = {
 	TEST_FUNC(test_dfs_read, 1104, TEST_FLAGS_IO),
-	TEST_FUNC(test_cache_invalidate, 1337, TEST_FLAGS_NONE),
+	TEST_FUNC(test_cache_invalidate, 1763, TEST_FLAGS_NONE),
 
 #if BENCHMARK_TESTS
 	TEST_FUNC(test_ticks, 0, TEST_FLAGS_NO_BENCHMARK),

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -152,14 +152,15 @@ int assert_equal_mem(TestContext *ctx, const uint8_t *a, const uint8_t *b, int l
 #include "test_dfs.c"
 #include "test_cache.c"
 #include "test_ticks.c"
+#include "test_irq.c"
 
 /**********************************************************************
  * MAIN
  **********************************************************************/
 
 // Testsuite definition
-#define TEST_FLAGS_NONE 0x0
-#define TEST_FLAGS_IO 0x1
+#define TEST_FLAGS_NONE         0x0
+#define TEST_FLAGS_IO           0x1
 #define TEST_FLAGS_NO_BENCHMARK 0x2
 
 #define TEST_FUNC(fn, dur, flags)   { #fn, fn, dur, flags }
@@ -170,11 +171,12 @@ static const struct Testsuite
 	uint32_t duration;
 	uint32_t flags;
 } tests[] = {
-	TEST_FUNC(test_dfs_read, 1104, TEST_FLAGS_IO),
-	TEST_FUNC(test_cache_invalidate, 1763, TEST_FLAGS_NONE),
+	TEST_FUNC(test_irq_reentrancy,         0, TEST_FLAGS_NO_BENCHMARK),  // FIXME: this test uses timer.c so we can't measure it yet
+	TEST_FUNC(test_dfs_read,            1104, TEST_FLAGS_IO),
+	TEST_FUNC(test_cache_invalidate,    1763, TEST_FLAGS_NONE),
 
 #if BENCHMARK_TESTS
-	TEST_FUNC(test_ticks, 0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_ticks,                  0, TEST_FLAGS_NO_BENCHMARK),
 #endif
 };
 
@@ -229,12 +231,12 @@ int main() {
 			}
 		}
 	#if BENCHMARK_TESTS
-		// If there's more than a 1% (10% for IO tests) drift on the running time
+		// If there's more than a 5% (10% for IO tests) drift on the running time
 		// (/1024) compared to the expected one, make the test fail. Something
 		// happened and we need to double check this.
 		else if (
 			!(tests[i].flags & TEST_FLAGS_NO_BENCHMARK) &&
-			((float)test_diff / (float)test_duration > ((tests[i].flags & TEST_FLAGS_IO) ? 0.1 : 0.01))
+			((float)test_diff / (float)test_duration > ((tests[i].flags & TEST_FLAGS_IO) ? 0.1 : 0.05))
 		) {
 			failures++;
 			printf("FAIL\n\n");


### PR DESCRIPTION
GCC has an extension that allows to create nested functions that can
refer to variable in the outer scope (aka lexical closures). This is
more useful than it sounds even in the context of N64 programming,
to define stuff like interrupt callbacks.

Since this feature requires generating a trampoline at runtime, GCC
generates a call to a function named "_flush_cache" that must be
implemented by the operating system runtime, to flush the instruction
cache. This PR adds such a function, whose implementation is trivial.

While implementing this, I noticed that cache ops are wrong for
instruction cache because the cachelines are 32 bytes (instead of
16 bytes like the data cache).

Also, while writing the code, an existing test started to fail and I realized
it was not correct (a buffer that was supposedly in cache was only
written and never read). I fixed this as well.