### PR TITLE
audio: add zero-copy write functions.

### DIFF
--- a/include/audio.h
+++ b/include/audio.h
@@ -35,6 +35,9 @@ void audio_close();
 int audio_get_frequency();
 int audio_get_buffer_length();
 
+short* audio_write_begin(void);
+void audio_write_end(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This commit adds a way to do zero-copy audio output using the audio.c
API. Currently, the APIs to produce audio like audio_write() require
the caller to provide a buffer that will be copied to the internal
buffer. Instead, the new audio_write_begin() returns a pointer to the
internal buffer, so that samples can be generated there directly.