### PR TITLE
First kernel prototype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ libdragonsys.a: $(BUILD_DIR)/system.o
 	@echo "    [AR] $@"
 	$(N64_AR) -rcs -o $@ $^
 
-libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o $(BUILD_DIR)/backtrace.o \
+libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o $(BUILD_DIR)/kernel.o $(BUILD_DIR)/backtrace.o \
 			 $(BUILD_DIR)/fmath.o $(BUILD_DIR)/inthandler.o $(BUILD_DIR)/entrypoint.o \
 			 $(BUILD_DIR)/debug.o $(BUILD_DIR)/debugcpp.o $(BUILD_DIR)/usb.o $(BUILD_DIR)/libcart/cart.o $(BUILD_DIR)/fatfs/ff.o \
 			 $(BUILD_DIR)/fatfs/ffunicode.o $(BUILD_DIR)/rompak.o $(BUILD_DIR)/dragonfs.o \
@@ -101,6 +101,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/cop1.h $(INSTALLDIR)/mips64-elf/include/cop1.h
 	install -Cv -m 0644 include/mi.h $(INSTALLDIR)/mips64-elf/include/mi.h
 	install -Cv -m 0644 include/interrupt.h $(INSTALLDIR)/mips64-elf/include/interrupt.h
+	install -Cv -m 0644 include/kernel.h $(INSTALLDIR)/mips64-elf/include/kernel.h
 	install -Cv -m 0644 include/dma.h $(INSTALLDIR)/mips64-elf/include/dma.h
 	install -Cv -m 0644 include/dragonfs.h $(INSTALLDIR)/mips64-elf/include/dragonfs.h
 	install -Cv -m 0644 include/asset.h $(INSTALLDIR)/mips64-elf/include/asset.h

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -93,6 +93,11 @@
  * #kthread_new returns a pointer to the thread (a pointer
  * to kthread_t) that can be used to externally manage the
  * thread like changing its priority or killing it.
