### PR TITLE
Make n64tool print dfs DEADBEEF address

### DIFF
--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -39,7 +39,7 @@
 /* Easier to write from here */
 static int title[TITLE_SIZE];
 static int wrote_title = 0;
-static unsigned char zero[1024] = {0};
+static unsigned char zero[1024];
 
 void print_usage(char *prog_name)
 {
@@ -230,6 +230,9 @@ int main(int argc, char *argv[])
 	/* Set default title */
 	memset(title, 0x20, TITLE_SIZE);
 	memcpy(title, DEF_TITLE, (strlen(DEF_TITLE) > TITLE_SIZE) ? TITLE_SIZE : strlen(DEF_TITLE));
+
+	/* Initialize zero array */
+	memset(zero, 0x00, 1024*sizeof(*zero));
 
 	if(argc <= 1)
 	{

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -43,18 +43,21 @@ static unsigned char zero[1024] = {0};
 
 void print_usage(char *prog_name)
 {
-	fprintf(stderr, "Usage: %s [-b] -l <size>B/K/M -h <file> -o <file> -t <title> <file> [[-s <offset>B/K/M] <file>]*\n\n", prog_name);
-	fprintf(stderr, "This program appends a header to an arbitrary number of binaries,\n");
-	fprintf(stderr, "the first being an Nintendo64 binary and the rest arbitrary data.\n\n");
-	fprintf(stderr, "\t-b\t\tByteswap the resulting output.\n");
-	fprintf(stderr, "\t-l <size>\tForce output to <size> bytes.\n");
-	fprintf(stderr, "\t-h <file>\tUse <file> as header.\n");
-	fprintf(stderr, "\t-o <file>\tOutput is saved to <file>.\n");
-	fprintf(stderr, "\t-t <title>\tTitle of ROM.\n");
-	fprintf(stderr, "\t-s <offset>\tNext file starts at <offset> from top of memory.  Offset must be 32bit aligned.\n");
-	fprintf(stderr, "\t\t\tB for byte offset.\n");
-	fprintf(stderr, "\t\t\tK for kilobyte offset.\n");
-	fprintf(stderr, "\t\t\tM for megabyte offset.\n");
+	const char *message = ""
+	"Usage: %s [-b] -l <size>B/K/M -h <file> -o <file> -t <title> <file> [[-s <offset>B/K/M] <file>]*\n\n"
+	"This program appends a header to an arbitrary number of binaries,\n"
+	"the first being an Nintendo64 binary and the rest arbitrary data.\n\n"
+	"\t-b\t\tByteswap the resulting output.\n"
+	"\t-l <size>\tForce output to <size> bytes.\n"
+	"\t-h <file>\tUse <file> as header.\n"
+	"\t-o <file>\tOutput is saved to <file>.\n"
+	"\t-t <title>\tTitle of ROM.\n"
+	"\t-s <offset>\tNext file starts at <offset> from top of memory.  Offset must be 32bit aligned.\n"
+	"\t\t\tB for byte offset.\n"
+	"\t\t\tK for kilobyte offset.\n"
+	"\t\t\tM for megabyte offset.\n";
+
+	fprintf(stderr, message, prog_name);
 }
 
 uint32_t get_file_size(FILE *fp)


### PR DESCRIPTION
This PR adds a logic for n64tool to print the initialization address required by `dfs_init()`. It also fixes the following minor issues I found in the code:

- The `zero` array was not being properly initialized. Using array[N] = {0} do not initialize all its elements to zero, but only the first element. The reason why this array was being initialized with 0 is because on x86_64, the .data segment is always initialized with 0. This is a latent bug that may show up in other platforms.
-  Reduced the number of calls to `fprintf` to one in `print_message`
-  Removed all trailing whitespaces and tabs.