### PR TITLE
Default exception handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ install: libdragon.a libdragonsys.a
 	install -m 0644 libdragonsys.a $(INSTALLDIR)/mips64-elf/lib/libdragonsys.a
 	install -m 0644 include/n64sys.h $(INSTALLDIR)/mips64-elf/include/n64sys.h
 	install -m 0644 include/cop0.h $(INSTALLDIR)/mips64-elf/include/cop0.h
+	install -m 0644 include/cop1.h $(INSTALLDIR)/mips64-elf/include/cop1.h
 	install -m 0644 include/interrupt.h $(INSTALLDIR)/mips64-elf/include/interrupt.h
 	install -m 0644 include/dma.h $(INSTALLDIR)/mips64-elf/include/dma.h
 	install -m 0644 include/dragonfs.h $(INSTALLDIR)/mips64-elf/include/dragonfs.h

--- a/include/console.h
+++ b/include/console.h
@@ -40,10 +40,18 @@
  * @{
  */
 
-/** @brief The console width in characters */
-#define CONSOLE_WIDTH       74
-/** @brief The console height in characters */
-#define CONSOLE_HEIGHT      30
+/**
+ * @brief The console width in characters
+ * @note Right padding is not enforced by code, adjust this to fit into
+ * [horizontal resolution] - 2 * HORIZONTAL_PADDING
+ */
+#define CONSOLE_WIDTH       64
+/**
+ * @brief The console height in characters
+ * @note Bottom padding is not enforced by code, adjust this to fit into
+ * [vertical resolution] - 2 * VERTICAL_PADDING
+ */
+#define CONSOLE_HEIGHT      28
 /** @} */
 
 /** 
@@ -51,7 +59,19 @@
  *
  * @note This needs to divide evenly into #CONSOLE_WIDTH 
  */
-#define TAB_WIDTH           5
+#define TAB_WIDTH           4
+
+/**
+ * @brief Padding from the left and right ends of the screen in pixels
+ *
+ * @note This should be ~10% of the horizontal resolution to be safely visible
+ */
+#define HORIZONTAL_PADDING  64
+
+/**
+ * @brief Padding from the top and bottom ends of the screen in pixels
+ */
+#define VERTICAL_PADDING    8
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/console.h
+++ b/include/console.h
@@ -41,9 +41,9 @@
  */
 
 /** @brief The console width in characters */
-#define CONSOLE_WIDTH       35
+#define CONSOLE_WIDTH       74
 /** @brief The console height in characters */
-#define CONSOLE_HEIGHT      25
+#define CONSOLE_HEIGHT      30
 /** @} */
 
 /** 

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -89,12 +89,12 @@
 /* COP0 interrupt bits definition. These are compatible bothwith mask and pending bits. */
 #define C0_INTERRUPT_0      0x00000100
 #define C0_INTERRUPT_1      0x00000200
-#define C0_INTERRUPT_2      0x00000400 // RCP
+#define C0_INTERRUPT_RCP    0x00000400 // RCP
 #define C0_INTERRUPT_3      0x00000800
 #define C0_INTERRUPT_4      0x00001000
 #define C0_INTERRUPT_5      0x00002000
 #define C0_INTERRUPT_6      0x00004000
-#define C0_INTERRUPT_7      0x00008000 // Timer
+#define C0_INTERRUPT_TIMER  0x00008000 // Timer
 
 /**
  * @brief Get the CE value from the COP0 status register

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -51,6 +51,30 @@
 })
 
 /**
+ * @brief Returns the COP0 register $13 (Cause Register)
+ *
+ * The coprocessor 0 (system control coprocessor - COP0) register $13 is a read
+ * write register keeping pending interrupts, exception code, coprocessor unit
+ * number referenced for a coprocessor unusable exception.
+ *
+ * @see #C0_GET_CAUSE_EXC_CODE, #C0_GET_CAUSE_CE and #C0_CAUSE_BD
+ */
+#define C0_READ_CR() ({ \
+	uint32_t x; \
+	asm volatile("mfc0 %0,$13" : "=r" (x) : ); \
+	x; \
+})
+
+/**
+ * @brief Write the COP0 register $13 (Cause register)
+ * 
+ * Use this to update it for a custom exception handler.
+ * */
+#define C0_WRITE_CR(x) ({ \
+    asm volatile("mtc0 %0,$13"::"r"(x)); \
+})
+
+/**
  * @brief Returns the COP0 register $8 (BadVAddr)
  *
  * The coprocessor 0 (system control coprocessor - COP0) register $8 is a read

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -73,8 +73,16 @@
  * needs correction in the exception handler. This macro is for writing its
  * value so that execution continues there.
  */
-#define C0_WRITE_EPC(dest) ({ asm volatile("mtc0 %0,$14"::"r"(dest)); })
+#define C0_WRITE_EPC(value) ({ asm volatile("mtc0 %0,$14"::"r"(value)); })
 
+/**
+ * @brief Read the COP0 register $14 (EPC)
+ */
+#define C0_READ_EPC() ({ \
+	uint32_t x; \
+	asm volatile("mfc0 %0,$14" : "=r" (x) : ); \
+	x; \
+})
 
 /* COP0 Status bits definition. Please refer to MIPS R4300 manual. */
 #define C0_STATUS_IE        0x00000001

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -50,19 +50,49 @@
     asm volatile("mtc0 %0,$12"::"r"(x)); \
 })
 
+/**
+ * @brief Returns the COP0 register $8 (BadVAddr)
+ *
+ * The coprocessor 0 (system control coprocessor - COP0) register $8 is a read
+ * only register holding the last virtual address to be translated which became
+ * invalid, or a virtual address for which an addressing error occurred.
+ */
+#define C0_READ_BADVADDR() ({ \
+	uint32_t x; \
+	asm volatile("mfc0 %0,$8" : "=r" (x) : ); \
+	x; \
+})
+
+/**
+ * @brief Writes to the COP0 register $14 (EPC)
+ *
+ * The coprocessor 0 (system control coprocessor - COP0) register $14 is the
+ * return from exception program counter. For asynchronous exceptions it points
+ * to the place to continue execution whereas for synchronous (caused by code)
+ * exceptions, point to the instruction causing the fault condition, which
+ * needs correction in the exception handler. This macro is for writing its
+ * value so that execution continues there.
+ */
+#define C0_WRITE_EPC(dest) ({ asm volatile("mtc0 %0,$14"::"r"(dest)); })
+
+
 /* COP0 Status bits definition. Please refer to MIPS R4300 manual. */
 #define C0_STATUS_IE        0x00000001
 #define C0_STATUS_EXL       0x00000002
 #define C0_STATUS_ERL       0x00000004
 
-#define C0_STATUS_IM0       0x00000100
-#define C0_STATUS_IM1       0x00000200
-#define C0_STATUS_IM2       0x00000400
-#define C0_STATUS_IM3       0x00000800
-#define C0_STATUS_IM4       0x00001000
-#define C0_STATUS_IM5       0x00002000
-#define C0_STATUS_IM6       0x00004000
-#define C0_STATUS_IM7       0x00008000
+/* COP0 Cause bits definition. Please refer to MIPS R4300 manual. */
+#define C0_CAUSE_BD         0x80000000
+
+/* COP0 interrupt bits definition. These are compatible bothwith mask and pending bits. */
+#define C0_INTERRUPT_0      0x00000100
+#define C0_INTERRUPT_1      0x00000200
+#define C0_INTERRUPT_2      0x00000400 // RCP
+#define C0_INTERRUPT_3      0x00000800
+#define C0_INTERRUPT_4      0x00001000
+#define C0_INTERRUPT_5      0x00002000
+#define C0_INTERRUPT_6      0x00004000
+#define C0_INTERRUPT_7      0x00008000 // Timer
 
 /** @} */
 

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -83,6 +83,8 @@
 
 /* COP0 Cause bits definition. Please refer to MIPS R4300 manual. */
 #define C0_CAUSE_BD         0x80000000
+#define C0_CAUSE_CE         0x30000000
+#define C0_CAUSE_EXC_CODE   0x0000007C
 
 /* COP0 interrupt bits definition. These are compatible bothwith mask and pending bits. */
 #define C0_INTERRUPT_0      0x00000100
