### PR TITLE
Rewrite timer.c to avoid messing up the COP0 hardware counter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ install: libdragon.a libdragonsys.a
 	install -m 0644 header $(INSTALLDIR)/mips64-elf/lib/header
 	install -m 0644 libdragonsys.a $(INSTALLDIR)/mips64-elf/lib/libdragonsys.a
 	install -m 0644 include/n64sys.h $(INSTALLDIR)/mips64-elf/include/n64sys.h
+	install -m 0644 include/cop0.h $(INSTALLDIR)/mips64-elf/include/cop0.h
 	install -m 0644 include/interrupt.h $(INSTALLDIR)/mips64-elf/include/interrupt.h
 	install -m 0644 include/dma.h $(INSTALLDIR)/mips64-elf/include/dma.h
 	install -m 0644 include/dragonfs.h $(INSTALLDIR)/mips64-elf/include/dragonfs.h

--- a/files.in
+++ b/files.in
@@ -24,7 +24,7 @@ OFILES_LDS  = $(CURDIR)/build/system.o
 $(CURDIR)/build/n64sys.o: $(CURDIR)/src/n64sys.c
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/n64sys.o $(CURDIR)/src/n64sys.c
-$(CURDIR)/build/interrupt.o: $(CURDIR)/src/interrupt.c
+$(CURDIR)/build/interrupt.o: $(CURDIR)/src/interrupt.c ./include/cop0.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/interrupt.o $(CURDIR)/src/interrupt.c
 $(CURDIR)/build/dma.o: $(CURDIR)/src/dma.c ./include/n64sys.h

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -1,0 +1,69 @@
+/**
+ * @file cop0.h
+ * @brief N64 COP0 Interface
+ * @ingroup n64sys
+ */
+
+/**
+ * @addtogroup n64sys
+ * @{
+ */
+
+#ifndef __LIBDRAGON_COP0_H
+#define __LIBDRAGON_COP0_H
+
+/** @brief Read the COP0 Count register (see also TICKS_READ). */
+#define C0_COUNT() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$9":"=r"(x)); \
+    x; \
+})
+
+/** @brief Write the COP0 Count register. */
+#define C0_WRITE_COUNT(x) ({ \
+    asm volatile("mtc0 %0,$9"::"r"(x)); \
+})
+
+
+/** @brief Read the COP0 Compare register. */
+#define C0_COMPARE() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$11":"=r"(x)); \
+    x; \
+})
+
+/** @brief Write the COP0 Compare register. */
+#define C0_WRITE_COMPARE(x) ({ \
+    asm volatile("mtc0 %0,$11"::"r"(x)); \
+})
+
+
+/** @brief Read the COP0 Status register. */
+#define C0_STATUS() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$12":"=r"(x)); \
+    x; \
+})
+
+/** @brief Write the COP0 Status register. */
+#define C0_WRITE_STATUS(x) ({ \
+    asm volatile("mtc0 %0,$12"::"r"(x)); \
+})
+
+/* COP0 Status bits definition. Please refer to MIPS R4300 manual. */
+#define C0_STATUS_IE        0x00000001
+#define C0_STATUS_EXL       0x00000002
+#define C0_STATUS_ERL       0x00000004
+
+#define C0_STATUS_IM0       0x00000100
+#define C0_STATUS_IM1       0x00000200
+#define C0_STATUS_IM2       0x00000400
+#define C0_STATUS_IM3       0x00000800
+#define C0_STATUS_IM4       0x00001000
+#define C0_STATUS_IM5       0x00002000
+#define C0_STATUS_IM6       0x00004000
+#define C0_STATUS_IM7       0x00008000
+
+/** @} */
+
+#endif

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -7,6 +7,7 @@
 #define __LIBDRAGON_N64SYS_H
 
 #include <stdbool.h>
+#include "cop0.h"
 
 /**
  * @addtogroup n64sys
@@ -93,11 +94,7 @@
  * actually being executed. This macro is for reading that value.
  * Do not use for comparison without special handling.
  */
