### PR TITLE
examples: fix timers example

### DIFF
--- a/examples/timers/timers.c
+++ b/examples/timers/timers.c
@@ -66,9 +66,9 @@ int main(void)
         console_render();
     }
 	end = timer_ticks();
-	timer_close();
 	// one-shot timers have to be explicitly freed
 	delete_timer(one_shot_t);
+	timer_close();
 
     console_clear();
 


### PR DESCRIPTION
It was calling delete_timer after shutting down the timer module.
I'm not sure it was supported back at at time, but it now asserts
(and rightly so).