### PR TITLE
n64tool: return error in case the seek offset required backward seek.

### DIFF
--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -165,7 +165,12 @@ int output_zeros(FILE *dest, int amount)
 		/* Don't support odd word alignments */
 		return -1;
 	}
-	
+	if(amount < 0)
+	{
+		/* Can't backward seek */
+		return -1;
+	}
+
 	int i;
 	while (amount > 0) {
 		int sz = amount;
@@ -339,13 +344,13 @@ int main(int argc, char *argv[])
 							print_usage(argv[0]);
 							return -1;
 						}
-						
+
 						/* Write out needed number of zeros */
 						int num_zeros = offset - total_bytes;
-						
+
 						if(output_zeros(write_file, num_zeros))
 						{
-							fprintf(stderr, "Invalid offset to seek to in %s!\n", output);
+							fprintf(stderr, "Invalid offset %d to seek to in %s!\n", offset, output);
 							return -1;
 						}
 						


### PR DESCRIPTION
For instance, if the user asks to put a DFS at 1M, but the code/data is
2M, it simply can't be done. Instead of silently putting the DFS at 2M,
better return an error and let the user handle it, especially since
the seek offset needs to be passed to dfs_init() so the user needs
to be aware of the correct value.

Fixes #141