### PR TITLE
Fix lib/include paths in tests Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,8 +5,8 @@ MKDFSPATH = $(ROOTDIR)/bin/mkdfs
 HEADERPATH = $(ROOTDIR)/mips64-elf/lib
 N64TOOL = $(ROOTDIR)/bin/n64tool
 HEADERNAME = header
-LINK_FLAGS = -L$(ROOTDIR)/mips64-elf/lib -L$(ROOTDIR)/lib -ldragon -lmikmod -lc -lm -ldragonsys -Tn64.ld --gc-sections
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include -I$(ROOTDIR)/include
+LINK_FLAGS = -L$(ROOTDIR)/mips64-elf/lib -ldragon -lmikmod -lc -lm -ldragonsys -Tn64.ld --gc-sections
+CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
 ASFLAGS = -mtune=vr4300 -march=vr4300
 CC = $(GCCN64PREFIX)gcc
 AS = $(GCCN64PREFIX)as


### PR DESCRIPTION
This PR changes the tests Makefile so that it will only look for libraries and includes in N64_INST/mips64-elf, just like the current example Makefiles already do. Without this change, compiling the tests when the toolchain is installed in /usr (as in for example the Arch Linux AUR packages) will fail as the compilation will try to use the libraries of the host system.