### PR TITLE
debug: misc SD bugs

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -275,6 +275,8 @@ static DRESULT fat_disk_write_64drive(const BYTE* buff, LBA_t sector, UINT count
 		usb_64drive_wait();
 		io_write(D64_CIBASE_ADDRESS + D64_REGISTER_COMMAND, D64_COMMAND_SD_WRITE);
 		usb_64drive_wait();
+
+		buff += 512;
 	}
 
 	return RES_OK;

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -1081,7 +1081,10 @@ static void *__open( char *name, int flags )
     dfs_chdir("/");
 
     /* We disregard flags here */
-    return (void *)dfs_open( name );
+    int handle = dfs_open( name );
+    if (handle <= 0)
+        return NULL;
+    return (void *)handle;
 }
 
 /**

--- a/src/usb.c
+++ b/src/usb.c
@@ -604,7 +604,7 @@ s8 usb_64drive_wait()
         #endif
         
         // Took too long, abort
-        if((timeout++) > 10000)
+        if((timeout++) > 100000)
             return -1;
     }
     while((ret >> 8) & D64_CI_BUSY);


### PR DESCRIPTION
This PR contains misc fixes to the recently-committed SD support in the debug library, plus it fixes an historical issue with `fopen()` in dragonfs.