### PR TITLE
Fix breaking change

### DIFF
--- a/n64.ld
+++ b/n64.ld
@@ -76,10 +76,12 @@ SECTIONS {
 
         but g++ seem to already do this (though incorrectly placing an 0xFFFFFFFF)
         and that breaks things if we also add it. Ideally this should be parsed
-        by the code but we already know the end as well. We have migrated
-        everything to be linked via g++ by default but if you ever need to link
-        with ld, in __do_global_ctors you'd need to loop including the sentinel.
-        This is something we currently don't support*/
+        by the code but we already know the end as well.
+
+        The new build system links everything via g++ by default and should use
+        __wrap___do_global_ctors and enables it via the --wrap linker option.
+        When linking with ld, we should use __do_global_ctors, which is the default
+        if you don't provide the --wrap option. */
         KEEP(*(.ctors))
          /* Similarly we should have a;
 

--- a/n64.mk
+++ b/n64.mk
@@ -33,7 +33,7 @@ N64_CFLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
 N64_CFLAGS += -falign-functions=32 -ffunction-sections -fdata-sections
 N64_CFLAGS += -DN64 -O2 -Wall -Werror -fdiagnostics-color=always
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings
-N64_LDFLAGS = -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections
+N64_LDFLAGS = -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections --wrap __do_global_ctors
 
 N64_TOOLFLAGS = --header $(N64_HEADERPATH) --title $(N64_ROM_TITLE)
 N64_ED64ROMCONFIGFLAGS =  $(if $(N64_ROM_SAVETYPE),--savetype $(N64_ROM_SAVETYPE))

--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -24,18 +24,43 @@ extern func_ptr __CTOR_END__ __attribute__((section (".data")));
  * @brief Execute global constructors
  * "Constructors are called in reverse order of the list"
  * @see https://gcc.gnu.org/onlinedocs/gccint/Initialization.html
+ *
+ * This version of the function is kept for compatibility for projects not using
+ * the build system but linking directly with ld in a legacy setup. For the
+ * modern version see #__wrap___do_global_ctors which is activated by the new
+ * build system (n64.mk) via --wrap linker flag. Do not use that flag if you are
+ * using ld so that this function is used instead.
  */
 void __do_global_ctors()
 {
-	// Somehow __CTOR_END__ points to the next location after the list and the
-	// last item is a zero, so start from the actual end.
+	func_ptr * ctor_addr = &__CTOR_END__ - 1;
+	func_ptr * ctor_sentinel = &__CTOR_LIST__;
+	while (ctor_addr > ctor_sentinel) {
+		if (*ctor_addr) (*ctor_addr)();
+		ctor_addr--;
+	}
+}
+
+/**
+ * @brief Execute global constructors
+ * This version is used by the new build system (n64.mk) via the --wrap linker
+ * flag. When that is provided, this version will be utilized instead. New build
+ * system always links with g++ which is not directly compatible with ld when it
+ * comes to constructors abd enables that flag by default.
+ */
+void __wrap___do_global_ctors()
+{
+	// g++ seem to insert a rogue __CTOR_END__ symbol that shifts it to the next
+	// 4 bytes but weirdly disassembly shows it in correct place. __CTOR_END__ - 1
+	// is the actual value and we subtract one more to skip the zero value and
+	// thus the "-2".
 	func_ptr * ctor_addr = &__CTOR_END__ - 2;
 	func_ptr * ctor_sentinel = &__CTOR_LIST__;
 	// This will break if you link using LD. You'll need to change the linker
 	// script and add the sentinel manually. g++ already does that but ld does
 	// not. In that case, this will skip the last function. If this was an
 	// inclusive loop, it would fail for g++ as the last item won't be a valid
-	// pointer. Also see __CTOR_LIST__ in n64.ld
+	// pointer. Also see __CTOR_LIST__ in n64.ld and #__do_global_ctors
 	assertf(
 		(uint32_t)*ctor_sentinel == 0xFFFFFFFF && (uint32_t)*(&__CTOR_END__ - 1) == 0x0,
 		"Invalid sentinel, ensure you link via g++"


### PR DESCRIPTION
This fixes #200

We are using linker's `--wrap` option to provide an alternative `__do_global_ctors` function when linking with g++. It does not actually wrap the original but just provides an alternative (new version).

When that options is not provided, the function from before #195 is used to introduce minimum breakage as possible to our knowledge.