### PR TITLE
C++ support for n64.mk

### DIFF
--- a/examples/cpptest/Makefile
+++ b/examples/cpptest/Makefile
@@ -1,37 +1,21 @@
-PROG_NAME = cpptest
+BUILD_DIR=build
+SOURCE_DIR=.
+include $(N64_INST)/include/n64.mk
 
-ROOTDIR = $(N64_INST)
-GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
+cpptest.z64: MAPCMD=-Wl,-Map
+cpptest.z64: LD=$(N64_CXX)
+cpptest.z64: LDFLAGS=-L$(N64_ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -ldragonsys -Wl,-Tn64.ld -Wl,--gc-sections
 
-CC = $(GCCN64PREFIX)gcc
-CXX = $(GCCN64PREFIX)g++
-AS = $(GCCN64PREFIX)as
-LD = $(GCCN64PREFIX)ld
-OBJCOPY = $(GCCN64PREFIX)objcopy
-N64TOOL = $(ROOTDIR)/bin/n64tool
-CHKSUM64 = $(ROOTDIR)/bin/chksum64
+all: cpptest.z64
 
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
-CXXFLAGS = -std=c++11 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
-LDFLAGS = -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -lstdc++ -ldragonsys -Tn64.ld -Wl,--gc-sections
-N64TOOLFLAGS = -l 1M -h $(ROOTDIR)/mips64-elf/lib/header -t "C++ Test"
+$(BUILD_DIR)/cpptest.elf: \
+	$(BUILD_DIR)/cpptest.o
 
-ifeq ($(N64_BYTE_SWAP),true)
-$(PROG_NAME).v64: $(PROG_NAME).z64
-	dd conv=swab if=$^ of=$@
-endif
+cpptest.z64: N64_ROM_TITLE="cpptest"
 
-$(PROG_NAME).z64: $(PROG_NAME).bin
-	$(N64TOOL) $(N64TOOLFLAGS) -o $@ $^
-	$(CHKSUM64) $@
-
-$(PROG_NAME).bin: $(PROG_NAME).elf
-	$(OBJCOPY) $< $@ -O binary
-
-# Use g++ to link the compiled C++ object into an ELF executable
-$(PROG_NAME).elf: $(PROG_NAME).o
-	$(CXX) -o $@ $^ $(LDFLAGS)
-
-.PHONY: clean
 clean:
-	rm -f *.v64 *.z64 *.elf *.o *.bin
+	rm -rf $(BUILD_DIR) cpptest.z64
+
+-include $(wildcard $(BUILD_DIR)/*.d)
+
+.PHONY: all clean

--- a/n64.mk
+++ b/n64.mk
@@ -114,7 +114,6 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp
 %.elf: $(N64_ROOTDIR)/mips64-elf/lib/libdragon.a $(N64_ROOTDIR)/mips64-elf/lib/libdragonsys.a $(N64_ROOTDIR)/mips64-elf/lib/n64.ld
 	@mkdir -p $(BUILD_DIR)
 	@echo "    [LD] $@"
-	@echo "    [LD] ${LD}"
 	$(LD) -o $@ $(filter-out $(N64_ROOTDIR)/mips64-elf/lib/n64.ld,$^) $(LDFLAGS) $(MAPCMD)=$(BUILD_DIR)/$(notdir $(basename $@)).map
 	$(N64_SIZE) -G $@
 


### PR DESCRIPTION
This pull request introduces c++ support to the n64.mk build system. I'm looking for feedback on how to handle linking c++ code, as linking c++ code with LD can be pain, so I opted to hijack the link command and replace it with CXX to use the C++ compiler for linking. I'm not sure if this is the best/cleanest approach, so please provide thoughts if you can.