+ * 
+ * NOTE: this structure should be considered internal and subject
+ * to future changes. It is exposed just for debugging purposes
+ * and should not be relied upon. Please do not change any
+ * field without going through a function of the public API.
  */
 typedef struct kthread_s
 {
@@ -137,6 +142,11 @@ typedef struct kthread_s
  * simply return a failure in that case.
  *
  * Threads can receive mails using #kmbox_recv or #kmbox_try_recv.
+ *
+ * NOTE: this structure should be considered internal and subject
+ * to future changes. It is exposed just for debugging purposes
+ * and should not be relied upon. Please do not change any
+ * field without going through a function of the public API.
  */
 typedef struct kmbox_s
 {
@@ -169,6 +179,11 @@ typedef struct kmbox_s
  *
  * It is also possible to attach a mailbox to an event using #mbox_attach_event.
  * This is useful if a thread needs to wait for multiple events.
+ *
+ * NOTE: this structure should be considered internal and subject
+ * to future changes. It is exposed just for debugging purposes
+ * and should not be relied upon. Please do not change any
+ * field without going through a function of the public API.
  */
 typedef struct kevent_s
 {
@@ -354,7 +369,7 @@ const char* kthread_name(kthread_t *th);
  *
  * If the thread needs to handle multiple events and/or a more
  * elaborate communication with other threads, you can use
- * #thread_listen_event instead.
+ * #kmbox with #kmbox_attach_event instead.
  *
  * @param[in] evt
  *            The event to wait for

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1,0 +1,529 @@
+/**
+ * @file kernel.h
+ * @brief Multi-threading kernel
+ * @ingroup kernel
+ */
+#ifndef KERNEL_H
+#define KERNEL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "exception.h"
+
+/**
+ * @defgroup kernel Multi-threading kernel
+ * @ingroup libdragon
+ * @brief A multi-threading kernel that can be used by libdragon applications.
+ *
+ * This module implements a hybrid cooperative/preemptive multi-threaded
+ * kernel for parallel execution of code.
+ *
+ * The scheduler uses a very simple logic:
+ * 
+ *   * A thread is "ready" whenever is able to run, that is, it is not waiting
+ *     for some event or otherwise sleeping. A ready thread can technically be
+ *     scheduled at any time, whenever the scheduler decides so.
+ *   * When a thread switch happens, the scheduler selects the ready thread which
+ *     has the highest priority.
+ *   * If there are multiple threads with the same priority (higher than any
+ *     other ready thread), the scheduler will round-robin among them.
+ * 
+ * A thread switch can happen in a few specific situations:
+ * 
+ *   * The active thread explicitly starts waiting for some event, or sleeps
+ *     for a definite amount of time. In general, whenever a kthread_* function
+ *     is invoked, it might cause a context switch.
+ *   * An interrupt occurs, which triggers an event, which wakes up some thread
+ *     whose priority is higher than the currently running thread.
+ * 
+ * Given the above rules, we can say that the kernel is "hard real-time": any
+ * thread with high priority that is ready (not blocked) will always have
+ * priority over lower priority threads. This is required to allow threads to
+ * implement operations that require low latency, for instance preparing audio
+ * when the AI interrupt fires.
+ *
+ * Also, the kernel is not fully preemptive; in particular, there is no timer
+ * interrupt that switches among ready threads at a fixed interval. This
+ * is not deemed necessary as applications will usually have a low number
+ * threads that are mostly blocked waiting for specific events like
+ * hardware interrupts or background activities like RSP ucode.
+ * 
+ * An event, represented by a #kevent_t instance, is a signal that can
+ * be broadcasted to many different threads. A thread can use
+ * #kthread_wait_event to wait for a specific event to fire. The kernel
+ * library includes a set of events bound to MI peripheral interrupts,
+ * so that it's possible for threads to wait for specific interrupts and
+ * act after them.
+ *
+ * Typically, applications will keep the main thread at low priority
+ * for the main business logic, and will spawn a few threads to handle
+ * high-priority / low-latency responses to hardware events.
+ *
+ * In addition to threads (#kthread_t) and events (#kevent_t), the kernel
+ * library offers a message passing communication primitive called "mail
+ * box" (#kmbox_t). A mailbox is a circular buffer of messages called
+ * "mails"; any number of threads can try to send mails into a mailbox,
+ * and any number of threads can try to read mails from a mailbox. Once a
+ * thread receives a mail from a mailbox, the mail is removed and other
+ * threads will not see it anymore. 
+ *
+ * Mailboxes can be useful as communicative primitives among threads
+ * (eg: to send tasks to other threads), or a synchronization primitive
+ * to wait for multiple events (see #kmbox_attach_event).
+ *
+ * @{
+ */
+
+/**
+ * @brief a kernel thread for parallel execution
+ *
+ * This structure represents a thread that can be scheduled
+ * for parallel execution. Create a thread with #kthread_new,
+ * allocating the required memory for the stack.
+ *
+ * Normally, there's no need to explicitly manage the lifetime
+ * or state of a thread. Once the thread is created, it is
+ * immediately started, and the kernel will scheduled it when
+ * required. If the thread exits (by simply returning by its
+ * entry point function), it will be cleaned up and the memory
+ * released.
+ *
+ * #kthread_new returns a pointer to the thread (a pointer
+ * to kthread_t) that can be used to externally manage the
+ * thread like changing its priority or killing it.
+ */
+typedef struct kthread_s
+{
+	/** Pointer to the top of the stack, which contains the thread register state */
+	reg_block_t* stack_state;
+	/** Current state of interrupt depth for this thread */
+	int interrupt_depth;
+	/** Size of the stack in bytes */
+	int stack_size;
+	/** Name of thread (for debugging purposes) */
+	const char *name;
+	/** Internal flags */
+	uint8_t flags;
+	/** Priority of the thread (0=lowest, use positive numbers only) */
+	int8_t pri;
+	/** Intrusive link to next thread in a waiting list */
+	struct kthread_s *next;
+	/** Entry point function for the thread */
+	void (*user_entry)(void*);
+	/** Custom argument to be passed to the entry point */
+	void *user_data;
+	/** Pointer to the stack buffer */
+	void *stack;
+} kthread_t;
+
+/**
+ * @brief A kernel mailbox.
+ *
+ * A mailbox is a circular buffer of messages called
+ * "mails"; any number of threads can try to send mails into a mailbox,
+ * and any number of threads can try to read mails from a mailbox. Once a
+ * thread receives a mail from a mailbox, the mail is removed and other
+ * threads will not see it anymore.
+ *
+ * A mailbox can be allocated either on the heap (#mbox_new) or on
+ * the stack (#mbox_new_stack). In both cases, the size of the buffer
+ * (maximum number of mails that can be kept within the mailbox)
+ * must be specified.
+ *
+ * Threads can send mails using #kmbox_send or #kmbox_try_send: the former
+ * will block the thread if the mailbox is full, while the later will
+ * simply return a failure in that case.
+ *
+ * Threads can receive mails using #kmbox_recv or #kmbox_try_recv.
+ */
+typedef struct kmbox_s
+{
+	/** Read index of the circular buffer */
+	uint8_t r;
+	/** Write index of the circular buffer */
+	uint8_t w;
+	/** Size of the buffer (maximum number of mails) */
+	uint8_t max;
+	/** Number of events this mailbox is attached to */
+	uint8_t evts;
+	/** Linked list of threads waiting on this mailbox */
+	kthread_t *wait_list;
+	/** Circular buffer of mails */
+	void* mails[0];
+} kmbox_t;
+
+/** Maximum number of mailboxes that can be attached to a single event. */
+#define MAX_MAILBOXES_PER_EVENT 8
+
+/**
+ * @brief a kernel event.
+ *
+ * An event, represented by a #kevent_t instance, is a signal that can
+ * be broadcasted to many different threads. A thread can use
+ * #kthread_wait_event to wait for a specific event to fire. The kernel
+ * library includes a set of events bound to MI peripheral interrupts,
+ * so that it's possible for threads to wait for specific interrupts and
+ * act after them.
+ *
+ * It is also possible to attach a mailbox to an event using #mbox_attach_event.
+ * This is useful if a thread needs to wait for multiple events.
+ */
+typedef struct kevent_s
+{
+	/** Mailboxes attached to this event */
+	kmbox_t *mboxes[MAX_MAILBOXES_PER_EVENT];
+} kevent_t;
+
+
+/** @brief Event generated when a SP interrupt is triggered */
+extern kevent_t KEVENT_IRQ_SP;
+/** @brief Event generated when a SI interrupt is triggered */
+extern kevent_t KEVENT_IRQ_SI;
+/** @brief Event generated when a AI interrupt is triggered */
+extern kevent_t KEVENT_IRQ_AI;
+/** @brief Event generated when a VI interrupt is triggered */
+extern kevent_t KEVENT_IRQ_VI;
+/** @brief Event generated when a PI interrupt is triggered */
+extern kevent_t KEVENT_IRQ_PI;
+/** @brief Event generated when a DP interrupt is triggered */
+extern kevent_t KEVENT_IRQ_DP;
+/** @brief Event generated when the RESET button is pushed (pre-NMI exception) */
+extern kevent_t KEVENT_RESET;
+
+
+/** 
+ * @brief Initialize the multi-threading kernel
+ *
+ * The current execution context becomes the main thread of the
+ * program, with priority set to 0 (you can change priority
+ * to the main thread as well using #thread_set_pri).
+ *
+ * The main thread uses the original stack allocated for the
+ * whole process, so it is technically unbounded (or limited by
+ * heap size).
+ *
+ * @return a pointer to the main thread.
+ *
+ */
+kthread_t* kernel_init(void);
+
+/** 
+ * @brief Shutdown the multi-threading kernel
+ *
+ * This function is mostly useful for testing purposes.
+ * Since the kernel does not keep track of all created threads,
+ * this function should be called only when all created threads
+ * are exited or have been killed.
+ */
+void kernel_close(void);
+
+/**
+ * @brief Create a new thread
+ *
+ * Create a new thread, with a specified stack size and priority.
+ * The thread is immediately made ready after creation, so if it has
+ * a priority higher than or equal to the current thread, it will be
+ * scheduled immediately, before thread_new returns.
+ *
+ * The thread will begin execution from the specified entry point
+ * function. If the function ever returns, the thread is automatically
+ * killed.
+ *
+ * @param[in] name
+ *            Name of the thread (for debugging purposes)
+ * @param[in] stack_size
+ *            Size of the stack in bytes. Minimum suggested size
+ *            is 2048.
+ * @param[in] pri
+ *            Priority of the thread (0-127). Negative values are not allowed.
+ *            Higher number means higher priority.
+ * @param[in] user_entry
+ *            Entry point of the thread. This is the function that will
+ *            be called when the thread begins execution. If this function
+ *            ever returns, the thread is automatically killed.
+ * @param[in] user_data
+ *            Argument that will be passed to the entry point of the thread.
+ *
+ * @return    A pointer to the new thread. It is not necessary to store
+ *            this reference if not required; the thread will clean up
+ *            after itself when it exits.
+ */
+kthread_t* kthread_new(const char *name, int stack_size, int8_t pri,
+	void (*user_entry)(void*), void *user_data);
+
+
+/**
+ * @brief Yield execution of the current thread and run the scheduler.
+ *
+ * This function allows the current thread to cooperatively yield
+ * its execution to allow other threads to run.
+ *
+ * The scheduler will switch to the highest priority thread that is
+ * currently ready to run. If no ready thread has a priority higher than
+ * the current thread, the scheduler will switch to a different thread 
+ * of the same priority of the current one (the scheduler will guarantee
+ * a correct round-robin scheduling among threads of the same priority).
+ * If no ready thread has a priority higher or equal than the current
+ * one, the scheduler will reschedule the current thread, that will
+ * continue execution.
+ *
+ * @note The scheduler is semi-preemptive. Any interrupt could cause
+ * a thread switch to happen if the interrupt itself makes a thread
+ * become ready. If you need a block of code to be executed without
+ * any context switch, make sure to disable interrupts.
+ */
+void kthread_yield(void);
+
+
+/**
+ * @brief Sleep for the specified interval, allowing execution of other threads.
+ *
+ * This function will put the current thread to sleep for a specified
+ * time interval, allowing other threads to run.
+ *
+ * The sleeping interval is expressed in hardware ticks. See #TICKS_READ
+ * for an explanation of hardware ticks, and #TICKS_PER_SECOND and #TICKS_FROM_MS
+ * for constants and macros that simplify conversion to standard time units.
+ *
+ * Notice that #wait_ticks and #wait_ms are not threading aware, so they will
+ * just spin-wait while keeping the current thread ready. Other higher-priority
+ * threads might still be scheduled if they are awaken by an interrupt, but in
+ * general thread_sleep is a better primitive if you want the current thread
+ * to yield.
+ *
+ * @note This function requires the timer module, so #timer_init must have
+ *       been called.
+ *
+ * @param[in] ticks
+ *            The number of hardware ticks to sleep.
+ */
+void kthread_sleep(uint32_t ticks);
+
+/** 
+ * @brief Change priority of a thread.
+ * 
+ * Change priority of the specified thread. If the argument is NULL,
+ * this function changes priority to the current thread.
+ *
+ * The change of priority is immediately effective. It may cause
+ * a context switch if the changed thread is ready and its priority
+ * is changed in a way to start/stop it relative to the other ready
+ * threads.
+ *
+ * @param[in]  th
+ *             Reference to the thread (NULL = current thread)
+ * @param[in]  pri
+ *             New priority of the thread (0-127). Higher number means
+ *             higher priority.
+ *
+ */
+void kthread_set_pri(kthread_t *th, int8_t pri);
+
+
+/** 
+ * @brief Kill a thread, aborting its execution.
+ *
+ * The specified thread is aborted, and its memory freed (including
+ * its stack). This function can executed for any thread, including the
+ * current one. The execution will be aborted and the memory released
+ * to the heap for further use.
+ *
+ * @param[in]  th
+ *             Reference to the thread to kill (NULL = current thread)
+ *
+ */
+void kthread_kill(kthread_t *th);
+
+
+/**
+ * @brief Return the name of the specified thread.
+ *
+ * @param[in]  th
+ *             Reference to thread (NULL = current thread)
+ */
+const char* kthread_name(kthread_t *th);
+
+/**
+ * @brief Wait for a single hardware event.
+ *
+ * This functions blocks the current thread until a specified
+ * hardware event happens. The CPU is yielded so that other
+ * threads will be scheduled.
+ *
+ * If the thread needs to handle multiple events and/or a more
+ * elaborate communication with other threads, you can use
+ * #thread_listen_event instead.
+ *
+ * @param[in] evt
+ *            The event to wait for
+ *
+ */
+void kthread_wait_event(kevent_t *evt);
+
+/**
+ * @brief Allocate a new mailbox (on the heap).
+ *
+ * @param[in] max_mails
+ *            Maximum number of pending mails in the mailbox.
+ *
+ * @return The allocated mailbox
+ *
+ * @note See #mbox_new_stack to allocate a mailbox on the stack.
+ */
+kmbox_t* kmbox_new(int max_mails);
+
+/**
+ * @brief Allocate a new mailbox (on the stack).
+ *
+ * @param[in] max_mails
+ *            Maximum number of pending mails in the mailbox.
+ *
+ * @return The allocated mailbox
+ *
+ * @note See #mbox_new to allocate a mailbox on the heap.
+ */
+#define kmbox_new_stack(max_mails) ({ \
+	int sz = sizeof(kmbox_t) + (max_mails)*sizeof(void*); \
+	kmbox_t *mb = alloca(sz); \
+	bzero(mb, sz); \
+	mb->max = max_mails; \
+	mb; \
+})
+
+/**
+ * @brief Free a heap mailbox when it's not needed anymore.
+ *
+ * @note Do not call this function on a mailbox allocated with
+ *       #kmbox_new_stack. As the mailbox is on the stack, there is
+ *       no need to explicitly free it.
+ */
+void kmbox_free(kmbox_t *mbox);
+
+/** @brief Return true if the mailbox is empty */
+bool kmbox_empty(kmbox_t *mbox);
+
+/** @brief Return true if the mailbox is full */
+bool kmbox_full(kmbox_t *mbox);
+
+/** 
+ * @brief Try sending a mail to a mailbox. 
+ *
+ * This function tries to send a mail to a mailbox. If the
+ * mailbox is full, it returns false without blocking.
+ *
+ * @param[in] mbox The mailbox to send the mail to
+ * @param[in] mail The mail to send (must not be NULL)
+ *
+ * @return true if the mail was sent, false if the mailbox was full
+ */
+bool kmbox_try_send(kmbox_t *mbox, void *mail);
+
+/** 
+ * @brief Send a mail to a mailbox. 
+ *
+ * This function sends a mail to a mailbox. If the
+ * mailbox is full, it will block until another thread
+ * receive a pending mail, so that the mailbox has space
+ * for the new mail.
+ *
+ * @param[in] mbox The mailbox to send the mail to
+ * @param[in] mail The mail to send (must not be NULL)
+ *
+ */
+void kmbox_send(kmbox_t *mbox, void *mail);
+
+/** 
+ * @brief Try receiving a mail from a mailbox. 
+ *
+ * This function tries to receive a mail to a mailbox. If the
+ * mailbox is empty, it will return NULL without blocking.
+ *
+ * @param[in] mbox The mailbox to receive the mail from
+ *
+ * @return the received mail, or NULL if the mailbox was empty
+ *
+ */
+void* kmbox_try_recv(kmbox_t *mbox);
+
+/** 
+ * @brief Receive a mail from a mailbox. 
+ *
+ * This function receives a mail from a mailbox. If the
+ * mailbox is empty, it will block until a mail is available.
+ *
+ * @param[in] mbox The mailbox to receive the mail from
+ *
+ * @return the received mail
+ *
+ */
+void* kmbox_recv(kmbox_t *mbox);
+
+
+/**
+ * @brief Attach an event to a mailbox, so that a mail arrives when the event
+ *        is triggered.
+ *
+ * This functions connects a mailbox to the specified event, so that
+ * when the event is triggered, a mail is posted to the
+ * mailbox. The thread can then poll the mailbox to see when the
+ * event is arrived. The received mail will be the event itself.
+ *
+ * This function is useful for threads that need to react to multiple
+ * events and/or handle messages from other threads. If you just
+ * want to wait for a single interrupt, it is easier to simply
+ * call #thread_wait_event.
+ *
+ * Example:
+ *
+ *     kmbox_t *mbox = kmbox_new_stack(4);
+ *     kmbox_attach_event(mbox, &KEVENT_IRQ_SP);
+ *     kmbox_attach_event(mbox, &KEVENT_IRQ_DP);
+ *
+ *     void *mail;
+ *     while ((mail = kmbox_recv(mbox)))
+ *     {
+ *        if (mail == &KEVENT_IRQ_SP)
+ *        {
+ *            [...]
+ *        }
+ *        else if (mail == &KEVENT_IRQ_DP)
+ *        {
+ *            [...]
+ *        }
+ *     }
+ *
+ *     // Always detach mailboxes before freeing them!
+ *     kmbox_detach_event(mbox, &KEVENT_IRQ_SP);
+ *     kmbox_detach_event(mbox, &KEVENT_IRQ_DP);
+ *
+ *
+ * @note It is mandatory to detach all attached events before
+ *       destroying a mailbox.
+ *
+ * @note If the mailbox happens to be full when the event is triggered,
+ *       the event will be missed. When you attach a mailbox to an event,
+ *       make always sure to have enough space in the mailbox.
+ *
+ * @param[in] mbox The mailbox that will receive the event
+ * @param[in] evt The event to attach to
+ */
+void kmbox_attach_event(kmbox_t *mbox, kevent_t *evt);
+
+
+/**
+ * @brief Detach an event from a mailbox.
+ *
+ * @note It is mandatory to detach all attached events before
+ *       destroying a mailbox.
+ *
+ * @param[in] mbox The mailbox that is receiving the event
+ * @param[in] evt The event to detach from
+ */
+void kmbox_detach_event(kmbox_t *mbox, kevent_t *evt);
+
+
+/** @} */
+
+#endif /* KERNEL_H */

--- a/include/kernelinternal.h
+++ b/include/kernelinternal.h
@@ -1,0 +1,33 @@
+/**
+ * @file kernelinternal.h
+ * @brief Internal Kernel Definitions
+ * @ingroup kernel
+ */
+#ifndef __LIBDRAGON_KERNELINTERNAL_H
+#define __LIBDRAGON_KERNELINTERNAL_H
+
+#include "kernel.h"
+
+/**
+ * @addtogroup kernel
+ * @{
+ */
+
+#define TH_FLAG_ZOMBIE  (1<<0)
+#define TH_FLAG_INLIST  (1<<1)
+
+/** Kernel initialization flag. */
+extern bool __kernel;
+
+/** Trigger the specified event, broadcasted to all threads waiting for it. */
+void kevent_trigger(kevent_t* evt);
+
+/** Same as #event_trigger, but to be called under interrupt. */
+void kevent_trigger_isr(kevent_t* evt);
+
+/** @brief Syscall handler to run the scheduler and optionally switch current thread */
+reg_block_t* __kthread_syscall_schedule(reg_block_t *stack_state);
+
+/** @} */ /* kernel */
+
+#endif

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -44,6 +44,7 @@
 #include "graphics.h"
 #include "mi.h"
 #include "interrupt.h"
+#include "kernel.h"
 #include "n64sys.h"
 #include "backtrace.h"
 #include "rdp.h"

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -6,6 +6,7 @@
 #include <malloc.h>
 #include "libdragon.h"
 #include "regsinternal.h"
+#include "kernelinternal.h"
 
 /** @brief Bit to set to clear the PI interrupt */
 #define PI_CLEAR_INTERRUPT 0x02
@@ -26,7 +27,7 @@
  * interrupt enable calls that need to be made to re-enable interrupts.  A negative
  * number means that the interrupt system hasn't been initialized yet.
  */
-static int __interrupt_depth = -1;
+int __interrupt_depth = -1;
 
 /** @brief Value of the status register at the moment interrupts
  *         got disabled.
@@ -186,6 +187,9 @@ void __MI_handler(void)
         /* Clear interrupt */
         SP_regs->status=SP_CLEAR_INTERRUPT;
 
+        /* Trigger kernel event */
+        if (__kernel) kevent_trigger_isr(&KEVENT_IRQ_SP);
+
         __call_callback(SP_callback);
     }
 