-#define TICKS_READ() ({ \
-    uint32_t x; \
-    asm volatile("mfc0 %0,$9":"=r"(x)); \
-    x; \
-})
+#define TICKS_READ() C0_COUNT()
 
 /**
  * @brief Number of updates to the count register per second

--- a/include/timer.h
+++ b/include/timer.h
@@ -6,6 +6,8 @@
 #ifndef __LIBDRAGON_TIMER_H
 #define __LIBDRAGON_TIMER_H
 
+#include <stdint.h>
+
 /** 
  * @addtogroup timer
  * @{
@@ -16,10 +18,10 @@
  */
 typedef struct timer_link
 {
-    /** @brief Ticks left until callback */
-    int left;
+    /** @brief Absolute ticks value at which the timer expires. */
+    uint32_t left;
     /** @brief Ticks to set if continuous */
-    int set;
+    uint32_t set;
     /** @brief To correct for drift */
     int ovfl;
     /** @brief Timer flags.  See #TF_ONE_SHOT and #TF_CONTINUOUS */

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -594,10 +594,9 @@ void init_interrupts()
         __interrupt_depth = 0;
 
         /* Enable interrupts systemwide. We set the global interrupt enable,
-           and then specifically enable RCP interrupts (IM2) and COP0 timer
-           interrupt (IM7). */
+           and then specifically enable RCP interrupts (IM2). */
         uint32_t sr = C0_STATUS();
-        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_STATUS_IM2 | C0_STATUS_IM7);
+        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_STATUS_IM2);
     }
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -593,8 +593,11 @@ void init_interrupts()
         /* Set that we are enabled */
         __interrupt_depth = 0;
 
-        /* Enable interrupts systemwide */
-        asm("\tmfc0 $8,$12\n\tori $8,0x8401\n\tmtc0 $8,$12\n\tnop":::"$8");
+        /* Enable interrupts systemwide. We set the global interrupt enable,
+           and then specifically enable RCP interrupts (IM2) and COP0 timer
+           interrupt (IM7). */
+        uint32_t sr = C0_STATUS();
+        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_STATUS_IM2 | C0_STATUS_IM7);
     }
 }
 
@@ -612,7 +615,7 @@ void disable_interrupts()
     if( __interrupt_depth == 0 )
     {
         /* Interrupts are enabled, so its safe to disable them */
-        asm("\tmfc0 $8,$12\n\tla $9,~1\n\tand $8,$9\n\tmtc0 $8,$12\n\tnop":::"$8","$9");
+        C0_WRITE_STATUS(C0_STATUS() & ~C0_STATUS_IE);
         interrupt_disabled_tick = TICKS_READ();
     }
 
@@ -637,8 +640,7 @@ void enable_interrupts()
 
     if( __interrupt_depth == 0 )
     {
-        /* Interrupts are disabled but we hit the base nesting level, time to enable */
-        asm("\tmfc0 $8,$12\n\tori $8,1\n\tmtc0 $8,$12\n\tnop":::"$8");
+        C0_WRITE_STATUS(C0_STATUS() | C0_STATUS_IE);
     }
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -594,7 +594,7 @@ void init_interrupts()
         __interrupt_depth = 0;
 
         /* Enable interrupts systemwide */
-        asm("\tmfc0 $8,$12\n\tori $8,0x401\n\tmtc0 $8,$12\n\tnop":::"$8");
+        asm("\tmfc0 $8,$12\n\tori $8,0x8401\n\tmtc0 $8,$12\n\tnop":::"$8");
     }
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -112,6 +112,9 @@
  */
 static int __interrupt_depth = -1;
 
+/** @brief tick at which interrupts were disabled. */
+uint32_t interrupt_disabled_tick = 0;
+
 /**
  * @brief Structure of an interrupt callback
  */
@@ -610,6 +613,7 @@ void disable_interrupts()
     {
         /* Interrupts are enabled, so its safe to disable them */
         asm("\tmfc0 $8,$12\n\tla $9,~1\n\tand $8,$9\n\tmtc0 $8,$12\n\tnop":::"$8","$9");
+        interrupt_disabled_tick = TICKS_READ();
     }
 
     /* Ensure that we remember nesting levels */

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -137,7 +137,11 @@ notprenmi:
 	and $30,k1,0x8000
 	beqz $30,notcount
 	nop
-	mtc0 $0,$11
+	/* Writing C0_COMPARE acknowledges the timer interrupt (clear the interrupt
+	   bit in C0_CAUSE, otherwise the interrupt would retrigger). We write
+	   the current value so that we don't destroy it in case it's needed. */
+	mfc0 k0,C0_COMPARE
+	mtc0 k0,C0_COMPARE
 
 	/* handle timer exception */
 	jal __TI_handler

--- a/src/timer.c
+++ b/src/timer.c
@@ -210,11 +210,13 @@ void timer_init(void)
 	}
 
 	/* Reset the count and compare registers. Avoid to accidentally trigger
-	   an interrupt by setting count to 1 and compare to 0. */
+	   an interrupt by setting count to 1 and compare to 0. Also enable
+	   timer interrupts in COP0. */
 	disable_interrupts();
 	ticks64_high = 0;
 	C0_WRITE_COUNT(1);
 	C0_WRITE_COMPARE(0);
+	C0_WRITE_STATUS(C0_STATUS() | C0_STATUS_IM7);
 	enable_interrupts();
 
 	register_TI_handler(timer_callback);
