### PR TITLE
Link everything with g++

### DIFF
--- a/examples/cpptest/Makefile
+++ b/examples/cpptest/Makefile
@@ -1,37 +1,17 @@
-PROG_NAME = cpptest
+BUILD_DIR=build
+SOURCE_DIR=.
+include $(N64_INST)/include/n64.mk
 
-ROOTDIR = $(N64_INST)
-GCCN64PREFIX = $(ROOTDIR)/bin/mips64-elf-
+all: cpptest.z64
 
-CC = $(GCCN64PREFIX)gcc
-CXX = $(GCCN64PREFIX)g++
-AS = $(GCCN64PREFIX)as
-LD = $(GCCN64PREFIX)ld
-OBJCOPY = $(GCCN64PREFIX)objcopy
-N64TOOL = $(ROOTDIR)/bin/n64tool
-CHKSUM64 = $(ROOTDIR)/bin/chksum64
+$(BUILD_DIR)/cpptest.elf: \
+	$(BUILD_DIR)/cpptest.o
 
-CFLAGS = -std=gnu99 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
-CXXFLAGS = -std=c++11 -march=vr4300 -mtune=vr4300 -O2 -Wall -Werror -I$(ROOTDIR)/mips64-elf/include
-LDFLAGS = -L$(ROOTDIR)/mips64-elf/lib -ldragon -lc -lm -lstdc++ -ldragonsys -Tn64.ld -Wl,--gc-sections
-N64TOOLFLAGS = -l 1M -h $(ROOTDIR)/mips64-elf/lib/header -t "C++ Test"
+cpptest.z64: N64_ROM_TITLE="C++ test"
 
-ifeq ($(N64_BYTE_SWAP),true)
-$(PROG_NAME).v64: $(PROG_NAME).z64
-	dd conv=swab if=$^ of=$@
-endif
-
-$(PROG_NAME).z64: $(PROG_NAME).bin
-	$(N64TOOL) $(N64TOOLFLAGS) -o $@ $^
-	$(CHKSUM64) $@
-
-$(PROG_NAME).bin: $(PROG_NAME).elf
-	$(OBJCOPY) $< $@ -O binary
-
-# Use g++ to link the compiled C++ object into an ELF executable
-$(PROG_NAME).elf: $(PROG_NAME).o
-	$(CXX) -o $@ $^ $(LDFLAGS)
-
-.PHONY: clean
 clean:
-	rm -f *.v64 *.z64 *.elf *.o *.bin
+	rm -rf $(BUILD_DIR) cpptest.z64
+
+-include $(wildcard $(BUILD_DIR)/*.d)
+
+.PHONY: all clean

--- a/n64.ld
+++ b/n64.ld
@@ -69,6 +69,16 @@ SECTIONS {
 
     .ctors : {
         __CTOR_LIST__ = .;
+        /* Actually we should place the count here like;
+
+        LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 2)
+
+        but g++ seem to already do this (though incorrectly placing an 0xFFFFFFFF)
+        and that breaks things if we also add it. Ideally this should be parsed
+        by the code but we already know the end as well. We have migrated
+        everything to be linked via g++ by default but if you ever need to link
+        with ld, in __do_global_ctors you'd need to loop including the sentinel.
+        This is something we currently don't support*/
         KEEP(*(.ctors))
         __CTOR_END__ = .;
     } > mem

--- a/n64.ld
+++ b/n64.ld
@@ -65,7 +65,8 @@ SECTIONS {
         . = ALIGN(8);
     } > mem
 
