### PR TITLE
PI dma: add support for misaligned transfers using undocumented hw features

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -11,14 +11,21 @@ extern "C" {
 #endif
 
 void dma_write(const void * ram_address, unsigned long pi_address, unsigned long len);
+void dma_read_raw_async(void *ram_address, unsigned long pi_address, unsigned long len);
+void dma_read_async(void *ram_address, unsigned long pi_address, unsigned long len);
 void dma_read(void * ram_address, unsigned long pi_address, unsigned long len);
-volatile int dma_busy();
+
+void dma_wait(void);
 
 /* 32 bit IO read from PI device */
 uint32_t io_read(uint32_t pi_address);
 
 /* 32 bit IO write to PI device */
 void io_write(uint32_t pi_address, uint32_t data);
+
+__attribute__((deprecated("use dma_wait instead"))) 
+volatile int dma_busy(void);
+
 
 #ifdef __cplusplus
 }

--- a/src/dma.c
+++ b/src/dma.c
@@ -47,30 +47,43 @@ static volatile struct PI_regs_s * const PI_regs = (struct PI_regs_s *)0xa460000
  *
  * @return nonzero if the DMA controller is busy or 0 otherwise
  */
-volatile int dma_busy() 
+volatile int __dma_busy(void)
 {
     return PI_regs->status & (PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY);
 }
 
+volatile int dma_busy(void)
+{
+    return __dma_busy();
+}
+
 /**
- * @brief Read from a peripheral
+ * @brief Start reading data from a peripheral through PI DMA (low-level)
  *
- * This function should be used when reading from the cartridge.
+ * This function should be used when reading from a cartridge peripheral (typically
+ * ROM). This function just begins executing a raw DMA transfer, which is
+ * well-defined only for RAM addresses which are multiple of 8, ROM addresses
+ * which are  multiple of 2, and lengths which are multiple of 2.
+ * 
+ * Use #dma_wait to wait for the end of the transfer.
+ * 
+ * See #dma_read_async for a higher level primitive which can perform almost
+ * arbitrary transfers.
  *
  * @param[out] ram_address
- *             Pointer to a buffer to place read data
+ *             Pointer to a buffer to place read data (must be 8-byte aligned)
  * @param[in]  pi_address
- *             Memory address of the peripheral to read from
+ *             Memory address of the peripheral to read from (must be 2-byte aligned)
  * @param[in]  len
- *             Length in bytes to read into ram_address
+ *             Length in bytes to read into ram_address (must be multiple of 2)
  */