@@ -193,6 +197,9 @@ void __MI_handler(void)
     {
         /* Clear interrupt */
         SI_regs->status=SI_CLEAR_INTERRUPT;
+
+        /* Trigger kernel event */
+        if (__kernel) kevent_trigger_isr(&KEVENT_IRQ_SI);
 
         __call_callback(SI_callback);
     }
@@ -202,6 +209,9 @@ void __MI_handler(void)
         /* Clear interrupt */
     	AI_regs->status=AI_CLEAR_INTERRUPT;
 
+        /* Trigger kernel event */
+        if (__kernel) kevent_trigger_isr(&KEVENT_IRQ_AI);
+
 	    __call_callback(AI_callback);
     }
 
@@ -209,6 +219,9 @@ void __MI_handler(void)
     {
         /* Clear interrupt */
     	VI_regs->cur_line=VI_regs->cur_line;
+
+        /* Trigger kernel event */
+        if (__kernel) kevent_trigger_isr(&KEVENT_IRQ_VI);
 
     	__call_callback(VI_callback);
     }
@@ -218,6 +231,9 @@ void __MI_handler(void)
         /* Clear interrupt */
         PI_regs->status=PI_CLEAR_INTERRUPT;
 
+        /* Trigger kernel event */
+        if (__kernel) kevent_trigger_isr(&KEVENT_IRQ_PI);
+
         __call_callback(PI_callback);
     }
 
@@ -225,6 +241,9 @@ void __MI_handler(void)
     {
         /* Clear interrupt */
         *MI_MODE = MI_WMODE_CLR_DPINT;
+
+        /* Trigger kernel event */
+        if (__kernel) kevent_trigger_isr(&KEVENT_IRQ_DP);
 
         __call_callback(DP_callback);
     }

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -134,13 +134,17 @@ exception_critical:
 	nop
 
 exception_syscall:
-	# Syscall exception
+	# Run the syscall exception handler. This one can optionally
+	# switch to a different thread: the return value is the new
+	# stack pointer to use.
 	jal __onSyscallException
 	addiu a0, sp, 32
 
-	j end_interrupt
-	nop
-
+	# Exit the exception and restore *all* registers including caller-saved
+	# ones, because if the syscall handler switched to a different thread,
+	# the new thread might have different values in those registers.
+	j end_exception_restore_all
+	addiu sp, v0, -32
 
 exception_coprocessor:
 	# Extract CE bits (28..29) from CR
@@ -264,9 +268,60 @@ notcart:
 	jal __MI_handler
 	addiu a0, sp, 32
 
-	# No more interrupts to process, we can exit
-	# (fallthrough)
+	# No more interrupts to process
 	sw zero, interrupt_exception_frame
+
+	# Check if some interrupt handler requested
+	# a reschedule to happen
+	la t0, __isr_force_schedule
+	lbu t1, (t0)
+	beqz t1, end_interrupt
+	sb zero, (t0)
+
+thread_schedule_from_interrupt:
+	# Save full exception context in preparation for stack switching
+	mfc0 t0, C0_SR
+	or t0, SR_CU1
+	mtc0 t0, C0_SR
+	jal save_fpu_regs
+	move a0, sp
+	jal finalize_exception_frame
+	nop
+
+	# Call the scheduler
+	jal __kthread_syscall_schedule
+	addiu a0, sp, 32
+	addiu sp, v0, -32
+	# fallthrough to end_exception_restore_all
+
+end_exception_restore_all:
+	# Restore also caller-saved registers. These are only saved during an exception
+	# (by finalize_exception_frame), and we need to restore them only in case of
+	# kernel stack switch (because otherwise, the C handler for an exception will
+	# never modify them without restoring them too, so it would be useless to
+	# restore them here).
+	ld $16,(STACK_GPR+16*8)(sp)   # S0
+	ld $17,(STACK_GPR+17*8)(sp)   # S1
+	ld $18,(STACK_GPR+18*8)(sp)   # S2
+	ld $19,(STACK_GPR+19*8)(sp)   # S3
+	ld $20,(STACK_GPR+20*8)(sp)   # S4
+	ld $21,(STACK_GPR+21*8)(sp)   # S5
+	ld $22,(STACK_GPR+22*8)(sp)   # S6
+	ld $23,(STACK_GPR+23*8)(sp)   # S7
+	ld $28,(STACK_GPR+28*8)(sp)   # GP
+	ld $30,(STACK_GPR+30*8)(sp)   # FP
+	ldc1 $f20,(STACK_FPR+20*8)(sp)
+	ldc1 $f21,(STACK_FPR+21*8)(sp)
+	ldc1 $f22,(STACK_FPR+22*8)(sp)
+	ldc1 $f23,(STACK_FPR+23*8)(sp)
+	ldc1 $f24,(STACK_FPR+24*8)(sp)
+	ldc1 $f25,(STACK_FPR+25*8)(sp)
+	ldc1 $f26,(STACK_FPR+26*8)(sp)
+	ldc1 $f27,(STACK_FPR+27*8)(sp)
+	ldc1 $f28,(STACK_FPR+28*8)(sp)
+	ldc1 $f29,(STACK_FPR+29*8)(sp)
+	ldc1 $f30,(STACK_FPR+30*8)(sp)
+	ldc1 $f31,(STACK_FPR+31*8)(sp)
 
 end_interrupt:
 	mfc0 t0, C0_SR
