### PR TITLE
CI: build tools with MinGW.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - completed
 
 jobs:
-  ci:
+  Compile-Library-And-Examples:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,3 +57,42 @@ jobs:
           --workdir=/libdragon \
           ghcr.io/dragonminded/libdragon:latest \
           ./build.sh
+
+  Build-Tools-Windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+       include: [
+         { sys: mingw64, arch: x86_64, build: tools},
+         { sys: mingw32, arch: i686,   build: tools}
+       ]
+    steps:
+     - uses: msys2/setup-msys2@v2
+       with:
+         msystem: ${{matrix.sys}}
+         install: >-
+           mingw-w64-${{ matrix.arch }}-libpng
+           base-devel
+           mingw-w64-${{ matrix.arch }}-toolchain
+         update: true
+
+     - uses: actions/checkout@v2
+       with:
+         fetch-depth: 0
+
+     - name: Correct MSYS2 pthread.h to allow static libraries (otherwise you would need to use a lib DLL, rather than it being built into the EXE.)
+       shell: msys2 {0}
+       run: |
+         sed -z 's/#else\n#define WINPTHREAD_API __declspec(dllimport)/#else\n#define WINPTHREAD_API/' /${{matrix.sys}}/${{ matrix.arch }}-w64-mingw32/include/pthread.h
+
+     - name: Build ${{ matrix.build }}
+       shell: msys2 {0}
+       run: |
+         make ${{ matrix.build }}
+
+     - name: "Upload ${{ matrix.build }} executables"
+       uses: actions/upload-artifact@v2
+       with:
+         name: windows-${{ matrix.arch }}-${{ matrix.build }}
+         path: ${{ github.workspace }}/**/tools/**/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tools/mkdfs/mkdfs
 tools/mksprite/convtool
 tools/mksprite/mksprite
 tools/n64tool
+tools/**/*.exe
 
 ## OSX junk
 .DS_Store

--- a/src/audio/libxm/context.c
+++ b/src/audio/libxm/context.c
@@ -699,7 +699,7 @@ int xm_context_load(xm_context_t** ctxp, FILE* in, uint32_t rate) {
 			DEBUG("invalid mempool size allocated (diff: %d)\n", (unsigned)(mempool-mempool_end));
 			free(*ctxp);
 			*ctxp = NULL;
-			return 1;		
+			return 2;
 		}
 
 		// FIXME: currently, it's normal to use less memory than declared.

