### PR TITLE
Improve fastpath of dfs_read and add dfs_rom_addr

### DIFF
--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -93,6 +93,7 @@ int dfs_tell(uint32_t handle);
 int dfs_close(uint32_t handle);
 int dfs_eof(uint32_t handle);
 int dfs_size(uint32_t handle);
+uint32_t dfs_rom_addr(const char *path);
 
 #ifdef __cplusplus
 }

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -1047,6 +1047,44 @@ int dfs_size(uint32_t handle)
 }
 
 /**
+ * @brief Return the physical address of a file (in ROM space)
+ *
+ * This function should be used for highly-specialized, high-performance
+ * use cases. Using dfs_open / dfs_read is generally acceptable
+ * performance-wise, and is easier to use rather than managing
+ * direct access to PI space.
+ * 
+ * Direct access to ROM data must go through io_read or dma_read. Do not
+ * dereference directly as the console might hang if the PI is busy.
+ *
+ * @param[in] filename
+ *            Name of the file
+ *
+ * @return A pointer to the physical address of the file body, or 0
+ *         if the file was not found.
+ * 
+ */
+uint32_t dfs_rom_addr(const char *path)
+{
+    /* Try to find file */
+    directory_entry_t *dirent;
+    int ret = recurse_path(path, WALK_OPEN, &dirent, TYPE_FILE);
+
+    if(ret != DFS_ESUCCESS)
+    {
+        /* File not found, or other error */
+        return 0;
+    }
+
+    /* We now have the pointer to the file entry */
+    directory_entry_t t_node;
+    grab_sector(dirent, &t_node);
+
+    /* Return the starting location in ROM */
+    return get_start_location(&t_node);
+}
+
+/**
  * @brief Return whether the end of file has been reached
  *
  * @param[in] handle

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -25,14 +25,14 @@ void test_dfs_read(TestContext *ctx) {
 	// random stress, aligned buffer
 	for (int i=0;i<256;i++) {
 		uint8_t *ubuf = buf+8+RANDN(4)*8;
-		int to_read = RANDN(3)*8;
-		int seek = RANDN(8)*256;
+		int to_read = 1+RANDN(7);
+		int seek = RANDN(16);
 
 		dfs_seek(fh, seek, SEEK_SET);
 		memset(buf, 0xAA, sizeof(buf));
 		dfs_read(ubuf, 1, to_read, fh);
 		ASSERT_EQUAL_MEM(ubuf,
-			(uint8_t*)"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+			(uint8_t*)"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17" + seek,
 			to_read, "invalid aligned read (%d/%d)", ubuf-buf, to_read);
 		ASSERT_EQUAL_MEM(ubuf+to_read, (uint8_t*)"\xaa\xaa", 2, "aligned buffer overflow");
 		ASSERT_EQUAL_MEM(ubuf-2, (uint8_t*)"\xaa\xaa", 2, "aligned buffer underflow");

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -29,9 +29,9 @@ typedef void (*TestFunc)(TestContext *ctx);
 
 // LOG(msg, ...): log something that will be displayed if the test fails.
 #define LOG(msg, ...)  ({ \
-	int n = snprintf(ctx->log, ctx->logleft, msg, ##__VA_ARGS__); \
-	fwrite(ctx->log, 1, n, stderr); \
-	ctx->log += n; ctx->logleft -= n; \
+	int __n = snprintf(ctx->log, ctx->logleft, msg, ##__VA_ARGS__); \
+	fwrite(ctx->log, 1, __n, stderr); \
+	ctx->log += __n; ctx->logleft -= __n; \
 })
 
 // DEFER(stmt): execute "stmt" statement when the current lexical block exits.

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -270,6 +270,7 @@ int main() {
 		} else if (ctx.result == TEST_SKIPPED) {
 			skipped++;
 			printf("SKIP\n\n");
+			debugf("SKIP\n");
 		}
 
 		// If there's more than a 5% (10% for IO tests) drift on the running time
@@ -283,6 +284,7 @@ int main() {
 		) {
 			failures++;
 			printf("FAIL\n\n");
+			debugf("TIMING FAIL\n");
 
 			printf("Duration changed by %.1f%%\n", (float)test_diff * 100.0 / (float)test_duration);
 			printf("(expected: %ldK, measured: %ldK)\n\n", tests[i].duration, test_duration);
@@ -295,6 +297,7 @@ int main() {
 
 	int64_t total_time = TIMER_MICROS(stop-start) / 1000000;
 
-	printf("\nTestsuite finished in %02lld:%02lld\n", total_time%60, total_time/60);
+	console_set_debug(true);
+	printf("\nTestsuite finished in %02lld:%02lld\n", total_time/60, total_time%60);
 	printf("Passed: %d out of %d (%d skipped)\n", successes, NUM_TESTS, skipped);
 }

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -196,6 +196,7 @@ static const struct Testsuite
 	TEST_FUNC(test_timer_disabled_restart,	 733, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_irq_reentrancy,       	 230, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_dfs_read,            	1104, TEST_FLAGS_IO),
+	TEST_FUNC(test_dfs_rom_addr,              25, TEST_FLAGS_IO),
 	TEST_FUNC(test_cache_invalidate,    	1763, TEST_FLAGS_NONE),
 	TEST_FUNC(test_debug_sdfs,             	   0, TEST_FLAGS_NO_BENCHMARK),
 };


### PR DESCRIPTION
dfs_read improvements:

In dfs_read, there's a fastpath that bypasses the internal file cache
and DMA the data directly into the output buffer. The existing code
assumed that this was possible only when both the RDRAM and ROM addresses
and the size were all multiple of 8.

This is wrong: PI is able to DMA from any even ROM address; also, the DMA
length must follow some weird rules (in general only even lengths, but
small lengths are supported). The constraint of 8-bytes aligned only
stands for RDRAM.

dfs_rom_addr:

For very advanced cases where you need to squeeze every bit of
performance, it might be needed to bypass the whole DFS layer and
physically access the ROM. One scenario is to run largish DMA transfers
in background (maybe triggered under interrupt).

Now that in Dragon FS 2.0 files are laid out linearly, this is indeed
possible. Add a function dfs_rom_addr that returns the initial ROM
address of a file (without opening it), so that it can be manually
accessed via io_read and dma_read.

This should not be required in most cases, but it's still useful to have.