### PR TITLE
Zero-initialize the token array to avoid -Werror=maybe-uninitialized.

### DIFF
--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -485,7 +485,7 @@ static directory_entry_t *find_dirent(char *name, directory_entry_t *cur_node)
 static int recurse_path(const char * const path, int mode, directory_entry_t **dirent, int type)
 {
     int ret = DFS_ESUCCESS;
-    char token[MAX_FILENAME_LEN+1];
+    char token[MAX_FILENAME_LEN+1] = {0};
     char *cur_path = (char *)path;
     uint32_t dir_stack[MAX_DIRECTORY_DEPTH];
     uint32_t dir_loc = directory_top;

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -492,7 +492,7 @@ static int recurse_path(const char * const path, int mode, directory_entry_t **d
     int last_type = TYPE_ANY;
     int ignore = 1; // Do not, by default, read again during the first while
 
-    /* Initialize token to avoid -Werror=maybe-unitialized errors */
+    /* Initialize token to avoid -Werror=maybe-uninitialized errors */
     token[0] = 0;
 
     /* Save directory stack */

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -485,12 +485,15 @@ static directory_entry_t *find_dirent(char *name, directory_entry_t *cur_node)
 static int recurse_path(const char * const path, int mode, directory_entry_t **dirent, int type)
 {
     int ret = DFS_ESUCCESS;
-    char token[MAX_FILENAME_LEN+1] = {0};
+    char token[MAX_FILENAME_LEN+1];
     char *cur_path = (char *)path;
     uint32_t dir_stack[MAX_DIRECTORY_DEPTH];
     uint32_t dir_loc = directory_top;
     int last_type = TYPE_ANY;
     int ignore = 1; // Do not, by default, read again during the first while
+
+    /* Initialize token to avoid -Werror=maybe-unitialized errors */
+    token[0] = 0;
 
     /* Save directory stack */
     memcpy(dir_stack, directories, sizeof(uint32_t) * MAX_DIRECTORY_DEPTH);

--- a/tools/dumpdfs/dumpdfs.c
+++ b/tools/dumpdfs/dumpdfs.c
@@ -271,7 +271,7 @@ static directory_entry_t *find_dirent(char *name, directory_entry_t *cur_node)
 static int recurse_path(const char * const path, int mode, directory_entry_t **dirent, int type)
 {
     int ret = DFS_ESUCCESS;
-    char token[MAX_FILENAME_LEN+1];
+    char token[MAX_FILENAME_LEN+1] = {0};
     char *cur_path = (char *)path;
     uint32_t dir_stack[MAX_DIRECTORY_DEPTH];
     uint32_t dir_loc = directory_top;

--- a/tools/dumpdfs/dumpdfs.c
+++ b/tools/dumpdfs/dumpdfs.c
@@ -278,7 +278,7 @@ static int recurse_path(const char * const path, int mode, directory_entry_t **d
     int last_type = TYPE_ANY;
     int ignore = 1; // Do not, by default, read again during the first while
 
-    /* Initialize token to avoid -Werror=maybe-unitialized errors */
+    /* Initialize token to avoid -Werror=maybe-uninitialized errors */
     token[0] = 0;
 
     /* Save directory stack */

--- a/tools/dumpdfs/dumpdfs.c
+++ b/tools/dumpdfs/dumpdfs.c
@@ -271,12 +271,15 @@ static directory_entry_t *find_dirent(char *name, directory_entry_t *cur_node)
 static int recurse_path(const char * const path, int mode, directory_entry_t **dirent, int type)
 {
     int ret = DFS_ESUCCESS;
-    char token[MAX_FILENAME_LEN+1] = {0};
+    char token[MAX_FILENAME_LEN+1];
     char *cur_path = (char *)path;
     uint32_t dir_stack[MAX_DIRECTORY_DEPTH];
     uint32_t dir_loc = directory_top;
     int last_type = TYPE_ANY;
     int ignore = 1; // Do not, by default, read again during the first while
+
+    /* Initialize token to avoid -Werror=maybe-unitialized errors */
+    token[0] = 0;
 
     /* Save directory stack */
     memcpy(dir_stack, directories, sizeof(uint32_t) * MAX_DIRECTORY_DEPTH);


### PR DESCRIPTION
When trying to build the latest libdragon-git package on Arch Linux, I got the following error:

```
/usr/bin/mips64-elf-gcc -std=gnu99 -O2 -Wall -Werror -ffunction-sections -fdata-sections -mtune=vr4300 -march=vr4300 -I/build/libdragon-git/src/libdragon/include -I/usr/mips64-elf/include -c -o /build/libdragon-git/src/libdragon/build/dragonfs.o /build/libdragon-git/src/libdragon/src/dragonfs.c
/build/libdragon-git/src/libdragon/src/dragonfs.c: In function 'recurse_path':
/build/libdragon-git/src/libdragon/src/dragonfs.c:501:8: error: 'token' may be used uninitialized [-Werror=maybe-uninitialized]
  501 |     if(strcmp(token, "/") == 0)
      |        ^~~~~~~~~~~~~~~~~~
````

This patch simply zero initializes the token array in both dragonfs.c and tools/dumpdfs/dumpfs.c, even though the latter only results in a warning. 