### PR TITLE
Implement cartridge save type detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ install: libdragon.a libdragonsys.a
 	install -m 0644 include/cop0.h $(INSTALLDIR)/mips64-elf/include/cop0.h
 	install -m 0644 include/cop1.h $(INSTALLDIR)/mips64-elf/include/cop1.h
 	install -m 0644 include/interrupt.h $(INSTALLDIR)/mips64-elf/include/interrupt.h
+	install -m 0644 include/cart.h $(INSTALLDIR)/mips64-elf/include/cart.h
 	install -m 0644 include/dma.h $(INSTALLDIR)/mips64-elf/include/dma.h
 	install -m 0644 include/dragonfs.h $(INSTALLDIR)/mips64-elf/include/dragonfs.h
 	install -m 0644 include/audio.h $(INSTALLDIR)/mips64-elf/include/audio.h

--- a/examples/ctest/ctest.c
+++ b/examples/ctest/ctest.c
@@ -37,10 +37,12 @@ const char * format_save_type( cart_save_type_t save_type )
             return "256 kilobit SRAM detected";
         case SAVE_TYPE_SRAM_768KBIT:
             return "768 kilobit SRAM detected";
-        case SAVE_TYPE_SRAM_1MBIT:
-            return "1 megabit SRAM detected";
         case SAVE_TYPE_FLASHRAM_1MBIT:
             return "1 megabit FlashRAM detected";
+        case SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS:
+            return "1 megabit contiguous SRAM detected";
+        case SAVE_TYPE_SRAM_1MBIT_BANKED:
+            return "1 megabit banked SRAM detected";
         default:
             return "Unknown cartridge save type";
     }

--- a/examples/ctest/ctest.c
+++ b/examples/ctest/ctest.c
@@ -23,53 +23,50 @@ const char * format_type( int accessory )
     }
 }
 
-const char * format_save_type( cart_save_type_t save_type )
-{
-    switch(save_type)
-    {
-        case SAVE_TYPE_NONE:
-            return "No cartridge save detected";
-        case SAVE_TYPE_EEPROM_4KBIT:
-            return "4 kilobit EEPROM detected";
-        case SAVE_TYPE_EEPROM_16KBIT:
-            return "16 kilobit EEPROM detected";
-        case SAVE_TYPE_SRAM_256KBIT:
-            return "256 kilobit SRAM detected";
-        case SAVE_TYPE_SRAM_768KBIT:
-            return "768 kilobit SRAM detected";
-        case SAVE_TYPE_FLASHRAM_1MBIT:
-            return "1 megabit FlashRAM detected";
-        case SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS:
-            return "1 megabit contiguous SRAM detected";
-        case SAVE_TYPE_SRAM_1MBIT_BANKED:
-            return "1 megabit banked SRAM detected";
-        default:
-            return "Unknown cartridge save type";
-    }
-}
-
 const char * format_flashram_type( flashram_type_t flashram )
 {
     switch( flashram )
     {
         case FLASHRAM_TYPE_NONE:
-            return "FlashRAM not detected";
+            return "not detected";
         case FLASHRAM_TYPE_MX29L0000:
-            return "FlashRAM identified: Macronix MX29L0000";
+            return "identified: Macronix MX29L0000";
         case FLASHRAM_TYPE_MX29L0001:
-            return "FlashRAM identified: Macronix MX29L0001";
+            return "identified: Macronix MX29L0001";
         case FLASHRAM_TYPE_MX29L1100:
-            return "FlashRAM identified: Macronix MX29L1100";
+            return "identified: Macronix MX29L1100";
         case FLASHRAM_TYPE_MX29L1101_A:
-            return "FlashRAM identified: Macronix MX29L1101";
+            return "identified: Macronix MX29L1101";
         case FLASHRAM_TYPE_MX29L1101_B:
         case FLASHRAM_TYPE_MX29L1101_C:
-            return "FlashRAM identified: 29L1100KC-15B0 (MX29L1101 compatible)";
+            return "identified: 29L1100KC-15B0 (MX29L1101 compatible)";
         case FLASHRAM_TYPE_MN63F81MPN:
-            return "FlashRAM identified: Matsushita MN63F81MPN";
+            return "identified: Matsushita MN63F81MPN";
         default:
-            return "Unknown FlashRAM detected";
+            return "not identified";
     }
+}
+
+void print_save_type( uint8_t save_type, flashram_type_t flashram )
+{
+    if( save_type == SAVE_TYPE_NONE )
+        printf( "No cartridge save detected\n" );
+    if( save_type & SAVE_TYPE_EEPROM_4KBIT )
+        printf( "4Kbit EEPROM detected\n" );
+    if( save_type & SAVE_TYPE_EEPROM_16KBIT )
+        printf( "16Kbit EEPROM detected\n" );
+    if( save_type & SAVE_TYPE_SRAM_256KBIT )
+        printf( "256Kbit SRAM detected\n" );
+    if( save_type & SAVE_TYPE_SRAM_768KBIT_BANKED )
+        printf( "768Kbit banked SRAM detected\n" );
+    if( save_type & SAVE_TYPE_SRAM_1MBIT_BANKED )
+        printf( "1Mbit banked SRAM detected\n" );
+    if( save_type & SAVE_TYPE_SRAM_768KBIT_CONTIGUOUS )
+        printf( "768Kbit contiguous SRAM detected\n" );
+    if( save_type & SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS )
+        printf( "1Mbit contiguous SRAM detected\n" );
+    if( flashram )
+        printf( "1Mbit FlashRAM %s\n", format_flashram_type( flashram ) );
 }
 
 int main(void)
@@ -92,7 +89,7 @@ int main(void)
     uint8_t data[32];
     memset( data, 0, 32 );
 
-    cart_save_type_t save_type = cart_detect_save_type();
+    uint8_t save_type = cart_detect_save_type();
     flashram_type_t flashram = cart_detect_flashram();
 
     /* Main loop test */
@@ -142,13 +139,10 @@ int main(void)
         printf( "Accessory 4 %spresent %s\n", (accessories & CONTROLLER_4_INSERTED) ? "" : "not ",
                                               (accessories & CONTROLLER_4_INSERTED) ? format_type( identify_accessory( 3 ) ) : "" );
 
-        printf("\n%s\n", format_save_type(save_type));
-        if( save_type == SAVE_TYPE_FLASHRAM_1MBIT )
-        {
-            printf("%s\n", format_flashram_type(flashram));
-        }
+        printf( "\n" );
+        print_save_type( save_type, flashram );
 
-        printf("\n%d\n\n", testv++ );
+        printf( "\n%d\n\n", testv++ );
 
         current_time = time( NULL );
         if( current_time != -1 )

--- a/examples/ctest/ctest.c
+++ b/examples/ctest/ctest.c
@@ -8,7 +8,7 @@
 static resolution_t res = RESOLUTION_320x240;
 static bitdepth_t bit = DEPTH_32_BPP;
 
-char *format_type( int accessory )
+const char * format_type( int accessory )
 {
     switch( accessory )
     {
@@ -20,6 +20,53 @@ char *format_type( int accessory )
             return "(vru)";
         default:
             return "(none)";
+    }
+}
+
+const char * format_save_type( cart_save_type_t save_type )
+{
+    switch(save_type)
+    {
+        case SAVE_TYPE_NONE:
+            return "No cartridge save detected";
+        case SAVE_TYPE_EEPROM_4KBIT:
+            return "4 kilobit EEPROM detected";
+        case SAVE_TYPE_EEPROM_16KBIT:
+            return "16 kilobit EEPROM detected";
+        case SAVE_TYPE_SRAM_256KBIT:
+            return "256 kilobit SRAM detected";
+        case SAVE_TYPE_SRAM_768KBIT:
+            return "768 kilobit SRAM detected";
+        case SAVE_TYPE_SRAM_1MBIT:
+            return "1 megabit SRAM detected";
+        case SAVE_TYPE_FLASHRAM_1MBIT:
+            return "1 megabit FlashRAM detected";
+        default:
+            return "Unknown cartridge save type";
+    }
+}
+
+const char * format_flashram_type( flashram_type_t flashram )
+{
+    switch( flashram )
+    {
+        case FLASHRAM_TYPE_NONE:
+            return "FlashRAM not detected";
+        case FLASHRAM_TYPE_MX29L0000:
+            return "FlashRAM identified: Macronix MX29L0000";
+        case FLASHRAM_TYPE_MX29L0001:
+            return "FlashRAM identified: Macronix MX29L0001";
+        case FLASHRAM_TYPE_MX29L1100:
+            return "FlashRAM identified: Macronix MX29L1100";
+        case FLASHRAM_TYPE_MX29L1101_A:
+            return "FlashRAM identified: Macronix MX29L1101";
+        case FLASHRAM_TYPE_MX29L1101_B:
+        case FLASHRAM_TYPE_MX29L1101_C:
+            return "FlashRAM identified: 29L1100KC-15B0 (MX29L1101 compatible)";
+        case FLASHRAM_TYPE_MN63F81MPN:
+            return "FlashRAM identified: Matsushita MN63F81MPN";
+        default:
+            return "Unknown FlashRAM detected";
     }
 }
 
@@ -42,6 +89,9 @@ int main(void)
     int press = 0;
     uint8_t data[32];
     memset( data, 0, 32 );
+
+    cart_save_type_t save_type = cart_detect_save_type();
+    flashram_type_t flashram = cart_detect_flashram();
 
     /* Main loop test */
     while(1) 
@@ -89,6 +139,12 @@ int main(void)
                                               (accessories & CONTROLLER_3_INSERTED) ? format_type( identify_accessory( 2 ) ) : "" );
         printf( "Accessory 4 %spresent %s\n", (accessories & CONTROLLER_4_INSERTED) ? "" : "not ",
                                               (accessories & CONTROLLER_4_INSERTED) ? format_type( identify_accessory( 3 ) ) : "" );
+
+        printf("\n%s\n", format_save_type(save_type));
+        if( save_type == SAVE_TYPE_FLASHRAM_1MBIT )
+        {
+            printf("%s\n", format_flashram_type(flashram));
+        }
 
         printf("\n%d\n\n", testv++ );
 