@@ -400,3 +455,49 @@ inthandler_end:
 	.p2align 2
 	.lcomm interrupt_exception_frame, 4
 
+	ld k1,STACK_LO(k0)
+	mtlo k1
+
+	ld k1,STACK_HI(k0)
+	mthi k1
+
+	ldc1 $f0,(STACK_FPR+0*8)(k0)
+	ldc1 $f1,(STACK_FPR+1*8)(k0)
+	ldc1 $f2,(STACK_FPR+2*8)(k0)
+	ldc1 $f3,(STACK_FPR+3*8)(k0)
+	ldc1 $f4,(STACK_FPR+4*8)(k0)
+	ldc1 $f5,(STACK_FPR+5*8)(k0)
+	ldc1 $f6,(STACK_FPR+6*8)(k0)
+	ldc1 $f7,(STACK_FPR+7*8)(k0)
+	ldc1 $f8,(STACK_FPR+8*8)(k0)
+	ldc1 $f9,(STACK_FPR+9*8)(k0)
+	ldc1 $f10,(STACK_FPR+10*8)(k0)
+	ldc1 $f11,(STACK_FPR+11*8)(k0)
+	ldc1 $f12,(STACK_FPR+12*8)(k0)
+	ldc1 $f13,(STACK_FPR+13*8)(k0)
+	ldc1 $f14,(STACK_FPR+14*8)(k0)
+	ldc1 $f15,(STACK_FPR+15*8)(k0)
+	ldc1 $f16,(STACK_FPR+16*8)(k0)
+	ldc1 $f17,(STACK_FPR+17*8)(k0)
+	ldc1 $f18,(STACK_FPR+18*8)(k0)
+	ldc1 $f19,(STACK_FPR+19*8)(k0)
+	ldc1 $f20,(STACK_FPR+20*8)(k0)
+	ldc1 $f21,(STACK_FPR+21*8)(k0)
+	ldc1 $f22,(STACK_FPR+22*8)(k0)
+	ldc1 $f23,(STACK_FPR+23*8)(k0)
+	ldc1 $f24,(STACK_FPR+24*8)(k0)
+	ldc1 $f25,(STACK_FPR+25*8)(k0)
+	ldc1 $f26,(STACK_FPR+26*8)(k0)
+	ldc1 $f27,(STACK_FPR+27*8)(k0)
+	ldc1 $f28,(STACK_FPR+28*8)(k0)
+	ldc1 $f29,(STACK_FPR+29*8)(k0)
+	ldc1 $f30,(STACK_FPR+30*8)(k0)
+	ldc1 $f31,(STACK_FPR+31*8)(k0)
+
+	lw k1, STACK_FC31(k0)
+	ctc1 k1, $f31
+
+	.set noat
+	ld $1,(STACK_GPR+1*8)(k0)
+	eret
+	nop

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -208,7 +208,7 @@ reg_block_t* __kthread_syscall_schedule(reg_block_t *stack_state)
 				// the thread must already have been added to a waiting list,
 				// otherwise it wouldn't ever be scheduled again.
 				assert(th_cur->flags & TH_FLAG_INLIST);
