### PR TITLE
n64tool: misc improvements

### DIFF
--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -320,7 +320,7 @@ int main(int argc, char *argv[])
 
 			if(output_zeros(write_file, num_zeros))
 			{
-				fprintf(stderr, "ERROR: Invalid offset %d to seek to in %s!\n", offset, output);
+				fprintf(stderr, "ERROR: Invalid offset %zd to seek to in %s!\n", offset, output);
 				return STATUS_ERROR;
 			}
 
@@ -407,7 +407,7 @@ int main(int argc, char *argv[])
 	/* If the declared size is too small, error out */
 	if(declared_size && declared_size < total_bytes_written)
 	{
-		fprintf(stderr, "ERROR: Couldn't fit ROM in %d bytes as requested.\n", declared_size);
+		fprintf(stderr, "ERROR: Couldn't fit ROM in %zu bytes as requested.\n", declared_size);
 		return print_usage(argv[0]);
 	}
 
@@ -420,7 +420,7 @@ int main(int argc, char *argv[])
 
 		if(output_zeros(write_file, num_zeros))
 		{
-			fprintf(stderr, "ERROR: Couldn't pad %d bytes to %d bytes.\n", total_bytes_written, declared_size);
+			fprintf(stderr, "ERROR: Couldn't pad %zu bytes to %zu bytes.\n", total_bytes_written, declared_size);
 			return print_usage(argv[0]);
 		}
 	}

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -165,10 +165,8 @@ ssize_t parse_bytes(const char * arg)
 			size *= 1024;
 		case 'b':
 		case 'B':
-			return size;
 		default:
-			/* Invalid! */
-			return 0;
+			return size;
 	}
 }
 

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -264,7 +264,13 @@ int main(int argc, char *argv[])
 				fprintf(stderr, "ERROR: Invalid size argument; must be at least %d bytes\n\n", MIN_SIZE);
 				return print_usage(argv[0]);
 			}
-
+			if (size % 4 != 0)
+			{
+				/* Invalid size */
+				fprintf(stderr, "ERROR: Invalid size argument; must be a multiple of 4 bytes\n\n");
+				return print_usage(argv[0]);				
+			}
+ 
 			declared_size = size;
 			continue;
 		}


### PR DESCRIPTION
3 improvements in 3 different commits (cc @meeq):

* n64tool: make the -l option optional
Currently, -l is mandatory and contrary to before, n64tool errors out
correctly if the specified size is less then necessary. This means
that now clients are forced to specify a valid size even if they
don't really care about it (like most of the time when developing on
an emulator).
This is a nuisance that is better solved by making the size optional,
and let n64tool build a file as big as necessary, which is what most
users would expect by default.

* n64tool: declared size must be a multiple of 4.
This is required by IPL3 (used in the standard header)

* n64tool: generate a temporary file while working
If n64tool aborts at any point, it can currently leave a partial output
file on the disk. This might confuse users that don't read error messages,
and also breaks standard build system like GNU make that will believe
that the output file has been already generated.
Fix this by going through a temporary file, which is renamed to the
final name in case of success.