-void dma_read(void * ram_address, unsigned long pi_address, unsigned long len) 
+void dma_read_raw_async(void * ram_address, unsigned long pi_address, unsigned long len) 
 {
     assert(len > 0);
 
     disable_interrupts();
 
-    while (dma_busy()) ;
+    while (__dma_busy()) ;
     MEMORY_BARRIER();
     PI_regs->ram_address = ram_address;
     MEMORY_BARRIER();
@@ -78,9 +91,184 @@ void dma_read(void * ram_address, unsigned long pi_address, unsigned long len)
     MEMORY_BARRIER();
     PI_regs->write_length = len-1;
     MEMORY_BARRIER();
-    while (dma_busy()) ;
 
     enable_interrupts();
+}
+
+/** @brief Low-level 32-bit aligned ROM read.
+ * 
+ * @note This function must be called with interrupts disabled.
+ */
+static uint32_t __io_read32(unsigned long pi_address) {
+    while (__dma_busy()) {}
+    MEMORY_BARRIER();
+    return *(volatile uint32_t*)pi_address;
+}
+
+/** @brief Low-level 32-bit unaligned PI ROM read.
+ * 
+ * @note This function must be called with interrupts disabled.
+ */
+static uint32_t __io_read32u(unsigned long pi_address) {
+    uint32_t val = 0;
+
+    // We need to manually issue assembly opcodes here because we must
+    // wait for #dma_busy inbetween. So we can't simply tell GCC to 
+    // generate the LWL/LWR pair via __attribute__((aligned(1)), otherwise
+    // we would only be able to wait once before both of them.
+    while (__dma_busy()) {}
+    MEMORY_BARRIER();
+    __asm volatile("lwl %0,0(%1)" : "+r"(val) : "r"(pi_address));    
+
+    while (__dma_busy()) {}
+    MEMORY_BARRIER();
+    __asm volatile("lwr %0,3(%1)" : "+r"(val) : "r"(pi_address));
+
+    return val;
+}
+
+/** @brief Low-level 16-bit aligned PI ROM read.
+ * 
+ * 16-bit PI ROM reads are undocumented. Testing on real hardware shows
+ * that they only work for 32-bit aligned addresses, so this function
+ * falls back to a full 32bit read for misaligned addresses.
+ * 
+ * @note This function must be called with interrupts disabled.
+ */
+static uint16_t __io_read16(unsigned long pi_address) {
+    if (pi_address & 2) {
+        return (uint16_t)__io_read32(pi_address^2);
+    } else {
+        while (__dma_busy()) {}
+        MEMORY_BARRIER();
+        return *(volatile uint16_t*)pi_address;
+    }
+}
+
+
+/** @brief Low-level 8-bit PI ROM read.
+ * 
+ * 8-bit PI ROM reads are undocumented. Testing on real hardware shows
+ * that they do not consistently work, so this function falls back to using
+ * 16-bit reads and extracting the requested byte.
+ * 
+ * @note This function must be called with interrupts disabled.
+ */
+static uint8_t __io_read8(unsigned long pi_address) {
+    if (pi_address&1)
+        return (uint8_t)__io_read16(pi_address^1);
+    else
+        return __io_read16(pi_address)>>8;
+}
+
+/**
+ * @brief Start reading data from a peripheral through PI DMA
+ *
+ * This function must be used when reading a chunk of data from a cartridge 
+ * peripheral (typically, ROM). It is a wrapper over #dma_read_raw_async that allows
+ * arbitrary aligned addresses and any length (including odd sizes). For
+ * fully-aligned addresses it quickly falls back to #dma_read_raw_async, so it can
+ * be used generically as "default" PI DMA transfer function.
+ * 
+ * The only constraint on alignment is that the RAM and PI addresses must have
+ * the same 1-bit misalignment, that is they must either be even addresses or
+ * odd addresses. Notice that this function will assert if this constraint is
+ * not respected.
+ * 
+ * Use #dma_wait to wait for the end of the transfer.
+ *
+ * For non performance sensitive tasks such as reading and parsing data from
+ * ROM at loading time, a better option is to use DragonFS, where #dfs_read
+ * falls back to a CPU memory copy to realign the data when required.
+ * 
+ * @param[out] ram_address
+ *             Pointer to a buffer to place read data
+ * @param[in]  pi_address
+ *             Memory address of the peripheral to read from
+ * @param[in]  len
+ *             Length in bytes to read into ram_address
+ */
+void dma_read_async(void *ram_address, unsigned long pi_address, unsigned long len)
+{
+    unsigned long ram = (unsigned long)UncachedAddr(ram_address);
+    unsigned long rom = pi_address;
+
+    assert(len > 0);
+    assert(((ram ^ rom) & 1) == 0); 
+
+    disable_interrupts();
+    union { uint64_t mem64; uint32_t mem32[2]; uint16_t mem16[4]; uint8_t mem8[8]; } val;
+
+    // Check if the RDRAM address is misaligned. If so, this requires some
+    // handling as it's officially "not supported".
+    int misalign = ram & 7;
+
+    if (misalign) {
+        if ((misalign&1) == 0 && len < 0x7F-misalign*2) {
+            // Fast-path: RDRAM even-misaligned addresses work correctly
+            // for small transfers (up to some magic value), though they transfer
+            // less then requested. Tweak the length accordingly and do the transfer.
+            len += misalign;
+        } else {        
+            // Manually transfer the first bytes, up to creating a 8-byte
+            // alignment. The code is complicated by the fact that we can
+            // only use uncached addresses here (to mimic DMA), which means
+            // that we can only do 32-bit RDRAM accesses, and PI accesses
+            // which have weird bugs.
+            uint64_t *ram0 = (uint64_t*)(ram - misalign);
+            ram += 8-misalign;
+
+            // Fetch the initial (aligned) 8-byte word, then loop to transfer
+            // the required bytes. Only some bytes of the word will be modified.
+            val.mem64 = *ram0;
+
+            do {
+                // If we're at an odd address (or this is the last byte), read
+                // 8-bit from PI into RDRAM, so that we immediately align
+                // to do 2-bytes, and we can do 16-bit reads/writes later.
+                if ((misalign & 1) || len == 1) {
+                    val.mem8[misalign] = __io_read8(rom);
+                    misalign += 1; rom += 1; len -= 1;
+                } else {
+                    val.mem16[misalign/2] = __io_read16(rom);
+                    misalign += 2; rom += 2; len -= 2;
+                }
+            } while (misalign < 8 && len > 0);
+
+            // Store back the modified 8-byte word.
+            *ram0 = val.mem64;
+        }
+    }
+
+    // Now the transfer is 8-byte aligned. Check the length: we can do odd-length
+    // transfer (at aligned addresses) up to 0x7E bytes. For larger odd transfers,
+    // we need to write the last odd byte ourselves, and we do that with a 32-bit
+    // unaligned transfer (LWL/LWR + SWL/SWR).
+    if ((len & 1) != 0 && len >= 0x7F) {
+        typedef uint32_t u_uint32_t __attribute__((aligned(1)));
+        *(u_uint32_t*)(ram+len-4) = __io_read32u(rom+len-4);
+        len -= 3;
+    }
+
+    // Start the actual DMA transfer, if still needed.
+    if (len)
+        dma_read_raw_async((void*)ram, (unsigned long)rom, len);
+
+    enable_interrupts();
+}
+
+/** @brief Wait until an async DMA transfer is finished. */
+void dma_wait(void)
+{
+    while (__dma_busy()) {}
+}
+
+
+/** @brief Read data from a peripheral through PI DMA, waiting for completion. */
+void dma_read(void *ram_address, unsigned long pi_address, unsigned long len)
+{
+    dma_read_async(ram_address, pi_address, len);
+    dma_wait();
 }
 
 /**
@@ -101,7 +289,7 @@ void dma_write(const void * ram_address, unsigned long pi_address, unsigned long
 
     disable_interrupts();
 
-    while (dma_busy()) ;
+    while (__dma_busy()) ;
     MEMORY_BARRIER();
     PI_regs->ram_address = (void*)ram_address;
     MEMORY_BARRIER();
@@ -109,7 +297,7 @@ void dma_write(const void * ram_address, unsigned long pi_address, unsigned long
     MEMORY_BARRIER();
     PI_regs->read_length = len-1;
     MEMORY_BARRIER();
-    while (dma_busy()) ;
+    while (__dma_busy()) ;
 
     enable_interrupts();
 }
@@ -124,17 +312,10 @@ void dma_write(const void * ram_address, unsigned long pi_address, unsigned long
  */
 uint32_t io_read(uint32_t pi_address)
 {
-    volatile uint32_t *uncached_address = (uint32_t *)(pi_address | 0xa0000000);
-    uint32_t retval = 0;
+    uint32_t retval;
 
     disable_interrupts();
-
-    /* Wait until there isn't a DMA transfer and grab a word */
-    while (dma_busy()) ;
-    MEMORY_BARRIER();
-    retval = *uncached_address;
-    MEMORY_BARRIER();
-
+    retval = __io_read32(pi_address | 0xA0000000);
     enable_interrupts();
 
     return retval;
@@ -154,7 +335,7 @@ void io_write(uint32_t pi_address, uint32_t data)
 
     disable_interrupts();
 
-    while (dma_busy()) ;
+    while (__dma_busy()) ;
     MEMORY_BARRIER();
     *uncached_address = data;
     MEMORY_BARRIER();

--- a/src/usb.c
+++ b/src/usb.c
@@ -1282,7 +1282,7 @@ static void usb_everdrive_read()
     // Set up DMA transfer between RDRAM and the PI
     #ifdef LIBDRAGON
         data_cache_hit_writeback_invalidate(usb_buffer, BUFFER_SIZE);
-        while (dma_busy());
+        dma_wait();
         *(vu32*)0xA4600010 = 3;
         dma_read(usb_buffer, ED_BASE + DEBUG_ADDRESS + usb_readblock, BUFFER_SIZE);
         data_cache_hit_writeback_invalidate(usb_buffer, BUFFER_SIZE);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,55 +1,26 @@
-PROG_NAME = testrom
+BUILD_DIR=build/
+include n64.mk
 
-ROOTDIR = $(N64_INST)
-GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
+all: testrom.z64 testrom_emu.z64
 
-CC = $(GCCN64PREFIX)gcc
-AS = $(GCCN64PREFIX)as
-LD = $(GCCN64PREFIX)ld
-OBJCOPY = $(GCCN64PREFIX)objcopy
-N64TOOL = $(ROOTDIR)/bin/n64tool
-CHKSUM64 = $(ROOTDIR)/bin/chksum64
-MKDFS = $(ROOTDIR)/bin/mkdfs
+$(BUILD_DIR)/testrom.dfs: $(wildcard filesystem/*)
 
-ASFLAGS = -mtune=vr4300 -march=vr4300
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include -I$(ROOTDIR)/include
-LDFLAGS = -L$(ROOTDIR)/mips64-elf/lib -L$(ROOTDIR)/lib -ldragon -lmikmod -lc -lm -ldragonsys -Tn64.ld  --gc-sections
-N64TOOLFLAGS = -l 2M -h $(ROOTDIR)/mips64-elf/lib/header -t "libdragon tests"
+$(BUILD_DIR)/testrom.elf: ${BUILD_DIR}/testrom.o
+testrom.z64: N64_ROM_TITLE="Libdragon Test ROM"
+testrom.z64: $(BUILD_DIR)/testrom.dfs
 
-ifeq ($(N64_BYTE_SWAP),true)
-$(PROG_NAME).v64: $(PROG_NAME).z64
-	dd conv=swab if=$^ of=$@
-endif
+$(BUILD_DIR)/testrom_emu.elf: ${BUILD_DIR}/testrom_emu.o
+testrom_emu.z64: N64_ROM_TITLE="Libdragon Test ROM"
+testrom_emu.z64: $(BUILD_DIR)/testrom.dfs
 
-CFLAGS+=-MMD    # automatic .d dependency generation
-
-all: $(PROG_NAME).z64 $(PROG_NAME)_emu.z64
-
-$(PROG_NAME).z64: $(PROG_NAME).bin $(PROG_NAME).dfs
-	$(N64TOOL) $(N64TOOLFLAGS) -o $@ $(PROG_NAME).bin -s 1M $(PROG_NAME).dfs
-	$(CHKSUM64) $@
-$(PROG_NAME)_emu.z64: $(PROG_NAME)_emu.bin $(PROG_NAME).dfs
-	$(N64TOOL) $(N64TOOLFLAGS) -o $@ $(PROG_NAME)_emu.bin -s 1M $(PROG_NAME).dfs
-	$(CHKSUM64) $@
-
-$(PROG_NAME).bin: $(PROG_NAME).elf
-	$(OBJCOPY) $< $@ -O binary
-$(PROG_NAME)_emu.bin: $(PROG_NAME)_emu.elf
-	$(OBJCOPY) $< $@ -O binary
-
-$(PROG_NAME).elf: $(PROG_NAME).o
-	$(LD) -o $@ $^ $(LDFLAGS)
-$(PROG_NAME)_emu.elf: $(PROG_NAME)_emu.o
-	$(LD) -o $@ $^ $(LDFLAGS)
-
-$(PROG_NAME)_emu.o: $(PROG_NAME).c
-	$(CC) $(CFLAGS) -DIN_EMULATOR=1 -c -o $@ $<
-
-$(PROG_NAME).dfs:
-	$(MKDFS) $@ ./filesystem/
+${BUILD_DIR}/testrom_emu.o: testrom.c
+	@mkdir -p $(dir $@)
+	@echo "    [CC] $<"
+	$(CC) -c $(CFLAGS) -DIN_EMULATOR=1 -o $@ $<
 
 clean:
-	rm -f *.v64 *.z64 *.elf *.o *.bin *.dfs *.d
+	rm -rf $(BUILD_DIR) testrom.z64 testrom_emu.z64
 
--include $(PROG_NAME).d $(PROG_NAME)_emu.d
+-include $(wildcard $(BUILD_DIR)/*.d)
 
+.PHONY: all clean

--- a/tests/test_dma.c
+++ b/tests/test_dma.c
@@ -1,0 +1,27 @@
+
+void test_dma_read_misalign(TestContext *ctx) {
+	uint32_t rom = dfs_rom_addr("counter.dat");
+	uint8_t rom_copy[512] __attribute__((aligned(8)));
+	uint8_t ram[512] __attribute__((aligned(8)));
+
+	data_cache_hit_writeback_invalidate(rom_copy, sizeof(rom_copy));
+	dma_read(rom_copy, rom, 512);
+
+	static const uint8_t expAA[16] = { 0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA, };
+
+	void run(int ram_offset, int rom_offset, int length) {
+		memset(ram, 0xAA, sizeof(ram));
+		data_cache_hit_writeback_invalidate(ram, sizeof(ram));
+		dma_read(ram+ram_offset, rom+rom_offset, length);
+
+		ASSERT_EQUAL_MEM(ram+ram_offset-16, expAA, 16, "invalid prefix [%d/%d/%d]", ram_offset&7, rom_offset, length);
+		ASSERT_EQUAL_MEM(ram+ram_offset, rom_copy+rom_offset, length, "invalid data [%d/%d/%d]", ram_offset&7, rom_offset, length);
+		ASSERT_EQUAL_MEM(ram+ram_offset+length, expAA, 16, "invalid suffix [%d/%d/%d]", ram_offset&7, rom_offset, length);
+	}
+
+	for (int i=56; i<64; i++) {
+		for (int j=1;j<256;j++) {
+			run(i, i&1, j);
+		}
+	}
+}


### PR DESCRIPTION
Nominally, PI DMA is able only to transfer an even number of bytes
from/to 8-byte aligned addresses. In reality, there's a half-baked
hardware implementation to transfer any number of bytes between 2-byte
aligned addresses that unfortunately does not fully work.

This commit modifies dma_read so that it handles almost all misaligned
addresses by relying on this half-baked support and supplementing it
with a few manual I/O read/writes to complete the transfer.

It also adds a dma_read_async function that only starts the transfers,
and a dma_wait function that waits for completion. dma_busy is
deprecated instead: first, we prefer busy waits to happen within
libdragon (so that they're easier to port to the multitasking kernel),
and second dma_busy is a misnomer and both waits for DMA and any other
kind of PI busy. So it is better to phase it out.

The previous low-level DMA primitive is now exposed as dma_read_raw_async,
just in case somebody absolutely need to just program the hardware, but
dma_read_async is pretty fast to falling back to it for aligned addresses,
so there should be in principle no reasons to call it anymore. This
is also why I decided to improve the dma_read API rather than adding
a dma_read_misaligned API.

The test does a bruteforce for all small sizes and all alignments, so
that we can be confident on the implementation.