### PR TITLE
Initialize arguments to main.

### DIFF
--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -4,6 +4,8 @@
 
 #include "regs.S"
 
+	.set noreorder
+
 	.section .boot
 	.global _start
 _start:
@@ -82,8 +84,9 @@ loadintvectorloop:
 
 	jal __do_global_ctors		/* call global constructors */
 	nop
+	li a0, 0
 	jal main					/* call main app */
-	nop
+	li a1, 0
 
 deadloop:
 	j deadloop


### PR DESCRIPTION
In C, main can accept argc/argv arguments. On N64 these are meaningless,
but nonetheless, to help users write code portable between PC/N64, we
should probably set those arguments to something, otherwise they get
random values at boot. Let's try to set argc=0 / argv=NULL, which at
least should be compatible with most standard usages in C code
(including getopt) without crashing.