-    . = ALIGN(8);
+    /* This is important to keep __CTOR_END__ consistent */
+    . = ALIGN(4);
 
     .ctors : {
         __CTOR_LIST__ = .;
@@ -80,6 +81,11 @@ SECTIONS {
         with ld, in __do_global_ctors you'd need to loop including the sentinel.
         This is something we currently don't support*/
         KEEP(*(.ctors))
+         /* Similarly we should have a;
+
+        LONG(0)
+
+        here, and g++ seem to insert it at __CTOR_END__ */
         __CTOR_END__ = .;
     } > mem
 

--- a/n64.mk
+++ b/n64.mk
@@ -13,7 +13,10 @@ N64_LIBDIR = $(N64_ROOTDIR)/mips64-elf/lib
 N64_GCCPREFIX = $(N64_BINDIR)/mips64-elf-
 N64_HEADERPATH = $(N64_LIBDIR)/header
 
+COMMA:=,
+
 N64_CC = $(N64_GCCPREFIX)gcc
+N64_CXX = $(N64_GCCPREFIX)g++
 N64_AS = $(N64_GCCPREFIX)as
 N64_LD = $(N64_GCCPREFIX)ld
 N64_OBJCOPY = $(N64_GCCPREFIX)objcopy
@@ -29,8 +32,11 @@ N64_AUDIOCONV = $(N64_BINDIR)/audioconv64
 N64_CFLAGS =  -std=gnu99 -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
 N64_CFLAGS += -falign-functions=32 -ffunction-sections -fdata-sections
 N64_CFLAGS += -DN64 -O2 -Wall -Werror -fdiagnostics-color=always
+N64_CXXFLAGS =  -std=c++11 -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
+N64_CXXFLAGS += -falign-functions=32 -ffunction-sections -fdata-sections
+N64_CXXFLAGS += -DN64 -O2 -Wall -Werror -fdiagnostics-color=always
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings
-N64_LDFLAGS = -L$(N64_LIBDIR) -ldragon -lc -lm -ldragonsys -Tn64.ld --gc-sections
+N64_LDFLAGS = -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections
 
 N64_TOOLFLAGS = --header $(N64_HEADERPATH) --title $(N64_ROM_TITLE)
 N64_ED64ROMCONFIGFLAGS =  $(if $(N64_ROM_SAVETYPE),--savetype $(N64_ROM_SAVETYPE))
@@ -39,18 +45,22 @@ N64_ED64ROMCONFIGFLAGS += $(if $(N64_ROM_REGIONFREE),--regionfree)
 
 ifeq ($(D),1)
 CFLAGS+=-g3
+CXXFLAGS+=-g3
 ASFLAGS+=-g
 LDFLAGS+=-g
 endif
 
-CFLAGS+=-MMD     # automatic .d dependency generation
+CFLAGS+=-MMD     # automatic .d dependency generationc
+CXXFLAGS+=-MMD     # automatic .d dependency generationc
 ASFLAGS+=-MMD    # automatic .d dependency generation
 
 # Change all the dependency chain of z64 ROMs to use the N64 toolchain.
 %.z64: CC=$(N64_CC)
+%.z64: CXX=$(N64_CXX)
 %.z64: AS=$(N64_AS)
 %.z64: LD=$(N64_LD)
 %.z64: CFLAGS+=$(N64_CFLAGS)
+%.z64: CXXFLAGS+=$(N64_CXXFLAGS)
 %.z64: ASFLAGS+=$(N64_ASFLAGS)
 %.z64: LDFLAGS+=$(N64_LDFLAGS)
 %.z64: $(BUILD_DIR)/%.elf
@@ -117,10 +127,15 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c
 	@echo "    [CC] $<"
 	$(CC) -c $(CFLAGS) -o $@ $<
 
+$(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp
+	@mkdir -p $(dir $@)
+	@echo "    [CXX] $<"
+	$(CXX) -c $(CXXFLAGS) -o $@ $<
+
 %.elf: $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a $(N64_LIBDIR)/n64.ld
 	@mkdir -p $(dir $@)
 	@echo "    [LD] $@"
-	$(LD) -o $@ $(filter-out $(N64_LIBDIR)/n64.ld,$^) $(LDFLAGS) -Map=$(BUILD_DIR)/$(notdir $(basename $@)).map
+	$(CXX) -o $@ $(filter-out $(N64_LIBDIR)/n64.ld,$^) -lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map
 	$(N64_SIZE) -G $@
 
 ifneq ($(V),1)

--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -27,7 +27,9 @@ void __do_global_ctors()
 {
 	func_ptr * ctor_addr = &__CTOR_END__ - 1;
 	func_ptr * ctor_sentinel = &__CTOR_LIST__;
-	while (ctor_addr >= ctor_sentinel) {
+	// This will break if you link using LD. You'll need to change this to be >=
+	// in that case. See __CTOR_LIST__ in n64.ld
+	while (ctor_addr > ctor_sentinel) {
 		if (*ctor_addr) (*ctor_addr)();
 		ctor_addr--;
 	}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,11 +5,11 @@ all: testrom.z64 testrom_emu.z64
 
 $(BUILD_DIR)/testrom.dfs: $(wildcard filesystem/*)
 
-$(BUILD_DIR)/testrom.elf: ${BUILD_DIR}/testrom.o
+$(BUILD_DIR)/testrom.elf: ${BUILD_DIR}/testrom.o ${BUILD_DIR}/test_constructors_cpp.o
 testrom.z64: N64_ROM_TITLE="Libdragon Test ROM"
 testrom.z64: $(BUILD_DIR)/testrom.dfs
 
-$(BUILD_DIR)/testrom_emu.elf: ${BUILD_DIR}/testrom_emu.o
+$(BUILD_DIR)/testrom_emu.elf: ${BUILD_DIR}/testrom_emu.o ${BUILD_DIR}/test_constructors_cpp.o
 testrom_emu.z64: N64_ROM_TITLE="Libdragon Test ROM"
 testrom_emu.z64: $(BUILD_DIR)/testrom.dfs
 

--- a/tests/test_constructors.c
+++ b/tests/test_constructors.c
@@ -1,5 +1,13 @@
-extern unsigned int __global_constructor_test_value;
+extern unsigned int __global_cpp_constructor_test_value;
+
+unsigned int __global_constructor_test_value;
+
+__attribute__((constructor)) void __global_constructor_test()
+{
+    __global_constructor_test_value = 0xC0C70125;
+}
 
 void test_constructors(TestContext *ctx) {
-	ASSERT(__global_constructor_test_value == 0xC70125, "Global constructors did not get executed!");
+	ASSERT(__global_constructor_test_value == 0xC0C70125, "Global constructors did not get executed!");
+	ASSERT(__global_cpp_constructor_test_value == 0xD0C70125, "Global C++ constructors did not get executed!");
 }

--- a/tests/test_constructors.c
+++ b/tests/test_constructors.c
@@ -1,0 +1,5 @@
+extern unsigned int __global_constructor_test_value;
+
+void test_constructors(TestContext *ctx) {
+	ASSERT(__global_constructor_test_value == 0xC70125, "Global constructors did not get executed!");
+}

--- a/tests/test_constructors_cpp.cpp
+++ b/tests/test_constructors_cpp.cpp
@@ -1,13 +1,13 @@
 
 extern "C" {
-    unsigned int __global_constructor_test_value;
+    unsigned int __global_cpp_constructor_test_value;
 }
 
 class TestClass
 {
     public:
         TestClass() {
-            __global_constructor_test_value = 0xC70125;
+            __global_cpp_constructor_test_value = 0xD0C70125;
         }
 };
 

--- a/tests/test_constructors_cpp.cpp
+++ b/tests/test_constructors_cpp.cpp
@@ -1,0 +1,15 @@
+
+extern "C" {
+    unsigned int __global_constructor_test_value;
+}
+
+class TestClass
+{
+    public:
+        TestClass() {
+            __global_constructor_test_value = 0xC70125;
+        }
+};
+
+TestClass globalClass;
+

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -168,6 +168,7 @@ int assert_equal_mem(TestContext *ctx, const char *file, int line, const uint8_t
 #include "test_debug.c"
 #include "test_dma.c"
 #include "test_cop1.c"
+#include "test_constructors.c"
 
 /**********************************************************************
  * MAIN
@@ -205,6 +206,8 @@ static const struct Testsuite
 	TEST_FUNC(test_debug_sdfs,             	   0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dma_read_misalign,       7003, TEST_FLAGS_NONE),
 	TEST_FUNC(test_cop1_denormalized_float,    0, TEST_FLAGS_NO_EMULATOR),
+	TEST_FUNC(test_constructors,               0, TEST_FLAGS_NO_EMULATOR),
+	
 };
 
 int main() {

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -190,6 +190,7 @@ static const struct Testsuite
 	uint32_t flags;
 } tests[] = {
 	TEST_FUNC(test_exception,              	   5, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_constructors,               0, TEST_FLAGS_NONE),
 	TEST_FUNC(test_ticks,                  	   0, TEST_FLAGS_NO_BENCHMARK | TEST_FLAGS_NO_EMULATOR),
 	TEST_FUNC(test_timer_ticks,          	 292, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_timer_oneshot,        	 596, TEST_FLAGS_RESET_COUNT),
@@ -206,8 +207,6 @@ static const struct Testsuite
 	TEST_FUNC(test_debug_sdfs,             	   0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dma_read_misalign,       7003, TEST_FLAGS_NONE),
 	TEST_FUNC(test_cop1_denormalized_float,    0, TEST_FLAGS_NO_EMULATOR),
-	TEST_FUNC(test_constructors,               0, TEST_FLAGS_NO_EMULATOR),
-	
 };
 
 int main() {


### PR DESCRIPTION
- Start linking with `g++` by default.
- Revert the equality on `__do_global_ctors`. Linking with `g++` seem to
add an initail item to the constructor list thus breaking initialization.
This started to be an issue as we have started using the constructos for
regular initialization as well. Now that we link with `g++` by default everythng is
compatible. The only problem is we cannot link with ld anymore if ever needed.
On the other hand `g++` is working as fast and can create equivalent output.