-				assert(*(uint32_t*)th_cur->stack_state->epc == 0x4C);
+				assertf(*(uint32_t*)th_cur->stack_state->epc == 0x0000004C, "invalid opcode found by __kthread_syscall_schedule:\nexpected 0x0000004C (SYSCALL 0x1), found: %08lx", *(uint32_t*)th_cur->stack_state->epc);
 				th_cur->stack_state->epc += 4;
 			}
 			else

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,0 +1,645 @@
+#include <libdragon.h>
+#include "kernel.h"
+#include "kernelinternal.h"
+#include "timer.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <memory.h>
+
+#define DEBUG_KERNEL   0
+
+#define STACK_COOKIE   0xDEADBEEFBAADC0DE
+#define STACK_GUARD    64
+
+/** @brief Read the current value of the gp register */
+#define REG_GP()     ({ uint64_t gp; __asm("move %0, $28": "=r" (gp)); gp; })
+
+/**
+ * @brief Execute a context switch.
+ *
+ * This forces a context switch to happen, by invoking the syscall 0x1. The
+ * syscall will be intercepted by the generic interrupt handler (inthandler.S)
+ * that will call #__kthread_syscall_schedule.
+ *
+ * This macro is very low level and is called as part of higher-level primitives
+ * that force a context switch like #thread_yield.
+ *
+ * Do not call this under interrupt; use #KTHREAD_SWITCH_ISR instead.
+ */
+#define KTHREAD_SWITCH()      __asm("syscall 0x1")
+
+/**
+ * @brief Executed a context switch, during an ongoing interrupt service routing.
+ *
+ * This forces a context switch to happen just like #KTHREAD_SWITCH, but it is
+ * the right version to call if the code is currently servicing an interrupt.
+ */
+#define KTHREAD_SWITCH_ISR()  ({ __isr_force_schedule = true; })
+
+/** @brief Main thread */
+kthread_t th_main;
+/** @brief Pointer to the current thread */
+kthread_t *th_cur;
+/** @brief Pounter to the idle thread */
+kthread_t *th_idle;
+/** @brief List of ready threads */
+static kthread_t *th_ready;
+/** @brief Number of live thread */
+static int th_count;
+
+kevent_t KEVENT_IRQ_AI = {0};
+kevent_t KEVENT_IRQ_DP = {0};
+kevent_t KEVENT_IRQ_SP = {0};
+kevent_t KEVENT_IRQ_SI = {0};
+kevent_t KEVENT_IRQ_VI = {0};
+kevent_t KEVENT_IRQ_PI = {0};
+kevent_t KEVENT_RESET  = {0};
+
+/** @brief True if the multithreading kernel has been initialized and is running. */
+bool __kernel = false;
+/** @brief True if a context switch must be done at the end of current interrupt. */
+bool __isr_force_schedule = false;
+/* Global current interrupt depth (defined in interrupt.c) */ 
+extern int __interrupt_depth;
+
+/** 
+ * @brief Boot function for a kthread.
+ *
+ * It invokes the user entry function, and then kills the thread
+ * if the function ever returns.
+ */
+void __kthread_boot(void)
+{
+	// Initialize GP register. This is the same as done in the entrypoint
+	// and is also used by the backtrace code as marker to stop walking.
+	asm volatile ("la $gp, _gp");
+	th_cur->user_entry(th_cur->user_data);
+	if (DEBUG_KERNEL) debugf("thread end: %s[%p]\n", th_cur->name, th_cur);
+	kthread_kill(NULL);
+}
+
+void __kthread_check_overflow(kthread_t *th)
+{
+	// If the current stack pointer is beyond the end of the stack,
+	// this is a stack overflow even without checking the integrity of the
+	// guard.
+	assertf((void*)th->stack_state >= th->stack + STACK_GUARD,
+		"stack overflow in thread: %s[%p]\nSP:%p | Stack top: %p | Overflow: %d bytes",
+		th->name, th,
+		th->stack_state, th->stack+STACK_GUARD,
+		th->stack+STACK_GUARD-(void*)th->stack_state);
+
+	// Check if the stack guard has been corrupted. This indicates that
+	// has a stack overflow has happened, even if right now the stack has
+	// rolled back.
+	uint64_t *cookie = (uint64_t*)th->stack;
+	for (int i=0;i<STACK_GUARD/8;i++)
+		assertf(cookie[i] == STACK_COOKIE, "stack overflow in thread: %s[%p]\nStack guard is corrupted", th->name, th);
+}
+
+/** @brief Add a thread to a linked list */
+void __thlist_add(kthread_t **list, kthread_t *th)
+{
+	assert(!(th->flags & TH_FLAG_INLIST));
+	th->flags |= TH_FLAG_INLIST;
+
+	th->next = *list;
+	*list = th;	
+}
+
+/** @brief Add a thread to a linked list sorted by priority */
+void __thlist_add_pri(kthread_t **list, kthread_t *th)
+{
+	while (*list && (*list)->pri >= th->pri)
+		list = &((*list)->next);
+	__thlist_add(list, th);
+}
+
+/** @brief Peek the head of a thread list (without popping it) */
+kthread_t* __thlist_head(kthread_t **list)
+{
+	if (!list) return NULL;
+	return *list;
+}
+
+/** @brief Pop the head of a thread list */
+kthread_t* __thlist_rem(kthread_t **list)
+{
+	kthread_t *th = *list;
+	if (th)
+	{
+		assert(th->flags & TH_FLAG_INLIST);
+		th->flags &= ~TH_FLAG_INLIST;
+
+		*list = th->next;
+		th->next = NULL;
+	}
+	return th;
+}
+
+/** 
+ * @brief Move all threads from list src to list dst, respecting priority. 
+ *
+ * @return true if at least a thread of priority equal or higher than the
+ *         the current one has been moved.
+ **/
+bool __thlist_splice_pri(kthread_t **dst, kthread_t **src)
+{
+	bool highpri = false;
+	kthread_t *th;
+	while ((th = __thlist_rem(src)))
+	{
+		highpri = highpri || (th->pri >= th_cur->pri);
+		__thlist_add_pri(dst, th);
+	}
+	return highpri;
+}
+
+/** 
+ * @brief Kernel scheduler: park the current thread and schedule the next thread
+ *
+ * This is the main scheduling function. It is invoked by the interrupt handler
+ * if explicitly requested via a syscall exception (#KTHREAD_SWITCH) or if
+ * an interrupt handler is preempting the current thread (#KTHREAD_SWITCH_ISR).
+ *
+ * @param stack_state Stack pointer containing the register block for the
+ *                    the current thread.
+ *
+ * @return The stack pointer containing the register block of the thread to
+ *         be activated.
+ **/
+reg_block_t* __kthread_syscall_schedule(reg_block_t *stack_state)
+{
+	if (th_cur)
+	{
+		// For debugging purposes: check if the current thread has overflown
+		// its allocated stack.
+		th_cur->stack_state = stack_state;
+		__kthread_check_overflow(th_cur);
+
+	 	if (th_cur->flags & TH_FLAG_ZOMBIE)
+	 	{
+	 		// If the current thread is marked as zombie, it means that it must
+	 		// be freed.
+	 		if (DEBUG_KERNEL) debugf("[kernel] killing zombie: %s(%p) PC=%lx\n", th_cur->name, th_cur, stack_state->epc);
+			assert(!(th_cur->flags & TH_FLAG_INLIST));
+			free(th_cur->stack);
+	 	}
+		else
+		{
+			// Save the current thread state.
+			if (DEBUG_KERNEL) debugf("[kernel] parking %s(%p) PC=%lx\n", th_cur->name, th_cur, stack_state->epc);
+
+			// Check how we got here. There are two possibilities: explicit
+			// syscall forcing a thread switch (THREAD_SWITCH), or an interrupt
+			// that awakes a higher priority thread (THREAD_SWITCH_ISR).
+			if (C0_GET_CAUSE_EXC_CODE(stack_state->cr) == EXCEPTION_CODE_SYS_CALL)
+			{
+				// Skip syscall instruction when this thread will be scheduled
+				// again. Notice that, given that this is an explicit syscall,
+				// the thread must already have been added to a waiting list,
+				// otherwise it wouldn't ever be scheduled again.
+				assert(th_cur->flags & TH_FLAG_INLIST);
+				assert(*(uint32_t*)th_cur->stack_state->epc == 0x4C);
+				th_cur->stack_state->epc += 4;
+			}
+			else
+			{
+				// If this is a preemptive switch forced by an interrupt,
+				// the current thread was running and it's still ready, so
+				// add it to the ready list again.
+				assertf(!(th_cur->flags & TH_FLAG_INLIST), "thread %s[%p] in list? flags=%x", th_cur->name, th_cur, th_cur->flags);
+				__thlist_add_pri(&th_ready, th_cur);
+			}
+
+			// Save the current interrupt depth. Interrupt depth is actually
+			// per-thread, so we just save/restore it every time a thread is
+			// scheduled.
+			th_cur->interrupt_depth = __interrupt_depth;
+		}
+	}
+
+	// Schedule the highest-priority thread that is ready. This would be
+	// the first thread in the ready list. There is always at least a thread
+	// here: the idle thread.
+	th_cur = __thlist_rem(&th_ready);
+	assert(th_cur != NULL);
+	if (DEBUG_KERNEL) debugf("[kernel] switching to %s(%p) PC=%lx\n", th_cur->name, th_cur, th_cur->stack_state->epc);
+	assert(!(th_cur->flags & TH_FLAG_INLIST));
+
+	// Set the current interrupt depth to that of the current thread.
+	__interrupt_depth = th_cur->interrupt_depth;
+
+	return th_cur->stack_state;
+}
+
+/**
+ * @brief Idle thread function
+ *
+ * Since there must always be something run by the CPU, the kernel creates
+ * a "idle" thread: a lowest-priority thread that is run only when all
+ * user-created threads are blocked.
+ *
+ * This thread does absolutely nothing. It just waits for any other thread
+ * to wake up so that it will be preempted.
+ */
+void __kthread_idle(void *arg)
+{
+	// When this thread is scheduled, there are no
+	// ready threads and all threads are probably waiting for some
+	// hardware event to happen. Just spin-wait here.
+	while(1) {}
+}
+
+kthread_t* kernel_init(void)
+{
+	assert(!__kernel);
+	th_ready = NULL;  // empty ready list
+	th_count = 1; // start with the main thread
+
+	// Configure the main thread
+	memset(&th_main, 0, sizeof(th_main));
+	th_main.pri = 0;
+	th_main.name = "main";
+
+	// NOTE: keep this in sync with system.c
+	#define STACK_SIZE 0x10000
+	th_main.stack = (char*)0x80000000 + get_memory_size() - STACK_SIZE;
+
+	uint64_t *s = (uint64_t*)th_main.stack;
+	for (int i=0;i<STACK_GUARD/8;i++)
+		s[i] = STACK_COOKIE;
+
+	// The main thread is the currently scheduled one.
+	th_cur = &th_main;
+
+	// Allocate the idle thread
+	th_idle = kthread_new("idle", 4096, -1, __kthread_idle, 0);
+
+	__kernel = true;
+	return th_cur;
+}
+
+void kernel_close(void)
+{
+	assert(__kernel);
+	assertf(th_cur == &th_main, "kthread_close can only be called from main thread");
+
+	// Kill the idle thread to release the memory
+	kthread_kill(th_idle);
+	th_idle = NULL;
+
+	assertf(th_count == 1, "not all threads were killed");
+
+	th_cur = NULL;
+	__kernel = false;
+	__isr_force_schedule = false;
+}
+
+kthread_t* kthread_new(const char *name, int stack_size, int8_t pri, void (*user_entry)(void*), void *user_data)
+{
+	assert((stack_size % 8) == 0);
+
+	// Allocate memory for the stack, the stack guard area, and the kthread_t
+	// structure
+	//
+	// |             |                        |             |
+	// | Stack guard |   Stack                | kthread_t   |
+	// |             |                        |             |
+	//
+	//
+	// For the kthread structure, we will use the final part of
+	// the buffer: since the stack grows downward, this makes sure that
+	// overflowing the stack doesn't corrupt the thread structure, which might
+	// make debugging more difficult and might even cause the kernel to crash.
+	void *thmem = malloc(STACK_GUARD + stack_size + sizeof(kthread_t));
+	assertf(thmem, "out of free memory");
+	kthread_t *th = thmem + STACK_GUARD + stack_size;
+
+	// Initialize the thread structure
+	memset(th, 0, sizeof(kthread_t));
+	th->stack = thmem;
+
+	th->name = name;
+	th->user_entry = user_entry;
+	th->user_data = user_data;
+	th->pri = pri;
+
+	// Initialize the stack guard
+	uint64_t *s = (uint64_t*)th->stack;
+	for (int i=0;i<STACK_GUARD/8;i++)
+		s[i] = STACK_COOKIE;
+
+	// Top of the stack is the end of the stack area, so where the kthread_t
+	// structure is. Remember that the stack grows downward.
+	void *top_stack = (void*)th;
+
+	// Put the initial regblock at the top of the stack. This is the
+	// block that will be popped when the thread is first scheduled, and needs to
+	// initialize all the registers and jump to the entry point.
+	th->stack_state = (reg_block_t*)(top_stack - sizeof(reg_block_t));
+	assert(((uint32_t)th->stack_state & 7) == 0);
+	memset(th->stack_state, 0, sizeof(reg_block_t));
+
+	// EPC: __thread_boot function (which will then invoke the user entry point)
+	th->stack_state->epc = (uint32_t)&__kthread_boot;
+
+	// SR: start in exception mode (we will be within an exception during scheduling),
+	// and with interrupts enabled.
+	th->stack_state->sr = C0_STATUS() | C0_STATUS_EXL | C0_STATUS_IE;
+
+	// GP: this is needed by the compiler to point to the global memory pool,
+	// so let's initialize to the same value it has in this thread.
+	th->stack_state->gpr[28] = REG_GP();
+
+	// SP: top of stack
+	th->stack_state->gpr[29] = (int64_t)(int32_t)top_stack;
+
+	disable_interrupts();
+	th_count++;
+	__thlist_add_pri(&th_ready, th);
+	enable_interrupts();
+
+	// If the new thread has a priority higher or equal to the current one,
+	// yield immediately so that it will get started. This preserves the basic
+	// invariant that a higher priority thread is immediately scheduled whenever
+	// it becomes ready.
+	if (th->pri >= th_cur->pri)
+		kthread_yield();
+
+	return th;
+}
+
+void kthread_kill(kthread_t *th)
+{
+	if (th == NULL) th = th_cur;
+	
+	if (DEBUG_KERNEL) debugf("killing: %s[%p] (flags:%x)\n", th->name, th, th->flags);
+	
+	disable_interrupts();
+	th_count--;
+
+	// In general, we cannot just free the memory. If the thread is enqueued
+	// in some list (eg: waiting on a mailbox), we would need to remove it
+	// from that list before freeing it, but we don't have a way to do it
+	// (a thread doesn't have a reference to the list it's in, just a next
+	// pointer).
+	// So just mark the thread as zombie. This will cause the scheduler to
+	// free it as soon as the thread is first scheduled.
+	th->flags |= TH_FLAG_ZOMBIE;
+
+	// If we're trying to kill ourselves, it's sufficient to force a context
+	// switch now.
+	if (th == th_cur)
+		KTHREAD_SWITCH();
+	enable_interrupts();
+}
+
+void kthread_yield(void)
+{
+	// Check if there's a ready thread that has priority
+	// higher than or equal to the current thread, otherwise it's
+	// useless to force a context switch: the current thread would
+	// be rescheduled again.
+	kthread_t *th = __thlist_head(&th_ready);
+	if (th && th->pri >= th_cur->pri)
+	{
+		if (DEBUG_KERNEL) debugf("yielding: %s[%p] (flags:%x, status:%lx)\n", th_cur->name, th_cur, th_cur->flags, C0_STATUS());
+		disable_interrupts();
+
+		__thlist_add_pri(&th_ready, th_cur);
+		KTHREAD_SWITCH();
+
+		enable_interrupts();
+	}
+}
+
+void kthread_set_pri(kthread_t *th, int8_t pri)
+{
+	assertf(pri >= 0, "thread priority cannot be negative");
+	if (th == NULL) th = th_cur;
+	th->pri = pri;
+
+	// Yield in case the priority change has immediate effect
+	kthread_yield();
+}
+
+void kthread_sleep(uint32_t ticks)
+{
+	kthread_t *th = th_cur;
+
+	// Timer callback. This will be invoked when the timer elapses after the
+	// requested delay.
+	void cb(int ovlf)
+	{
+		if (DEBUG_KERNEL) debugf("[kernel] sleep finished %s[%p]\n", th->name, th);
+
+		// Put the thread again in the ready list, and forces a context switch
+		th->flags &= ~TH_FLAG_INLIST;
+		__thlist_add_pri(&th_ready, th);
+		KTHREAD_SWITCH_ISR();
+	}
+
+	if (DEBUG_KERNEL) debugf("[kernel] sleeping %ld %s[%p]\n", ticks, th->name, th);
+	disable_interrupts();
+
+	// Start a timer for the specified delay.
+	timer_link_t timer;
+	start_timer(&timer, ticks, TF_ONE_SHOT, cb);
+
+	// Mark the thread as being in a list to avoid the scheduler to panic.
+	// This is not "technically true", but it's "semantically true": when
+	// we say "a thread is in a list" it means that it's registered somewhere
+	// so that there's a way to wake it up in the future. In this case,
+	// the timer callback will do it, so we can reassure the kernel scheduler
+	// that everything is fine.
+	th->flags |= TH_FLAG_INLIST;
+
+	// Context switch
+	KTHREAD_SWITCH();
+
+	enable_interrupts();
+}
+
+void kthread_wait_event(kevent_t *evt)
+{
+	// Simplified API to wait for a single event. Just allocate a mailbox
+	// on the stack, attach to the event, and receive from it.
+	kmbox_t *mbox = kmbox_new_stack(1);
+	kmbox_attach_event(mbox, evt);
+	kmbox_recv(mbox);
+	kmbox_detach_event(mbox, evt);
+}
+
+kmbox_t* kmbox_new(int max_mails)
+{
+	// Allocate memory for the mailbox structure plus the mail array
+	int sz = sizeof(kmbox_t) + (max_mails)*sizeof(void*);
+	kmbox_t *mb = malloc(sz);
+	assertf(mb, "out of free memory");
+	memset(mb, 0, sz);
+	mb->max = max_mails;
+	return mb;
+}
+
+void kmbox_free(kmbox_t *mbox)
+{
+	assertf(mbox->evts == 0, "mbox_free() called, but missing %d mbox_detach_event() calls", mbox->evts);
+	free(mbox);
+}
+
+bool kmbox_empty(kmbox_t *mbox)
+{
+	return mbox->mails[mbox->r] == NULL;
+}
+
+bool kmbox_full(kmbox_t *mbox)
+{
+	return mbox->mails[mbox->w] != NULL;
+}
+
+/**
+ * @brief  Enqueue a mail into a mailbox (lower-level primitive).
+ *
+ * @note   This function must be called with interrupts disabled, as it
+ *         manipulates the ready list.
+ *
+ * @return 0 if the mail was not sent (mbox full)
+ *         1 if the mail was sent
+ *         2 if mail was sent and a higher-priority thread was awaken,
+ *         so a context switch should be done as soon as possible.
+ */
+int __kmbox_try_send(kmbox_t *mbox, void *mail)
+{
+	// If the mbox is full, there's nothing to do
+	if (kmbox_full(mbox))
+		return 0;
+
+	// Enqueue the new mail
+	mbox->mails[mbox->w++] = mail;
+	if (mbox->w == mbox->max)
+		mbox->w = 0;
+
+	// Awake pending threads. If a higher-priority thread is awaken,
+	// notify it to the caller.
+	return __thlist_splice_pri(&th_ready, &mbox->wait_list) ? 2 : 1;
+}
+
+bool kmbox_try_send(kmbox_t *mbox, void *mail)
+{
+	int ret;
+
+	disable_interrupts();
+	ret = __kmbox_try_send(mbox, mail);
+	if (ret == 2)
+		kthread_yield();
+	enable_interrupts();
+
+	return ret != 0;
+}
+
+void kmbox_send(kmbox_t *mbox, void *mail)
+{
+	disable_interrupts();
+	while (!kmbox_try_send(mbox, mail))
+	{
+		__thlist_add(&mbox->wait_list, th_cur);
+		KTHREAD_SWITCH();
+	}
+	enable_interrupts();
+}
+
+void* kmbox_try_recv(kmbox_t *mbox)
+{
+	void *mail = NULL;
+	disable_interrupts();
+	if (!kmbox_empty(mbox))
+	{
+		mail = mbox->mails[mbox->r];
+		mbox->mails[mbox->r++] = NULL;
+		if (mbox->r == mbox->max) mbox->r = 0;
+		if (__thlist_splice_pri(&th_ready, &mbox->wait_list)) {
+			if (DEBUG_KERNEL) debugf("kmbox_try_recv: switching out\n");
+			kthread_yield();
+			if (DEBUG_KERNEL) debugf("kmbox_try_recv: back %p\n", mail);
+		}
+	}
+	enable_interrupts();
+	return mail;
+}
+
+void* kmbox_recv(kmbox_t *mbox)
+{
+	void* mail;
+	disable_interrupts();
+	while (!(mail = kmbox_try_recv(mbox)))
+	{
+		__thlist_add(&mbox->wait_list, th_cur);
+		KTHREAD_SWITCH();		
+	}
+	enable_interrupts();
+	return mail;
+}
+
+/** @brief Underlying implementation for #kevent_trigger and #kevent_trigger_isr */
+void __kevent_trigger(kevent_t *evt, bool isr)
+{
+	bool should_yield = false;
+
+	disable_interrupts();
+	for (int i = 0; i < MAX_MAILBOXES_PER_EVENT; i++)
+	{
+		// Send the event to the attached mailboxes, and remember
+		// if we have woken up a higher-priority thread.
+		if (evt->mboxes[i] && __kmbox_try_send(evt->mboxes[i], evt) == 2)
+			should_yield = true;
+	}
+
+	// If a higher-priority thread has been waken up,
+	// force a context switch. Depending on whether we are
+	// running under interrupt or not, call the correct function.
+	if (should_yield)
+	{
+		if (isr)
+			KTHREAD_SWITCH_ISR();
+		else
+			kthread_yield();
+	}
+
+	enable_interrupts();
+}
+
+void kevent_trigger(kevent_t *evt)     { __kevent_trigger(evt, false); }
+void kevent_trigger_isr(kevent_t *evt) { __kevent_trigger(evt, true);  }
+
+void kmbox_attach_event(kmbox_t *mbox, kevent_t *evt)
+{
+	disable_interrupts();
+	for (int i=0;i<MAX_MAILBOXES_PER_EVENT;i++)
+	{
+		// Find a free slot for the mailbox in the event.
+		if (!evt->mboxes[i])
+		{
+			evt->mboxes[i] = mbox;
+			mbox->evts++;
+			break;
+		}
+	}
+	enable_interrupts();
+}
+
+void kmbox_detach_event(kmbox_t *mbox, kevent_t *evt)
+{
+	disable_interrupts();
+	for (int i=0;i<MAX_MAILBOXES_PER_EVENT;i++)
+	{
+		// Search for the mailbox in the event, and remove it
+		if (evt->mboxes[i] == mbox)
+		{
+			evt->mboxes[i] = NULL;
+			mbox->evts--;
+			break;
+		}
+	}
+	enable_interrupts();
+}

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -1,0 +1,444 @@
+
+void test_kernel_basic(TestContext *ctx) {
+	kernel_init();
+	DEFER(kernel_close());
+
+	uint8_t thcalled[16] = {0};
+	uint8_t thcalled_idx = 0;
+
+	void func_th(void *arg)
+	{
+		int thid = (int)arg;
+
+		thcalled[thcalled_idx++] = thid;
+		kthread_yield();		
+		thcalled[thcalled_idx++] = thid;
+		kthread_yield();
+		thcalled[thcalled_idx++] = thid;
+	}
+
+	// Create two threads. Pause their execution by making
+	// sure they have lower priority than main thread.
+	kthread_set_pri(NULL, 5);
+	kthread_new("test1", 2048, 3, func_th, (void*)1);
+	kthread_new("test2", 2048, 3, func_th, (void*)2);
+
+	// Now lower the priority of the main thread. This will
+	// immediately force a switch to the two threads that
+	// have now higher priority.
+	kthread_set_pri(NULL, 1);
+
+	// Once we get there, the two threads have already finished
+	// execution. Check that they were called in the expected order.
+	uint8_t exp[] = { 1,2,1,2,1,2,0 };
+	ASSERT_EQUAL_MEM(thcalled, exp, sizeof(exp), "invalid order of threads");
+}
+
+void test_kernel_priority(TestContext *ctx) {
+	kernel_init();
+	DEFER(kernel_close());
+
+	uint8_t thcalled[16] = {0};
+	uint8_t thcalled_idx = 0;
+
+	void func_th1(void *arg)
+	{
+		thcalled[thcalled_idx++] = 1;
+		kthread_yield();		
+		thcalled[thcalled_idx++] = 1;
+		kthread_yield();
+		thcalled[thcalled_idx++] = 1;
+	}
+
+	void func_th2(void *arg)
+	{
+		thcalled[thcalled_idx++] = 2;
+		kthread_new("test1", 2048, 5, func_th1, 0);
+		thcalled[thcalled_idx++] = 2;
+	}
+
+	void func_th3(void *arg)
+	{
+		thcalled[thcalled_idx++] = 3;
+		kthread_new("test2", 2048, 6, func_th2, 0);
+		thcalled[thcalled_idx++] = 3;
+		kthread_yield();
+		thcalled[thcalled_idx++] = 3;
+	}
+
+	kthread_set_pri(NULL, 1);
+	kthread_new("test3", 2048, 5, func_th3, 0);
+
+	uint8_t exp[] = { 3,2,2,3,1,3,1,1,0 };
+	ASSERT_EQUAL_MEM(thcalled, exp, sizeof(exp), "invalid order of threads");
+}
+
+void test_kernel_sleep(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	kernel_init();
+	DEFER(kernel_close());
+
+	uint8_t thcalled[16] = {0};
+	uint8_t thcalled_idx = 0;
+	volatile uint8_t thexit = 0;
+
+	void func_th1(void *arg)
+	{
+		LOG("func_th1 called\n");
+		thcalled[thcalled_idx++] = 1;
+		kthread_sleep(TICKS_FROM_MS(5));
+		thcalled[thcalled_idx++] = 1;
+		kthread_sleep(TICKS_FROM_MS(5));
+		thcalled[thcalled_idx++] = 1;
+		++thexit;
+	}
+
+	void func_th2(void *arg)
+	{
+		LOG("func_th2 called\n");
+		thcalled[thcalled_idx++] = 2;
+		kthread_sleep(TICKS_FROM_MS(8));
+		thcalled[thcalled_idx++] = 2;
+		++thexit;
+	}
+
+	kthread_set_pri(NULL, 6);
+	kthread_new("test1", 2048, 4, func_th1, 0);
+	kthread_new("test2", 2048, 5, func_th2, 0);
+
+	LOG("sleeping\n");
+	kthread_set_pri(NULL, 1);
+	kthread_sleep(TICKS_FROM_MS(15));
+
+	uint8_t exp[] = { 2,1,1,2,1,0 };
+	ASSERT_EQUAL_MEM(thcalled, exp, sizeof(exp), "invalid order of threads");
+}
+
+// Test mbox with writer thread having priority higher than reader thread.
+void test_kernel_mbox_1(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	kernel_init();
+	DEFER(kernel_close());
+
+	uint8_t msg1=1, msg2=2, msg3=3, msg4=4, msg5=5, msg6=6, msg7=7, msg8=8;
+	kmbox_t *mbox = kmbox_new(4);
+	DEFER(kmbox_free(mbox));
+
+	uint8_t msgread[16] = {0};
+	uint8_t msgread_idx = 0;
+
+	void read_thread(void* arg)
+	{
+		uint8_t *msg;
+		LOG("read_thread() %d\n", kmbox_empty(mbox));
+		while ((msg = kmbox_recv(mbox)))
+		{
+			LOG("mbox_recv(): %p:%d\n", msg, *msg);
+			msgread[msgread_idx++] = *msg;
+		}
+	}
+
+	// Bump priority of main thread
+	kthread_set_pri(NULL, 2);
+
+	// Create reader thread
+	kthread_t *th1 = kthread_new("read_thread", 2048, 1, read_thread, NULL);
+	DEFER(kthread_kill(th1));
+
+	// Enqueue 4 messages
+	ASSERT(kmbox_empty(mbox), "mbox not empty?");
+	ASSERT(!kmbox_full(mbox), "mbox full?");
+	ASSERT(kmbox_try_send(mbox, &msg1), "mbox send failure");
+
+	ASSERT(!kmbox_empty(mbox), "mbox empty?");
+	ASSERT(!kmbox_full(mbox), "mbox full?");
+	ASSERT(kmbox_try_send(mbox, &msg2), "mbox send failure");
+
+	ASSERT(!kmbox_empty(mbox), "mbox empty?");
+	ASSERT(!kmbox_full(mbox), "mbox full?");
+	ASSERT(kmbox_try_send(mbox, &msg3), "mbox send failure");
+
+	ASSERT(!kmbox_empty(mbox), "mbox empty?");
+	ASSERT(!kmbox_full(mbox), "mbox full?");
+	ASSERT(kmbox_try_send(mbox, &msg4), "mbox send failure");
+
+	ASSERT(!kmbox_empty(mbox), "mbox empty?");
+	ASSERT(kmbox_full(mbox), "mbox not full?");
+
+	// 5th message: not possible because it's full
+	ASSERT(!kmbox_try_send(mbox, &msg5), "kmbox_try_send should not succeed with full mailbox");
+
+	// At this point, the read thread has not read anything yet
+	// because it's lower priority.
+	uint8_t exp_initial[] = { 0 };
+	ASSERT_EQUAL_MEM(msgread, exp_initial, sizeof(exp_initial), "invalid order of messages");
+
+	// This will block, and at this point the reader thread will be scheduled.
+	// As soon as it reads one message off the mbox, it will be switched away
+	// without having time to process it.
+	LOG("kmbox_send(5)\n");
+	kmbox_send(mbox, &msg5);
+	LOG("after kmbox_send(5)\n");
+
+	uint8_t exp_after5[] = { 0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after5, sizeof(exp_after5), "invalid order of messages");
+
+	LOG("kmbox_send(6)\n");
+	kmbox_send(mbox, &msg6);
+	LOG("after kmbox_send(6)\n");
+	kmbox_send(mbox, &msg7);
+	kmbox_send(mbox, &msg8);
+
+	uint8_t exp_after8[] = { 1,2,3,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after8, sizeof(exp_after8), "invalid order of messages");
+
+	// Yielding the thread doesn't produce anything because the main
+	// thread is higher priority
+	kthread_yield();
+
+	uint8_t exp_after_yield[] = { 1,2,3,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after_yield, sizeof(exp_after_yield), "invalid order of messages");
+
+	// Sleep to let the reader thread finish
+	kthread_sleep(TICKS_FROM_MS(3));
+
+	uint8_t exp_final[] = { 1,2,3,4,5,6,7,8,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_final, sizeof(exp_final), "invalid order of messages");
+}
+
+
+// Test mbox with writer thread having priority equal to reader thread.
+void test_kernel_mbox_2(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	kernel_init();
+	DEFER(kernel_close());
+
+	uint8_t msg1=1, msg2=2, msg3=3, msg4=4, msg5=5, msg6=6, msg7=7, msg8=8;
+	kmbox_t *mbox = kmbox_new(4);
+	DEFER(kmbox_free(mbox));
+
+	uint8_t msgread[16] = {0};
+	uint8_t msgread_idx = 0;
+
+	void read_thread(void* arg)
+	{
+		uint8_t *msg;
+		LOG("read_thread() %d\n", kmbox_empty(mbox));
+		while ((msg = kmbox_recv(mbox)))
+		{
+			LOG("mbox_recv(): %p:%d\n", msg, *msg);
+			msgread[msgread_idx++] = *msg;
+		}
+	}
+
+	// Bump priority of main thread to suspend the reader thread
+	kthread_set_pri(NULL, 2);
+
+	// Create reader thread
+	kthread_t *th1 = kthread_new("read_thread", 2048, 1, read_thread, NULL);
+	DEFER(kthread_kill(th1));
+
+	// Enqueue messages. The reader thread has not started yet because it
+	// has lower priority for now
+	kmbox_send(mbox, &msg1);
+	kmbox_send(mbox, &msg2);
+	kmbox_send(mbox, &msg3);
+	kmbox_send(mbox, &msg4);
+
+	// At this point, the read thread has not read anything yet because we have
+	// never context switched
+	uint8_t exp_initial[] = { 0 };
+	ASSERT_EQUAL_MEM(msgread, exp_initial, sizeof(exp_initial), "invalid order of messages");
+
+	// Now lower the priority of the main thread. This will cause the
+	// reader thread to start, and it will then flush the whole mbox right
+	// away.
+	kthread_set_pri(NULL, 1);
+
+	uint8_t exp_after_pri[] = { 1,2,3,4,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after_pri, sizeof(exp_after_pri), "invalid order of messages");
+
+	// Now writing a message will trigger a read right away
+	kmbox_send(mbox, &msg5);
+
+	uint8_t exp_after5[] = { 1,2,3,4,5,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after5, sizeof(exp_after5), "invalid order of messages");
+
+	kmbox_send(mbox, &msg6);
+	kmbox_send(mbox, &msg7);
+	kmbox_send(mbox, &msg8);
+
+	uint8_t exp_after8[] = { 1,2,3,4,5,6,7,8,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after8, sizeof(exp_after8), "invalid order of messages");
+}
+
+
+// Test mbox with writer thread having priority lower than reader thread.
+void test_kernel_mbox_3(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	kernel_init();
+	DEFER(kernel_close());
+
+	uint8_t msg1=1, msg2=2, msg3=3, msg4=4, msg5=5, msg6=6, msg7=7, msg8=8;
+	kmbox_t *mbox = kmbox_new(4);
+	DEFER(kmbox_free(mbox));
+
+	uint8_t msgread[16] = {0};
+	uint8_t msgread_idx = 0;
+
+	void read_thread(void* arg)
+	{
+		uint8_t *msg;
+		LOG("read_thread() %d\n", kmbox_empty(mbox));
+		while ((msg = kmbox_recv(mbox)))
+		{
+			LOG("mbox_recv(): %p:%d\n", msg, *msg);
+			msgread[msgread_idx++] = *msg;
+		}
+	}
+
+	// Bump priority of main thread
+	kthread_set_pri(NULL, 1);
+
+	// Create reader thread
+	kthread_t *th1 = kthread_new("read_thread", 2048, 2, read_thread, NULL);
+	DEFER(kthread_kill(th1));
+
+	// Enqueue messages. They will be processed right away
+	// because the reader thread has higher priority.
+	kmbox_send(mbox, &msg1);
+	uint8_t exp_initial[] = { 1,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_initial, sizeof(exp_initial), "invalid order of messages");
+
+	kmbox_send(mbox, &msg2);
+	kmbox_send(mbox, &msg3);
+	kmbox_send(mbox, &msg4);
+	uint8_t exp_after_4[] = { 1,2,3,4,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_after_4, sizeof(exp_after_4), "invalid order of messages");
+
+	// This will block, and at this point the reader thread will be scheduled.
+	// As soon as it reads one message off the mbox, it will be switched away
+	// without having time to process it.
+	kmbox_send(mbox, &msg5);
+	kmbox_send(mbox, &msg6);
+	kmbox_send(mbox, &msg7);
+	kmbox_send(mbox, &msg8);
+
+	uint8_t exp_final[] = { 1,2,3,4,5,6,7,8,0 };
+	ASSERT_EQUAL_MEM(msgread, exp_final, sizeof(exp_final), "invalid order of messages");
+}
+
+void test_kernel_event_1(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	kernel_init();
+	DEFER(kernel_close());
+
+	set_SP_interrupt(true);
+	DEFER(set_SP_interrupt(false));
+
+	bool called = false;
+
+	void wait_thread(void *arg)
+	{
+		kthread_wait_event(&KEVENT_IRQ_SP);
+		called = true;
+	}
+
+	void rsp_thread(void* arg)
+	{
+		uint32_t __attribute__((aligned(8))) miniucode[] = { 0x0000000d }; // BREAK opcode
+		
+		data_cache_hit_writeback_invalidate(miniucode, sizeof(miniucode));
+		load_ucode(miniucode, sizeof(miniucode));
+		run_ucode();
+	}
+
+	kthread_set_pri(NULL, 1);
+	kthread_new("wait_thread", 2048, 2, wait_thread, NULL);
+	kthread_new("rsp_thread", 2048, 2, rsp_thread, NULL);
+
+	kthread_sleep(TICKS_FROM_MS(5));
+	ASSERT(called, "event not triggered");
+}
+
+void test_kernel_event_2(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	kernel_init();
+	DEFER(kernel_close());
+
+	set_SP_interrupt(true);
+	DEFER(set_SP_interrupt(false));
+
+	uint8_t called[16] = {0};
+	int called_idx = 0;
+
+	kmbox_t *m1 = kmbox_new_stack(1);
+	kmbox_t *m2 = kmbox_new_stack(1);
+
+	void read_kthread_1(void* arg)
+	{
+		while (kmbox_recv(m1) == &KEVENT_IRQ_SP)
+			called[called_idx++] = 1;
+	}
+
+	void read_kthread_2(void* arg)
+	{
+		while (kmbox_recv(m2) == &KEVENT_IRQ_SP)
+			called[called_idx++] = 2;
+	}
+
+	void rsp_thread(void* arg)
+	{
+		uint32_t __attribute__((aligned(8))) miniucode[] = { 0x0000000d }; // BREAK opcode
+		
+		data_cache_hit_writeback_invalidate(miniucode, sizeof(miniucode));
+		load_ucode(miniucode, sizeof(miniucode));
+		run_ucode();
+	}
+
+	kmbox_attach_event(m1, &KEVENT_IRQ_SP);
+	DEFER(kmbox_detach_event(m1, &KEVENT_IRQ_SP));
+
+	kmbox_attach_event(m2, &KEVENT_IRQ_SP);
+	DEFER(kmbox_detach_event(m2, &KEVENT_IRQ_SP));
+
+	kthread_set_pri(NULL, 5);
+	kthread_new("rsp_thread", 2048, 2, rsp_thread, NULL);
+
+	kthread_t *rth1 = kthread_new("read_kthread_1", 2048, 3, read_kthread_1, NULL);
+	DEFER(kthread_kill(rth1));
+
+	kthread_t *rth2 = kthread_new("read_kthread_2", 2048, 4, read_kthread_2, NULL);
+	DEFER(kthread_kill(rth2));
+
+	// Go to sleep. Now the RSP will run, trigger the two reader threads, and
+	// they will register themselves in the called array.
+	kthread_sleep(TICKS_FROM_MS(5));
+
+	// Make sure the order is correct (first the higher priority thread).
+	uint8_t exp1[] = { 2, 1, 0 };
+	ASSERT_EQUAL_MEM(called, exp1, sizeof(exp1), "invalid order of threads");
+
+	// Now detach thread 2 from the event, so it will not be triggered anymore.
+	kmbox_detach_event(m2, &KEVENT_IRQ_SP);
+
+	// Run the RSP again.
+	kthread_new("rsp_thread", 2048, 2, rsp_thread, NULL);
+	kthread_sleep(TICKS_FROM_MS(5));
+
+	// Only thread 1 should have been called
+	uint8_t exp2[] = { 2, 1, 1, 0 };
+	ASSERT_EQUAL_MEM(called, exp2, sizeof(exp2), "invalid order of threads");
+}