@@ -349,6 +351,9 @@ void timer_close(void)
 {
 	disable_interrupts();
     
+    /* Disable generation of timer interrupt. */
+	C0_WRITE_STATUS(C0_STATUS() & ~C0_STATUS_IM7);
+
     unregister_TI_handler(timer_callback);
 
 	timer_link_t *head = TI_timers;

--- a/src/timer.c
+++ b/src/timer.c
@@ -222,9 +222,8 @@ void timer_init(void)
 	C0_WRITE_COUNT(1);
 	C0_WRITE_COMPARE(0);
 	C0_WRITE_STATUS(C0_STATUS() | C0_STATUS_IM7);
-	enable_interrupts();
-
 	register_TI_handler(timer_callback);
+	enable_interrupts();
 }
 
 /**

--- a/src/timer.c
+++ b/src/timer.c
@@ -33,26 +33,39 @@
 
 /** @brief Internal linked list of timers */
 static timer_link_t *TI_timers = 0;
-/** @brief Total ticks elapsed since timer subsystem initialization */
-static long long total_ticks;
 
-/**
- * @brief Write the count to the count register
- *
- * @param[in] x
- *            Value to write into the count register
- */
-#define write_count(x) asm volatile("mtc0 %0,$9\n\t nop \n\t" :  : "r" (x) )
-/**
- * @brief Set the compare register
- *
- * This sets up the compare register so that when the count register equals the compare
- * register, an interrupt will be generated.
- *
- * @param[in] x
- *            Value to write into the compare register
- */
-#define write_compare(x) asm volatile("mtc0 %0,$11\n\t nop \n\t" :  : "r" (x) )
+/** @brief Higher-part of 64-bit tick counter */
+volatile uint32_t ticks64_high;
+
+/** @brief Time at which interrupts were disabled */
+extern volatile uint32_t interrupt_disabled_tick;
+
+/* @brief Timer is the special overflow timer. */
+#define TF_OVERFLOW    0x40
+
+/* @brief Timer has been called once in this interrupt. */
+#define TF_CALLED      0x80
+
+/* @brief Update the compare register to match the first expiring timer. */
+static void timer_update_compare(timer_link_t *head) {
+	uint32_t now = TICKS_READ();
+	uint32_t smallest = 0xFFFFFFFF;
+
+	while (head)
+	{
+		/* See how much time is left before the timer expires. Notice that
+		   the subtraction is also safe with overflows. */
+		uint32_t left = head->left - now;
+		if (left < smallest)
+			smallest = left;
+
+		/* Go to next */
+		head = head->next;
+	}
+
+	/* set compare to shortest time left */
+	C0_WRITE_COMPARE(now + smallest);
+}
 
 /**
  * @brief Process linked list of timers
@@ -69,33 +82,52 @@ static long long total_ticks;
  * @retval 1 The list needs reprocessing
  * @retval 0 All timer operations were handled successfully
  */