--- a/files.in
+++ b/files.in
@@ -20,6 +20,7 @@ OFILES_LD += $(CURDIR)/build/graphics.o
 OFILES_LD += $(CURDIR)/build/rdp.o
 OFILES_LD += $(CURDIR)/build/rsp.o
 OFILES_LD += $(CURDIR)/build/dma.o
+OFILES_LD += $(CURDIR)/build/cart.o
 OFILES_LD += $(CURDIR)/build/timer.o
 OFILES_LD += $(CURDIR)/build/version.o
 OFILES_LD += $(CURDIR)/build/exception.o
@@ -37,6 +38,9 @@ $(CURDIR)/build/interrupt.o: $(CURDIR)/src/interrupt.c ./include/cop0.h
 $(CURDIR)/build/dma.o: $(CURDIR)/src/dma.c ./include/n64sys.h
 	mkdir -p $(CURDIR)/build
 	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/dma.o $(CURDIR)/src/dma.c
+$(CURDIR)/build/cart.o: $(CURDIR)/src/cart.c ./include/n64sys.h
+	mkdir -p $(CURDIR)/build
+	$(CC) $(CFLAGS) -c -o $(CURDIR)/build/cart.o $(CURDIR)/src/cart.c
 $(CURDIR)/build/inthandler.o: $(CURDIR)/src/inthandler.S
 	mkdir -p $(CURDIR)/build
 	$(CC) -c -o $(CURDIR)/build/inthandler.o $(CURDIR)/src/inthandler.S

--- a/include/cart.h
+++ b/include/cart.h
@@ -11,21 +11,23 @@
 typedef enum cart_save_type_t
 {
     /** @brief No cartridge save capabilities detected. */
-    SAVE_TYPE_NONE                  = 0x00,
+    SAVE_TYPE_NONE                    = 0x00,
     /** @brief 4 kilobit EEPROM present */
-    SAVE_TYPE_EEPROM_4KBIT          = 0x10,
+    SAVE_TYPE_EEPROM_4KBIT            = 0x01,
     /** @brief 16 kilobit EEPROM present */
-    SAVE_TYPE_EEPROM_16KBIT         = 0x20,
-    /** @brief 256 kilobit SRAM present */
-    SAVE_TYPE_SRAM_256KBIT          = 0x30,
-    /** @brief 768 kilobit banked SRAM present */
-    SAVE_TYPE_SRAM_768KBIT          = 0x40,
+    SAVE_TYPE_EEPROM_16KBIT           = 0x02,
     /** @brief 1 megabit FlashRAM present */
-    SAVE_TYPE_FLASHRAM_1MBIT        = 0x50,
-    /** @brief 1 megabit contiguous SRAM present */
-    SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS = 0x60,
+    SAVE_TYPE_FLASHRAM_1MBIT          = 0x04,
+    /** @brief 256 kilobit SRAM present */
+    SAVE_TYPE_SRAM_256KBIT            = 0x08,
+    /** @brief 768 kilobit banked SRAM present */
+    SAVE_TYPE_SRAM_768KBIT_BANKED     = 0x10,
     /** @brief 1 megabit banked SRAM present */
-    SAVE_TYPE_SRAM_1MBIT_BANKED     = 0x70,
+    SAVE_TYPE_SRAM_1MBIT_BANKED       = 0x20,
+    /** @brief 768 kilobit contiguous SRAM present (not supported) */
+    SAVE_TYPE_SRAM_768KBIT_CONTIGUOUS = 0x40,
+    /** @brief 1 megabit contiguous SRAM present (not supported) */
+    SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS   = 0x80,
 } cart_save_type_t;
 
 typedef enum flashram_type_t
@@ -58,19 +60,20 @@ typedef enum flashram_type_t
 extern "C" {
 #endif
 
-cart_save_type_t cart_detect_save_type( void );
+uint8_t cart_detect_save_type( void );
 flashram_type_t cart_detect_flashram( void );
-bool cart_detect_sram(uint32_t offset);
-bool cart_detect_sram_bank(uint8_t bank, uint32_t offset);
+
+void cart_dom1_addr2_read(void * dest, uint32_t offset, uint32_t len);
+void cart_dom1_addr2_write(const void * src, uint32_t offset, uint32_t len);
+
+void cart_dom2_addr2_read(void * dest, uint32_t offset, uint32_t len);
+void cart_dom2_addr2_write(const void * src, uint32_t offset, uint32_t len);
 
 void cart_rom_read(void * dest, uint32_t offset, uint32_t len);
 void cart_rom_write(const void * src, uint32_t offset, uint32_t len);
 
-void cart_ram_read(void * dest, uint32_t offset, uint32_t len);
-void cart_ram_write(const void * src, uint32_t offset, uint32_t len);
-
-void cart_sram_bank_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len);
-void cart_sram_bank_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len);
+void cart_sram_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len);
+void cart_sram_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len);
 
 #ifdef __cplusplus
 }

--- a/include/cart.h
+++ b/include/cart.h
@@ -1,0 +1,77 @@
+/**
+ * @file cart.h
+ * @brief Cartridge
+ * @ingroup cart
+ */
+#ifndef __LIBDRAGON_CART_H
+#define __LIBDRAGON_CART_H
+
+#include <stdint.h>
+
+typedef enum cart_save_type_t
+{
+    /** @brief No cartridge save capabilities detected. */
+    SAVE_TYPE_NONE           = 0x00,
+    /** @brief 4 kilobit EEPROM present */
+    SAVE_TYPE_EEPROM_4KBIT   = 0x10,
+    /** @brief 16 kilobit EEPROM present */
+    SAVE_TYPE_EEPROM_16KBIT  = 0x20,
+    /** @brief 256 kilobit SRAM present */
+    SAVE_TYPE_SRAM_256KBIT   = 0x30,
+    /** @brief 768 kilobit SRAM present */
+    SAVE_TYPE_SRAM_768KBIT   = 0x40,
+    /** @brief 1 megabit SRAM present */
+    SAVE_TYPE_SRAM_1MBIT     = 0x60,
+    /** @brief 1 megabit FlashRAM present */
+    SAVE_TYPE_FLASHRAM_1MBIT = 0x50,
+} cart_save_type_t;
+
+typedef enum flashram_type_t
+{
+    /** @brief No FlashRAM chip detected */
+    FLASHRAM_TYPE_NONE        = 0x00000000,
+    /** @brief Macronix MX29L0000 */
+    FLASHRAM_TYPE_MX29L0000   = 0x00C20000,
+    /** @brief Macronix MX29L0001 */
+    FLASHRAM_TYPE_MX29L0001   = 0x00C20001,
+    /** @brief Macronix MX29L1100 */
+    FLASHRAM_TYPE_MX29L1100   = 0x00C2001E,
+    /** @brief Macronix MX29L1101 */
+    FLASHRAM_TYPE_MX29L1101_A = 0x00C2001D,
+    /**
+     * @brief Actual chip is labeled 29L1100KC-15B0, but is compatible with MX29L1101.
+     * NOTE: Vendor code `0x00C2` is not 100% certain for this part; needs verification.
+     */
+    FLASHRAM_TYPE_MX29L1101_B = 0x00C20084,
+    /**
+     * @brief Actual chip is labeled 29L1100KC-15B0, but is compatible with MX29L1101.
+     * NOTE: Vendor code `0x00C2` is not 100% certain for this part; needs verification.
+     */
+    FLASHRAM_TYPE_MX29L1101_C = 0x00C2008E,
+    /** @brief Matsushita MN63F81MPN */
+    FLASHRAM_TYPE_MN63F81MPN  = 0x003200F1,
+} flashram_type_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+cart_save_type_t cart_detect_save_type( void );
+flashram_type_t cart_detect_flashram( void );
+bool cart_detect_sram(uint32_t offset);
+bool cart_detect_sram_768kbit(uint8_t bank, uint32_t offset);
+
+void cart_rom_read(void * dest, uint32_t offset, uint32_t len);
+void cart_rom_write(const void * src, uint32_t offset, uint32_t len);
+
+void cart_ram_read(void * dest, uint32_t offset, uint32_t len);
+void cart_ram_write(const void * src, uint32_t offset, uint32_t len);
+
+void cart_sram_768kbit_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len);
+void cart_sram_768kbit_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/cart.h
+++ b/include/cart.h
@@ -11,19 +11,21 @@
 typedef enum cart_save_type_t
 {
     /** @brief No cartridge save capabilities detected. */
-    SAVE_TYPE_NONE           = 0x00,
+    SAVE_TYPE_NONE                  = 0x00,
     /** @brief 4 kilobit EEPROM present */
-    SAVE_TYPE_EEPROM_4KBIT   = 0x10,
+    SAVE_TYPE_EEPROM_4KBIT          = 0x10,
     /** @brief 16 kilobit EEPROM present */
-    SAVE_TYPE_EEPROM_16KBIT  = 0x20,
+    SAVE_TYPE_EEPROM_16KBIT         = 0x20,
     /** @brief 256 kilobit SRAM present */
-    SAVE_TYPE_SRAM_256KBIT   = 0x30,
-    /** @brief 768 kilobit SRAM present */
-    SAVE_TYPE_SRAM_768KBIT   = 0x40,
-    /** @brief 1 megabit SRAM present */
-    SAVE_TYPE_SRAM_1MBIT     = 0x60,
+    SAVE_TYPE_SRAM_256KBIT          = 0x30,
+    /** @brief 768 kilobit banked SRAM present */
+    SAVE_TYPE_SRAM_768KBIT          = 0x40,
     /** @brief 1 megabit FlashRAM present */
-    SAVE_TYPE_FLASHRAM_1MBIT = 0x50,
+    SAVE_TYPE_FLASHRAM_1MBIT        = 0x50,
+    /** @brief 1 megabit contiguous SRAM present */
+    SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS = 0x60,
+    /** @brief 1 megabit banked SRAM present */
+    SAVE_TYPE_SRAM_1MBIT_BANKED     = 0x70,
 } cart_save_type_t;
 
 typedef enum flashram_type_t
