### PR TITLE
Three followups to the XM player

### DIFF
--- a/include/xm64.h
+++ b/include/xm64.h
@@ -126,6 +126,26 @@ void xm64player_seek(xm64player_t *player, int patidx, int row, int tick);
 void xm64player_set_vol(xm64player_t *player, float volume);
 
 /**
+ * @brief Set a custom effect callback to allow music synchronization.
+ * 
+ * This function configures a callback that will be called whenever the player
+ * finds an unknown / unsupported effect in any channel. These unknown effects
+ * can be used to add custom "sync cues" in the music score, and synchronize
+ * graphic effects or gameplay logic to them.
+ * 
+ * There are many unused effect letters in XM format. For instance, a good
+ * choice can be effect Xxx which is used as modplug hack for MIDI support,
+ * but is unimplemented by standard XM players like this one.
+ * 
+ * The callback will be called passing as arguments a custom context, the
+ * channel number, and the effect code and the effect parameter. The effect
+ * code is the code in extended hex format (A-F are 10-15 as in normal hex,
+ * but then G-Z are 16-35), while the effect parameter is one free byte that
+ * can be inserted in the music score.
+ */
+void xm64player_set_effect_callback(xm64player_t *player, void (*cb)(void*, uint8_t, uint8_t, uint8_t), void *ctx);
+
+/**
  * @brief Close and deallocate the XM64 player.
  */
 void xm64player_close(xm64player_t *player);

--- a/include/xm64.h
+++ b/include/xm64.h
@@ -45,6 +45,7 @@ typedef struct xm64player_s {
 	FILE *fh;                 // open handle of XM64 file
 	int first_ch;             // first channel used in the mixer
 	bool playing;             // playing flag
+	bool looping;             // true if the XM is configured to loop
 	struct {
 		int patidx, row, tick;
 	} seek;                   // seeking to be performed
@@ -68,6 +69,19 @@ void xm64player_open(xm64player_t *player, const char *fn);
  * Notice that the player needs to use one mixer channel per each XM64 channel.
  */
 int xm64player_num_channels(xm64player_t *player);
+
+/**
+ * @brief Configure a XM64 file for looping.
+ * 
+ * By default, XM64 files will be played in loop. Use this function
+ * to disable looping.
+ * 
+ * @param[in] player 
+ *            XM64 player
+ * @param[in] loop
+ *            true to enable looping, false to disable looping.
+ */
+void xm64player_set_loop(xm64player_t *player, bool loop);
 
 /**
  * @brief Start playing the XM64 module.

--- a/src/audio/libxm/context.c
+++ b/src/audio/libxm/context.c
@@ -848,3 +848,9 @@ uint16_t xm_get_instrument_of_channel(xm_context_t* ctx, uint16_t chn) {
 	if(ch->instrument == NULL) return 0;
 	return 1 + (ch->instrument - ctx->module.instruments);
 }
+
+void xm_set_effect_callback(xm_context_t *ctx, xm_effect_callback_t cb, void *cbctx) {
+	ctx->effect_callback = cb;
+	ctx->effect_callback_ctx = cbctx;
+}
+

--- a/src/audio/libxm/play.c
+++ b/src/audio/libxm/play.c
@@ -1231,6 +1231,8 @@ void xm_tick(xm_context_t* ctx) {
 			break;
 
 		default:
+			if(ctx->current_tick == 0 && ctx->effect_callback)
+				ctx->effect_callback(ctx->effect_callback_ctx, i, ch->current->effect_type, ch->current->effect_param);
 			break;
 
 		}

--- a/src/audio/libxm/xm.h
+++ b/src/audio/libxm/xm.h
@@ -289,4 +289,8 @@ float xm_get_volume_of_channel(xm_context_t*, uint16_t);
  */
 float xm_get_panning_of_channel(xm_context_t*, uint16_t);
 
+/** Set the effect callback that can be used to process unknown effects. */
+typedef void (*xm_effect_callback_t)(void*, uint8_t, uint8_t, uint8_t);
+void xm_set_effect_callback(xm_context_t*, xm_effect_callback_t, void *);
+
 #endif

--- a/src/audio/libxm/xm_internal.h
+++ b/src/audio/libxm/xm_internal.h
@@ -326,6 +326,8 @@ struct xm_context_s {
 	};
 
 	FILE* fh;  /* open file for streaming content (if requested) */
+	xm_effect_callback_t effect_callback;
+	void *effect_callback_ctx;
 
 #if XM_STREAM_PATTERNS
 	xm_pattern_slot_t *slot_buffer;

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -196,9 +196,6 @@ void mixer_close(void) {
 
 void mixer_ch_set_freq(int ch, float frequency) {
 	mixer_channel_t *c = &Mixer.channels[ch];
-	assertf(frequency <= Mixer.limits[ch].max_frequency,
-		"mixer_ch_set_freq: frequency %.2f is higher than allowed (%.2f).\nUse mixer_ch_set_limits to bump the limit",
-		frequency, Mixer.limits[ch].max_frequency);
 	assertf(!(c->flags & CH_FLAGS_STEREO_SUB), "mixer_ch_set_freq: cannot call on secondary stereo channel %d", ch);
 	c->step = MIXER_FX64(frequency / (float)Mixer.sample_rate) << (c->flags & CH_FLAGS_BPS_SHIFT);
 }

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -208,6 +208,10 @@ void xm64player_set_vol(xm64player_t *player, float volume) {
 	player->ctx->amplification = volume * 0.25f;
 }
 
+void xm64player_set_effect_callback(xm64player_t *player, void (*cb)(void*, uint8_t, uint8_t, uint8_t), void *ctx) {
+	xm_set_effect_callback(player->ctx, cb, ctx);
+}
+
 void xm64player_close(xm64player_t *player) {
 	// FIXME: we need to stop playing without racing with the audio thread.
 	// This is not correct and may crash.

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -20,9 +20,10 @@ static int tick(void *arg) {
 	}
 
 	// If we're requested to stop playback, do it.
-	if (!xmp->playing) {
+	if (!xmp->playing || (!xmp->looping && ctx->loop_count > 0)) {
 		for (int i=0;i<ctx->module.num_channels;i++)
 			mixer_ch_stop(xmp->first_ch+i);
+		xmp->playing = false;
 		// Do not reschedule again
 		return 0;
 	}
@@ -143,10 +144,17 @@ void xm64player_open(xm64player_t *player, const char *fn) {
 			samp->wave->ctx = samp;
 		}
 	}
+
+	// By default XM64 files loop
+	player->looping = true;
 }
 
 int xm64player_num_channels(xm64player_t *player) {
 	return xm_get_number_of_channels(player->ctx);
+}
+
+void xm64player_set_loop(xm64player_t *player, bool loop) {
+	player->looping = loop;
 }
 
 void xm64player_play(xm64player_t *player, int first_ch) {


### PR DESCRIPTION
 * Allow to enable / disable looping playback
 * Add API to register a callback for unused XM effects. This can be used to put custom music cues in the score and synchronize graphics and music.
 * Remove an assert on invalid channel frequency, given that we can't enforce it correctly yet (see commit message)
