### PR TITLE
Introduce CPU_FREQUENCY and further fixes to timer examples

### DIFF
--- a/examples/timers/timers.c
+++ b/examples/timers/timers.c
@@ -75,7 +75,7 @@ int main(void)
     printf( "\n Every msec    : %f", t1 );
     printf( "\n Every half sec: %f", t2 );
     printf( "\n Every sec     : %f", t3 );
-    printf( "\n\n Done in %f", (double)(end-start)*0.021333333/1000000.0);
+    printf( "\n\n Done in %f", (float)TIMER_MICROS_LL(end-start)/1000000.0f);
 
     console_render();
 

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -16,6 +16,11 @@
  * @{
  */
 
+/**
+ * @brief Frequency of the MIPS R4300 CPU
+ */
+#define CPU_FREQUENCY    93750000 
+
 
 /**
  * @brief void pointer to cached and non-mapped memory start address
@@ -109,7 +114,7 @@
  *
  * Every second, this many counts will have passed in the count register
  */
-#define TICKS_PER_SECOND (93750000/2)
+#define TICKS_PER_SECOND (CPU_FREQUENCY/2)
 
 /**
  * @brief The signed difference of time between "from" and "to".

--- a/include/timer.h
+++ b/include/timer.h
@@ -7,6 +7,7 @@
 #define __LIBDRAGON_TIMER_H
 
 #include <stdint.h>
+#include "n64sys.h"
 
 /** 
  * @addtogroup timer
@@ -47,7 +48,7 @@ typedef struct timer_link
  *
  * @return Timer ticks
  */
-#define TIMER_TICKS(us) ((int)((long long)(us) * 46875LL / 1000LL))
+#define TIMER_TICKS(us) ((int)TIMER_TICKS_LL(us))
 /**
  * @brief Calculate microseconds based on timer ticks
  *
@@ -56,7 +57,7 @@ typedef struct timer_link
  *
  * @return Microseconds
  */
-#define TIMER_MICROS(tk) ((int)((long long)(tk) * 1000LL / 46875LL))
+#define TIMER_MICROS(tk) ((int)TIMER_MICROS_LL(tk))
 
 /** 
  * @brief Calculate timer ticks based on microseconds 
@@ -66,7 +67,7 @@ typedef struct timer_link
  *
  * @return Timer ticks as a long long
  */
-#define TIMER_TICKS_LL(us) ((long long)(us) * 46875LL / 1000LL)
+#define TIMER_TICKS_LL(us) ((long long)(us) * TICKS_PER_SECOND / 1000000)
 /**
  * @brief Calculate microseconds based on timer ticks
  *
@@ -75,7 +76,7 @@ typedef struct timer_link
  *
  * @return Microseconds as a long long
  */
-#define TIMER_MICROS_LL(tk) ((long long)(tk) * 1000LL / 46875LL)
+#define TIMER_MICROS_LL(tk) ((long long)(tk) * 1000000 / TICKS_PER_SECOND)
 
 /** @} */
 


### PR DESCRIPTION
This PR factors all references to timer frequencies into a new macro CPU_FREQUENCY, in preparation of supporting overclocked consoles.