### PR TITLE
Update VI origin every frame according to current field

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -428,7 +428,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
 
     /* Set which line to call back on in order to flip screens */
     register_VI_handler( __display_callback );
-    set_VI_interrupt( 1, 0x200 );
+    set_VI_interrupt( 1, 0x2 );
 }
 
 /**

--- a/src/display.c
+++ b/src/display.c
@@ -240,15 +240,21 @@ static void __write_dram_register( void const * const dram_val )
  */
 static void __display_callback()
 {
+    uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
+
+    /* Least significant bit of the current line register indicates
+       if the currently displayed field is odd or even. */
+    bool field = reg_base[4] & 1;
+
     /* Only swap frames if we have a new frame to swap, otherwise just
        leave up the current frame */
     if(show_next >= 0 && show_next != now_drawing)
     {
-        __write_dram_register( __safe_buffer[show_next] );
-
         now_showing = show_next;
         show_next = -1;
     }
+
+    __write_dram_register(__safe_buffer[now_showing] + (!field ? __width * __bitdepth : 0));
 }
 
 /**

--- a/src/display.c
+++ b/src/display.c
@@ -316,9 +316,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     switch( bit )
     {
         case DEPTH_16_BPP:
-            /* We enable divot filter in 16bpp mode to give our gradients
-               a slightly smoother look */
-            control |= 0x10002;
+            control |= 0x2;
             break;
         case DEPTH_32_BPP:
             control |= 0x3;
@@ -343,18 +341,32 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
         case ANTIALIAS_OFF:
             /* Set AA off flag */
             control |= 0x300;
+
+            /* Dither filter should not be enabled with this AA mode
+               as it will cause ugly vertical streaks */
             break;
         case ANTIALIAS_RESAMPLE:
             /* Set AA on resample as well as divot on */
             control |= 0x210;
+
+            /* Dither filter should not be enabled with this AA mode
+               as it will cause ugly vertical streaks */
             break;
         case ANTIALIAS_RESAMPLE_FETCH_NEEDED:
             /* Set AA on resample and fetch as well as divot on */
             control |= 0x110;
+
+            /* Enable dither filter in 16bpp mode to give gradients
+               a slightly smoother look */
+            if ( bit == DEPTH_16_BPP ) { control |= 0x10000; }
             break;
         case ANTIALIAS_RESAMPLE_FETCH_ALWAYS:
             /* Set AA on resample always and fetch as well as divot on */
             control |= 0x010;
+
+            /* Enable dither filter in 16bpp mode to give gradients
+               a slightly smoother look */
+            if ( bit == DEPTH_16_BPP ) { control |= 0x10000; }
             break;
     }
 


### PR DESCRIPTION
This small change improves the look of the interlaced video modes significantly, this is done by alternating the starting line of the VI origin (framebuffer) register according to the current field.

Commercial games also modify V_VIDEO and V_BURST (for PAL), I did not see any significant improvement when trying those modifications and it would require a bit more of restructuring than this PR, though it could be looked at further in the future.

@Rasky also noted that the VI interrupt currently seems to be triggered mid-frame, the initialized VI interrupt register value was therefore changed so that the interrupts would appear in vblank.

Also changed the display initialization to only enable the dither filter used for 16-bit color if anti-aliasing is enabled as the filter will otherwise cause ugly vertical streaks, see #159.