### PR TITLE
Add missing extern "C" in debug.h

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -10,6 +10,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** 
  * @brief Flag to activate the USB logging channel.
  *
@@ -197,5 +201,9 @@
 // Underlying assertion function for assert() and assertf().
 void debug_assert_func_f(const char *file, int line, const char *func, const char *failedexpr, const char *msg, ...)
    __attribute__((noreturn, format(printf, 5, 6)));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif


### PR DESCRIPTION
When compiling any .cpp file which calls any function defined
in debug.h, the linker fails to find its symbol because GCC
thinks its name is mangled. This commit fixes that by declaring
these symbols as having "C" names.