-static int __proc_timers(timer_link_t * head)
+static int __proc_timers(timer_link_t * thead)
 {
+	timer_link_t *head = thead;
 	timer_link_t *last = 0;
-    int smallest = 0x3FFFFFFF;			// ~ 22.9 secs
-	int start, now;
+	uint32_t start = C0_COMPARE();
+	uint32_t now = TICKS_READ();
 
-	start = TICKS_READ();
-	total_ticks += start;
-
-    while (head)
-    {
-		head->left -= start;
-		// within ~5us?
-		if (head->left < 234)
+	while (head)
+	{
+		/* Consider a timer as expired if its deadline is at the
+		 * COMPARE value (time at which the interrupt triggered) or up to 5
+		 * microseconds after. This 5 microseconds window is useful to cluster
+		 * timers that expire close to each other; eg: if the client creates
+		 * many timers with the same period, they will be created in a fast
+		 * sequence and have a little delay between each other. */
+		if (!(head->flags & TF_CALLED) && 
+			TICKS_DISTANCE(start, head->left) >= 0 && 
+			TICKS_DISTANCE(head->left, now+TIMER_TICKS(5)) >= 0)
 		{
 			/* yes - timed out, do callback */
-			head->ovfl = head->left;
+			head->ovfl = TICKS_DISTANCE(head->left, now);
 			if (head->callback)
 				head->callback(head->ovfl);
 
 			/* reset ticks if continuous */
 			if (head->flags & TF_CONTINUOUS)
 			{
-				head->left = head->set + head->ovfl;
-				if (head->left < smallest)
-					smallest = head->left;
+				head->left += head->set;
 				last = head;
+
+				/* Special case: the internal overflow timer has a period
+				 * of 2**32, so next occurrence will look exactly like the
+				 * current one. Since we're going to reprocess the list, we
+				 * would keep executing it many times until we eventually
+				 * exit the 5 microseconds window.
+				 * So we mark this timer as already called (TF_CALLED) and
+				 * avoid calling it again. 
+				 *
+				 * Notice that we do this only for overflow because other timers
+				 * with a short period might actually be called multiple times
+				 * under interrupt. For instance, if a continuous timer with
+				 * a short period is followed by a very slow one-shot timer,
+				 * when the latter is finished the former might need to fire again.
+				 */
+				if (head->flags & TF_OVERFLOW)
+					head->flags |= TF_CALLED;
 			}
 			else
 			{
@@ -105,30 +137,22 @@ static int __proc_timers(timer_link_t * head)
 				else
 					TI_timers = head->next;
 			}
-		}
-		else
-		{
-			/* no, just check if remaining time is smallest */
-			if (head->left < smallest)
-				smallest = head->left;
-			last = head;
+
+			/* Go through timer list again. If the callback was slow, maybe
+			   other timers have expired. */
+			return 1;
 		}
 
-        /* Go to next */
-	    head = head->next;
-    }
-
-	/* check if shortest time left < 5us */
-	now = TICKS_READ();
-	if (smallest < (now - start + 234))
-	{
-		total_ticks += (now - start);
-		write_count(now - start);
-		return 1;						// reprocess the list
+		/* Go to next */
+		last = head;
+		head = head->next;
 	}
-	/* set compare to shortest time left */
-	write_count(0);
-	write_compare(smallest - (now - start));
+
+	/* Clear the TF_CALLED flag from the overflow timer (if any) */
+	while (thead) {
+		thead->flags &= ~TF_CALLED;
+		thead = thead->next;
+	}
 	return 0;							// exit timer callback
 }
 
@@ -140,32 +164,60 @@ static int __proc_timers(timer_link_t * head)
  */
 static void timer_callback(void)
 {
-	if (TI_timers)
-	{
-		while (__proc_timers(TI_timers)) ;
-	}
-	else
-	{
-		int now = TICKS_READ();
-		total_ticks += now;
-		write_count(0);
-		write_compare(0x7FFFFFFF);
-	}
+	while (__proc_timers(TI_timers))
+		{}
+
+	// Update counter for next interrupt.
+	timer_update_compare(TI_timers);
+}
+
+/**
+ * @brief Timer callback overflow function
+ *
+ * This function is the callback of the internal overflow timer, which
+ * is configured by timer_init() and is used to create a 64-bit timer
+ * accessed by timer_ticks().
+ */
+static void timer_callback_overflow(int ovfl)
+{
+	ticks64_high++;
 }
 
 /**
  * @brief Initialize the timer subsystem
  *
- * @note This will currently mess with get_ticks, get_ticks_ms and related wait
- * routines as it is explicitly manipulating the system timer.
+ * This function will reset the COP0 ticks counter to 0. Even if you
+ * later access the hardware counter directly (via TICKS_READ()), it should not
+ * be a problem if you call timer_init() early in the application main.
  *
+ * Do not modify the COP0 ticks counter after calling this function. Doing so
+ * will impede functionality of the timer module.
  */
 void timer_init(void)
 {
-	total_ticks = 0;
-	write_count(0);
-	write_compare(0x7FFFFFFF);
-    register_TI_handler(timer_callback);
+	/* Create first timer for overflows: expires when counter is 0 and
+	 * has a period of 2**32. */
+	timer_link_t *timer = malloc(sizeof(timer_link_t));
+	if (timer)
+	{
+		timer->left = 0;
+		timer->set = 0;
+		timer->flags = TF_CONTINUOUS | TF_OVERFLOW;
+		timer->callback = timer_callback_overflow;
+		timer->next = NULL;
+
+		TI_timers = timer;
+	}
+
+	/* Reset the count and compare registers. Avoid to accidentally trigger
+	   an interrupt by setting count to 1 and compare to 0. */
+	disable_interrupts();
+	ticks64_high = 0;
+	C0_WRITE_COUNT(1);
+	C0_WRITE_COMPARE(0);
+	enable_interrupts();
+
+	register_TI_handler(timer_callback);
 }
 
 /**
@@ -185,7 +237,7 @@ timer_link_t *new_timer(int ticks, int flags, void (*callback)(int ovfl))
 	timer_link_t *timer = malloc(sizeof(timer_link_t));
 	if (timer)
 	{
-		timer->left = ticks;
+		timer->left = TICKS_READ() + (int32_t)ticks;
 		timer->set = ticks;
 		timer->flags = flags;
 		timer->callback = callback;
@@ -194,14 +246,7 @@ timer_link_t *new_timer(int ticks, int flags, void (*callback)(int ovfl))
 
 		timer->next = TI_timers;
 		TI_timers = timer;
-		if (timer->next == 0)
-		{
-			/* first timer added to list */
-			write_count(0);
-			write_compare(timer->left);
-		}
-		else
-			timer_callback();			// force processing the timers
+		timer_update_compare(TI_timers);
 
 		enable_interrupts();
 	}