@@ -93,6 +95,19 @@
 #define C0_INTERRUPT_5      0x00002000
 #define C0_INTERRUPT_6      0x00004000
 #define C0_INTERRUPT_7      0x00008000 // Timer
+
+/**
+ * @brief Get the CE value from the COP0 status register
+ *
+ * Gets the Coprocessor unit number referenced by a coprocessor unusable
+ * exception from the given COP0 Status register value.
+ */
+#define C0_GET_CAUSE_CE(cr) (((cr) & C0_CAUSE_CE) >> 28)
+
+/**
+ * @brief Get the exception code value from the COP0 status register value
+ */
+#define C0_GET_CAUSE_EXC_CODE(sr) (((sr) & C0_CAUSE_EXC_CODE) >> 2)
 
 /** @} */
 

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -64,19 +64,14 @@
 })
 
 /**
- * @brief Writes to the COP0 register $14 (EPC)
+ * @brief Read the COP0 register $14 (EPC)
  *
  * The coprocessor 0 (system control coprocessor - COP0) register $14 is the
  * return from exception program counter. For asynchronous exceptions it points
  * to the place to continue execution whereas for synchronous (caused by code)
  * exceptions, point to the instruction causing the fault condition, which
- * needs correction in the exception handler. This macro is for writing its
- * value so that execution continues there.
- */
-#define C0_WRITE_EPC(value) ({ asm volatile("mtc0 %0,$14"::"r"(value)); })
-
-/**
- * @brief Read the COP0 register $14 (EPC)
+ * needs correction in the exception handler. This macro is for reading its
+ * value.
  */
 #define C0_READ_EPC() ({ \
 	uint32_t x; \

--- a/include/cop1.h
+++ b/include/cop1.h
@@ -1,0 +1,55 @@
+/**
+ * @file COP1.h
+ * @brief N64 COP1 Interface
+ * @ingroup n64sys
+ * 
+ * The coprocessor 1 (COP1) is implemented as a floating point unit (FPU)
+ */
+
+/**
+ * @addtogroup n64sys
+ * @{
+ */
+
+#ifndef __LIBDRAGON_COP1_H
+#define __LIBDRAGON_COP1_H
+
+/* COP1 Control/Status bits definition. Please refer to MIPS R4300 manual. */
+#define C1_FLAG_INEXACT_OP          0x00000004
+#define C1_FLAG_UNDERFLOW           0x00000008
+#define C1_FLAG_OVERFLOW            0x00000010
+#define C1_FLAG_DIV_BY_0            0x00000020
+#define C1_FLAG_INVALID_OP          0x00000040
+
+#define C1_ENABLE_INEXACT_OP        0x00000080
+#define C1_ENABLE_UNDERFLOW         0x00000100
+#define C1_ENABLE_OVERFLOW          0x00000200
+#define C1_ENABLE_DIV_BY_0          0x00000400
+#define C1_ENABLE_INVALID_OP        0x00000800
+
+#define C1_CAUSE_INEXACT_OP         0x00001000
+#define C1_CAUSE_UNDERFLOW          0x00002000
+#define C1_CAUSE_OVERFLOW           0x00004000
+#define C1_CAUSE_DIV_BY_0           0x00008000
+#define C1_CAUSE_INVALID_OP         0x00010000
+#define C1_CAUSE_NOT_IMPLEMENTED    0x00020000
+
+/** @brief Read the COP1 FCR31 register (floating-point control register 31)
+ *
+ * FCR31 is also known as the Control/Status register. It keeps control and
+ * status data for the FPU.
+ */
+#define C1_FCR31() ({ \
+    uint32_t x; \
+    asm volatile("cfc1 %0,$f31":"=r"(x)); \
+    x; \
+})
+
+/** @brief Write to the COP1 FCR31 register. */
+#define C1_WRITE_FCR31(x) ({ \
+    asm volatile("ctc1 %0,$f31"::"r"(x)); \
+})
+
+/** @} */
+
+#endif

--- a/include/exception.h
+++ b/include/exception.h
@@ -27,6 +27,28 @@ enum
 };
 
 /**
+ * @brief Exception codes
+ */
+typedef enum {
+	EXCEPTION_CODE_INTERRUPT = 0,
+	EXCEPTION_CODE_TLB_MODIFICATION = 1,
+	EXCEPTION_CODE_TLB_LOAD_I_MISS = 2,
+	EXCEPTION_CODE_TLB_STORE_MISS = 3,
+	EXCEPTION_CODE_LOAD_I_ADDRESS_ERROR = 4,
+	EXCEPTION_CODE_STORE_ADDRESS_ERROR = 5,
+	EXCEPTION_CODE_I_BUS_ERROR = 6,
+	EXCEPTION_CODE_D_BUS_ERROR = 7,
+	EXCEPTION_CODE_SYS_CALL = 8,
+	EXCEPTION_CODE_BREAKPOINT = 9,
+	EXCEPTION_CODE_RESERVED_INSTRUCTION = 10,
+	EXCEPTION_CODE_COPROCESSOR_UNUSABLE = 11,
+	EXCEPTION_CODE_ARITHMETIC_OVERFLOW = 12,
+	EXCEPTION_CODE_TRAP = 13,
+	EXCEPTION_CODE_FLOATING_POINT = 15,
+	EXCEPTION_CODE_WATCH = 23,
+} exception_code_t;
+
+/**
  * @brief Structure representing a register block
  *
  * DO NOT modify the order unless editing inthandler.S
@@ -46,7 +68,7 @@ typedef volatile struct
     /** @brief LO */
 	volatile uint64_t lo;
     /** @brief FC31 */
-	volatile uint64_t fc31;
+	volatile uint32_t fc31;
     /** @brief Floating point registers 1-32 */
 	volatile uint64_t fpr[32];
 } reg_block_t;
@@ -74,6 +96,7 @@ extern "C" {
 #endif
 
 void register_exception_handler( void (*cb)(exception_t *) );
+void exception_default_handler( exception_t* ex );
 
 #ifdef __cplusplus
 }

--- a/include/exception.h
+++ b/include/exception.h
@@ -60,7 +60,7 @@ typedef volatile struct
     /** @brief SR */
 	volatile uint32_t sr;
     /** @brief CR */
-	volatile uint32_t cr;
+	volatile const uint32_t cr;
     /**
 	 * @brief represents EPC - COP0 register $14
 	 *

--- a/include/exception.h
+++ b/include/exception.h
@@ -90,7 +90,7 @@ typedef struct
     /** @brief String information of exception */
 	const char* info;
     /** @brief Registers at point of exception */
-	volatile const reg_block_t* regs;
+	volatile reg_block_t* regs;
 } exception_t;
 
 /** @} */

--- a/include/exception.h
+++ b/include/exception.h
@@ -83,6 +83,10 @@ typedef struct
      * @see #EXCEPTION_TYPE_RESET, #EXCEPTION_TYPE_CRITICAL
      */
 	int32_t type;
+	/**
+	 * @brief Underlying exception code
+	 */
+	exception_code_t code;
     /** @brief String information of exception */
 	const char* info;
     /** @brief Registers at point of exception */

--- a/include/exception.h
+++ b/include/exception.h
@@ -61,7 +61,16 @@ typedef volatile struct
 	volatile uint32_t sr;
     /** @brief CR */
 	volatile uint32_t cr;
-    /** @brief EPC */
+    /**
+	 * @brief represents EPC - COP0 register $14
+	 *
+	 * The coprocessor 0 (system control coprocessor - COP0) register $14 is the
+	 * return from exception program counter. For asynchronous exceptions it points
+	 * to the place to continue execution whereas for synchronous (caused by code)
+	 * exceptions, point to the instruction causing the fault condition, which
+	 * needs correction in the exception handler. This member is for reading/writing
+	 * its value.
+	 * */
 	volatile uint32_t epc;
     /** @brief HI */
 	volatile uint64_t hi;

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -8,6 +8,7 @@
 
 #include <stdbool.h>
 #include "cop0.h"
