### PR TITLE
Start building a docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: Build
+
+on:
+  # For default branch, wait for the "Docker Build" workflow instead so that
+  # we will run this against the latest image.
+  push:
+    branches-ignore:
+      - 'trunk'
+  pull_request:
+
+  workflow_run:
+    workflows: ["Docker Build"]
+    branches:
+      - trunk
+    types:
+      - completed
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # We first compare the default branch to the event commit. In case this is
+      # the default branch, this should return 0, skipping the build and using
+      # the latest image from "Docker Build"
+      - name: Compare build-toolchain.sh to default branch
+        id: toolchain_change
+        shell: bash {0}
+        continue-on-error: true
+        run: |
+          git diff --exit-code -s \
+          ${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }} \
+          ${{ github.sha }} \
+          ./tools/build-toolchain.sh
+          echo "::set-output name=exitCode::$?"
+
+      # Build the toolchain if ./tools/build-toolchain.sh changed w.r.t default
+      # which is where we release the images and we can use from registry o/w
+      - name: Set up Docker Buildx
+        if: ${{ steps.toolchain_change.outputs.exitCode == 1 }}
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build image
+        if: ${{ steps.toolchain_change.outputs.exitCode == 1 }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: false
+          tags: ghcr.io/${{ github.actor }}/libdragon:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # As we have a "latest" tagged image now, we can use that to run build.sh
+      # if it is built in the previous step. o/w it will be downloaded from the
+      # registry. Then verify everything is building properly
+      - name: Build libdragon
+        run: |
+          docker run \
+          --mount type=bind,source=$(pwd),target=/libdragon \
+          --workdir=/libdragon \
+          ghcr.io/${{ github.actor }}/libdragon:latest \
+          ./build.sh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,56 @@
+# Build and push a docker image whenever toolchain script is updated. It is
+# important that this workflow always runs to be able to trigger the default
+# branch ci check.
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - trunk
+
+jobs:
+  Build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Compare toolchain build script to github.event.before and skip the build
+      # if it did not change.
+      - name: Compare build-toolchain.sh to default branch
+        id: toolchain_change
+        shell: bash {0}
+        continue-on-error: true
+        run: |
+          git diff --exit-code -s \
+          ${{ github.event.before }} \
+          ${{ github.sha }} \
+          ./tools/build-toolchain.sh
+          echo "::set-output name=exitCode::$?"
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.toolchain_change.outputs.exitCode == 1 }}
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the container registry
+        if: ${{ steps.toolchain_change.outputs.exitCode == 1 }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        if: ${{ steps.toolchain_change.outputs.exitCode == 1 }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.actor }}/libdragon:${{ github.sha }}
+            ghcr.io/${{ github.actor }}/libdragon:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1 - Build the toolchain
+FROM ubuntu:18.04
+ARG N64_INST=/n64_toolchain
+ENV N64_INST=${N64_INST}
+
+# install dependencies
+RUN apt-get update
+RUN apt-get install -yq wget bzip2 gcc g++ make file libmpfr-dev libmpc-dev zlib1g-dev texinfo git gcc-multilib
+
+# Build
+COPY ./tools/build-toolchain.sh /tmp/tools/build-toolchain.sh
+WORKDIR /tmp/tools
+RUN ./build-toolchain.sh
+
+# Strip executables
+RUN find ${N64_INST}/bin -type f | xargs strip
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/plugin/gengtype
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/liblto_plugin.so.0.0.0
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/liblto_plugin.so.0
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/lto-wrapper
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/collect2
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/cc1plus
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/cc1
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/install-tools/fixincl
+RUN strip ${N64_INST}/libexec/gcc/mips64-elf/10.2.0/lto1
+RUN rm -rf ${N64_INST}/share/locale/*
+
+# Stage 2 - Prepare minimal image
+FROM ubuntu:18.04
+ARG N64_INST=/n64_toolchain
+ENV N64_INST=${N64_INST}
+
+COPY --from=0 ${N64_INST} ${N64_INST}
+RUN apt-get update && \
+    apt-get install -yq gcc g++ make libpng-dev git  && \
+    apt-get clean && \
+    apt autoremove -yq

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Libdragon
 
-[![Build Status](https://travis-ci.org/DragonMinded/libdragon.svg?branch=trunk)](https://travis-ci.org/DragonMinded/libdragon)
+[![Build](https://github.com/DragonMinded/libdragon/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/DragonMinded/libdragon/actions/workflows/ci.yml)
 
 This is a simple library for N64 that allows one to code using the gcc compiler suite and nothing else. No proprietary library is needed.
 

--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,8 @@ LIBMIKMOD_COMMIT=738b1e8b11b470360b1b919680d1d88429d9d174
 LIBMIKMOD_DIR=/tmp/libmikmod
 
 # Clean, build, and install libdragon + tools
-make -j${CPU_COUNT} clobber
-make -j${CPU_COUNT} install tools-install
+make -j${CPU_COUNT} -I${N64_INST}/include clobber
+make -j${CPU_COUNT} -I${N64_INST}/include install tools-install
 
 # Remove the cloned libmikmod repo if it already exists
 [ -d "$LIBMIKMOD_DIR" ] && rm -Rf $LIBMIKMOD_DIR
@@ -21,10 +21,10 @@ make -j${CPU_COUNT} install tools-install
 git clone $LIBMIKMOD_REPO $LIBMIKMOD_DIR
 pushd $LIBMIKMOD_DIR/n64
 git checkout $LIBMIKMOD_COMMIT
-make -j${CPU_COUNT}
-make install
+make -j${CPU_COUNT} -I${N64_INST}/include
+make -j${CPU_COUNT} -I${N64_INST}/include install
 popd
 rm -Rf $LIBMIKMOD_DIR
 
 # Build all of the libdragon examples
-make -j${CPU_COUNT} examples
+make -j${CPU_COUNT} -I${N64_INST}/include examples

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -1,11 +1,9 @@
 #! /bin/bash
-# N64 toolchain install script for Unix distributions by Shaun Taylor.
-# Tested working on Ubuntu 18.04.
+# N64 MIPS GCC toolchain build/install script for Unix distributions
+# (c) 2012-2021 Shaun Taylor and libDragon Contributors.
+# See the root folder for license information.
 
-# You may be prompted for your password for installation steps.
-# If the script tells you that writing failed on chksum64 and n64tool,
-# this does not mean it failed.  The script simply retried with sudo
-# and your password was cached.
+
 
 # Before calling this script, make sure you have GMP, MPFR and TexInfo
 # packages installed in your system.  On a Debian-based system this is
@@ -18,7 +16,7 @@
 # Exit on error
 set -e
 
-# EDIT THIS LINE TO CHANGE YOUR INSTALL PATH!
+# Set N64_INST before calling the script to change the default installation directory path
 export INSTALL_PATH=${N64_INST:-/usr/local}
 
 export JOBS=${JOBS:-`getconf _NPROCESSORS_ONLN`}
@@ -28,47 +26,20 @@ export FORCE_DEFAULT_GCC=${FORCE_DEFAULT_GCC:-false}
 # Set up path for newlib to compile later
 export PATH=$PATH:$INSTALL_PATH/bin
 
-# Versions
+# Dependency source libs (Versions)
 export BINUTILS_V=2.36.1
 export GCC_V=10.2.0
 export NEWLIB_V=4.1.0
 
-# Download stage
-test -f binutils-$BINUTILS_V.tar.gz || wget -c ftp://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz
-test -f gcc-$GCC_V.tar.gz || wget -c ftp://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz
-test -f newlib-$NEWLIB_V.tar.gz || wget -c ftp://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz
+# Dependency source: Download stage
+test -f binutils-$BINUTILS_V.tar.gz || wget -c https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz
+test -f gcc-$GCC_V.tar.gz || wget -c https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz
+test -f newlib-$NEWLIB_V.tar.gz || wget -c https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz
 
-# Extract stage
+# Dependency source: Extract stage
 test -d binutils-$BINUTILS_V || tar -xzf binutils-$BINUTILS_V.tar.gz
 test -d gcc-$GCC_V || tar -xzf gcc-$GCC_V.tar.gz
 test -d newlib-$NEWLIB_V || tar -xzf newlib-$NEWLIB_V.tar.gz
-
-# Use same native GCC
-
-if [ ! $(gcc --version | grep $GCC_V) ] && [ $FORCE_DEFAULT_GCC == 'false' ]; then
-    rm -rf build_binutils
-    mkdir build_binutils
-
-    # Compile binutils
-    cd build_binutils
-    ../binutils-$BINUTILS_V/configure --prefix=${INSTALL_PATH}/gcc-$GCC_V --disable-werror
-    make -j$JOBS
-    make install || sudo make install || su -c "make install"
-
-    # Compile gcc (native)
-    cd ..
-    rm -rf build_gcc
-    mkdir build_gcc
-    cd build_gcc
-    ../gcc-$GCC_V/configure --prefix=${INSTALL_PATH}/gcc-$GCC_V --enable-languages=c,c++ --disable-nls
-    make -j$JOBS
-    make install || sudo make install || su -c "make install"
-
-    # Use new compiler
-    export PATH="${INSTALL_PATH}/gcc-$GCC_V/bin:${PATH}"
-    export COMPILED_CUSTOM_NATIVE_GCC="true"
-    cd ..
-fi
 
 # Binutils and newlib support compiling in source directory, GCC does not
 rm -rf gcc_compile
@@ -76,13 +47,33 @@ mkdir gcc_compile
 
 # Compile binutils
 cd binutils-$BINUTILS_V
-./configure --prefix=${INSTALL_PATH} --target=mips64-elf --with-cpu=mips64vr4300 --disable-werror
+./configure \
+  --prefix=${INSTALL_PATH} \
+  --target=mips64-elf \
+  --with-cpu=mips64vr4300 \
+  --disable-werror
 make -j$JOBS
 make install || sudo make install || su -c "make install"
 
-# Compile gcc (pass 1)
+# Compile GCC for MIPS N64 (pass 1)
 cd ../gcc_compile
-../gcc-$GCC_V/configure --prefix=${INSTALL_PATH} --target=mips64-elf --with-arch=vr4300 --with-tune=vr4300 --enable-languages=c --without-headers --with-newlib --disable-libssp --enable-multilib --disable-shared --with-gcc --disable-threads --disable-win32-registry --disable-nls --disable-werror --with-system-zlib
+../gcc-$GCC_V/configure \
+  --prefix=${INSTALL_PATH} \
+  --target=mips64-elf \
+  --with-arch=vr4300 \
+  --with-tune=vr4300 \
+  --enable-languages=c \
+  --without-headers \
+  --with-newlib \
+  --disable-libssp \
+  --enable-multilib \
+  --disable-shared \
+  --with-gcc \
+  --disable-threads \
+  --disable-win32-registry \
+  --disable-nls \
+  --disable-werror \
+  --with-system-zlib
 make all-gcc -j$JOBS
 make all-target-libgcc -j$JOBS
 make install-gcc || sudo make install-gcc || su -c "make install-gcc"
@@ -90,19 +81,35 @@ make install-target-libgcc || sudo make install-target-libgcc || su -c "make ins
 
 # Compile newlib
 cd ../newlib-$NEWLIB_V
-CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC" ./configure --target=mips64-elf --prefix=${INSTALL_PATH} --with-cpu=mips64vr4300 --disable-threads --disable-libssp --disable-werror
+CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC" ./configure \
+  --target=mips64-elf \
+  --prefix=${INSTALL_PATH} \
+  --with-cpu=mips64vr4300 \
+  --disable-threads \
+  --disable-libssp \
+  --disable-werror
 make -j$JOBS
 make install || sudo env PATH="$PATH" make install || su -c "env PATH=$PATH make install"
 
-# Compile gcc (pass 2)
+# Compile GCC for MIPS N64 (pass 2)
 cd ..
 rm -rf gcc_compile
 mkdir gcc_compile
 cd gcc_compile
-CFLAGS_FOR_TARGET="-G0 -O2" CXXFLAGS_FOR_TARGET="-G0 -O2" ../gcc-$GCC_V/configure --prefix=${INSTALL_PATH} --target=mips64-elf --with-arch=vr4300 --with-tune=vr4300 --enable-languages=c,c++ --with-newlib --disable-libssp --enable-multilib --disable-shared --with-gcc --disable-threads --disable-win32-registry --disable-nls --with-system-zlib
+CFLAGS_FOR_TARGET="-G0 -O2" CXXFLAGS_FOR_TARGET="-G0 -O2" ../gcc-$GCC_V/configure \
+  --prefix=${INSTALL_PATH} \
+  --target=mips64-elf \
+  --with-arch=vr4300 \
+  --with-tune=vr4300 \
+  --enable-languages=c,c++ \
+  --with-newlib \
+  --disable-libssp \
+  --enable-multilib \
+  --disable-shared \
+  --with-gcc \
+  --disable-threads \
+  --disable-win32-registry \
+  --disable-nls \
+  --with-system-zlib
 make -j$JOBS
 make install || sudo make install || su -c "make install"
-
-if [ "$COMPILED_CUSTOM_NATIVE_GCC" == "true" ]; then
-    rm -rf ${INSTALL_PATH}/gcc-$GCC_V
-fi


### PR DESCRIPTION
- Changed build.sh to support non-default installation locations. make searches
default locations (i.e `/usl/local/include`) for `n64.mk` but when it is
installed elsewhere, the script was failing

- Added a two step dockerfile. It builds the toolchain in the first stage and
then it installs the files to N64_INST on second stage to produce a minimal
image.

- Removed the unnecessary native GCC build.

- Apply build script improvements from https://github.com/rasky/libdragon/pull/8

- Add two workflows to verify everything is building fine (`ci.yml`)
and build and push the docker file (`docker-build.yml`).

The default branch (`trunk`) is where we build and push the docker image to
GitHub Packages. `build.sh` script will get executed whenever we push something
or open a pull request over the latest docker image. If `build-toolchain.sh`
file is changed, then it will be used to create a temporary "latest" image to
run the build. The file is always compared against the default branch as latest
image is pushed from there.

If someone changes the toolchain script, next push will trigger a test run which
will build a new image. Once the image is built, its layers will get cached and
if you then open a pull request, they will be utilized thus the workflow gets
executed quickly.

When something is merged to the default branch, the ci workflow is executed for
it after the docker-build workflow publishes the new image if necessary. We
should wait for it in order not to rebuild everything from scratch for default
branch ci check. For all other branches, we build the image in the ci workflow
when necessary.

There are a few caveats;
We use the cache implementation of `docker/build-push-action` and the cache key
is per-branch thus we will re-build the images on default branch again even if
we have already built one during the PR process. This can be remedied by
implementing a custom cache but I think the toolchain updates are rare enough
that this is not a problem in practice. Also the cache might grow with time and
I'm not sure if this will be an issue. The buildkit cache is experimental and we
can try to find workarounds or open issues if we face any problems.
The other problem is that if a new PR utilizing a newly building image its ci
will fail as the default branch already have the same toolchain script and ci
will skip building a new temporary image but this is an unlikely event. Even if
it happens its a matter of restarting that job to make it pass after the image
is pushed.

- Update the build badge to use the new workflow.

@DragonMinded It is important that you approve this PR as it is using your
`GITHUB_TOKEN`