@@ -59,7 +61,7 @@ extern "C" {
 cart_save_type_t cart_detect_save_type( void );
 flashram_type_t cart_detect_flashram( void );
 bool cart_detect_sram(uint32_t offset);
-bool cart_detect_sram_768kbit(uint8_t bank, uint32_t offset);
+bool cart_detect_sram_bank(uint8_t bank, uint32_t offset);
 
 void cart_rom_read(void * dest, uint32_t offset, uint32_t len);
 void cart_rom_write(const void * src, uint32_t offset, uint32_t len);
@@ -67,8 +69,8 @@ void cart_rom_write(const void * src, uint32_t offset, uint32_t len);
 void cart_ram_read(void * dest, uint32_t offset, uint32_t len);
 void cart_ram_write(const void * src, uint32_t offset, uint32_t len);
 
-void cart_sram_768kbit_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len);
-void cart_sram_768kbit_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len);
+void cart_sram_bank_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len);
+void cart_sram_bank_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len);
 
 #ifdef __cplusplus
 }

--- a/include/dma.h
+++ b/include/dma.h
@@ -6,19 +6,25 @@
 #ifndef __LIBDRAGON_DMA_H
 #define __LIBDRAGON_DMA_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void dma_write(const void * ram_address, unsigned long pi_address, unsigned long len);
-void dma_read(void * ram_address, unsigned long pi_address, unsigned long len);
-volatile int dma_busy();
+volatile int dma_busy(void);
+
+void dma_read(void * dest, uint32_t cart_address, uint32_t len);
+void dma_write(const void * src, uint32_t cart_address, uint32_t len);
+
+void pi_dma_read(void * dest, uint32_t pi_address, uint32_t len);
+void pi_dma_write(const void * src, uint32_t pi_address, uint32_t len);
 
 /* 32 bit IO read from PI device */
-uint32_t io_read(uint32_t pi_address);
+uint32_t io_read(uint32_t address);
 
 /* 32 bit IO write to PI device */
-void io_write(uint32_t pi_address, uint32_t data);
+void io_write(uint32_t address, uint32_t data);
 
 #ifdef __cplusplus
 }

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -54,6 +54,7 @@
 #include "tpak.h"
 #include "display.h"
 #include "dma.h"
+#include "cart.h"
 #include "dragonfs.h"
 #include "eepromfs.h"
 #include "graphics.h"