+#include "cop1.h"
 
 /**
  * @addtogroup n64sys
@@ -158,30 +159,8 @@ static inline volatile unsigned long get_ticks_ms(void)
     return TICKS_READ() / (TICKS_PER_SECOND / 1000);
 }
 
-/**
- * @brief Spin wait until the number of ticks have elapsed
- *
- * @param[in] wait
- *            Number of ticks to wait
- *            Maximum accepted value is 0xFFFFFFFF ticks
- */
-static inline void wait_ticks( unsigned long wait )
-{
-    unsigned int initial_tick = TICKS_READ();
-    while( TICKS_READ() - initial_tick < wait );
-}
-
-/**
- * @brief Spin wait until the number of millisecounds have elapsed
- *
- * @param[in] wait
- *            Number of millisecounds to wait
- *            Maximum accepted value is 91625 ms
- */
-static inline void wait_ms( unsigned long wait_ms )
-{
-    wait_ticks(TICKS_FROM_MS(wait_ms));
-}
+void wait_ticks( unsigned long wait );
+void wait_ms( unsigned long wait_ms );
 
 void data_cache_hit_invalidate(volatile void *, unsigned long);
 void data_cache_hit_writeback(volatile void *, unsigned long);

--- a/src/console.c
+++ b/src/console.c
@@ -268,7 +268,7 @@ static void __console_render()
 
             /* Draw to the screen using the forecolor and backcolor set in the graphics
              * subsystem */
-            graphics_draw_character( dc, 24 + 8 * x, 8 * y, t_buf );
+            graphics_draw_character( dc, HORIZONTAL_PADDING + 8 * x, VERTICAL_PADDING + 8 * y, t_buf );
         }
     }
 

--- a/src/console.c
+++ b/src/console.c
@@ -106,6 +106,11 @@ static int __console_write( char *buf, unsigned int len )
             case '\r':
             case '\n':
                 /* Add enough space to get to next line */
