### PR TITLE
Update makefiles to work properly with custom $N64_INST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install-mk: n64.mk
 	# n64.mk must be installed into $PREFIX, otherwise make will not be
 	# able to find it later with "include n64.mk". This is the only file that
 	# must go outside of $INSTALLDIR.
-	install -Cv -m 0644 n64.mk $(PREFIX)/include/n64.mk
+	sudo install -Cv -m 0644 n64.mk $(PREFIX)/include/n64.mk
 
 install: install-mk libdragon
 	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,9 @@ tools-clean:
 
 install-mk: n64.mk
 	# n64.mk must be installed into $PREFIX, otherwise make will not be
-	# able to find it later with "include n64.mk". This is the only file that
+	# able to find it later with "include $(N64_INST)/include/n64.mk". This is the only file that
 	# must go outside of $INSTALLDIR.
-	sudo install -Cv -m 0644 n64.mk $(PREFIX)/include/n64.mk
+	install -Cv -m 0644 n64.mk $(INSTALLDIR)/include/n64.mk
 
 install: install-mk libdragon
 	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a

--- a/examples/spritemap/Makefile
+++ b/examples/spritemap/Makefile
@@ -1,5 +1,6 @@
 BUILD_DIR=build
-include n64.mk
+include $(N64_INST)/include/n64.mk
+
 
 src = spritemap.c
 

--- a/examples/ucodetest/Makefile
+++ b/examples/ucodetest/Makefile
@@ -1,5 +1,5 @@
 BUILD_DIR=build
-include n64.mk
+include $(N64_INST)/include/n64.mk
 
 all: ucodetest.z64
 

--- a/n64.mk
+++ b/n64.mk
@@ -70,19 +70,19 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.S
 	@mkdir -p $(dir $@)
 	set -e; if case $(notdir $(basename $@)) in "rsp"*) true;; *) false;; esac; then \
 		echo "    [RSP] $<"; \
-		$(N64_CC) $(N64_ASFLAGS) -nostartfiles -MMD -Wl,-Ttext=0x1000 -Wl,-Tdata=0x0 -Wl,-e0x1000 -o $@ $<; \
+		$(N64_CC) $(ASFLAGS) -nostartfiles -MMD -Wl,-Ttext=0x1000 -Wl,-Tdata=0x0 -Wl,-e0x1000 -o $@ $<; \
 		$(N64_OBJCOPY) -O binary -j .text $@ $(basename $@).text.bin; \
 		$(N64_OBJCOPY) -O binary -j .data $@ $(basename $@).data.bin; \
 		$(N64_OBJCOPY) -I binary -O elf32-bigmips -B mips4300 \
-				--redefine-sym _binary_$(subst /,_,$(basename $@))_text_bin_start=$(notdir $(basename $@))_text_start \
-				--redefine-sym _binary_$(subst /,_,$(basename $@))_text_bin_end=$(notdir $(basename $@))_text_end \
-				--redefine-sym _binary_$(subst /,_,$(basename $@))_text_bin_size=$(notdir $(basename $@))_text_size \
+				--redefine-sym _binary_$(subst .,_,$(subst /,_,$(basename $@)))_text_bin_start=$(notdir $(basename $@))_text_start \
+				--redefine-sym _binary_$(subst .,_,$(subst /,_,$(basename $@)))_text_bin_end=$(notdir $(basename $@))_text_end \
+				--redefine-sym _binary_$(subst .,_,$(subst /,_,$(basename $@)))_text_bin_size=$(notdir $(basename $@))_text_size \
 				--set-section-alignment .data=8 \
 				--rename-section .text=.data $(basename $@).text.bin $(basename $@).text.o; \
 		$(N64_OBJCOPY) -I binary -O elf32-bigmips -B mips4300 \
-				--redefine-sym _binary_$(subst /,_,$(basename $@))_data_bin_start=$(notdir $(basename $@))_data_start \
-				--redefine-sym _binary_$(subst /,_,$(basename $@))_data_bin_end=$(notdir $(basename $@))_data_end \
-				--redefine-sym _binary_$(subst /,_,$(basename $@))_data_bin_size=$(notdir $(basename $@))_data_size \
+				--redefine-sym _binary_$(subst .,_,$(subst /,_,$(basename $@)))_data_bin_start=$(notdir $(basename $@))_data_start \
+				--redefine-sym _binary_$(subst .,_,$(subst /,_,$(basename $@)))_data_bin_end=$(notdir $(basename $@))_data_end \
+				--redefine-sym _binary_$(subst .,_,$(subst /,_,$(basename $@)))_data_bin_size=$(notdir $(basename $@))_data_size \
 				--set-section-alignment .data=8 \
 				--rename-section .text=.data $(basename $@).data.bin $(basename $@).data.o; \
 		$(N64_SIZE) -G $@; \


### PR DESCRIPTION
These changes fix the following issues:

1. Update n64.mk to install using `sudo` so if you do have permission to write to $PREFIX you will be able to write there
2. Update the RSP build command to use $ASFLAGS instead of $N64_ASFLAGS. This fixes an issue I saw when trying to build @snacchus ugfx code with a custom $N64_INST path. $N64_ASFLAGS does not include the additional -I$(CURDIR)/include so rsp code that is in the libdragon library tree won't be able to find rsp.inc
3.  Another problem seen with ugfx, if you're building rsp code in the libdragon library tree, when it creates the section names it will use the whole $BUILD_DIR path in the section name. If the path name has periods in it, gcc will make those underscores instead. The make file needs to substitute periods with underscores like it does for slashes.