--- a/src/cart.c
+++ b/src/cart.c
@@ -1,0 +1,385 @@
+/**
+ * @file cart.c
+ * @brief Cartridge
+ * @ingroup cart
+ */
+
+#include "libdragon.h"
+
+/**
+ * @defgroup cart Cartridge interface
+ * @ingroup libdragon
+ * @brief Routines for interacting with the cartridge and hardware attached to it.
+ *
+ * The cartridge contains the ROM (up to 64 megabytes), as well as optional writable
+ * memory in the form of SRAM or FlashRAM (up to 128 kilobytes). There may also be
+ * an EEPROM or Real-Time Clock, which are handled by the Joybus interface.
+ *
+ * In general, the best way to access ROM or RAM is through DMA transfers. The functions
+ * here are mostly convenience helpers on top of the Peripheral Interface, which manages
+ * DMA transfers.
+ *
+ * SRAM is the simplest save type, allowing direct access using DMA reads/writes. If your
+ * storage needs are less than 256 kilobits (32 kilobytes), you should probably use SRAM.
+ * If you need more space, you can still consider SRAM, but there are trade-offs. The only
+ * practical reason why it might not make sense to use SRAM is if you want compatibility
+ * with emulators that do not support SRAM larger than 256 kilobits, or wish to make
+ * a reproduction cartridge (which typically only support up to 256 kilobit SRAM).
+ * 
+ * Only one published cartridge ever used the 768 kilobit SRAM configuration (Dezaemon 3D),
+ * which is actually implemented as a logic chip selecting between 3 256 kilobit SRAM banks.
+ * Emulator support for this save type is not widespread, and there are no reproduction
+ * cartridge boards that support SRAM bank switching, although flash carts do support it.
+ *
+ * For ROMs that need to store up to 1 megabit (128 kilobytes), the most widely-compatible
+ * save type is FlashRAM. Unfortunately, it is significantly more complicated to write
+ * data to FlashRAM. At this time, libdragon does not offer convenience functions to
+ * abstract the complexities of the various FlashRAM chips that could be on the cartridge.
+ *
+ * If your ROM does not need to store more than 16 kilobits (2 kilobytes), you could use
+ * EEPROM. In the age of emulators and flash carts, there is no real advantage to EEPROM
+ * over SRAM. EEPROM is lower-capacity, slower to write, must be accessed in 8-byte blocks,
+ * and should use parity bits or checksums to ensure consistency (on real hardware). The
+ * strongest reason why you might consider using EEPROM is if you wanted to make your own
+ * reproduction cartridge, since the boards often support EEPROM 4k/16k without needing
+ * to scavenge "donor chips" from a real N64 cartridge.
+ *
+ * @{
+ */
+
+#define CART_DOM1_ADDR2_START 0x10000000
+#define CART_DOM1_ADDR2_END   0x1FBFFFFF
+#define CART_DOM2_ADDR2_START 0x08000000
+#define CART_DOM2_ADDR2_END   0x0FFFFFFF
+
+/** @brief ROM can be up to 64 megabytes */
+#define ROM_ADDRESS_MASK  0x03FFFFFF
+/** @brief SRAM/FlashRAM can be up to 128 kilobytes */
+#define RAM_ADDRESS_MASK  0x0001FFFF
+#define SRAM_256KBIT_MASK 0x00007FFF
+
+/** @brief This value has no significance, it's just for probing purposes */
+#define SRAM_TEST_VALUE  0xFEDCBA98
+
+#define FLASHRAM_IDENTIFIER                0x11118001
+#define FLASHRAM_OFFSET_COMMAND            0x00010000
+#define FLASHRAM_OFFSET_MASK               0x0000FFFF
+#define FLASHRAM_COMMAND_SET_ERASE_OFFSET  0x4B000000
+#define FLASHRAM_COMMAND_SET_ERASE_MODE    0x78000000
+#define FLASHRAM_COMMAND_SET_WRITE_OFFSET  0xA5000000
+#define FLASHRAM_COMMAND_SET_WRITE_MODE    0xB4000000
+#define FLASHRAM_COMMAND_COMMIT            0xD2000000
+#define FLASHRAM_COMMAND_SET_IDENTIFY_MODE 0xE1000000
+#define FLASHRAM_COMMAND_SET_READ_MODE     0xF0000000
+
+/**
+ * @brief Clamp length from a start address so that it does not go past an end address.
+ *
+ * Used by DMA functions to ensure the read/writes stay in defined ranges.
+ *
+ * @param[in] len
+ *            Length to clamp (in bytes).
+ * @param[in] start
+ *            Starting address to add length to.
+ * @param[in] end
+ *            Ending address that start+len cannot exceed.
+ *
+ * @return Clamped length.
+ */
+static uint32_t clamp(uint32_t len, uint32_t start, uint32_t end)
+{
+    int32_t overage = (int32_t)(start + len) - (int32_t)(end + 1);
+    return ( overage > 0 ) ? len - overage : len;
+}
+
+/**
+ * @brief Determine which save type is available on the cartridge.
+ *
+ * This function checks for EEPROM, then FlashRAM, then SRAM.
+ *
+ * On real N64 hardware it is not possible for there to be more than one
+ * save type available, although some emulators do not enfore this
+ * limitation and may allow EEPROM to co-exist with SRAM or FlashRAM.
+ * It is not possible for SRAM and FlashRAM to co-exist.
+ *
+ * @return the detected save type on the cartridge.
+ */
+cart_save_type_t cart_detect_save_type( void )
+{
+    eeprom_type_t eeprom = eeprom_present();
+    if( eeprom == EEPROM_4K ) return SAVE_TYPE_EEPROM_4KBIT;
+    if( eeprom == EEPROM_16K ) return SAVE_TYPE_EEPROM_16KBIT;
+
+    flashram_type_t flashram = cart_detect_flashram();
+    if( flashram != FLASHRAM_TYPE_NONE ) return SAVE_TYPE_FLASHRAM_1MBIT;
+
+    if( cart_detect_sram(0x0001FFFF) ) return SAVE_TYPE_SRAM_1MBIT;
+    if( cart_detect_sram_768kbit(2, 0x00007FFF) ) return SAVE_TYPE_SRAM_768KBIT;
+    if( cart_detect_sram(0x00007FFF) ) return SAVE_TYPE_SRAM_256KBIT;
+
+    return SAVE_TYPE_NONE;
+}
+
+/**
+ * @brief Determine which FlashRAM chip is installed on the cartridge.
+ *
+ * The various FlashRAM chips all have slightly different behaviors, so it is helpful
+ * to know which one is installed.
+ *
+ * @return the detected FlashRAM type on the cartridge.
+ */
+flashram_type_t cart_detect_flashram( void )
+{
+    /* Tell the FlashRAM to identify itself */
+    io_write(CART_DOM2_ADDR2_START | FLASHRAM_OFFSET_COMMAND, FLASHRAM_COMMAND_SET_IDENTIFY_MODE) ;
+
+    /* Read the identifiers */
+    uint32_t __attribute__((aligned(16))) silicon_id[2];
+    data_cache_hit_writeback_invalidate(silicon_id, sizeof(silicon_id));
+    cart_ram_read(silicon_id, 0, sizeof(silicon_id));
+
+    /* Check for the magic "this is FlashRAM" value, followed by which chip it is. */
+    if( silicon_id[0] == FLASHRAM_IDENTIFIER ) return silicon_id[1];
+    return FLASHRAM_TYPE_NONE;
+}
+
+/**
+ * @brief Determine whether SRAM on the cartridge is writable at a given offset.
+ *
+ * Unfortunately, the only way to check this is to actually perform a DMA write/read,
+ * which is a destructive operation. This routine attempts to preserve the data before
+ * clobbering it during the test, and writes back the original data if SRAM exists.
+ *
+ * @param[in] offset
+ *            Offset of SRAM in bytes to check. SRAM potentially goes up to 1 megabit.
+ *
+ * @return whether the SRAM was able to read and write successfully at the offset.
+ */
+bool cart_detect_sram(uint32_t offset)
+{
+    uint32_t __attribute__((aligned(16))) backup_buf;
+    uint32_t __attribute__((aligned(16))) detect_buf;
+
+    /* Offset is potentially the end of the writable space, so go back a few bytes */
+    uint32_t len = sizeof(backup_buf);
+    uint32_t start = offset - len;
+    if (start < 0 ) start = 0;
+
+    /* Read the current data before writing over it */
+    data_cache_hit_writeback_invalidate(&backup_buf, len);
+    cart_ram_read(&backup_buf, start, len);
+
+    /* Write a test value into SRAM... */
+    detect_buf = SRAM_TEST_VALUE;
+    data_cache_hit_writeback_invalidate(&detect_buf, len);
+    cart_ram_write(&detect_buf, start, len);
+
+    /* Read the test value back to see if it persisted */
+    detect_buf = 0;
+    data_cache_hit_writeback_invalidate(&detect_buf, len);
+    cart_ram_read(&detect_buf, start, len);
+
+    if( detect_buf == SRAM_TEST_VALUE )
+    {
+        /* Restore the data that was overwritten to test SRAM */
+        data_cache_hit_writeback_invalidate(&backup_buf, len);
+        cart_ram_write(&backup_buf, start, len);
+        return true;
+    }
+    else
+    {
+        /* There is no SRAM at this offset */
+        return false;
+    }
+}
+
+/**
+ * @brief Determine whether the SRAM bank on the cartridge is writable at a given offset.
+ *
+ * 768Kbit SRAM is implemented as three separate 256Kbit SRAM chips with a logic circuit
+ * to determine which chip to access.
+ * 
+ * Unfortunately, the only way to check this is to actually perform a DMA write/read,
+ * which is a destructive operation. This routine attempts to preserve the data before
+ * clobbering it during the test, and writing back the original data if successful.
+ *
+ * @param[in] bank
+ *            Which of the three 256Kbit SRAM banks to select
+ * @param[in] offset
+ *            Offset of SRAM in bytes to check. An SRAM bank goes up to 256 kilobits.
+ */
+bool cart_detect_sram_768kbit(uint8_t bank, uint32_t offset)
+{
+    uint32_t __attribute__((aligned(16))) backup_buf;
+    uint32_t __attribute__((aligned(16))) detect_buf;
+
+    /* Offset is potentially the end of the writable space, so go back a few bytes */
+    uint32_t len = sizeof(backup_buf);
+    uint32_t start = offset - len;
+    if (start < 0 ) start = 0;
+
+    /* Read the current data before writing over it */
+    data_cache_hit_writeback_invalidate(&backup_buf, len);
+    cart_sram_768kbit_read(&backup_buf, bank, start, len);
+
+    /* Write a test value into SRAM... */
+    detect_buf = SRAM_TEST_VALUE;
+    data_cache_hit_writeback_invalidate(&detect_buf, len);
+    cart_sram_768kbit_write(&detect_buf, bank, start, len);
+
+    /* Read the test value back to see if it persisted */
+    detect_buf = 0;
+    data_cache_hit_writeback_invalidate(&detect_buf, len);
+    cart_sram_768kbit_read(&detect_buf, bank, start, len);
+
+    if( detect_buf == SRAM_TEST_VALUE )
+    {
+        /* Restore the data that was overwritten to test SRAM */
+        data_cache_hit_writeback_invalidate(&backup_buf, len);
+        cart_sram_768kbit_write(&backup_buf, bank, start, len);
+        return true;
+    }
+    else
+    {
+        /* There is no SRAM at this bank/offset */
+        return false;
+    }
+}
+
+/**
+ * @brief Read from Cartridge Domain 1 Address 2
+ *
+ * This function should be used when reading from the cartridge.
+ *
+ * @param[out] dest
+ *             Pointer to a buffer to place read data
+ * @param[in]  offset
+ *             Offset in bytes from the start of Cartridge Domain 1 Address 2 to read from
+ * @param[in]  len
+ *             Length in bytes to read into dest
+ */
+void cart_rom_read(void * dest, uint32_t offset, uint32_t len)
+{
+    assert(offset < 0x04000000);
+    assert(len > 1);
+    uint32_t pi_address = ((offset & ROM_ADDRESS_MASK) | CART_DOM1_ADDR2_START);
+    pi_dma_read(dest, pi_address, clamp(len, pi_address, CART_DOM1_ADDR2_END));
+}
+
+/**
+ * @brief Write to Cartridge Domain 1 Address 2
+ *
+ * This function should be used when writing to the cartridge.
+ *
+ * @param[in] src
+ *            Pointer to a buffer to read data from
+ * @param[in] offset
+ *            Offset in bytes from the start of Cartridge Domain 1 Address 2 to write to
+ * @param[in] len
+ *            Length in bytes to write from src
+ */
+void cart_rom_write(const void * src, uint32_t offset, uint32_t len)
+{
+    assert(offset < 0x04000000);
+    assert(len > 1);
+    uint32_t pi_address = ((offset & ROM_ADDRESS_MASK) | CART_DOM1_ADDR2_START);
+    pi_dma_write(src, pi_address, clamp(len, pi_address, CART_DOM1_ADDR2_END));
+}
+
+/**
+ * @brief Read from Cartridge Domain 2 Address 2
+ *
+ * This function should be used when reading from SRAM or FlashRAM.
+ *
+ * @param[out] dest
+ *             Pointer to a buffer to place read data
+ * @param[in]  offset
+ *             Offset in bytes from the start of Cartridge Domain 1 Address 2 to read from
+ * @param[in]  len
+ *             Length in bytes to read into dest
+ */
+void cart_ram_read(void * dest, uint32_t offset, uint32_t len)
+{
+    assert(offset < 0x20000);
+    assert(len > 1);
+    uint32_t pi_address = ((offset & RAM_ADDRESS_MASK) | CART_DOM2_ADDR2_START);
+    pi_dma_read(dest, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+}
+
+/**
+ * @brief Write to Cartridge Domain 2 Address 2
+ *
+ * This function should be used when writing to the SRAM or FlashRAM.
+ *
+ * @param[in] src
+ *            Pointer to a buffer to read data from
+ * @param[in] offset
+ *            Offset in bytes from the start of Cartridge Domain 2 Address 2 to write to
+ * @param[in] len
+ *            Length in bytes to write from src
+ */
+void cart_ram_write(const void * src, uint32_t offset, uint32_t len)
+{
+    assert(offset < 0x20000);
+    assert(len > 1);
+    uint32_t pi_address = ((offset & RAM_ADDRESS_MASK) | CART_DOM2_ADDR2_START);
+    pi_dma_write(src, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+}
+
+/**
+ * @brief Read from 768 Kilobit SRAM
+ *
+ * 768Kbit SRAM is implemented as three separate 256Kbit SRAM chips with a logic circuit
+ * to determine which chip to access.
+ *
+ * @param[in] dest
+ *            Pointer to a buffer to place read data
+ * @param[in] bank
+ *            Which of the three 256Kbit SRAM banks to select
+ * @param[in] offset
+ *            Offset in bytes from the start of the 256Kbit SRAM bank to write to
+ * @param[in] len
+ *            Length in bytes to read into dest
+ */
+void cart_sram_768kbit_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len)
+{
+    assert(bank < 3);
+    assert(offset < 0x8000);
+    assert(len > 1);
+    uint32_t pi_address = (
+        ((uint32_t)bank << 18) |
+        (offset & SRAM_256KBIT_MASK) |
+        CART_DOM2_ADDR2_START
+    );
+    pi_dma_read(dest, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+}
+
+/**
+ * @brief Write to 768 Kilobit SRAM
+ *
+ * 768Kbit SRAM is implemented as three separate 256Kbit SRAM chips with a logic circuit
+ * to determine which chip to access.
+ *
+ * @param[in] src
+ *            Pointer to a buffer to read data from
+ * @param[in] bank
+ *            Which of the three 256Kbit SRAM banks to select
+ * @param[in] offset
+ *            Offset in bytes from the start of the 256Kbit SRAM bank to write to
+ * @param[in] len
+ *            Length in bytes to write from src
+ */
+void cart_sram_768kbit_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len)
+{
+    assert(bank < 3);
+    assert(offset < 0x8000);
+    assert(len > 1);
+    uint32_t pi_address = (
+        ((uint32_t)bank << 18) |
+        (offset & SRAM_256KBIT_MASK) |
+        CART_DOM2_ADDR2_START
+    );
+    pi_dma_write(src, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+}
+
+/** @} */ /* cart */

--- a/src/cart.c
+++ b/src/cart.c
@@ -4,6 +4,7 @@
  * @ingroup cart
  */
 
+#include <string.h>
 #include "libdragon.h"
 
 /**
@@ -12,54 +13,78 @@
  * @brief Routines for interacting with the cartridge and hardware attached to it.
  *
  * The cartridge contains the ROM (up to 64 megabytes), as well as optional writable
- * memory in the form of SRAM or FlashRAM (up to 128 kilobytes). There may also be
- * an EEPROM or Real-Time Clock, which are handled by the Joybus interface.
+ * memory in the form of SRAM or FlashRAM. The cartridge may also contain other hardware
+ * such as an EEPROM or Real-Time Clock, which are handled by the Joybus interface.
  *
  * In general, the best way to access ROM or RAM is through DMA transfers. The functions
  * here are mostly convenience helpers on top of the Peripheral Interface, which manages
  * DMA transfers.
+ * 
+ * If your ROM does not need to store more than 16 kilobits (2 kilobytes), you could use
+ * the EEPROM save type. In the age of emulators and flash carts, EEPROM offers no real
+ * advantage over SRAM. EEPROM is lower-capacity, slower to write, must be accessed in
+ * 8-byte blocks, and (on real hardware) should use parity bits or checksums to ensure
+ * data consistency. The strongest reason why you might consider using EEPROM is if you
+ * wanted to make your own reproduction cartridge, since the boards often support EEPROM
+ * in 4Kbit and 16Kbit capacities without needing to scavenge for "donor chips".
  *
  * SRAM is the simplest save type, allowing direct access using DMA reads/writes. If your
- * storage needs are less than 256 kilobits (32 kilobytes), you should probably use SRAM.
- * If you need more space, you can still consider SRAM, but there are trade-offs. The only
- * practical reason why it might not make sense to use SRAM is if you want compatibility
- * with emulators that do not support SRAM larger than 256 kilobits, or wish to make
- * a reproduction cartridge (which typically only support up to 256 kilobit SRAM).
+ * storage needs are greater than 16 kilobits (2 kilobytes) and less than 256 kilobits
+ * (32 kilobytes), you should probably use SRAM. If you still need more capacity, there
+ * are a few options, but each comes with its own trade-offs.
  * 
- * Only one published cartridge ever used the 768 kilobit SRAM configuration (Dezaemon 3D),
- * which is actually implemented as a logic chip selecting between 3 256 kilobit SRAM banks.
- * Emulator support for this save type is not widespread, and there are no reproduction
- * cartridge boards that support SRAM bank switching, although flash carts do support it.
- *
- * For ROMs that need to store up to 1 megabit (128 kilobytes), the most widely-compatible
+ * Controller Paks can also be used for extended storage; A single Controller Pak can
+ * store up to 256 kilobits (32 kilobytes); up to four paks can be connected at a time,
+ * and even more capacity is possible if the paks are swapped out between reads/writes.
+ * 
+ * For ROMs that need to store up to 1 megabit (128 kilobytes), your best choice for
  * save type is FlashRAM. Unfortunately, it is significantly more complicated to write
  * data to FlashRAM. At this time, libdragon does not offer convenience functions to
  * abstract the complexities of the various FlashRAM chips that could be on the cartridge.
- *
- * If your ROM does not need to store more than 16 kilobits (2 kilobytes), you could use
- * EEPROM. In the age of emulators and flash carts, there is no real advantage to EEPROM
- * over SRAM. EEPROM is lower-capacity, slower to write, must be accessed in 8-byte blocks,
- * and should use parity bits or checksums to ensure consistency (on real hardware). The
- * strongest reason why you might consider using EEPROM is if you wanted to make your own
- * reproduction cartridge, since the boards often support EEPROM 4k/16k without needing
- * to scavenge "donor chips" from a real N64 cartridge.
+ * 
+ * The 768 kilobit SRAM configuration was only ever used by one cartridge (Dezaemon 3D),
+ * and is implemented as a logic chip that selects between three 256 kilobit SRAM banks.
+ * Many flash carts do have support for Dezaemon 3D, but 64drive does not display the
+ * 768K save type in the menu and some EverDrive64 OS versions label it as "96K SRAM".
+ * Emulator support for the 768 kilobit SRAM configuration is not widespread, and there
+ * are no reproduction cartridge boards that support it. libdragon does not recommend
+ * using the 768 kilobit SRAM save type if you want your ROM to be widely-compatible:
+ * Prefer the 1 megabit FlashRAM save type instead.
+ * 
+ * EverDrive64 offers a 1 megabit SRAM save type, which many emulators and flash carts
+ * have chosen not to support because it is not an authentic save type that was ever
+ * used by any retail cartridge. libdragon does not recommend using the 1 megabit SRAM
+ * save type if you want your ROM to be widely-compatible: Prefer FlashRAM instead.
+ * 
+ * Some flash carts and emulators may offer up to 1 megabit of SRAM storage using a
+ * contiguous address space up to 0x1FFFF. libdragon does not support or recommend
+ * taking advantage of this implementation detail: it is an emulation accuracy bug.
+ * If your ROM relies on inaccurate behavior, it may not behave as expected in many
+ * emulators or on real hardware. Please do not fragment the ecosystem or cause
+ * unnecessary headaches for emulator maintainers and your end-users.
  *
  * @{
  */
 
-#define CART_DOM1_ADDR2_START 0x10000000
-#define CART_DOM1_ADDR2_END   0x1FBFFFFF
-#define CART_DOM2_ADDR2_START 0x08000000
-#define CART_DOM2_ADDR2_END   0x0FFFFFFF
+#define CART_DOM1_ADDR2_START     0x10000000
+#define CART_DOM1_ADDR2_END       0x1FBFFFFF
+#define CART_DOM1_ADDR2_MASK      0x0FFFFFFF
+#define CART_DOM1_ADDR2_SIZE      0x0FC00000
 
-/** @brief ROM can be up to 64 megabytes */
-#define ROM_ADDRESS_MASK  0x03FFFFFF
-/** @brief SRAM/FlashRAM can be up to 128 kilobytes */
-#define RAM_ADDRESS_MASK  0x0001FFFF
-#define SRAM_256KBIT_MASK 0x00007FFF
+#define CART_DOM2_ADDR2_START     0x08000000
+#define CART_DOM2_ADDR2_END       0x0FFFFFFF
+#define CART_DOM2_ADDR2_MASK      0x07FFFFFF
+#define CART_DOM2_ADDR2_SIZE      0x08000000
 
-/** @brief This value has no significance, it's just for probing purposes */
-#define SRAM_TEST_VALUE  0xFEDCBA98
+#define CART_ROM_MASK             0x03FFFFFF
+#define CART_ROM_SIZE             0x04000000
+#define FLASHRAM_MASK             0x0001FFFF
+#define FLASHRAM_SIZE             0x00020000
+#define SRAM_256KBIT_MASK         0x00007FFF
+#define SRAM_256KBIT_SIZE         0x00008000
+#define SRAM_256KBIT_BANKS        1
+#define SRAM_768KBIT_BANKS        3
+#define SRAM_1MBIT_BANKS          4
 
 #define FLASHRAM_IDENTIFIER                0x11118001
 #define FLASHRAM_OFFSET_COMMAND            0x00010000
@@ -72,6 +97,9 @@
 #define FLASHRAM_COMMAND_SET_IDENTIFY_MODE 0xE1000000
 #define FLASHRAM_COMMAND_SET_READ_MODE     0xF0000000
 
+static uint8_t cart_detect_sram( void );
+static bool cart_sram_verify( uint8_t bank );
+
 /**
  * @brief Clamp length from a start address so that it does not go past an end address.
  *
@@ -79,8 +107,10 @@
  *
  * @param[in] len
  *            Length to clamp (in bytes).
+ * 
  * @param[in] start
  *            Starting address to add length to.
+ * 
  * @param[in] end
  *            Ending address that start+len cannot exceed.
  *
@@ -97,28 +127,29 @@ static uint32_t clamp(uint32_t len, uint32_t start, uint32_t end)
  *
  * This function checks for EEPROM, then FlashRAM, then SRAM.
  *
- * On real N64 hardware it is not possible for there to be more than one
- * save type available, although some emulators do not enfore this
- * limitation and may allow EEPROM to co-exist with SRAM or FlashRAM.
  * It is not possible for SRAM and FlashRAM to co-exist.
+ * 
+ * There were no N64 retail releases that included more than one save type,
+ * but it is possible for EEPROM and either SRAM or FlashRAM to be installed
+ * simultaneously.
+ * 
+ * Your code should check the bitfield for the desired save type instead of
+ * testing for equality with a single save type (except for SAVE_TYPE_NONE).
  *
- * @return the detected save type on the cartridge.
+ * @return a bitfield of save types detected on the cartridge.
  */
-cart_save_type_t cart_detect_save_type( void )
+uint8_t cart_detect_save_type( void )
 {
+    uint8_t detected = SAVE_TYPE_NONE;
+
     eeprom_type_t eeprom = eeprom_present();
-    if( eeprom == EEPROM_4K ) return SAVE_TYPE_EEPROM_4KBIT;
-    if( eeprom == EEPROM_16K ) return SAVE_TYPE_EEPROM_16KBIT;
+    if( eeprom == EEPROM_4K ) detected |= SAVE_TYPE_EEPROM_4KBIT;
+    if( eeprom == EEPROM_16K ) detected |= SAVE_TYPE_EEPROM_16KBIT;
 
-    flashram_type_t flashram = cart_detect_flashram();
-    if( flashram != FLASHRAM_TYPE_NONE ) return SAVE_TYPE_FLASHRAM_1MBIT;
+    if( cart_detect_flashram() ) detected |= SAVE_TYPE_FLASHRAM_1MBIT;
+    else detected |= cart_detect_sram();
 
-    if( cart_detect_sram_bank(3, 0x00007FFF) ) return SAVE_TYPE_SRAM_1MBIT_BANKED;
-    if( cart_detect_sram_bank(2, 0x00007FFF) ) return SAVE_TYPE_SRAM_768KBIT;
-    if( cart_detect_sram(0x0001FFFF) ) return SAVE_TYPE_SRAM_1MBIT_CONTIGUOUS;
-    if( cart_detect_sram(0x00007FFF) ) return SAVE_TYPE_SRAM_256KBIT;
-
-    return SAVE_TYPE_NONE;
+    return detected;
 }
 
 /**
@@ -137,7 +168,7 @@ flashram_type_t cart_detect_flashram( void )
     /* Read the identifiers */
     uint32_t __attribute__((aligned(16))) silicon_id[2];
     data_cache_hit_writeback_invalidate(silicon_id, sizeof(silicon_id));
-    cart_ram_read(silicon_id, 0, sizeof(silicon_id));
+    cart_dom2_addr2_read(silicon_id, 0, sizeof(silicon_id));
 
     /* Check for the magic "this is FlashRAM" value, followed by which chip it is. */
     if( silicon_id[0] == FLASHRAM_IDENTIFIER ) return silicon_id[1];
@@ -145,146 +176,53 @@ flashram_type_t cart_detect_flashram( void )
 }
 
 /**
- * @brief Determine whether SRAM on the cartridge is writable at a given offset.
- *
- * Unfortunately, the only way to check this is to actually perform a DMA write/read,
- * which is a destructive operation. This routine attempts to preserve the data before
- * clobbering it during the test, and writes back the original data if SRAM exists.
- *
- * @param[in] offset
- *            Offset of SRAM in bytes to check. SRAM potentially goes up to 1 megabit.
- *
- * @return whether the SRAM was able to read and write successfully at the offset.
- */
-bool cart_detect_sram(uint32_t offset)
-{
-    uint32_t __attribute__((aligned(16))) backup_buf;
-    uint32_t __attribute__((aligned(16))) detect_buf;
-
-    /* Offset is potentially the end of the writable space, so go back a few bytes */
-    uint32_t len = sizeof(backup_buf);
-    uint32_t start = offset - len;
-    if (start < 0 ) start = 0;
-
-    /* Read the current data before writing over it */
-    data_cache_hit_writeback_invalidate(&backup_buf, len);
-    cart_ram_read(&backup_buf, start, len);
-
-    /* Write a test value into SRAM... */
-    detect_buf = SRAM_TEST_VALUE;
-    data_cache_hit_writeback_invalidate(&detect_buf, len);
-    cart_ram_write(&detect_buf, start, len);
-
-    /* Read the test value back to see if it persisted */
-    detect_buf = 0;
-    data_cache_hit_writeback_invalidate(&detect_buf, len);
-    cart_ram_read(&detect_buf, start, len);
-
-    if( detect_buf == SRAM_TEST_VALUE )
-    {
-        /* Restore the data that was overwritten to test SRAM */
-        data_cache_hit_writeback_invalidate(&backup_buf, len);
-        cart_ram_write(&backup_buf, start, len);
-        return true;
-    }
-    else
-    {
-        /* There is no SRAM at this offset */
-        return false;
-    }
-}
-
-/**
- * @brief Determine whether the SRAM bank on the cartridge is writable at a given offset.
- *
- * 768Kbit SRAM is implemented as three separate 256Kbit SRAM chips with a logic circuit
- * to determine which chip to access.
- * 
- * Unfortunately, the only way to check this is to actually perform a DMA write/read,
- * which is a destructive operation. This routine attempts to preserve the data before
- * clobbering it during the test, and writing back the original data if successful.
- *
- * @param[in] bank
- *            Which 256Kbit SRAM banks to select (0-3)
- * @param[in] offset
- *            Offset of SRAM in bytes to check. An SRAM bank goes up to 256 kilobits.
- */
-bool cart_detect_sram_bank(uint8_t bank, uint32_t offset)
-{
-    uint32_t __attribute__((aligned(16))) backup_buf;
-    uint32_t __attribute__((aligned(16))) detect_buf;
-
-    /* Offset is potentially the end of the writable space, so go back a few bytes */
-    uint32_t len = sizeof(backup_buf);
-    uint32_t start = offset - len;
-    if (start < 0 ) start = 0;
-
-    /* Read the current data before writing over it */
-    data_cache_hit_writeback_invalidate(&backup_buf, len);
-    cart_sram_bank_read(&backup_buf, bank, start, len);
-
-    /* Write a test value into SRAM... */
-    detect_buf = SRAM_TEST_VALUE;
-    data_cache_hit_writeback_invalidate(&detect_buf, len);
-    cart_sram_bank_write(&detect_buf, bank, start, len);
-
-    /* Read the test value back to see if it persisted */
-    detect_buf = 0;
-    data_cache_hit_writeback_invalidate(&detect_buf, len);
-    cart_sram_bank_read(&detect_buf, bank, start, len);
-
-    if( detect_buf == SRAM_TEST_VALUE )
-    {
-        /* Restore the data that was overwritten to test SRAM */
-        data_cache_hit_writeback_invalidate(&backup_buf, len);
-        cart_sram_bank_write(&backup_buf, bank, start, len);
-        return true;
-    }
-    else
-    {
-        /* There is no SRAM at this bank/offset */
-        return false;
-    }
-}
-
-/**
  * @brief Read from Cartridge Domain 1 Address 2
  *
- * This function should be used when reading from the cartridge.
+ * This is a low-level function this is used by #cart_rom_read.
  *
  * @param[out] dest
  *             Pointer to a buffer to place read data
+ * 
  * @param[in]  offset
  *             Offset in bytes from the start of Cartridge Domain 1 Address 2 to read from
+ * 
  * @param[in]  len
  *             Length in bytes to read into dest
  */
-void cart_rom_read(void * dest, uint32_t offset, uint32_t len)
+void cart_dom1_addr2_read(void * dest, uint32_t offset, uint32_t len)
 {
-    assert(offset < 0x04000000);
+    assert(dest != NULL);
+    assert(offset < CART_DOM1_ADDR2_SIZE);
     assert(len > 1);
-    uint32_t pi_address = ((offset & ROM_ADDRESS_MASK) | CART_DOM1_ADDR2_START);
-    pi_dma_read(dest, pi_address, clamp(len, pi_address, CART_DOM1_ADDR2_END));
+
+    uint32_t cart_address = ((offset & CART_DOM1_ADDR2_MASK) | CART_DOM1_ADDR2_START);
+    len = clamp( len, cart_address, CART_DOM1_ADDR2_END );
+    pi_dma_read( dest, cart_address, len );
 }
 
 /**
  * @brief Write to Cartridge Domain 1 Address 2
  *
- * This function should be used when writing to the cartridge.
+ * This is a low-level function this is used by #cart_rom_write.
  *
  * @param[in] src
  *            Pointer to a buffer to read data from
+ * 
  * @param[in] offset
  *            Offset in bytes from the start of Cartridge Domain 1 Address 2 to write to
+ * 
  * @param[in] len
  *            Length in bytes to write from src
  */
-void cart_rom_write(const void * src, uint32_t offset, uint32_t len)
+void cart_dom1_addr2_write(const void * src, uint32_t offset, uint32_t len)
 {
-    assert(offset < 0x04000000);
+    assert(src != NULL);
+    assert(offset < CART_DOM1_ADDR2_SIZE);
     assert(len > 1);
-    uint32_t pi_address = ((offset & ROM_ADDRESS_MASK) | CART_DOM1_ADDR2_START);
-    pi_dma_write(src, pi_address, clamp(len, pi_address, CART_DOM1_ADDR2_END));
+
+    uint32_t cart_address = ((offset & CART_DOM1_ADDR2_MASK) | CART_DOM1_ADDR2_START);
+    len = clamp( len, cart_address, CART_DOM1_ADDR2_END );
+    pi_dma_write( src, cart_address, len );
 }
 
 /**
@@ -294,17 +232,22 @@ void cart_rom_write(const void * src, uint32_t offset, uint32_t len)
  *
  * @param[out] dest
  *             Pointer to a buffer to place read data
+ * 
  * @param[in]  offset
  *             Offset in bytes from the start of Cartridge Domain 1 Address 2 to read from
+ * 
  * @param[in]  len
  *             Length in bytes to read into dest
  */
-void cart_ram_read(void * dest, uint32_t offset, uint32_t len)
+void cart_dom2_addr2_read(void * dest, uint32_t offset, uint32_t len)
 {
-    assert(offset < 0x20000);
+    assert(dest != NULL);
+    assert(offset < CART_DOM2_ADDR2_SIZE);
     assert(len > 1);
-    uint32_t pi_address = ((offset & RAM_ADDRESS_MASK) | CART_DOM2_ADDR2_START);
-    pi_dma_read(dest, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+
+    uint32_t cart_address = ((offset & CART_DOM2_ADDR2_MASK) | CART_DOM2_ADDR2_START);
+    len = clamp( len, cart_address, CART_DOM2_ADDR2_END );
+    pi_dma_read( dest, cart_address, len );
 }
 
 /**
@@ -314,73 +257,261 @@ void cart_ram_read(void * dest, uint32_t offset, uint32_t len)
  *
  * @param[in] src
  *            Pointer to a buffer to read data from
+ * 
  * @param[in] offset
  *            Offset in bytes from the start of Cartridge Domain 2 Address 2 to write to
+ * 
  * @param[in] len
  *            Length in bytes to write from src
  */
-void cart_ram_write(const void * src, uint32_t offset, uint32_t len)
+void cart_dom2_addr2_write(const void * src, uint32_t offset, uint32_t len)
 {
-    assert(offset < 0x20000);
+    assert(src != NULL);
+    assert(offset < CART_DOM2_ADDR2_SIZE);
     assert(len > 1);
-    uint32_t pi_address = ((offset & RAM_ADDRESS_MASK) | CART_DOM2_ADDR2_START);
-    pi_dma_write(src, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+
+    uint32_t cart_address = ((offset & CART_DOM2_ADDR2_MASK) | CART_DOM2_ADDR2_START);
+    len = clamp( len, cart_address, CART_DOM2_ADDR2_END );
+    pi_dma_write( src, cart_address, len );
+}
+
+/**
+ * @brief Read from Cartridge ROM.
+ *
+ * @param[out] dest
+ *             Pointer to a buffer to place read data
+ * 
+ * @param[in]  offset
+ *             Offset in bytes from the start of Cartridge ROM to read from
+ * 
+ * @param[in]  len
+ *             Length in bytes to read into dest
+ */
+void cart_rom_read(void * dest, uint32_t offset, uint32_t len)
+{
+    assert(dest != NULL);
+    assert(offset < CART_ROM_SIZE);
+    assert(len > 1);
+    assert(offset + len <= CART_ROM_SIZE);
+
+    offset &= CART_ROM_MASK;
+    len = clamp( len, offset, CART_ROM_SIZE - 1 );
+    cart_dom1_addr2_read( dest, offset, len );
+}
+
+/**
+ * @brief Write to Cartridge ROM.
+ *
+ * @param[in] src
+ *            Pointer to a buffer to read data from
+ * 
+ * @param[in] offset
+ *            Offset in bytes from the start of Cartridge ROM to write to
+ * 
+ * @param[in] len
+ *            Length in bytes to write from src
+ */
+void cart_rom_write(const void * src, uint32_t offset, uint32_t len)
+{
+    assert(src != NULL);
+    assert(offset < CART_ROM_SIZE);
+    assert(len > 1);
+    assert(offset + len <= CART_ROM_SIZE);
+
+    offset &= CART_ROM_MASK;
+    len = clamp( len, offset, CART_ROM_SIZE - 1 );
+    cart_dom1_addr2_write( src, offset, len );
 }
 
 /**
  * @brief Read from an SRAM bank.
  *
- * 768Kbit SRAM is implemented as separate 256Kbit SRAM chips with a logic circuit
- * to determine which chip to access.
- *
  * @param[in] dest
  *            Pointer to a buffer to place read data
+ * 
  * @param[in] bank
  *            Which 256Kbit SRAM bank to select (0-3)
+ * 
  * @param[in] offset
  *            Offset in bytes from the start of the 256Kbit SRAM bank to write to
+ * 
  * @param[in] len
  *            Length in bytes to read into dest
  */
-void cart_sram_bank_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len)
+void cart_sram_read(void * dest, uint8_t bank, uint32_t offset, uint32_t len)
 {
-    assert(bank <= 3);
-    assert(offset < 0x8000);
+    assert(dest != NULL);
+    assert(bank < SRAM_1MBIT_BANKS);
+    assert(offset < SRAM_256KBIT_SIZE);
     assert(len > 1);
-    uint32_t pi_address = (
-        ((uint32_t)bank << 18) |
-        (offset & SRAM_256KBIT_MASK) |
-        CART_DOM2_ADDR2_START
-    );
-    pi_dma_read(dest, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+    assert(offset + len <= SRAM_256KBIT_SIZE);
+
+    offset &= SRAM_256KBIT_MASK;
+    len = clamp( len, offset, SRAM_256KBIT_SIZE - 1 );
+    uint32_t sram_address = ((uint32_t)bank << 18) | offset;
+    cart_dom2_addr2_read( dest, sram_address, len );
 }
 
 /**
  * @brief Write to an SRAM bank.
  *
- * 768Kbit SRAM is implemented as separate 256Kbit SRAM chips with a logic circuit
- * to determine which chip to access.
- *
  * @param[in] src
  *            Pointer to a buffer to read data from
+ * 
  * @param[in] bank
- *            Which SRAM bank to select (0-3)
+ *            Which 256Kbit SRAM bank to select (0-3)
+ * 
  * @param[in] offset
  *            Offset in bytes from the start of the 256Kbit SRAM bank to write to
+ * 
  * @param[in] len
  *            Length in bytes to write from src
  */
-void cart_sram_bank_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len)
+void cart_sram_write(const void * src, uint8_t bank, uint32_t offset, uint32_t len)
 {
-    assert(bank <= 3);
-    assert(offset < 0x8000);
+    assert(src != NULL);
+    assert(bank < SRAM_1MBIT_BANKS);
+    assert(offset < SRAM_256KBIT_SIZE);
     assert(len > 1);
-    uint32_t pi_address = (
-        ((uint32_t)bank << 18) |
-        (offset & SRAM_256KBIT_MASK) |
-        CART_DOM2_ADDR2_START
-    );
-    pi_dma_write(src, pi_address, clamp(len, pi_address, CART_DOM2_ADDR2_END));
+    assert(offset + len <= SRAM_256KBIT_SIZE);
+
+    offset &= SRAM_256KBIT_MASK;
+    len = clamp( len, offset, SRAM_256KBIT_SIZE - 1 );
+    uint32_t sram_address = ((uint32_t)bank << 18) | offset;
+    cart_dom2_addr2_write( src, sram_address, len );
+}
+
+/**
+ * @brief Probe the characteristics of the SRAM banks on the cartridge.
+ *
+ * 768Kbit SRAM is implemented as three separate 256Kbit SRAM chips with a logic circuit
+ * to determine which chip to access. 1Mbit SRAM can be implemented as a fourth SRAM chip
+ * in the same bank-selection arrangement.
+ * 
+ * Unfortunately, the only way to check this is to actually perform DMA writes/reads,
+ * which is a destructive operation. This routine attempts to preserve the data before
+ * clobbering it during the tests, and will restore the original data before returning.
+ * 
+ * @return a bitfield of SRAM save type configurations that were detected.
+ */
+uint8_t cart_detect_sram( void )
+{
+    uint8_t __attribute__((aligned(16))) backup[SRAM_256KBIT_SIZE][SRAM_1MBIT_BANKS];
+    uint8_t detected = SAVE_TYPE_NONE;
+    uint8_t restore_banks = 0;
+
+    /* Back up the SRAM data in the 1Mbit of bank-selected address spaces */
+    for( int i = 0; i < SRAM_1MBIT_BANKS; ++i )
+    {
+        data_cache_hit_writeback_invalidate( &backup[i], SRAM_256KBIT_SIZE );
+        cart_sram_read( &backup[i], i, 0, SRAM_256KBIT_SIZE );
+    }
+  
+    /* Check for the standard 256Kbit SRAM capacity */
+    if( cart_sram_verify( 0 ) )
+    {
+        detected |= SAVE_TYPE_SRAM_256KBIT;
+        restore_banks = SRAM_256KBIT_BANKS;
+        /* Check the bank-selected address spaces */
+        if( cart_sram_verify( 1 ) &&
+            cart_sram_verify( 2 ) )
+        {
+            detected |= SAVE_TYPE_SRAM_768KBIT_BANKED;
+            restore_banks = SRAM_768KBIT_BANKS;
+            if( cart_sram_verify( 3 ) )
+            {
+                detected |= SAVE_TYPE_SRAM_1MBIT_BANKED;
+                restore_banks = SRAM_1MBIT_BANKS;
+            }
+        }
+    }
+
+    /* Restore SRAM data to bank-selected address spaces */
+    if( restore_banks )
+    {
+        for( int i = 0; i < restore_banks; ++i )
+        {
+            data_cache_hit_writeback_invalidate( &backup[i], SRAM_256KBIT_SIZE );
+            cart_sram_write( &backup[i], i, 0, SRAM_256KBIT_SIZE );
+        }
+    }
+    
+    return detected;
+}
+
+/**
+ * @brief Verify that an SRAM bank is actually writable.
+ * 
+ * Some flash carts and emulators will wrap or mask SRAM addresses,
+ * so this routine has to check that the SRAM reads and writes data
+ * to the desired bank and does not also write to other SRAM banks.
+ * 
+ * This is a destructive operation across all SRAM banks, and this
+ * routine makes no effort to preserve any existing data! All data
+ * backup and restoration is handled by #cart_detect_sram.
+ * 
+ * @param[in]  bank
+ *             Which 256Kbit SRAM bank to select (0-3)
+ * 
+ * @return whether the SRAM bank exists and supports DMA writes. 
+ */
+bool cart_sram_verify( uint8_t bank )
+{
+    assert(bank < SRAM_1MBIT_BANKS);
+
+    uint8_t __attribute__((aligned(16))) write_buf[SRAM_256KBIT_SIZE];
+    uint8_t __attribute__((aligned(16))) read_buf[SRAM_256KBIT_SIZE];
+
+    /* Clear all previous SRAM banks to detect address wrapping */
+    memset( write_buf, 0, SRAM_256KBIT_SIZE );
+    for( int i = 0; i < bank; i++ )
+    {
+        /* No previous banks to erase if verifying the first one */
+        if( bank == 0 ) break;
+        /* Write all zeroes to the bank to read back later */
+        data_cache_hit_writeback_invalidate( write_buf, SRAM_256KBIT_SIZE );
+        cart_sram_write( write_buf, i, 0, SRAM_256KBIT_SIZE );
+    }
+
+    /* Generate test values based on the destination SRAM addresses */
+    uint32_t * write_words = (uint32_t *)write_buf;
+    for( int i = 0; i < SRAM_256KBIT_SIZE / sizeof(uint32_t); ++i )
+    {
+        write_words[i] = ((uint32_t)bank << 18) + i;
+    }
+
+    /* Write the test values into SRAM */
+    data_cache_hit_writeback_invalidate( write_buf, SRAM_256KBIT_SIZE );
+    cart_sram_write( write_buf, bank, 0, SRAM_256KBIT_SIZE );
+
+    /* Read the test values back to see if they persisted */
+    data_cache_hit_writeback_invalidate( read_buf, SRAM_256KBIT_SIZE );
+    cart_sram_read( read_buf, bank, 0, SRAM_256KBIT_SIZE );
+
+    /* Compare what was written to what was read back from SRAM */
+    if( memcmp( write_buf, read_buf, SRAM_256KBIT_SIZE ) != 0 )
+    {
+        /* There was a mismatch between what was written and read */
+        return false;
+    }
+
+    /* Check that no previous banks were modified by changing this one */
+    memset( write_buf, 0, SRAM_256KBIT_SIZE );
+    for( int i = 0; i < bank; i++ )
+    {
+        /* No previous banks to check if verifying the first one */
+        if( bank == 0 ) break;
+        /* Read back the bank to see if it's still all zeroes */
+        data_cache_hit_writeback_invalidate( read_buf, SRAM_256KBIT_SIZE );
+        cart_sram_read( read_buf, i, 0, SRAM_256KBIT_SIZE );
+        if( memcmp( write_buf, read_buf, SRAM_256KBIT_SIZE ) != 0 )
+        {
+            /* The write test appears to have wrapped into another bank */
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /** @} */ /* cart */

--- a/src/debug.c
+++ b/src/debug.c
@@ -227,7 +227,7 @@ static DRESULT fat_disk_read_64drive(BYTE* buff, LBA_t sector, UINT count)
 		if (((uint32_t)buff & 7) == 0) 
 		{
 			data_cache_hit_writeback_invalidate(buff, 512);
-			dma_read(buff, D64_CIBASE_ADDRESS + D64_BUFFER, 512);
+			cart_rom_read(buff, D64_CIBASE_ADDRESS + D64_BUFFER, 512);
 		}
 		else
 		{
@@ -256,7 +256,7 @@ static DRESULT fat_disk_write_64drive(const BYTE* buff, LBA_t sector, UINT count
 		if (((uint32_t)buff & 7) == 0) 
 		{
 			data_cache_hit_writeback(buff, 512);
-			dma_write(buff, D64_CIBASE_ADDRESS + D64_BUFFER, 512);
+			cart_rom_write(buff, D64_CIBASE_ADDRESS + D64_BUFFER, 512);
 		}
 		else
 		{

--- a/src/dma.c
+++ b/src/dma.c
@@ -67,7 +67,7 @@ volatile int dma_busy()
  * @param[in]  len
  *             Length in bytes to read into dest
  */
-void dma_read(void * dest, uint32_t address, uint32_t len)
+__attribute__((deprecated)) void dma_read(void * dest, uint32_t address, uint32_t len)
 {
     return cart_rom_read(dest, address, len);
 }
@@ -84,7 +84,7 @@ void dma_read(void * dest, uint32_t address, uint32_t len)
  * @param[in] len
  *            Length in bytes to write to peripheral
  */
-void dma_write(const void * src, uint32_t address, uint32_t len)
+__attribute__((deprecated)) void dma_write(const void * src, uint32_t address, uint32_t len)
 {
     return cart_rom_write(src, address, len);
 }

--- a/src/dma.c
+++ b/src/dma.c
@@ -23,10 +23,10 @@
  * cartridge peripherals such as the ROM, SRAM, or FlashRAM. Refer to the
  * @ref cart "Cartridge interface" for DMA functions in these specific domains.
  *
- * #io_read and #io_write allow a single 32-bit integer from uncached memory
- * to be safely read or written. This are especially useful for manipulating
- * registers on a cartridge such as a GameShark. Your code should always use
- * these functions to access the cartridge domains to prevent caching issues
+ * #io_read and #io_write allow safely reading and writing a word from
+ * uncached memory. These are especially useful for manipulating registers
+ * on a cartridge such as a GameShark. Your code should always use these
+ * functions to access the cartridge domains to prevent caching issues
  * and collisions that can occur with an in-progress DMA transfer.
  *
  * @{
@@ -165,7 +165,7 @@ void pi_dma_write(const void * src, uint32_t pi_address, uint32_t len)
 }
 
 /**
- * @brief Read a word from uncached memory.
+ * @brief Read a word from uncached memory safely.
  *
  * Waits for any active DMA transfers to finish.
  *
@@ -192,7 +192,7 @@ uint32_t io_read(uint32_t address)
 }
 
 /**
- * @brief Write a word to uncached memory.
+ * @brief Write a word to uncached memory safely.
  *
  * Waits for any active DMA transfers to finish.
  *

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -94,7 +94,7 @@ static inline void grab_sector(void *cart_loc, void *ram_loc)
     /* Make sure we have fresh cache */
     data_cache_hit_writeback_invalidate(ram_loc, SECTOR_SIZE);
 
-    dma_read((void *)(((uint32_t)ram_loc) & 0x1FFFFFFF), (uint32_t)cart_loc, SECTOR_SIZE);
+    cart_rom_read((void *)(((uint32_t)ram_loc) & 0x1FFFFFFF), (uint32_t)cart_loc, SECTOR_SIZE);
 }
 
 /**
@@ -980,7 +980,7 @@ int dfs_read(void * const buf, int size, int count, uint32_t handle)
         else
             data_cache_hit_writeback_invalidate(buf, to_read);
 
-        dma_read((void *)(((uint32_t)buf) & 0x1FFFFFFF),
+        cart_rom_read((void *)(((uint32_t)buf) & 0x1FFFFFFF),
             file->cart_start_loc + file->loc, to_read);
 
         file->loc += to_read;
@@ -1005,7 +1005,7 @@ int dfs_read(void * const buf, int size, int count, uint32_t handle)
                so the cachelines are not shared with other variables. */
             data_cache_hit_invalidate(file->cached_data, CACHED_SIZE);
 
-            dma_read((void *)(((uint32_t)file->cached_data) & 0x1FFFFFFF),
+            cart_rom_read((void *)(((uint32_t)file->cached_data) & 0x1FFFFFFF),
                 file->cart_start_loc + file->cached_loc, CACHED_SIZE);
         }
 
@@ -1054,7 +1054,7 @@ int dfs_size(uint32_t handle)
  * performance-wise, and is easier to use rather than managing
  * direct access to PI space.
  * 
- * Direct access to ROM data must go through io_read or dma_read. Do not
+ * Direct access to ROM data must go through io_read or cart_rom_read. Do not
  * dereference directly as the console might hang if the PI is busy.
  *
  * @param[in] filename

--- a/src/usb.c
+++ b/src/usb.c
@@ -763,7 +763,7 @@ static void usb_64drive_write(int datatype, const void* data, int size)
         // Set up DMA transfer between RDRAM and the PI
         #ifdef LIBDRAGON
             data_cache_hit_writeback(usb_buffer, block);
-            dma_write(usb_buffer, D64_BASE_ADDRESS + DEBUG_ADDRESS + read, block);
+            cart_rom_write(usb_buffer, D64_BASE_ADDRESS + DEBUG_ADDRESS + read, block);
         #else
             osWritebackDCache(usb_buffer, block);
             #if USE_OSRAW
@@ -927,7 +927,7 @@ static void usb_64drive_read()
     // Set up DMA transfer between RDRAM and the PI
     #ifdef LIBDRAGON
         data_cache_hit_writeback_invalidate(usb_buffer, BUFFER_SIZE);
-        dma_read(usb_buffer, D64_BASE_ADDRESS + DEBUG_ADDRESS + usb_readblock, BUFFER_SIZE);
+        cart_rom_read(usb_buffer, D64_BASE_ADDRESS + DEBUG_ADDRESS + usb_readblock, BUFFER_SIZE);
     #else
         osWritebackDCacheAll();
         #if USE_OSRAW
@@ -1309,7 +1309,7 @@ static void usb_everdrive_read()
         data_cache_hit_writeback_invalidate(usb_buffer, BUFFER_SIZE);
         while (dma_busy());
         *(vu32*)0xA4600010 = 3;
-        dma_read(usb_buffer, ED_BASE + DEBUG_ADDRESS + usb_readblock, BUFFER_SIZE);
+        cart_rom_read(usb_buffer, ED_BASE + DEBUG_ADDRESS + usb_readblock, BUFFER_SIZE);
         data_cache_hit_writeback_invalidate(usb_buffer, BUFFER_SIZE);
     #else
         osWritebackDCacheAll();
@@ -1523,7 +1523,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
         // Write data to buffer in SDRAM
         #ifdef LIBDRAGON
             data_cache_hit_writeback(usb_buffer, dma_length);
-            dma_write(usb_buffer, sdram_address, dma_length);
+            cart_rom_write(usb_buffer, sdram_address, dma_length);
         #else
             osWritebackDCache(usb_buffer, dma_length);
             #if USE_OSRAW
@@ -1654,8 +1654,8 @@ static u32 usb_sc64_poll(void)
 
             // Load data from FIFO to buffer in RDRAM
             #ifdef LIBDRAGON
-                dma_read(usb_buffer, SC64_MEM_USB_FIFO_BASE, dma_length);
-                dma_write(usb_buffer, sdram_address, dma_length);
+                cart_rom_read(usb_buffer, SC64_MEM_USB_FIFO_BASE, dma_length);
+                cart_rom_write(usb_buffer, sdram_address, dma_length);
             #else
                 #if USE_OSRAW
                     osPiRawStartDma(OS_READ, SC64_MEM_USB_FIFO_BASE, usb_buffer, dma_length);
@@ -1702,7 +1702,7 @@ static void usb_sc64_read(void)
 
     // Set up DMA transfer between RDRAM and the PI
     #ifdef LIBDRAGON
-        dma_read(usb_buffer, sdram_address, BUFFER_SIZE);
+        cart_rom_read(usb_buffer, sdram_address, BUFFER_SIZE);
         data_cache_hit_invalidate(usb_buffer, BUFFER_SIZE);
     #else
         #if USE_OSRAW

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -17,8 +17,8 @@ void test_cache_invalidate(TestContext *ctx) {
 			data_cache_hit_writeback_invalidate(buf+i, j);
 			
 			// Read from ROM (header of DFS)
-			dma_read(UncachedAddr(buf), DFS_DEFAULT_LOCATION, 32);
-			dma_read(UncachedAddr(buf+32), DFS_DEFAULT_LOCATION, 32);
+			cart_rom_read(UncachedAddr(buf), DFS_DEFAULT_LOCATION, 32);
+			cart_rom_read(UncachedAddr(buf+32), DFS_DEFAULT_LOCATION, 32);
 
 			// For each cache-line, check whether the contents
 			// match what we would expect from it:

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -83,7 +83,7 @@ void test_dfs_rom_addr(TestContext *ctx) {
 	ASSERT_EQUAL_HEX(io_read(rom), *(uint32_t*)buf1, "direct ROM address is different");
 	ASSERT_EQUAL_HEX(io_read(rom+8), *(uint32_t*)(buf1+8), "direct ROM address is different");
 
-	dma_read(buf2, rom, 128);
+	cart_rom_read(buf2, rom, 128);
 	data_cache_hit_invalidate(buf2, sizeof(buf2));
 
 	ASSERT_EQUAL_MEM(buf1, buf2, 128, "DMA ROM access is different");


### PR DESCRIPTION
* Refactor DMA functions to support SRAM/FlashRAM
  * Note that `dma_read`/`dma_write` have been deprecated and are now aliases to `cart_rom_read`/`cart_rom_write`. This was done so that existing code that depends on DMA transfers would not break.
  * There is now a lower-level `pi_dma_read`/`pi_dma_write` which abstracts the DMA transfer procedure without assuming an address domain.
* Expand ctest to include save type detection
* This branch does not support reading or writing FlashRAM, only detecting and identifying the chip.
  * Additional research is required to handle writes correctly, as there are various differences between the FlashRAM chips.
  * I do not have complete information on the different FlashRAM chips out there, specifically the identifiers for the two different chips labelled `29L1100KC-15B0`. This is a best-effort based on the source code for various emulators, forum posts, Discord conversations, and the firmware for the Sanni Cart Reader. 

Test ROM: [ctest.zip](https://github.com/DragonMinded/libdragon/files/6909987/ctest.zip)

**Note that this test ROM will crash cen64 with a segmentation fault.** See https://github.com/n64dev/cen64/pull/204 for a fix.