+                if(!(pos % CONSOLE_WIDTH))
+                {
+                    render_buffer[pos++] = ' ';
+                }
+
                 while(pos % CONSOLE_WIDTH)
                 {
                     render_buffer[pos++] = ' ';
@@ -175,7 +180,7 @@ void console_init()
 {
     /* In case they initialized the display already */
     display_close();
-    display_init( RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
 
     render_buffer = malloc(CONSOLE_SIZE);
 
@@ -263,7 +268,7 @@ static void __console_render()
 
             /* Draw to the screen using the forecolor and backcolor set in the graphics
              * subsystem */
-            graphics_draw_character( dc, 20 + 8 * x, 16 + 8 * y, t_buf );
+            graphics_draw_character( dc, 24 + 8 * x, 8 * y, t_buf );
         }
     }
 
@@ -278,6 +283,8 @@ static void __console_render()
  * it is not necessary to call.
  *
  * The color that is used to draw the text can be set using #graphics_set_color.
+ *
+ * Do not call while interrupts are disabled, or it will lock the system.
  */
 void console_render()
 {

--- a/src/console.c
+++ b/src/console.c
@@ -106,11 +106,6 @@ static int __console_write( char *buf, unsigned int len )
             case '\r':
             case '\n':
                 /* Add enough space to get to next line */
-                if(!(pos % CONSOLE_WIDTH))
-                {
-                    render_buffer[pos++] = ' ';
-                }
-
                 while(pos % CONSOLE_WIDTH)
                 {
                     render_buffer[pos++] = ' ';

--- a/src/exception.c
+++ b/src/exception.c
@@ -115,9 +115,9 @@ void exception_default_handler(exception_t* ex) {
 	console_set_render_mode(RENDER_MANUAL);
 	console_clear();
 
-	fprintf(stdout, "%s exception at PC:%08lX\n\n", ex->info, ex->regs->epc + (uint32_t)((cr & C0_CAUSE_BD) ? 4 : 0)));
+	fprintf(stdout, "%s exception at PC:%08lX\n\n", ex->info, (uint32_t)(ex->regs->epc + ((cr & C0_CAUSE_BD) ? 4 : 0)));
 
-	fprintf(stdout, "CR:%08lX (COP:%1lu BD:%lu)\n", cr, C0_GET_CAUSE_CE(cr), (bool)(cr & C0_CAUSE_BD));
+	fprintf(stdout, "CR:%08lX (COP:%1lu BD:%u)\n", cr, C0_GET_CAUSE_CE(cr), (bool)(cr & C0_CAUSE_BD));
 	fprintf(stdout, "SR:%08lX FCR31:%08X BVAdr:%08lX \n", sr, (unsigned int)fcr31, C0_READ_BADVADDR());
 	fprintf(stdout, "----------------------------------------------------------------");
 	fprintf(stdout, "FPU IOP UND OVE DV0 INV NI | INT sw0 sw1 ex0 ex1 ex2 ex3 ex4 tmr");

--- a/src/exception.c
+++ b/src/exception.c
@@ -77,10 +77,6 @@ static void exception_halt() {
 }
 
 void exception_default_handler(exception_t* ex) {
-	// We need to return from the ex handler to gracefully restore interrupt
-	// state so that we can continue using interrupt dependent functionalities.
-	ex->regs->epc = (uint32_t)&exception_halt;
-
 	uint32_t cr = ex->regs->cr;
 	uint32_t sr = ex->regs->sr;
 	uint32_t fcr31 = ex->regs->fc31;
@@ -119,9 +115,9 @@ void exception_default_handler(exception_t* ex) {
 	console_set_render_mode(RENDER_MANUAL);
 	console_clear();
 
-	fprintf(stdout, "%s exception at PC:%08lX\n\n", ex->info, ex->regs->epc);
+	fprintf(stdout, "%s exception at PC:%08lX\n\n", ex->info, ex->regs->epc + (uint32_t)((cr & C0_CAUSE_BD) ? 4 : 0)));
 
-	fprintf(stdout, "CR:%08lX (COP:%1lu BD:%lu)\n", cr, C0_GET_CAUSE_CE(cr), cr & C0_CAUSE_BD);
+	fprintf(stdout, "CR:%08lX (COP:%1lu BD:%lu)\n", cr, C0_GET_CAUSE_CE(cr), (bool)(cr & C0_CAUSE_BD));
 	fprintf(stdout, "SR:%08lX FCR31:%08X BVAdr:%08lX \n", sr, (unsigned int)fcr31, C0_READ_BADVADDR());
 	fprintf(stdout, "----------------------------------------------------------------");
 	fprintf(stdout, "FPU IOP UND OVE DV0 INV NI | INT sw0 sw1 ex0 ex1 ex2 ex3 ex4 tmr");
@@ -202,6 +198,10 @@ void exception_default_handler(exception_t* ex) {
 			fprintf(stdout, "\n");
 		}
 	}
+
+	// We need to return from the ex handler to gracefully restore interrupt
+	// state so that we can continue using interrupt dependent functionalities.
+	ex->regs->epc = (uint32_t)&exception_halt;
 }
 
 /**

--- a/src/exception.c
+++ b/src/exception.c
@@ -116,12 +116,12 @@ void exception_default_handler(exception_t* ex) {
 
 		(bool)(cr & C0_INTERRUPT_0),
 		(bool)(cr & C0_INTERRUPT_1),
-		(bool)(cr & C0_INTERRUPT_2),
+		(bool)(cr & C0_INTERRUPT_RCP),
 		(bool)(cr & C0_INTERRUPT_3),
 		(bool)(cr & C0_INTERRUPT_4),
 		(bool)(cr & C0_INTERRUPT_5),
 		(bool)(cr & C0_INTERRUPT_6),
-		(bool)(cr & C0_INTERRUPT_7)
+		(bool)(cr & C0_INTERRUPT_TIMER)
 	);
 	fprintf(stdout, "Enabled %3u %3u %3u %3u %3u   -  | MASK    %3u %3u %3u %3u %3u %3u %3u %3u",
 		(bool)(fcr31 & C1_ENABLE_INEXACT_OP),
@@ -132,12 +132,12 @@ void exception_default_handler(exception_t* ex) {
 
 		(bool)(sr & C0_INTERRUPT_0),
 		(bool)(sr & C0_INTERRUPT_1),
-		(bool)(sr & C0_INTERRUPT_2),
+		(bool)(sr & C0_INTERRUPT_RCP),
 		(bool)(sr & C0_INTERRUPT_3),
 		(bool)(sr & C0_INTERRUPT_4),
 		(bool)(sr & C0_INTERRUPT_5),
 		(bool)(sr & C0_INTERRUPT_6),
-		(bool)(sr & C0_INTERRUPT_7)
+		(bool)(sr & C0_INTERRUPT_TIMER)
 	);
 
 	fprintf(stdout, "Flags   %3u %3u %3u %3u %3u   -  |\n",

--- a/src/exception.c
+++ b/src/exception.c
@@ -63,66 +63,66 @@ void exception_default_handler(exception_t* ex) {
 
 	fprintf(stdout, "%s exception\n",	ex->info);
 	fprintf(stdout, "PC:%08lX ",		ex->regs->epc);
-	fprintf(stdout, "z0:%08llX ",		ex->regs->gpr[0]);
-	fprintf(stdout, "at:%08llX\n",		ex->regs->gpr[1]);
-	fprintf(stdout, "v0:%08llX ",		ex->regs->gpr[2]);
-	fprintf(stdout, "v1:%08llX ",		ex->regs->gpr[3]);
-	fprintf(stdout, "a0:%08llX\n",		ex->regs->gpr[4]);
-	fprintf(stdout, "a1:%08llX ",		ex->regs->gpr[5]);
-	fprintf(stdout, "a2:%08llX ",		ex->regs->gpr[6]);
-	fprintf(stdout, "a3:%08llX\n",		ex->regs->gpr[7]);
-	fprintf(stdout, "t0:%08llX ",		ex->regs->gpr[8]);
-	fprintf(stdout, "t1:%08llX ",		ex->regs->gpr[9]);
-	fprintf(stdout, "t2:%08llX\n",		ex->regs->gpr[10]);
-	fprintf(stdout, "t3:%08llX ",		ex->regs->gpr[11]);
-	fprintf(stdout, "t4:%08llX ",		ex->regs->gpr[12]);
-	fprintf(stdout, "t5:%08llX\n",		ex->regs->gpr[13]);
-	fprintf(stdout, "t6:%08llX ",		ex->regs->gpr[14]);
-	fprintf(stdout, "t7:%08llX ",		ex->regs->gpr[15]);
-	fprintf(stdout, "s0:%08llX\n",		ex->regs->gpr[16]);
-	fprintf(stdout, "s1:%08llX ",		ex->regs->gpr[17]);
-	fprintf(stdout, "s2:%08llX ",		ex->regs->gpr[18]);
-	fprintf(stdout, "s3:%08llX\n",		ex->regs->gpr[19]);
-	fprintf(stdout, "s4:%08llX ",		ex->regs->gpr[20]);
-	fprintf(stdout, "s5:%08llX ",		ex->regs->gpr[21]);
-	fprintf(stdout, "s6:%08llX\n",		ex->regs->gpr[22]);
-	fprintf(stdout, "s7:%08llX ",		ex->regs->gpr[23]);
-	fprintf(stdout, "t8:%08llX ",		ex->regs->gpr[24]);
-	fprintf(stdout, "t9:%08llX\n",		ex->regs->gpr[25]);
-	fprintf(stdout, "gp:%08llX ",		ex->regs->gpr[28]);
-	fprintf(stdout, "sp:%08llX ",		ex->regs->gpr[29]);
-	fprintf(stdout, "fp:%08llX\n",		ex->regs->gpr[30]);
-	fprintf(stdout, "ra:%08llX ",		ex->regs->gpr[31]);
-	fprintf(stdout, "lo:%08llX ",		ex->regs->lo);
-	fprintf(stdout, "hi:%08llX\n",		ex->regs->hi);
+	fprintf(stdout, "z0:%08lX ",		(uint32_t)ex->regs->gpr[0]);
+	fprintf(stdout, "at:%08lX\n",		(uint32_t)ex->regs->gpr[1]);
+	fprintf(stdout, "v0:%08lX ",		(uint32_t)ex->regs->gpr[2]);
+	fprintf(stdout, "v1:%08lX ",		(uint32_t)ex->regs->gpr[3]);
+	fprintf(stdout, "a0:%08lX\n",		(uint32_t)ex->regs->gpr[4]);
+	fprintf(stdout, "a1:%08lX ",		(uint32_t)ex->regs->gpr[5]);
+	fprintf(stdout, "a2:%08lX ",		(uint32_t)ex->regs->gpr[6]);
+	fprintf(stdout, "a3:%08lX\n",		(uint32_t)ex->regs->gpr[7]);
+	fprintf(stdout, "t0:%08lX ",		(uint32_t)ex->regs->gpr[8]);
+	fprintf(stdout, "t1:%08lX ",		(uint32_t)ex->regs->gpr[9]);
+	fprintf(stdout, "t2:%08lX\n",		(uint32_t)ex->regs->gpr[10]);
+	fprintf(stdout, "t3:%08lX ",		(uint32_t)ex->regs->gpr[11]);
+	fprintf(stdout, "t4:%08lX ",		(uint32_t)ex->regs->gpr[12]);
+	fprintf(stdout, "t5:%08lX\n",		(uint32_t)ex->regs->gpr[13]);
+	fprintf(stdout, "t6:%08lX ",		(uint32_t)ex->regs->gpr[14]);
+	fprintf(stdout, "t7:%08lX ",		(uint32_t)ex->regs->gpr[15]);
+	fprintf(stdout, "s0:%08lX\n",		(uint32_t)ex->regs->gpr[16]);
+	fprintf(stdout, "s1:%08lX ",		(uint32_t)ex->regs->gpr[17]);
+	fprintf(stdout, "s2:%08lX ",		(uint32_t)ex->regs->gpr[18]);
+	fprintf(stdout, "s3:%08lX\n",		(uint32_t)ex->regs->gpr[19]);
+	fprintf(stdout, "s4:%08lX ",		(uint32_t)ex->regs->gpr[20]);
+	fprintf(stdout, "s5:%08lX ",		(uint32_t)ex->regs->gpr[21]);
+	fprintf(stdout, "s6:%08lX\n",		(uint32_t)ex->regs->gpr[22]);
+	fprintf(stdout, "s7:%08lX ",		(uint32_t)ex->regs->gpr[23]);
+	fprintf(stdout, "t8:%08lX ",		(uint32_t)ex->regs->gpr[24]);
+	fprintf(stdout, "t9:%08lX\n",		(uint32_t)ex->regs->gpr[25]);
+	fprintf(stdout, "gp:%08lX ",		(uint32_t)ex->regs->gpr[28]);
+	fprintf(stdout, "sp:%08lX ",		(uint32_t)ex->regs->gpr[29]);
+	fprintf(stdout, "fp:%08lX\n",		(uint32_t)ex->regs->gpr[30]);
+	fprintf(stdout, "ra:%08lX ",		(uint32_t)ex->regs->gpr[31]);
+	fprintf(stdout, "lo:%08lX ",		(uint32_t)ex->regs->lo);
+	fprintf(stdout, "hi:%08lX\n",		(uint32_t)ex->regs->hi);
 
 	uint32_t cr = ex->regs->cr;
 	uint32_t sr = ex->regs->sr;
 	uint32_t fcr31 = ex->regs->fc31;
 	exception_code_t ex_code = (cr >> 2) & 0x1F;
 
-	fprintf(stdout, "Ex info (cr:%08X sr:%08X):\n", cr, ex->regs->sr);
-	fprintf(stdout, "Is branch delay: %u\n", cr & C0_CAUSE_BD);
+	fprintf(stdout, "Ex info (cr:%08lX sr:%08lX):\n", cr, ex->regs->sr);
+	fprintf(stdout, "Is branch delay: %lu\n", cr & C0_CAUSE_BD);
 
-	fprintf(stdout, "INTs sw0 sw1 ex0 ex1 ex2 ex3 ex4 tmr\n");
-	fprintf(stdout, "     %3u %3u %3u %3u %3u %3u %3u %3u\n",
-		cr & C0_INTERRUPT_0,
-		cr & C0_INTERRUPT_1,
-		cr & C0_INTERRUPT_2,
-		cr & C0_INTERRUPT_3,
-		cr & C0_INTERRUPT_4,
-		cr & C0_INTERRUPT_5,
-		cr & C0_INTERRUPT_6,
-		cr & C0_INTERRUPT_7);
-	fprintf(stdout, "MASK %3u %3u %3u %3u %3u %3u %3u %3u\n",
-		sr & C0_INTERRUPT_0,
-		sr & C0_INTERRUPT_1,
-		sr & C0_INTERRUPT_2,
-		sr & C0_INTERRUPT_3,
-		sr & C0_INTERRUPT_4,
-		sr & C0_INTERRUPT_5,
-		sr & C0_INTERRUPT_6,
-		sr & C0_INTERRUPT_7);
+	fprintf(stdout, "INTs sw0 sw1 ex0 ex1 ex2 ex3 ex4 tm\n");
+	fprintf(stdout, "     %3u %3u %3u %3u %3u %3u %3u %2u\n",
+		cr & C0_INTERRUPT_0 ? 1 : 0,
+		cr & C0_INTERRUPT_1 ? 1 : 0,
+		cr & C0_INTERRUPT_2 ? 1 : 0,
+		cr & C0_INTERRUPT_3 ? 1 : 0,
+		cr & C0_INTERRUPT_4 ? 1 : 0,
+		cr & C0_INTERRUPT_5 ? 1 : 0,
+		cr & C0_INTERRUPT_6 ? 1 : 0,
+		cr & C0_INTERRUPT_7 ? 1 : 0);
+	fprintf(stdout, "MASK %3u %3u %3u %3u %3u %3u %3u %2u\n",
+		sr & C0_INTERRUPT_0 ? 1 : 0,
+		sr & C0_INTERRUPT_1 ? 1 : 0,
+		sr & C0_INTERRUPT_2 ? 1 : 0,
+		sr & C0_INTERRUPT_3 ? 1 : 0,
+		sr & C0_INTERRUPT_4 ? 1 : 0,
+		sr & C0_INTERRUPT_5 ? 1 : 0,
+		sr & C0_INTERRUPT_6 ? 1 : 0,
+		sr & C0_INTERRUPT_7 ? 1 : 0);
 
 	switch(ex_code) {
 		case EXCEPTION_CODE_STORE_ADDRESS_ERROR:
@@ -160,7 +160,7 @@ void exception_default_handler(exception_t* ex) {
 					C1_CAUSE_INVALID_OP |
 					C1_CAUSE_NOT_IMPLEMENTED
 				)
-			)
+			);
 		break;
 		case EXCEPTION_CODE_WATCH:
 		case EXCEPTION_CODE_ARITHMETIC_OVERFLOW:

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -594,9 +594,9 @@ void init_interrupts()
         __interrupt_depth = 0;
 
         /* Enable interrupts systemwide. We set the global interrupt enable,
-           and then specifically enable RCP interrupts (IM2). */
+           and then specifically enable RCP interrupts (INTERRUPT_2). */
         uint32_t sr = C0_STATUS();
-        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_STATUS_IM2);
+        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_INTERRUPT_2);
     }
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -594,7 +594,7 @@ void init_interrupts()
         __interrupt_depth = 0;
 
         /* Enable interrupts systemwide. We set the global interrupt enable,
-           and then specifically enable RCP interrupts (INTERRUPT_2). */
+           and then specifically enable RCP interrupts. */
         uint32_t sr = C0_STATUS();
         C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_INTERRUPT_RCP);
     }

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -596,7 +596,7 @@ void init_interrupts()
         /* Enable interrupts systemwide. We set the global interrupt enable,
            and then specifically enable RCP interrupts (INTERRUPT_2). */
         uint32_t sr = C0_STATUS();
