### PR TITLE
Reset graphics FG/BG colors for assert and exception screens

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -489,6 +489,7 @@ void debug_assert_func_f(const char *file, int line, const char *func, const cha
 	console_init();
 	console_set_debug(true);
 	console_set_render_mode(RENDER_MANUAL);
+	graphics_set_color(0xFFFFFFFF, 0x00000000);
 
 	fprintf(stdout,
 		"ASSERTION FAILED: %s\n"

--- a/src/exception.c
+++ b/src/exception.c
@@ -4,6 +4,7 @@
  * @ingroup exceptions
  */
 #include "exception.h"
+#include "graphics.h"
 #include "console.h"
 #include "n64sys.h"
 
@@ -105,6 +106,7 @@ void exception_default_handler(exception_t* ex) {
 	console_init();
 	console_set_debug(true);
 	console_set_render_mode(RENDER_MANUAL);
+	graphics_set_color(0xFFFFFFFF, 0x00000000);
 
 	fprintf(stdout, "%s exception at PC:%08lX\n", ex->info, (uint32_t)(ex->regs->epc + ((cr & C0_CAUSE_BD) ? 4 : 0)));
 


### PR DESCRIPTION
Currently the console printed on crash screen (asserts or exceptions) will reuse whatever foreground/background graphics color settings the game used before the crash. This can cause readability issues if those colors happen to too similar. This PR resets the colors when entering those screens so that it will always be white text on black.