### PR TITLE
n64.mk: don't error on deprecated declarations

### DIFF
--- a/n64.mk
+++ b/n64.mk
@@ -31,7 +31,7 @@ N64_AUDIOCONV = $(N64_BINDIR)/audioconv64
 
 N64_CFLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
 N64_CFLAGS += -falign-functions=32 -ffunction-sections -fdata-sections
-N64_CFLAGS += -DN64 -O2 -Wall -Werror -fdiagnostics-color=always
+N64_CFLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings
 N64_LDFLAGS = -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections
 


### PR DESCRIPTION
In our strive to keep backward compatibility, we might need to deprecate
old functions and change them with newer APIs. We can keep the old APIs
around indefinitely, but we do mark them as deprecated using the GCC
deprecated attribute.

Unfortunately, we currently compile with -Werror which means that
deprecated warnings turn into errors, blocking compilation, and
effectively nullifying the effort of not breaking the build.

This change selectively disable -Werror just for the deprecation warning,
so that software using old APIs would get just a warning, which is
the goal.