### PR TITLE
Implement EEPROM helpers to read/write buffers

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -45,17 +45,21 @@
 /** @} */
 
 /**
- * @name EEPROM Probe Values
+ * @brief EEPROM Probe Values
  * @see #eeprom_present
- * @{
  */
-/** @brief No EEPROM present */
-#define EEPROM_NONE          0
-/** @brief 4 kilobit (64-block) EEPROM present */
-#define EEPROM_4k            1
-/** @brief 16 kilobit (256-block) EEPROM present */
-#define EEPROM_16k           2
-/** @} */
+typedef enum eeprom_type
+{
+    /** @brief No EEPROM present */
+    EEPROM_NONE = 0,
+    /** @brief 4 kilobit (64-block) EEPROM present */
+    EEPROM_4K   = 1,
+    /** @brief 16 kilobit (256-block) EEPROM present */
+    EEPROM_16K  = 2
+} eeprom_type; 
+
+/** @brief EEPROM is accessed in 8-byte blocks */
+#define EEPROM_BLOCK_SIZE 8
 
 /**
  * @name SI Error Values
@@ -208,9 +212,12 @@ int identify_accessory( int controller );
 void rumble_start( int controller );
 void rumble_stop( int controller );
 void execute_raw_command( int controller, int command, int bytesout, int bytesin, unsigned char *out, unsigned char *in );
-int eeprom_present();
+eeprom_type eeprom_present();
+int eeprom_total_blocks();
 void eeprom_read(int block, uint8_t * const buf);
 void eeprom_write(int block, const uint8_t * const data);
+void eeprom_read_bytes(uint8_t * dest, size_t start, size_t len);
+void eeprom_write_bytes(uint8_t * src, size_t start, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/controller.c
+++ b/src/controller.c
@@ -133,15 +133,11 @@ static void __controller_exec_PIF( const void *inblock, void *outblock )
 }
 
 /**
- * @brief Probe the EEPROM interface
+ * @brief Probe the EEPROM interface on the cartridge.
  *
- * Probe the EEPROM to see if it exists on this cartridge.
- *
- * @retval #EEPROM_16k The cartridge has a 16 kilobit EEPROM
- * @retval #EEPROM_4k The cartridge has a 4 kilobit EEPROM
- * @retval #EEPROM_NONE The cartridge does not have an EEPROM
+ * @return Which EEPROM type was detected on the cartridge.
  */
-int eeprom_present()
+eeprom_type eeprom_present()
 {
     static const unsigned long long SI_eeprom_status_block[8] =
     {
@@ -158,21 +154,28 @@ int eeprom_present()
 
     __controller_exec_PIF(SI_eeprom_status_block,output);
 
-    /* We are looking in the second byte returned, which
+    /* We are looking at the second byte returned, which
      * signifies which size EEPROM (if any) is present.*/
-    const uint8_t eeprom_type = (output[1] >> 48) & 0xFF;
+    switch( (output[1] >> 48) & 0xFF )
+    {
+        case 0xC0: return EEPROM_16K;
+        case 0x80: return EEPROM_4K;
+        default: return EEPROM_NONE;
+    }
+}
 
-    if( eeprom_type == 0xC0 )
+/**
+ * @brief Return how many blocks of EEPROM exist on the cartridge.
+ * 
+ * @return The capacity of the detected EEPROM type, or 0 if no EEPROM is present.
+ */
+int eeprom_total_blocks()
+{
+    switch ( eeprom_present() )
     {
-        return EEPROM_16k;
-    }
-    else if( eeprom_type == 0x80 )
-    {
-        return EEPROM_4k;
-    }
-    else
-    {
-        return EEPROM_NONE;
+        case EEPROM_16K: return 256;
+        case EEPROM_4K: return 64;
+        default: return 0;
     }
 }
 
@@ -199,9 +202,9 @@ void eeprom_read(int block, uint8_t * const buf)
     };
     static unsigned long long output[8];
 
-	SI_eeprom_read_block[0] = 0x0000000002080400 | (block & 255);
+    SI_eeprom_read_block[0] = 0x0000000002080400 | (block & 255);
     __controller_exec_PIF(SI_eeprom_read_block,output);
