### PR TITLE
graphics: speed up graphics_fill_screen

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -607,24 +607,12 @@ void graphics_fill_screen( display_context_t disp, uint32_t c )
 {
     if( disp == 0 ) { return; }
 
-    if( __bitdepth == 2 )
-    {
-        uint16_t *buffer = (uint16_t *)__get_buffer( disp );
+    int len = (__bitdepth == 2) ? __width * __height / 4 : __width * __height / 2;
 
-        for( int i = 0; i < __width * __height; i++ )
-        {
-            buffer[i] = c;
-        }
-    }
-    else
-    {
-        uint32_t *buffer = (uint32_t *)__get_buffer( disp );
-
-        for( int i = 0; i < __width * __height; i++ )
-        {
-            buffer[i] = c;
-        }
-    }
+    uint64_t c64 = ((uint64_t)c << 32) | c;
+    uint64_t *buffer = (uint64_t *)__get_buffer(disp);
+    for( int i = 0; i < len; i++ )
+        buffer[i] = c64;
 }
 
 /**


### PR DESCRIPTION
graphics.c does rendering with CPU, so it's meant for tasks that do not
require performance, such as the console. Clearing the screen touches
the whole buffer so it is a very slow operation, so it makes sense to
fetch this low hanging fruit and optimize it by doing 64-bit accesses.

This speed up 16-bit clearing by 4 and 32-bit clearing by 2. On real
hardware, now they respectively take 6.5ms and 13.8ms for a 512x240
buffer, which is still a lot, but much better than before. We can't do
much better without using RDP, but that's not the goal of graphics.c
anyway.