@@ -224,7 +269,7 @@ void start_timer(timer_link_t *timer, int ticks, int flags, void (*callback)(int
 {
 	if (timer)
 	{
-		timer->left = ticks;
+		timer->left = TICKS_READ() + (int32_t)ticks;
 		timer->set = ticks;
 		timer->flags = flags;
 		timer->callback = callback;
@@ -233,14 +278,7 @@ void start_timer(timer_link_t *timer, int ticks, int flags, void (*callback)(int
 
 		timer->next = TI_timers;
 		TI_timers = timer;
-		if (timer->next == 0)
-		{
-			/* first timer added to list */
-			write_count(0);
-			write_compare(timer->left);
-		}
-		else
-			timer_callback();			// force processing the timers
+		timer_update_compare(TI_timers);
 
 		enable_interrupts();
 	}
@@ -274,12 +312,13 @@ void stop_timer(timer_link_t *timer)
 				else
 					TI_timers = head->next;
 
-                break;
+				break;
 			}
 
 			last = head;
 			head = head->next;
 		}
+		timer_update_compare(TI_timers);
 		enable_interrupts();
 	}
 }
@@ -318,33 +357,63 @@ void timer_close(void)
 		timer_link_t *last = head;
 		head = head->next;
 
-        if (last->flags & TF_CONTINUOUS)
-        {
-            /* Only free if it is a continuous timer as one-shot timers are
-             * freed by the user.  If we free a timer here, the user will
-             * never know if a one shot expired and needs to be removed or
-             * was removed automatically by timer_close.  We avoid this race
-             * condition by ensuring that the timer system never frees a 
-             * one shot timer.
-             */
-    		free(last);
-        }
+		if (last->flags & TF_CONTINUOUS)
+		{
+			/* Only free if it is a continuous timer as one-shot timers are
+			 * freed by the user.  If we free a timer here, the user will
+			 * never know if a one shot expired and needs to be removed or
+			 * was removed automatically by timer_close.  We avoid this race
+			 * condition by ensuring that the timer system never frees a 
+			 * one shot timer.
+			 */
+			free(last);
+		}
 	}
 	TI_timers = 0;
 	enable_interrupts();
 }
 
 /**
- * @brief Return total ticks since timer was initialized
+ * @brief Return total ticks since timer was initialized, as a 64-bit counter.
  *
  * @return Then number of ticks since the timer was initialized
+ *
  */
 long long timer_ticks(void)
 {
-	disable_interrupts();
-	timer_callback();					// force processing the timers
-	enable_interrupts();
-	return total_ticks;
+	uint32_t low, high;
+
+	/* Check whether interrupts are enabled or not. We need a different strategy
+	 * to account for race conditions. */
+	if (C0_STATUS() & C0_STATUS_IE) {
+		/* Read the hardware counter twice, and fetch the high part counter
+		 * in between. In the unlikely case that the counter overflows exactly
+		 * during the sequence, it means that there's a race condition and
+		 * we can't really know whether high and low are coherent -- but in
+		 * that case, we just repeat the sequence again to avoid the ambiguity. */
+		uint32_t pre;
+		do {
+			pre = TICKS_READ();
+			MEMORY_BARRIER();
+			high = ticks64_high;
+			MEMORY_BARRIER();
+			low = TICKS_READ();
+		} while ((int32_t)pre < 0 && (int32_t)low >= 0);
+
+	} else {
+		/* Interrupts are currently disabled. If they've been disabled for more
+		 * than 2**32 ticks, it's game over because we can't know how many times
+		 * the counter has overflown.
+		 * So assuming they were disabled for not too long, check whether there
+		 * was a counter overflow between now and when they were disabled. 
+		 * If there was, increment high. */
+		low = TICKS_READ();
+		high = ticks64_high;
+		if (interrupt_disabled_tick > low)
+			high++;
+	}
+
+	return ((uint64_t)high << 32) + low;
 }
 
 /** @} */

--- a/src/timer.c
+++ b/src/timer.c
@@ -28,6 +28,11 @@
  * expired one-short timers will not be removed automatically and are the
  * responsibility of the calling code to be freed, regardless of a call to
  * #timer_close.