--- a/src/audio/libxm/context.c
+++ b/src/audio/libxm/context.c
@@ -109,6 +109,7 @@ int xm_create_context_safe(xm_context_t** ctxp, const char* moddata, size_t modd
 
 void xm_context_save(xm_context_t* ctx, FILE* out) {
 
+	#undef _W64 // defined by mingw
 	#define _CHKSZ(x,n) _Static_assert(sizeof(x) == n, "invalid type size");
 	#define _W8(x)     ({ putc((x)&0xFF, out); })
 	#define _W16(x)    ({ _W8 ((x)>>8);  _W8 (x); })

--- a/src/audio/libxm/load.c
+++ b/src/audio/libxm/load.c
@@ -152,6 +152,16 @@ void xm_get_memory_needed_for_context(const char* moddata, size_t moddata_length
 
 	memory_needed += num_channels * sizeof(xm_channel_context_t);
 	memory_needed += sizeof(xm_context_t);
+	#if _WIN32
+	// Unfortunately, not all XM structures have fixed size across different
+	// platforms, because of different padding. The loading/saving code is
+	// fully architecture independent, but estimating the memory to allocate
+	// it's not. Normally, we compile libdragon only on 64-bit platforms which
+	// behave similar enough, with the only exception being the tools like
+	// audioconv64 compiled with MinGW32. In that case, just declare a little
+	// bit of memory more so that it will be enough on N64.
+	memory_needed += 256;
+	#endif
 
 	*mem_ctx = memory_needed;
 	*mem_patterns = memory_patterns;

--- a/src/audio/libxm/xm.h
+++ b/src/audio/libxm/xm.h
@@ -89,6 +89,10 @@ void xm_context_save(xm_context_t* ctx, FILE* out);
 #endif
 
 /** Load a context from a XM64 file.
+ * 
+ * Returns 0 in case of success, 1 in case of generic error (file corrupted),
+ * or 2 in case the memory size estimated by the writer wasn't enough to load
+ * the file.
  */
 int xm_context_load(xm_context_t** ctxp, FILE* in, uint32_t rate);
 

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -90,16 +90,21 @@ void xm64player_open(xm64player_t *player, const char *fn) {
 	// Load the XM context
 	int sample_rate = audio_get_frequency();
 	assertf(sample_rate >= 0, "audio_init() and mixer_init() must be called before xm64player_open()");
-	if (xm_context_load(&player->ctx, player->fh, sample_rate) != 0) {
+	int err = xm_context_load(&player->ctx, player->fh, sample_rate);
+	if (err != 0) {
+		if (err == 2) {
+			assertf(0, "error loading XM64 file: %s\nMemory size estimation by audioconv64 was wrong\n", fn);
+		}
+
 		// Check if the file looks like a standard XM, so to provide
 		// a clear message in that case.
 		char signature[16] = {0};
 		fseek(player->fh, 0, SEEK_SET);
 		fread(signature, 1, 15, player->fh);
 		if (strcmp(signature, "Extended Module") == 0) {
-			assertf(0, "cannot load XM file %s -- please convert to XM64 with audio64", fn);
+			assertf(0, "cannot load XM file: %s\nPlease convert to XM64 with audioconv64", fn);
 		}
-		assertf(0, "error loading XM64 file -- file corrupted?");
+		assertf(0, "error loading XM64 file: %s\nFile corrupted", fn);
 	}
 
 	assertf(strncmp(fn, "rom:/", 5) == 0, "xm64player only supports files in ROM (rom:/)");

--- a/tools/audioconv64/audioconv64.c
+++ b/tools/audioconv64/audioconv64.c
@@ -125,7 +125,11 @@ void walkdir(char *inpath, char *outpath, void (*func)(char *, char*)) {
 				fprintf(stderr, "ERROR: %s is a file but should be a directory\n", outpath);
 				return;
 			}
+			#ifndef __MINGW32__
 			mkdir(outpath, 0777);
+			#else
+			mkdir(outpath);
+			#endif
 		}
 		DIR* d = opendir(inpath);
 		struct dirent *de;

--- a/tools/mkdfs/mkdfs.c
+++ b/tools/mkdfs/mkdfs.c
@@ -90,7 +90,7 @@ uint32_t add_file(const char * const file, uint32_t *size)
 
     printf("Adding '%s' to filesystem image.\n", file);
 
-    fp = fopen(file, "r");
+    fp = fopen(file, "rb");
 
     if(!fp)
     {
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
     }
 
     /* Write out filesystem */
-    FILE *fp = fopen(argv[1], "w");
+    FILE *fp = fopen(argv[1], "wb");
 
     if(!fp)
     {

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -24,7 +24,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __MINGW32__
 #include <sys/errno.h>
+#endif
 
 #define WRITE_SIZE   (1024 * 1024)
 #define HEADER_SIZE  0x1000


### PR DESCRIPTION
In https://github.com/DragonMinded/libdragon/issues/161, we agreed that a native Windows toolchain of libdragon should not be compiled with MSVC but with MinGW (GCC), to avoid too much overhead on contributors.

This PR makes the CI compile the tools with MinGW and also fixes a few bugs in them. I can't guarantee they work 100% now, but I did some quick runs and they seem to work at least in their basic usage.

Extracted from https://github.com/rasky/libdragon/pull/6, submitted by @networkfusion (thanks).