--- a/tests/test_kernel.c
+++ b/tests/test_kernel.c
@@ -359,8 +359,8 @@ void test_kernel_event_1(TestContext *ctx) {
 		uint32_t __attribute__((aligned(8))) miniucode[] = { 0x0000000d }; // BREAK opcode
 		
 		data_cache_hit_writeback_invalidate(miniucode, sizeof(miniucode));
-		load_ucode(miniucode, sizeof(miniucode));
-		run_ucode();
+		rsp_load_code(miniucode, sizeof(miniucode), 0);
+		rsp_run_async();
 	}
 
 	kthread_set_pri(NULL, 1);
@@ -404,8 +404,8 @@ void test_kernel_event_2(TestContext *ctx) {
 		uint32_t __attribute__((aligned(8))) miniucode[] = { 0x0000000d }; // BREAK opcode
 		
 		data_cache_hit_writeback_invalidate(miniucode, sizeof(miniucode));
-		load_ucode(miniucode, sizeof(miniucode));
-		run_ucode();
+		rsp_load_code(miniucode, sizeof(miniucode), 0);
+		rsp_run_async();
 	}
 
 	kmbox_attach_event(m1, &KEVENT_IRQ_SP);

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -193,6 +193,7 @@ int assert_equal_mem(TestContext *ctx, const char *file, int line, const uint8_t
  * TEST FILES
  **********************************************************************/
 
+#include "test_kernel.c"
 #include "test_dfs.c"
 #include "test_eepromfs.c"
 #include "test_cache.c"
@@ -245,6 +246,14 @@ static const struct Testsuite
 	TEST_FUNC(test_timer_disabled_start,     733, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_disabled_restart,   733, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_irq_reentrancy,           230, TEST_FLAGS_RESET_COUNT),
+	TEST_FUNC(test_kernel_basic,               5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_event_1,             5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_event_2,             5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_mbox_1,              5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_mbox_2,              5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_mbox_3,              5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_priority,            5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_kernel_sleep,               5, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dfs_read,                 948, TEST_FLAGS_IO),
 	TEST_FUNC(test_dfs_rom_addr,              25, TEST_FLAGS_IO),
 	TEST_FUNC(test_eepromfs,                   0, TEST_FLAGS_IO),


### PR DESCRIPTION
This PR introduces a multithreading kernel to libdragon. Having threads
is a very good way to make good use of the limited resources available
on the console as it makes it easier to switch away and do something
while a DMA is in progress or while the RSP is crunching. In theory,
everything can be done without threads, but in practice we posit that most
homebrew developers will be better served with a threading module.

In my upcoming audio library, threading Is basically necessary as processing
audio requires switching between CPU and RSP several times, and doing
that only with interrupts gets complicated fast. On the contrary, with threads,
it's very easy to keep audio processing in background.

This PR just introduces the kernel. It doesn't attempt to revisit all existing 
libdragon APIs to do some thread-aware yield instead of spin-looping. That's
something for another day. Also, we will have to discuss whether it makes sense
for APIs to automatically use threads if available and fallback to spinloops, or
it's better to have a different set of APIs. A good example to reason about is
`dma_read` or even `wait_ms`.

## Description of the kernel module

This module implements a hybrid cooperative/preemptive multi-threaded
kernel for parallel execution of code.

The kernel is "hard real-time": any thread with high priority that is
ready (not blocked) will always have priority over lower priority threads.
This is required to allow threads to implement operations that require
low latency, for instance preparing audio when the AI interrupt fires.

The kernel is not fully preemptive; in particular, there is no timer
interrupt that switches among ready threads at a fixed interval. This
is not deemed necessary as applications will usually have a low number
threads that are mostly blocked waiting for specific events like
hardware interrupts or background activities like RSP ucode.

An event, represented by a kevent_t instance, is a signal that can
be broadcasted to many different threads. A thread can use
kthread_wait_event to wait for a specific event to fire. The kernel
library includes a set of events bound to MI peripheral interrupts,
so that it's possible for threads to wait for specific interrupts and
act after them.

Typically, applications will keep the main thread at low priority
for the main business logic, and will spawn a few threads to handle
high-priority / low-latency responses to hardware events. Libdragon
itself offers libraries that need threading to provide a easy-to-use
API.

A context-switch between threads can happen in the following situations:

  * Preemptively: when a hardware interrupt generates a event that
    wakes up a thread (see kevent). This is the most common scenario:
    an event connected to an interrupt is fired, and a higher priority
    thread waiting for the event is woken up.

  * Cooperatively: when a thread explicitly calls a blocking function
    like kthread_sleep or kthread_wait_event to wait for an event.
    The kernel will put the current thread to sleep and schedule the
    highest-priority thread among the ready ones, including threads
    that have a priority lower than the one that goes to sleep. When
    the event is fired, the lower-priority thread will be preempted
    to give back control to the thread that just woke up.

  * Cooperatively: when a thread explicitly calls kthread_yield to
    leave the CPU to other threads that might be ready at the same time.
    Notice that, given the hard real-time guarantee, this only makes
    sense if there are multiple ready threads at the same priority level,
    as calling kthread_yield will not schedule a lower-priority thread.
    It is normally not necessary to call thread_yield.

In addition to threads (kthread_t) and events (kevent_t), the kernel
library offers a message passing communication primitive called "message
box" (kmbox_t). A mailbox is a circular buffer of messages called
"mails"; any number of threads can try to send mails into a mailbox,
and any number of threads can try to read mails from a mailbox. Once a
thread receives a mail from a mailbox, the mail is removed and other
threads will not see it anymore. 

Mailboxes can be useful as communicative primitives among threads
(eg: to send tasks to other threads), or a synchronization primitive
to wait for multiple events (see kmbox_attach_event).