-        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_INTERRUPT_2);
+        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_INTERRUPT_RCP);
     }
 }
 

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -172,8 +172,6 @@ endint:
 	mtc0 $30,C0_EPC
 	lw $30,saveSR
 	mtc0 $30,C0_SR
-	lw $30,saveCR
-	mtc0 $30,C0_CAUSE
 	ld $30,saveLO
 	mtlo $30
 	ld $30,saveHI

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -47,7 +47,14 @@ inthandler:
 	sd $13,save13
 	sd $14,save14
 	sd $15,save15
-	# No need to save $16-$23 GCC saves them on function entry & exit if necessary
+	sd $16,save16
+	sd $17,save17
+	sd $18,save18
+	sd $19,save19
+	sd $20,save20
+	sd $21,save21
+	sd $22,save22
+	sd $23,save23
 	sd $24,save24
 	sd $25,save25
 	# No need to save $26 (k0) & $27 (k1), the int handler is free to use them
@@ -161,11 +168,18 @@ endint:
 	ld $13,save13
 	ld $14,save14
 	ld $15,save15
-	# No need to restore $16-$23 GCC saves them on function entry & exit if necessary
+	ld $16,save16
+	ld $17,save17
+	ld $18,save18
+	ld $19,save19
+	ld $20,save20
+	ld $21,save21
+	ld $22,save22
+	ld $23,save23
 	ld $24,save24
 	ld $25,save25
 	# No need to restore $26 (k0) & $27 (k1), the int handler is free to use them
-	# No need to restore $28 (gp) GCC does not allow manipulating it
+	ld $28,save28
 	ld $29,save29
 	ld $31,save31
 	lw $30,saveEPC

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -92,7 +92,8 @@ inthandler:
 	sdc1 $f23,saveFR23
 	sdc1 $f24,saveFR24
 	sdc1 $f25,saveFR25
-	# No need to save $26 (k0) & $27 (k1)
+	sdc1 $f26,saveFR26
+	sdc1 $f27,saveFR27
 	sdc1 $f28,saveFR28
 	sdc1 $f29,saveFR29
 	sdc1 $f30,saveFR30
@@ -219,7 +220,18 @@ endint:
 	ldc1 $f31,saveFR31
 
 	ld $30,saveFC31
-	nop
+
+	# Override the cause bits (12-17) of stored value from cop1.
+	# If they were cleared by the ex. handler, they will remain cleared.
+	# We will restore the other values to their state before the exception
+	# has occured. If we restore all the bits, the exception handler will
+	# be unable to clear them if needed. This is important as they will
+	# re-trigger the exception upon handler exit if remains set.
+	cfc1 k0, $f31
+	and k0, 0x3F000
+	or k0, ~0x3F000
+	and $30, k0
+	ctc1 $30,$f31
 
 	ld $30,save30
 	.set noat

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -24,6 +24,9 @@ inthandler:
 	mfc0 k1,C0_SR
 	la $1,saveSR
 	sw k1,($1)
+	la $1, ~1
+	and k1,$1
+	mtc0 k1,C0_SR
 	.set at
 
 	/*Save EPC now*/
@@ -47,8 +50,8 @@ inthandler:
 	# No need to save $16-$23 GCC saves them on function entry & exit if necessary
 	sd $24,save24
 	sd $25,save25
-	# No need to save $26 (k0) & $27 (k1), the ibt handler is free to use them
-	# No need to save $28 (gp) GCC does not allow manipulating it
+	# No need to save $26 (k0) & $27 (k1), the int handler is free to use them
+	sd $28,save28
 	sd $29,save29
 	sd $30,save30
 	sd $31,save31
@@ -161,7 +164,7 @@ endint:
 	# No need to restore $16-$23 GCC saves them on function entry & exit if necessary
 	ld $24,save24
 	ld $25,save25
-	# No need to restore $26 (k0) & $27 (k1), the ibt handler is free to use them
+	# No need to restore $26 (k0) & $27 (k1), the int handler is free to use them
 	# No need to restore $28 (gp) GCC does not allow manipulating it
 	ld $29,save29
 	ld $31,save31

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -64,7 +64,7 @@ inthandler:
 	mfhi $30
 	sd $30,saveHI
 	cfc1 $30,$f31
-	sd $30,saveFC31
+	sw $30,saveFC31
 
 	sdc1 $f0,saveFR00
 	sdc1 $f1,saveFR01
@@ -219,7 +219,7 @@ endint:
 	ldc1 $f30,saveFR30
 	ldc1 $f31,saveFR31
 
-	ld $30,saveFC31
+	lw $30,saveFC31
 
 	# Override the cause bits (12-17) of stored value from cop1.
 	# If they were cleared by the ex. handler, they will remain cleared.

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -44,18 +44,11 @@ inthandler:
 	sd $13,save13
 	sd $14,save14
 	sd $15,save15