-    memcpy( buf, &output[1], 8 );
+    memcpy( buf, &output[1], EEPROM_BLOCK_SIZE );
 }
 
 /**
@@ -227,9 +230,107 @@ void eeprom_write(int block, const uint8_t * const data)
     };
     static unsigned long long output[8];
 
-	SI_eeprom_write_block[0] = 0x000000000a010500 | (block & 255);
-    memcpy( &SI_eeprom_write_block[1], data, 8 );
+    SI_eeprom_write_block[0] = 0x000000000a010500 | (block & 255);
+    memcpy( &SI_eeprom_write_block[1], data, EEPROM_BLOCK_SIZE );
     __controller_exec_PIF(SI_eeprom_write_block,output);
+}
+
+/**
+ * @brief Read a buffer of bytes from EEPROM
+ * 
+ * This is a convenience helper that abstracts away the 8-byte block access pattern.
+ * 
+ * @param[out] buf
+ *             Buffer to read data into
+ * @param[in]  start
+ *             Byte offset to start reading data from
+ * @param[in]  len
+ *             Byte length of data to read into buffer
+ */
+void eeprom_read_bytes(uint8_t * dest, size_t start, size_t len)
+{
+	uint8_t buf[EEPROM_BLOCK_SIZE];
+	size_t bytes_left = len;
+	size_t current_block = start / EEPROM_BLOCK_SIZE;
+	// If we need to read a partial block to start off...
+	size_t block_offset = start % EEPROM_BLOCK_SIZE;
+	if (block_offset)
+	{
+		eeprom_read(current_block++, buf);
+		bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
+		while (block_offset < EEPROM_BLOCK_SIZE)
+		{
+			*dest++ = buf[block_offset++];
+		}
+	}
+	// Read whole blocks at a time
+	while (bytes_left >= EEPROM_BLOCK_SIZE)
+	{
+		eeprom_read(current_block++, buf);
+		memcpy(dest, buf, EEPROM_BLOCK_SIZE);
+		dest += EEPROM_BLOCK_SIZE;
+		bytes_left -= EEPROM_BLOCK_SIZE;
+	}
+	// If we need to read a partial block at the end...
+	if (bytes_left)
+	{
+		eeprom_read(current_block++, buf);
+		memcpy(dest, buf, bytes_left);
+	}
+}
+
+/**
+ * @brief Write a buffer of bytes to EEPROM
+ * 
+ * This is a convenience helper that abstracts away the 8-byte block access pattern.
+ * 
+ * Each EEPROM block write takes approximately 15 milliseconds;
+ * this operation may block for a while with large buffer sizes:
+ * 
+ * * 4k EEPROM: 64 blocks * 15ms = 960ms!
+ * * 16k EEPROM: 256 blocks * 15ms = 3840ms!
+ * 
+ * You may want to pause audio before calling this.
+ *
+ * @param[in] src
+ *            Buffer of data to write
+ * @param[in] start
+ *            Byte offset to start writing data to
+ * @param[in] len
+ *            Byte length of the src buffer
+ */
+void eeprom_write_bytes(uint8_t * src, size_t start, size_t len)
+{
+	uint8_t buf[EEPROM_BLOCK_SIZE];
+	size_t bytes_left = len;
+	size_t current_block = start / EEPROM_BLOCK_SIZE;
+	// If we need to write a partial block to start off...
+	size_t block_offset = start % EEPROM_BLOCK_SIZE;
+	if (block_offset)
+	{
+		eeprom_read(current_block, buf);
+		bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
+		while (block_offset < EEPROM_BLOCK_SIZE)
+		{
+			buf[block_offset++] = *src++;
+		}
+		eeprom_write(current_block++, buf);
+	}
+	// Write whole blocks at a time
+	while (bytes_left >= EEPROM_BLOCK_SIZE)
+	{
+		memcpy(buf, src, EEPROM_BLOCK_SIZE);
+		eeprom_write(current_block++, buf);
+		src += EEPROM_BLOCK_SIZE;
+		bytes_left -= EEPROM_BLOCK_SIZE;
+	}
+	// If we need to write a partial block at the end...
+	if (bytes_left)
+	{
+		eeprom_read(current_block, buf);
+		memcpy(buf, src, bytes_left);
+		eeprom_write(current_block++, buf);
+	}
 }
 
 /**


### PR DESCRIPTION
This is a stripped-down version of #125 that ended up being "the simplest thing that could possibly work" for the project I was working on.

What I really wanted was an easy way to read and write structs in/out of EEPROM. The filesystem approach introduced a lot of extra complexity and an abstraction layer that leaked pretty badly in pathological cases.

I'd like to take another swing at the filesystem approach because I think it's clever and useful, but I need to write better tests for it and solve for some edge-cases before I'd call it "shippable".