### PR TITLE
Makefile: fix compilation of libdragon in paths containing symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all: libdragon
 
 V = 1  # force verbose (at least until we have converted all sub-Makefiles)
-SOURCE_DIR = $(CURDIR)/src
-BUILD_DIR = $(CURDIR)/build
+SOURCE_DIR = src
+BUILD_DIR = build
 include n64.mk
 INSTALLDIR = $(N64_INST)
 


### PR DESCRIPTION
RSP rules in n64.mk need to extract symbols from ELF files that encode
the path of files with some undocumented substitutions for symbols
performed by LD. We started growing a few rules (see SYMPREFIX in n64.mk)
but we cannot win this battle.

In general we shouldn't be playing this game at all because normally
the paths seen by the build system are not the full absolute paths.
The exception is libdragon's own Makefile that used $(CURDIR)/src
as source directory. Changing this to just "src" fixes the issue,
removing the absolute path component.