-	sd $16,save16
-	sd $17,save17
-	sd $18,save18
-	sd $19,save19
-	sd $20,save20
-	sd $21,save21
-	sd $22,save22
-	sd $23,save23
+	# No need to save $16-$23 GCC saves them on function entry & exit if necessary
 	sd $24,save24
 	sd $25,save25
-	# No need to save $26 (k0) & $27 (k1)
-	sd $28,save28
+	# No need to save $26 (k0) & $27 (k1), the ibt handler is free to use them
+	# No need to save $28 (gp) GCC does not allow manipulating it
 	sd $29,save29
 	sd $30,save30
 	sd $31,save31
@@ -165,22 +158,19 @@ endint:
 	ld $13,save13
 	ld $14,save14
 	ld $15,save15
-	ld $16,save16
-	ld $17,save17
-	ld $18,save18
-	ld $19,save19
-	ld $20,save20
-	ld $21,save21
-	ld $22,save22
-	ld $23,save23
+	# No need to restore $16-$23 GCC saves them on function entry & exit if necessary
 	ld $24,save24
 	ld $25,save25
-	# No need to save $26 (k0) & $27 (k1)
-	ld $28,save28
+	# No need to restore $26 (k0) & $27 (k1), the ibt handler is free to use them
+	# No need to restore $28 (gp) GCC does not allow manipulating it
 	ld $29,save29
 	ld $31,save31
+	lw $30,saveEPC
+	mtc0 $30,C0_EPC
 	lw $30,saveSR
 	mtc0 $30,C0_SR
+	lw $30,saveCR
+	mtc0 $30,C0_CAUSE
 	ld $30,saveLO
 	mtlo $30
 	ld $30,saveHI
@@ -217,20 +207,9 @@ endint:
 	ldc1 $f28,saveFR28
 	ldc1 $f29,saveFR29
 	ldc1 $f30,saveFR30
-	ldc1 $f31,saveFR31
 
 	lw $30,saveFC31
-
-	# Override the cause bits (12-17) of stored value from cop1.
-	# If they were cleared by the ex. handler, they will remain cleared.
-	# We will restore the other values to their state before the exception
-	# has occured. If we restore all the bits, the exception handler will
-	# be unable to clear them if needed. This is important as they will
-	# re-trigger the exception upon handler exit if remains set.
-	cfc1 k0, $f31
-	and k0, 0x3F000
-	or k0, ~0x3F000
-	and $30, k0
+	ldc1 $f31,saveFR31
 	ctc1 $30,$f31
 
 	ld $30,save30

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -17,7 +17,6 @@ inthandler:
 	.set noat
 	/*Fetch exception pc off cop#0*/
 	mfc0 $2,C0_EPC
-	nop
 
 	la k1,save01
 	sd $1,(k1)
@@ -25,9 +24,6 @@ inthandler:
 	mfc0 k1,C0_SR
 	la $1,saveSR
 	sw k1,($1)
-	la $1, ~1
-	and k1,$1
-	mtc0 k1,C0_SR
 	.set at
 
 	/*Save EPC now*/
@@ -58,8 +54,7 @@ inthandler:
 	sd $23,save23
 	sd $24,save24
 	sd $25,save25
-	sd $26,save26
-	sd $27,save27
+	# No need to save $26 (k0) & $27 (k1)
 	sd $28,save28
 	sd $29,save29
 	sd $30,save30
@@ -69,7 +64,6 @@ inthandler:
 	mfhi $30
 	sd $30,saveHI
 	cfc1 $30,$f31
-	nop
 	sd $30,saveFC31
 
 	sdc1 $f0,saveFR00
@@ -98,8 +92,7 @@ inthandler:
 	sdc1 $f23,saveFR23
 	sdc1 $f24,saveFR24
 	sdc1 $f25,saveFR25
-	sdc1 $f26,saveFR26
-	sdc1 $f27,saveFR27
+	# No need to save $26 (k0) & $27 (k1)
 	sdc1 $f28,saveFR28
 	sdc1 $f29,saveFR29
 	sdc1 $f30,saveFR30
@@ -181,8 +174,7 @@ endint:
 	ld $23,save23
 	ld $24,save24
 	ld $25,save25
-	ld $26,save26
-	ld $27,save27
+	# No need to save $26 (k0) & $27 (k1)
 	ld $28,save28
 	ld $29,save29
 	ld $31,save31
@@ -228,8 +220,6 @@ endint:
 
 	ld $30,saveFC31
 	nop
-
-	ctc1 $30,$f31
 
 	ld $30,save30
 	.set noat
@@ -282,7 +272,7 @@ endint:
 	.lcomm saveEPC, 4
 	.lcomm saveHI, 8
 	.lcomm saveLO, 8
-	.lcomm saveFC31, 8
+	.lcomm saveFC31, 4
 	.lcomm saveFR00, 8
 	.lcomm saveFR01, 8
 	.lcomm saveFR02, 8

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -209,4 +209,29 @@ tv_type_t get_tv_type()
     return *((uint32_t *) TV_TYPE_LOC);
 }
 
+/**
+ * @brief Spin wait until the number of ticks have elapsed
+ *
+ * @param[in] wait
+ *            Number of ticks to wait
+ *            Maximum accepted value is 0xFFFFFFFF ticks
+ */
+void wait_ticks( unsigned long wait )
+{
+    unsigned int initial_tick = TICKS_READ();
+    while( TICKS_READ() - initial_tick < wait );
+}
+
+/**
+ * @brief Spin wait until the number of millisecounds have elapsed
+ *
+ * @param[in] wait
+ *            Number of millisecounds to wait
+ *            Maximum accepted value is 91625 ms
+ */
+void wait_ms( unsigned long wait_ms )
+{
+    wait_ticks(TICKS_FROM_MS(wait_ms));
+}
+
 /** @} */

--- a/src/timer.c
+++ b/src/timer.c
@@ -221,7 +221,7 @@ void timer_init(void)
 	ticks64_high = 0;
 	C0_WRITE_COUNT(1);
 	C0_WRITE_COMPARE(0);
-	C0_WRITE_STATUS(C0_STATUS() | C0_STATUS_IM7);
+	C0_WRITE_STATUS(C0_STATUS() | C0_INTERRUPT_7);
 	register_TI_handler(timer_callback);
 	enable_interrupts();
 }
@@ -356,7 +356,7 @@ void timer_close(void)
 	disable_interrupts();
 	
 	/* Disable generation of timer interrupt. */
-	C0_WRITE_STATUS(C0_STATUS() & ~C0_STATUS_IM7);
+	C0_WRITE_STATUS(C0_STATUS() & ~C0_INTERRUPT_7);
 
 	unregister_TI_handler(timer_callback);
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -221,7 +221,7 @@ void timer_init(void)
 	ticks64_high = 0;
 	C0_WRITE_COUNT(1);
 	C0_WRITE_COMPARE(0);
-	C0_WRITE_STATUS(C0_STATUS() | C0_INTERRUPT_7);
+	C0_WRITE_STATUS(C0_STATUS() | C0_INTERRUPT_TIMER);
 	register_TI_handler(timer_callback);
 	enable_interrupts();
 }
@@ -356,7 +356,7 @@ void timer_close(void)
 	disable_interrupts();
 	
 	/* Disable generation of timer interrupt. */
-	C0_WRITE_STATUS(C0_STATUS() & ~C0_INTERRUPT_7);
+	C0_WRITE_STATUS(C0_STATUS() & ~C0_INTERRUPT_TIMER);
 
 	unregister_TI_handler(timer_callback);
 