+ *
+ * Because the MIPS internal counter wraps around after ~90 seconds (see
+ * TICKS_READ), it's not possible to schedule a timer more than 90 seconds
+ * in the future.
+ *
  * @{
  */
 
@@ -350,11 +355,11 @@ void delete_timer(timer_link_t *timer)
 void timer_close(void)
 {
 	disable_interrupts();
-    
-    /* Disable generation of timer interrupt. */
+	
+	/* Disable generation of timer interrupt. */
 	C0_WRITE_STATUS(C0_STATUS() & ~C0_STATUS_IM7);
 
-    unregister_TI_handler(timer_callback);
+	unregister_TI_handler(timer_callback);
 
 	timer_link_t *head = TI_timers;
 	while (head)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,7 +38,7 @@ testrom_emu$(ROM_EXTENSION): testrom_emu.elf test.dfs
 	$(CHKSUM64PATH) testrom_emu$(ROM_EXTENSION)
 
 testrom_emu.o : testrom.c
-	$(CC) $(CFLAGS) -DBENCHMARK_TESTS=0 -c -o $@ $<
+	$(CC) $(CFLAGS) -DIN_EMULATOR=1 -c -o $@ $<
 
 testrom.elf : testrom.o
 	$(LD) -o testrom.elf testrom.o $(LINK_FLAGS)

--- a/tests/test_irq.c
+++ b/tests/test_irq.c
@@ -14,7 +14,7 @@ void test_irq_reentrancy(TestContext *ctx) {
 		disable_interrupts();
 
 		// Wait for the other timer interrupt to trigger
-		wait_ms(30);
+		wait_ms(3);
 
 		// This enable_interrupts should not trigger the other
 		// interrupt, otherwise the test will fail.
@@ -33,9 +33,9 @@ void test_irq_reentrancy(TestContext *ctx) {
 	timer_init();
 	DEFER(timer_close());
 
-	timer_link_t *t1 = new_timer(TICKS_FROM_MS(10), TF_ONE_SHOT, cb1);
+	timer_link_t *t1 = new_timer(TICKS_FROM_MS(2), TF_ONE_SHOT, cb1);
 	DEFER(delete_timer(t1));
-	timer_link_t *t2 = new_timer(TICKS_FROM_MS(30), TF_ONE_SHOT, cb2);
+	timer_link_t *t2 = new_timer(TICKS_FROM_MS(4), TF_ONE_SHOT, cb2);
 	DEFER(delete_timer(t2));
 
 	while (!cb2_called) {}

--- a/tests/test_timer.c
+++ b/tests/test_timer.c
@@ -1,0 +1,238 @@
+
+void test_timer_oneshot(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	uint32_t tick0 = timer_ticks();
+
+	volatile int cb1_called = 0;
+	void cb1(int ovlf) {
+		cb1_called++;
+	}
+
+	timer_link_t *tt1 = new_timer(TICKS_FROM_MS(2), TF_ONE_SHOT, cb1);
+	DEFER(delete_timer(tt1));
+
+	wait_ms(2);
+	ASSERT_EQUAL_SIGNED(cb1_called, 1, "timer 1 not called");
+	wait_ms(3);
+	ASSERT_EQUAL_SIGNED(cb1_called, 1, "timer 1 called again?");
+	stop_timer(tt1);
+	wait_ms(3);
+	ASSERT_EQUAL_SIGNED(cb1_called, 1, "timer 1 called again?");
+
+	// Restart the timer. This time, wait with interrupts disabled, so that
+	// we check the the timer triggers as soon as we re-enable them.
+	start_timer(tt1, TICKS_FROM_MS(3), TF_ONE_SHOT, cb1);
+	wait_ms(2);
+	ASSERT_EQUAL_SIGNED(cb1_called, 1, "timer 1 called again?");
+	disable_interrupts();
+	wait_ms(3);
+	enable_interrupts();
+	ASSERT_EQUAL_SIGNED(cb1_called, 2, "timer 1 not called");
+
+	// Check that timer_ticks return approximate correct value across all timer executions
+	tick0 = timer_ticks() - tick0;
+	ASSERT_EQUAL_SIGNED(
+		TIMER_MICROS(tick0) / 1000,
+		2+3+3+2+3,
+		"invalid timer_ticks");
+}
+
+void test_timer_continuous(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	volatile int cb2_called = 0;
+	void cb2(int ovlf) {
+		cb2_called++;
+	}
+
+	timer_link_t *t2 = new_timer(TICKS_FROM_MS(2), TF_CONTINUOUS, cb2);
+	DEFER(delete_timer(t2));
+
+	uint64_t tick0 = timer_ticks();
+
+	wait_ms(7);
+	ASSERT_EQUAL_SIGNED(cb2_called, 3, "timer 2 not called");
+	stop_timer(t2);
+
+	wait_ms(3);
+	ASSERT_EQUAL_SIGNED(cb2_called, 3, "timer 2 called again?");
+
+	// try switching from continuous to one shot
+	start_timer(t2, TICKS_FROM_MS(2), TF_ONE_SHOT, cb2);
+	wait_ms(5);
+	ASSERT_EQUAL_SIGNED(cb2_called, 4, "timer 2 not called");
+
+	// Check that timer_ticks return approximate correct value across all timer executions
+	tick0 = timer_ticks() - tick0;
+	ASSERT_EQUAL_SIGNED(
+		TIMER_MICROS(tick0) / 1000, 
+		7+3+5,
+		"invalid timer_ticks");
+}
+
+void test_timer_mixed(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	volatile uint8_t called_list[256] = {0};
+	volatile int called_idx = 0;
+
+	void cb1(int ovlf) { called_list[called_idx++] = 1; }
+	void cb2(int ovlf) { called_list[called_idx++] = 2; }
+	void cb3(int ovlf) { called_list[called_idx++] = 3; }
+
+	timer_link_t *t2 = new_timer(TICKS_FROM_MS(2), TF_CONTINUOUS, cb2);
+	DEFER(delete_timer(t2));
+
+	timer_link_t *t3 = new_timer(TICKS_FROM_MS(7), TF_CONTINUOUS, cb3);
+	DEFER(delete_timer(t3));
+
+	timer_link_t *t1 = new_timer(TICKS_FROM_MS(11), TF_ONE_SHOT, cb1);
+	DEFER(delete_timer(t1));
+
+	uint64_t tick0 = timer_ticks();
+
+	wait_ms(12);
+	stop_timer(t2);
+
+	wait_ms(20);
+	stop_timer(t3);
+
+	uint8_t expected[] = { 2, 2, 2, 3, 2, 2, 1, 2, 3, 3, 3, 0 };
+	ASSERT_EQUAL_MEM((uint8_t*)called_list, expected, sizeof(expected), "invalid order of timer callbacks");
+
+	// Check that timer_ticks return approximate correct value across all timer executions
+	tick0 = timer_ticks() - tick0;
+	ASSERT_EQUAL_SIGNED(
+		TIMER_MICROS(tick0) / 1000, 
+		12+20,
+		"invalid timer_ticks");
+}
+
+void test_timer_slow_callback(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	// Check that if a callback is too slow, it doesn't prevent other
+	// timers from running.
+	volatile int called_slow = 0;
+	volatile int called_fast = 0;
+	void slow(int ovlf) { 
+		wait_ms(10);
+		called_slow++;
+	}
+
+	timer_link_t *t4;
+	void fast(int ovlf) {
+		called_fast++;
+	}
+
+	timer_link_t *t1 = new_timer(TICKS_FROM_MS(4), TF_ONE_SHOT, slow);
+	DEFER(delete_timer(t1));
+	timer_link_t *t2 = new_timer(TICKS_FROM_MS(2), TF_ONE_SHOT, slow);
+	DEFER(delete_timer(t2));
+	timer_link_t *t3 = new_timer(TICKS_FROM_MS(5), TF_ONE_SHOT, slow);
+	DEFER(delete_timer(t3));
+	t4 = new_timer(TICKS_FROM_MS(2), TF_CONTINUOUS, fast);
+	DEFER(delete_timer(t4));
+
+	uint64_t tick0 = timer_ticks();
+	wait_ms(10);
+	uint64_t tick1 = timer_ticks();
+
+	ASSERT_EQUAL_SIGNED(called_slow, 3, "slow timers not called");
+
+	// The total execution time is 30ms (3 slow timers) + 2ms (time before
+	// the first slow timer fires). The fast timer is run every 2ms in this
+	// interval.
+	ASSERT_EQUAL_SIGNED(called_fast, (30+2)/2, "fast timers not called");
+
+	ASSERT_EQUAL_SIGNED(
+		TIMER_MICROS(tick1-tick0) / 1000, 
+		30+2,
+		"invalid timer_ticks");
+}
+
+// Change the hardware count register.
+static uint32_t write_count(uint32_t x) {
+	uint32_t old = TICKS_READ();
+	C0_WRITE_COUNT(x);
+	return old;
+}
+
+void test_timer_ticks(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	// We want to fuzz different conditions around the overflow, that is
+	// when the hardware counter goes to zero. That's where all problems lie
+	// in the implementation. Try first to be exhaustive. Also, check with
+	// both enabled and disabled interrupts because the codepaths are different.
+	for (int j=0; j<2; j++) {
+		for (int i=0; i<512; i++) {
+			uint32_t start = (uint32_t)0 - i;
+			
+			uint32_t old = write_count(start);
+			if (j==1) disable_interrupts();
+			uint64_t t0 = timer_ticks();
+			uint64_t t1 = timer_ticks();
+			uint64_t t2 = timer_ticks();
+			uint64_t t3 = timer_ticks();
+			uint64_t t4 = timer_ticks();
+			uint64_t t5 = timer_ticks();
+			if (j==1) enable_interrupts();
+
+			write_count(old); // restore counter to not mess up with global time accounting
+
+			ASSERT(t0 < t1, "invalid timer_ticks [start=%lx]: %llx < %llx", start, t0, t1);
+			ASSERT(t1 < t2, "invalid timer_ticks [start=%lx]: %llx < %llx", start, t1, t2);
+			ASSERT(t2 < t3, "invalid timer_ticks [start=%lx]: %llx < %llx", start, t2, t3);
+			ASSERT(t3 < t4, "invalid timer_ticks [start=%lx]: %llx < %llx", start, t3, t4);
+			ASSERT(t4 < t5, "invalid timer_ticks [start=%lx,%d]: %llx < %llx < %llx < %llx < %llx < %llx", start, j, t0, t1, t2, t3, t4, t5);
+			ASSERT(t5-t0 < 1000, "invalid timer_ticks [start=%lx]: %llx - %llx", start, t0, t5);
+		}
+	}
+
+	// Now do the same testing as above, with full fuzzying. In the fuzzying,
+	// introduce also one shot timers expiring near or at overflow, to further
+	// stress any kind of condition
+	bool cbcalled = false;
+	void tcb(int ovfl) { cbcalled = true; }
+
+	timer_link_t *tt1 = new_timer(0, TF_ONE_SHOT, tcb);
+	stop_timer(tt1);
+	DEFER(delete_timer(tt1));
+
+	for (int i=0; i<4096; i++) {
+		uint32_t start = (uint32_t)0 - RANDN(128);
+		bool with_irq = RANDN(2) != 0;
+		bool use_timer = RANDN(2) != 0;
+
+		cbcalled = false;
+		if (use_timer) start_timer(tt1, start-TICKS_READ()+RANDN(64), TF_ONE_SHOT, tcb);
+
+		uint32_t old = write_count(start);
+		if (!with_irq) disable_interrupts();
+		uint64_t t0 = timer_ticks();
+		uint64_t t1 = timer_ticks();
+		uint64_t t2 = timer_ticks();
+		uint64_t t3 = timer_ticks();
+		uint64_t t4 = timer_ticks();
+		while (TICKS_BEFORE(TICKS_READ(), 128)) {}  // wait until tick 128 to make sure the timer triggers (if any)
+		uint64_t t5 = timer_ticks();
+		if (!with_irq) enable_interrupts();
+		write_count(old); // restore counter to not mess up with global time accounting
+
+		if (use_timer) stop_timer(tt1);
+
+		// Check that all ticks are monotonically increasing, that there are
+		// no large jumps (eg: high part incremented twice), and that the
+		// timer callback was called (if it was meant to).
+		ASSERT(t0 < t1 && t1 < t2 && t2 < t3 && t3 < t4 && t4 < t5 && (t5-t0)<1000 && cbcalled == use_timer, 
+			"invalid timer_ticks %d:[start=%lx,irq=%d,tt1=%d:%lx/%d]\n%llx < %llx < %llx < %llx < %llx < %llx",
+			i, start, with_irq, use_timer, tt1->left, cbcalled, t0, t1, t2, t3, t4, t5);
+	}
+}


### PR DESCRIPTION
The previous implementation of timer.c assumed that it could change
the COP0 counter as it pleased. While this makes sense if timer.c is
the only user of the hardware counter, this behavior makes it impossible
for applications or other modules to use the hardware counter for their
own bookkeeping.

Obviously, one could object that timer_ticks() should be used instead
but timer_ticks() used to be unpredictably slow when interrupts were
disabled (it would invoke timer callbacks that might have expired)
and in general far slower than just reading the hardware timers, which
makes it a bad fit for high-performance scenarios like profiling of
critical sections.

This PR rewrites timer.c so that it keeps the COP0 counter flowing
naturally, and adjusts the COP0 compare register as required to
trigger the timer callbacks. This in turn makes it harder to provide
a true 64-bit timer; the PR implements it by registering an internal
timer synchronized with the 32-bit overflow, and then doing some careful
very racy manipulations.

Since I were at it, I also improved timer.c a little bit around corner
cases; for instance, if a timer expires while another timer's callback
was being executed, depending on the timer list order, the former
timer could have been ignored. Now this bug is fixed.

The code comes with a comprehensive testsuite that tests many different
corner cases; it's been hard to get this code right, which I think
make sense and should prove that the code is relatively safe.
Especially the 64-bit counter is stress-tested with fuzzying trying
to uncover latent race conditions.

In one of the commits, I also fixed a long-standing bug where the timer
interrupt was never enabled under Libdragon (!), and timer.c worked
"by chance" because typically VI interrupts were happening often and
at that point also pending timer interrupts were being serviced (but with
a random added latency).