### PR TITLE
n64.mk: fix installation directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SOURCE_DIR = $(CURDIR)/src
 BUILD_DIR = $(CURDIR)/build
 include n64.mk
 INSTALLDIR = $(N64_INST)
+PREFIX ?= /usr/local
 
 # Activate N64 toolchain for libdragon build
 libdragon: CC=$(N64_CC)
@@ -57,7 +58,10 @@ tools-clean:
 	$(MAKE) -C tools clean
 
 install-mk: n64.mk
-	install -Cv -m 0644 n64.mk $(INSTALLDIR)/include/n64.mk
+	# n64.mk must be installed into $PREFIX, otherwise make will not be
+	# able to find it later with "include n64.mk". This is the only file that
+	# must go outside of $INSTALLDIR.
+	install -Cv -m 0644 n64.mk $(PREFIX)/include/n64.mk
 
 install: install-mk libdragon
 	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a


### PR DESCRIPTION
n64.mk is supposed to be found via "include n64.mk" after installation.
This only works if it is installed in the user prefix, irrespective
of $N64_INST / $INSTALLDIR. This is the only file that must go outside
it.