--- a/tests/test_exception.c
+++ b/tests/test_exception.c
@@ -1,0 +1,262 @@
+#define SET_REG(no, value) ({ \
+    asm volatile( \
+        ".set noat \n" \
+        "dli $" #no ", 0x" #value #value #value #value #value #value #value #value "\n" \
+        "dmtc1 $" #no ", $f" #no "\n" \
+        ".set at \n" \
+        :"=X"(dependency) \
+        : \
+        :"$" #no \
+    ); \
+})
+
+#define SET_FP_REG(no, value) ({ \
+    asm volatile( \
+        "dli $26, 0x" #value #value #value #value #value #value #value #value "\n" \
+        "dmtc1 $26, $f" #no "\n" \
+        :"=X"(dependency) \
+        : \
+        :"$26" \
+    ); \
+})
+
+#define GET_FP_REG(no) ({ \
+    asm volatile( \
+        "dmfc1 $26, $f" #no " \n" \
+        "sd $26,%0 \n" \
+        :"=m"(fp_registers_after_ex[no]) \
+        : \
+        :"$26" \
+    ); \
+})
+
+#define GET_REG(no, value) ({ \
+    asm volatile( \
+        ".set noat \n" \
+        "sd $" #no ",%0 \n" \
+        "dmfc1 $" #no ", $f" #no "\n" \
+        "sd $" #no ",%1 \n" \
+        ".set at \n" \
+        :"=m"(registers_after_ex[no]), "=m"(fp_registers_after_ex[no]) \
+        : \
+        :"$" #no \
+    ); \
+})
+
+#define ASSERT_REG(no, value) ({ \
+    ASSERT_EQUAL_HEX(registers_after_ex[no], 0x##value##value##value##value##value##value##value##value, "$" #no " not saved"); \
+    ASSERT_EQUAL_HEX(exception_regs->gpr[no], 0x##value##value##value##value##value##value##value##value, "$" #no " not available to the handler"); \
+    ASSERT_EQUAL_HEX(fp_registers_after_ex[no], 0x##value##value##value##value##value##value##value##value, "$f" #no " not saved"); \
+    ASSERT_EQUAL_HEX(exception_regs->fpr[no], 0x##value##value##value##value##value##value##value##value, "$f" #no " not available to the handler"); \
+})
+
+extern const void test_break_label;
+
+void test_exception(TestContext *ctx) {
+    uint64_t registers_after_ex[32];
+    uint64_t fp_registers_after_ex[32];
+    volatile int breakpoint_occured = 0;
+    // volatile int fp_occured = 0;
+    volatile const reg_block_t* exception_regs;
+
+    // This is only used to make sure we break after setting all the registers
+    uint32_t dependency;
+
+    void ex_handler(exception_t* ex) {
+        SET_REG(1,  A1);
+        SET_REG(2,  A2);
+        SET_REG(3,  A3);
+        SET_REG(4,  A4);
+        SET_REG(5,  A5);
+        SET_REG(6,  A6);
+        SET_REG(7,  A7);
+        SET_REG(8,  A8);
+        SET_REG(10, B0);
+        SET_REG(11, B1);
+        SET_REG(12, B2);
+        SET_REG(13, B3);
+        SET_REG(14, B4);
+        SET_REG(15, B5);
+        SET_REG(16, B6);
+        SET_REG(17, B7);
+        SET_REG(18, B8);
+        SET_REG(19, B9);
+        SET_REG(20, C0);
+        SET_REG(21, C1);
+        SET_REG(22, C2);
+        SET_REG(23, C3);
+        SET_REG(24, C4);
+        SET_REG(25, C5);
+
+        // We cannot set 28 & 29 via inline assembly
+
+        SET_FP_REG(26, C6);
+        SET_FP_REG(27, C7);
+        SET_FP_REG(28, C8);
+        SET_FP_REG(29, C9);
+
+        SET_REG(30, D0);
+        SET_REG(31, D1);
+
+        exception_regs = ex->regs;
+
+        switch(ex->code) {
+            // case EXCEPTION_CODE_FLOATING_POINT:
+            //     fp_occured++;
+            // break;
+            case EXCEPTION_CODE_BREAKPOINT:
+                breakpoint_occured++;
+                C0_WRITE_EPC(C0_READ_EPC() + 4);
+            break;
+            default:
+                exception_default_handler(ex);
+            break;
+        };
+    }
+
+    register_exception_handler(ex_handler);
+
+    // Set as many registers as possible to known values before the ex.
+    SET_REG(1, 01);
+    SET_REG(2, 02);
+    SET_REG(3, 03);
+    SET_REG(4, 04);
+    SET_REG(5, 05);
+    SET_REG(6, 06);
+    SET_REG(7, 07);
+    SET_REG(8, 08);
+    SET_REG(10, 10);
+    SET_REG(11, 11);
+    SET_REG(12, 12);
+    SET_REG(13, 13);
+    SET_REG(14, 14);
+    SET_REG(15, 15);
+    SET_REG(16, 16);
+    SET_REG(17, 17);
+    SET_REG(18, 18);
+    SET_REG(19, 19);
+    SET_REG(20, 20);
+    SET_REG(21, 21);
+    SET_REG(22, 22);
+    SET_REG(23, 23);
+    SET_REG(24, 24);
+    SET_REG(25, 25);
+
+    // Cannot set 28 & 29 as they are used by GCC and it complains about it
+    // instead get the current sp & gp. This will at least make sure the
+    // inthandler is not modifying them on its own
+    uint64_t gp;
+    asm volatile("sd $28,%0":"=m"(gp), "=X"(dependency));
+    uint64_t sp;
+    asm volatile("sd $29,%0":"=m"(sp), "=X"(dependency));
+
+    // Set fp registers 26-29 independent of GP registers
+    // as the SET_REG macro will try to manipulate sp & gp
+    SET_FP_REG(26, 26);
+    SET_FP_REG(27, 27);
+    SET_FP_REG(28, 28);
+    SET_FP_REG(29, 29);
+
+    SET_REG(30, 30);
+    SET_REG(31, 31);
+
+    // Make sure we trigger the exception after setting all the registers
+    // dependency may not be necessary in practice but let's inform GCC
+    // just in case.
+    asm volatile("test_break_label: \nbreak" ::"X"(dependency));
+
+    // Read all registers to mem at once
+    GET_REG(0,  00);
+    GET_REG(1,  01);
+    GET_REG(2,  02);
+    GET_REG(3,  03);
+    GET_REG(4,  04);
+    GET_REG(5,  05);
+    GET_REG(6,  06);
+    GET_REG(7,  07);
+    GET_REG(8,  08);
+    GET_REG(10, 10);
+    GET_REG(11, 11);
+    GET_REG(12, 12);
+    GET_REG(13, 13);
+    GET_REG(14, 14);
+    GET_REG(15, 15);
+    GET_REG(16, 16);
+    GET_REG(17, 17);
+    GET_REG(18, 18);
+    GET_REG(19, 19);
+    GET_REG(20, 20);
+    GET_REG(21, 21);
+    GET_REG(22, 22);
+    GET_REG(23, 23);
+    GET_REG(24, 24);
+    GET_REG(25, 25);
+
+    // Explicitly use k0 ($26) to read fp regs 26, 27, 28, 29 and gp regs
+    // 28 & 29 as the GET_REG macro will try to manipulate sp & gp
+    GET_FP_REG(26);
+    GET_FP_REG(27);
+    GET_FP_REG(28);
+    GET_FP_REG(29);
+
+    asm volatile( \
+        "sd $28,%0 \n" \
+        :"=m"(registers_after_ex[28])
+    );
+
+    asm volatile( \
+        "sd $29,%0 \n" \
+        :"=m"(registers_after_ex[29])
+    );
+
+    GET_REG(30, 30);
+    GET_REG(31, 31);
+
+    ASSERT_REG(0,  00);
+    ASSERT_REG(1,  01);
+    ASSERT_REG(2,  02);
+    ASSERT_REG(3,  03);
+    ASSERT_REG(4,  04);
+    ASSERT_REG(5,  05);
+    ASSERT_REG(6,  06);
+    ASSERT_REG(7,  07);
+    ASSERT_REG(8,  08);
+    ASSERT_REG(10, 10);
+    ASSERT_REG(11, 11);
+    ASSERT_REG(12, 12);
+    ASSERT_REG(13, 13);
+    ASSERT_REG(14, 14);
+    ASSERT_REG(15, 15);
+    ASSERT_REG(16, 16);
+    ASSERT_REG(17, 17);
+    ASSERT_REG(18, 18);
+    ASSERT_REG(19, 19);
+    ASSERT_REG(20, 20);
+    ASSERT_REG(21, 21);
+    ASSERT_REG(22, 22);
+    ASSERT_REG(23, 23);
+    ASSERT_REG(24, 24);
+    ASSERT_REG(25, 25);
+
+    ASSERT_EQUAL_HEX(registers_after_ex[28], gp, "$28 not saved");
+    ASSERT_EQUAL_HEX(exception_regs->gpr[28], gp, "$28 not available to the handler");
+    ASSERT_EQUAL_HEX(fp_registers_after_ex[28], 0x2828282828282828, "$f28 not saved");
+    ASSERT_EQUAL_HEX(exception_regs->fpr[28], 0x2828282828282828, "$f28 not available to the handler");
+
+    ASSERT_EQUAL_HEX(registers_after_ex[29], sp, "$29 saved");
+    ASSERT_EQUAL_HEX(exception_regs->gpr[29], sp, "$29 not available to the handler");
+    ASSERT_EQUAL_HEX(fp_registers_after_ex[29], 0x2929292929292929, "$f29 not saved");
+    ASSERT_EQUAL_HEX(exception_regs->fpr[29], 0x2929292929292929, "$f29 not available to the handler");
+
+    ASSERT_REG(30, 30);
+    ASSERT_REG(31, 31);
+
+    ASSERT_EQUAL_HEX(exception_regs->epc, (uint32_t)&test_break_label, "EPC not available to the handler");
+
+    // If the other tests change SR these may fail unnecessarily, but we expect tests to do proper cleanup
+    ASSERT_EQUAL_HEX(exception_regs->sr, 0x241004E3, "SR not available to the handler");
+    ASSERT_EQUAL_HEX(exception_regs->cr, 0x24, "SR not available to the handler");
+    ASSERT_EQUAL_HEX(exception_regs->fc31, 0x0, "FCR31 not available to the handler");
+
+    // TODO: test handler manipulation
+}

--- a/tests/test_exception.c
+++ b/tests/test_exception.c
@@ -57,6 +57,7 @@
 extern const void test_break_label;
 
 void test_exception(TestContext *ctx) {
+    // Bring FCR31 to a known state as some fp operations setting the inexact op flag
     uint32_t known_fcr31 = C1_FCR31();
     C1_WRITE_FCR31(0);
 

--- a/tests/test_exception.c
+++ b/tests/test_exception.c
@@ -57,6 +57,9 @@
 extern const void test_break_label;
 
 void test_exception(TestContext *ctx) {
+    uint32_t known_fcr31 = C1_FCR31();
+    C1_WRITE_FCR31(0);
+
     uint64_t registers_after_ex[32];
     uint64_t fp_registers_after_ex[32];
     uint64_t lo, hi;
@@ -295,4 +298,5 @@ void test_exception(TestContext *ctx) {
 
     // Cleanup
     register_exception_handler(exception_default_handler);
+    C1_WRITE_FCR31(known_fcr31);
 }

--- a/tests/test_ticks.c
+++ b/tests/test_ticks.c
@@ -140,4 +140,3 @@ void test_ticks(TestContext *ctx) {
 }
 
 #undef WRITE_TICKS
-#undef TEST

--- a/tests/test_ticks.c
+++ b/tests/test_ticks.c
@@ -1,6 +1,3 @@
-// Writes the 32bit value to COP0 register 9 (count)
-#define WRITE_TICKS(val) do { asm volatile("mtc0 %0,$9"::"r"(val)); } while(0)
-
 static volatile uint32_t test_ticks_mock = 0;
 static volatile enum test_ticks_state_t { Start = 0, Test = 1, Timeout = 2 } state = -1;
 
@@ -11,7 +8,7 @@ static void frame_callback() {
 
 	switch(state) {
 		case Test:
-			WRITE_TICKS(test_ticks_mock);
+			C0_WRITE_COUNT(test_ticks_mock);
 		break;
 		default:
 		break;
@@ -63,7 +60,7 @@ static void test_ticks_func(TestContext *ctx, void to_test(unsigned long), char 
 	for (int i=0; i < num_cases; i++) {
 		/* move ticks a little before the target to make sure it is actually doing some waiting */
 		test_ticks_mock = tests[i][1] - TICKS_FROM_MS(5);
-		WRITE_TICKS(tests[i][0]);
+		C0_WRITE_COUNT(tests[i][0]);
 		/* act */
 		(*to_test)(tests[i][2]);
 		uint32_t ticks_0 = TICKS_READ();
@@ -88,9 +85,9 @@ void test_ticks(TestContext *ctx) {
 
 	// Put the instructions on the same cacheline
 	for (int i = 0; i < 2; i++) {
-		WRITE_TICKS(0x0);
+		C0_WRITE_COUNT(0x0);
 		ticks_0 = TICKS_READ();
-		WRITE_TICKS(0xFFFFFFFF);
+		C0_WRITE_COUNT(0xFFFFFFFF);
 		ticks_1 = TICKS_READ();
 	}
 
@@ -102,9 +99,9 @@ void test_ticks(TestContext *ctx) {
 
 	// Make sure they are all in I-cache o/w ticks may increment irrespective of actually run instructions
 	for (int i = 0; i < 2; i++) {
-		WRITE_TICKS(0x0);
+		C0_WRITE_COUNT(0x0);
 		ticks_0 = get_ticks();
-		WRITE_TICKS(0xFFFFFFFF);
+		C0_WRITE_COUNT(0xFFFFFFFF);
 		ticks_1 = get_ticks();
 	}
 
@@ -116,9 +113,9 @@ void test_ticks(TestContext *ctx) {
 
 	// Make sure they are all in I-cache o/w ticks may increment irrespective of actually run instructions
 	for (int i = 0; i < 2; i++) {
-		WRITE_TICKS(0x0);
+		C0_WRITE_COUNT(0x0);
 		ticks_0 = get_ticks_ms();
-		WRITE_TICKS(0x7FFFFFFF);
+		C0_WRITE_COUNT(0x7FFFFFFF);
 		ticks_1 = get_ticks_ms();
 	}
 
@@ -136,7 +133,5 @@ void test_ticks(TestContext *ctx) {
 
 	// Cleanup
 	unregister_VI_handler(frame_callback);
-	WRITE_TICKS(continue_ticks);
+	C0_WRITE_COUNT(continue_ticks);
 }
-
-#undef WRITE_TICKS

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -175,7 +175,7 @@ static const struct Testsuite
 	uint32_t duration;
 	uint32_t flags;
 } tests[] = {
-	TEST_FUNC(test_exception,              5, TEST_FLAGS_NONE),
+	TEST_FUNC(test_exception,              5, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_ticks,                  0, TEST_FLAGS_NO_BENCHMARK | TEST_FLAGS_NO_EMULATOR),
 	TEST_FUNC(test_timer_ticks,          292, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_oneshot,        596, TEST_FLAGS_RESET_COUNT),

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -219,7 +219,7 @@ int main() {
 		ctx.result = TEST_SUCCESS;
 		rand_state = 1; // reset to be fully reproducible
 
-		printf("%-30s", tests[i].name);
+		printf("%-59s", tests[i].name);
 		fflush(stdout);
 
 		uint32_t test_start = TICKS_READ();

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -154,6 +154,7 @@ int assert_equal_mem(TestContext *ctx, const uint8_t *a, const uint8_t *b, int l
 #include "test_ticks.c"
 #include "test_timer.c"
 #include "test_irq.c"
+#include "test_exception.c"
 
 /**********************************************************************
  * MAIN
@@ -174,6 +175,7 @@ static const struct Testsuite
 	uint32_t duration;
 	uint32_t flags;
 } tests[] = {
+	TEST_FUNC(test_exception,              5, TEST_FLAGS_NONE),
 	TEST_FUNC(test_ticks,                  0, TEST_FLAGS_NO_BENCHMARK | TEST_FLAGS_NO_EMULATOR),
 	TEST_FUNC(test_timer_ticks,          292, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_oneshot,        596, TEST_FLAGS_RESET_COUNT),


### PR DESCRIPTION
~~Fix console new line bug~~

~~- Previously it was adding an extra space when the current line is exactly CONSOLE_WIDTH~~

Interrupt handler improvements

    - Remove some unnecessary nops
    - No need to disable interrupts while in the interrupt handler
    - No need to save/restore k0 & k1
    - Do not restore fcr31 register, it should be always cleared by the ex handler.
    - Store FCR31 as a 32bit value

Add cop0 & cop1 macros and start using them

Remove inline wait functions from the header

Implement and register a default exception handler

I'll be implementing a test for the interrupt handler next.