### PR TITLE
Fix RSP SYMPREFIX when path has a hyphen

### DIFF
--- a/n64.mk
+++ b/n64.mk
@@ -95,7 +95,7 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.S
 	set -e; \
 	FILENAME="$(notdir $(basename $@))"; \
 	if case "$$FILENAME" in "rsp"*) true;; *) false;; esac; then \
-		SYMPREFIX="$(subst .,_,$(subst /,_,$(basename $@)))"; \
+		SYMPREFIX="$(subst -,_,$(subst .,_,$(subst /,_,$(basename $@))))"; \
 		TEXTSECTION="$(basename $@).text"; \
 		DATASECTION="$(basename $@).data"; \
 		echo "    [RSP] $<"; \


### PR DESCRIPTION
@rasky 

This resolves an error I was seeing while trying to build FlappyBird-N64:

```
undefined reference to `rsp_mixer_{text,data}_{start,end}'
```

```
/home/cdb/Projects/personal/n64/mips64-toolchain/bin/mips64-elf-ld -o FlappyBird.elf src/background.o src/bird.o src/collision.o src/fps.o src/gfx.o src/main.o src/pipes.o src/sfx.o src/system.o src/ui.o --library=dragon --library=c --library=m --library=dragonsys --library-path=/home/cdb/Projects/personal/n64/mips64-toolchain/mips64-elf/lib --library-path=/home/cdb/Projects/personal/n64/FlappyBird-N64/libdragon --script=/home/cdb/Projects/personal/n64/FlappyBird-N64/libdragon/n64.ld --gc-sections
/home/cdb/Projects/personal/n64/mips64-toolchain/bin/mips64-elf-ld: /home/cdb/Projects/personal/n64/FlappyBird-N64/libdragon/libdragon.a(mixer.o):(.data.rsp_mixer+0x0): undefined reference to `rsp_mixer_text_start'
/home/cdb/Projects/personal/n64/mips64-toolchain/bin/mips64-elf-ld: /home/cdb/Projects/personal/n64/FlappyBird-N64/libdragon/libdragon.a(mixer.o):(.data.rsp_mixer+0x4): undefined reference to `rsp_mixer_text_end'
/home/cdb/Projects/personal/n64/mips64-toolchain/bin/mips64-elf-ld: /home/cdb/Projects/personal/n64/FlappyBird-N64/libdragon/libdragon.a(mixer.o):(.data.rsp_mixer+0x8): undefined reference to `rsp_mixer_data_start'
/home/cdb/Projects/personal/n64/mips64-toolchain/bin/mips64-elf-ld: /home/cdb/Projects/personal/n64/FlappyBird-N64/libdragon/libdragon.a(mixer.o):(.data.rsp_mixer+0xc): undefined reference to `rsp_mixer_data_end'
make: *** [Makefile:94: FlappyBird.elf] Error 1
```

It looks like the root cause is a hyphen, which needs to be escaped like period and slash are.