### PR TITLE
Free stdio file handles when closed

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -587,6 +587,17 @@ int close( int fildes )
         return -1;
     }
 
+    /* Free the open file handle */
+    for( int i = 0; i < MAX_OPEN_HANDLES; i++)
+    {
+        if( handles[i].fileno == fildes )
+        {
+            handles[i].fs_mapping = 0;
+            handles[i].handle = NULL;
+            handles[i].fileno = 0;
+        }
+    }
+
     if( fs->close == 0 )
     {
         /* Filesystem doesn't support close */
@@ -594,6 +605,7 @@ int close( int fildes )
         return -1;
     }
 
+    /* Tell the filesystem to close the file */
     return fs->close( handle );
 }
 


### PR DESCRIPTION
Previously there was no way to reclaim a file handle, so there was a hard limit of 100 file handles that could ever be opened. 

After 100, all attempts to open a file would fail, returning `NULL` and errno `ENOMEM`.