### PR TITLE
Fix clipped RDP rectangle drawing

### DIFF
--- a/src/rdp.c
+++ b/src/rdp.c
@@ -616,14 +616,14 @@ void rdp_draw_textured_rectangle_scaled( uint32_t texslot, int tx, int ty, int b
     /* Cant display < 0, so must clip size and move S,T coord accordingly */
     if( tx < 0 )
     {
-        if ( tx < -width * x_scale) { return; }
+        if ( tx < -(width * x_scale) ) { return; }
         s += (int)(((double)((-tx) << 5)) * (1.0 / x_scale));
         tx = 0;
     }
 
     if( ty < 0 )
     {
-        if ( ty < -height * y_scale ) { return; }
+        if ( ty < -(height * y_scale) ) { return; }
         t += (int)(((double)((-ty) << 5)) * (1.0 / y_scale));
         ty = 0;
     }


### PR DESCRIPTION
Fixes this issue with Flappy Bird, which uses clipped rectangles for the pipes and backgrounds as they scroll off-screen:

![2021-06-24_15-40](https://user-images.githubusercontent.com/11916110/123322809-ba77db00-d502-11eb-829f-1464e90b5238.png)

Turns out making an unsigned integer negative yields *strange* results.