### PR TITLE
Refactor build-toolchain.sh

### DIFF
--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -17,48 +17,62 @@
 set -e
 
 # Set N64_INST before calling the script to change the default installation directory path
-export INSTALL_PATH=${N64_INST:-/usr/local}
+INSTALL_PATH="${N64_INST:-/usr/local}"
+# Set PATH for newlib to compile using GCC for MIPS N64 (pass 1)
+export PATH="$PATH:$INSTALL_PATH/bin"
 
-export JOBS=${JOBS:-`getconf _NPROCESSORS_ONLN`}
-export JOBS=${JOBS:-1} # If getconf returned nothing, default to 1
-export FORCE_DEFAULT_GCC=${FORCE_DEFAULT_GCC:-false}
-
-# Set up path for newlib to compile later
-export PATH=$PATH:$INSTALL_PATH/bin
+# Determine how many parallel Make jobs to run based on CPU count
+JOBS="${JOBS:-`getconf _NPROCESSORS_ONLN`}"
+JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
 
 # Dependency source libs (Versions)
-export BINUTILS_V=2.36.1
-export GCC_V=10.2.0
-export NEWLIB_V=4.1.0
+BINUTILS_V=2.36.1
+GCC_V=10.2.0
+NEWLIB_V=4.1.0
+
+# Check if a command-line tool is available: status 0 means "yes"; status 1 means "no"
+command_exists () {
+  (command -v "$1" >/dev/null 2>&1)
+  return $?
+}
+
+# Download the file URL using wget or curl (depending on which is installed)
+download () {
+  if   command_exists wget ; then wget -c  "$1"
+  elif command_exists curl ; then curl -LO "$1"
+  else
+    echo "Install `wget` or `curl` to download toolchain sources" 1>&2
+    return 1
+  fi
+}
 
 # Dependency source: Download stage
-test -f binutils-$BINUTILS_V.tar.gz || wget -c https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz
-test -f gcc-$GCC_V.tar.gz || wget -c https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz
-test -f newlib-$NEWLIB_V.tar.gz || wget -c https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz
+test -f "binutils-$BINUTILS_V.tar.gz" || download "https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz"
+test -f "gcc-$GCC_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
+test -f "newlib-$NEWLIB_V.tar.gz"     || download "https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz"
 
 # Dependency source: Extract stage
-test -d binutils-$BINUTILS_V || tar -xzf binutils-$BINUTILS_V.tar.gz
-test -d gcc-$GCC_V || tar -xzf gcc-$GCC_V.tar.gz
-test -d newlib-$NEWLIB_V || tar -xzf newlib-$NEWLIB_V.tar.gz
-
-# Binutils and newlib support compiling in source directory, GCC does not
-rm -rf gcc_compile
-mkdir gcc_compile
+test -d "binutils-$BINUTILS_V" || tar -xzf "binutils-$BINUTILS_V.tar.gz"
+test -d "gcc-$GCC_V"           || tar -xzf "gcc-$GCC_V.tar.gz"
+test -d "newlib-$NEWLIB_V"     || tar -xzf "newlib-$NEWLIB_V.tar.gz"
 
 # Compile binutils
-cd binutils-$BINUTILS_V
+cd "binutils-$BINUTILS_V"
 ./configure \
-  --prefix=${INSTALL_PATH} \
+  --prefix="$INSTALL_PATH" \
   --target=mips64-elf \
   --with-cpu=mips64vr4300 \
   --disable-werror
-make -j$JOBS
+make -j "$JOBS"
 make install || sudo make install || su -c "make install"
 
-# Compile GCC for MIPS N64 (pass 1)
-cd ../gcc_compile
-../gcc-$GCC_V/configure \
-  --prefix=${INSTALL_PATH} \
+# Compile GCC for MIPS N64 (pass 1) outside of the source tree
+cd ..
+rm -rf gcc_compile
+mkdir gcc_compile
+cd gcc_compile
+../"gcc-$GCC_V"/configure \
+  --prefix="$INSTALL_PATH" \
   --target=mips64-elf \
   --with-arch=vr4300 \
   --with-tune=vr4300 \
@@ -74,30 +88,30 @@ cd ../gcc_compile
   --disable-nls \
   --disable-werror \
   --with-system-zlib
-make all-gcc -j$JOBS
-make all-target-libgcc -j$JOBS
+make all-gcc -j "$JOBS"
+make all-target-libgcc -j "$JOBS"
 make install-gcc || sudo make install-gcc || su -c "make install-gcc"
 make install-target-libgcc || sudo make install-target-libgcc || su -c "make install-target-libgcc"
 
 # Compile newlib
-cd ../newlib-$NEWLIB_V
+cd ../"newlib-$NEWLIB_V"
 CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC" ./configure \
   --target=mips64-elf \
-  --prefix=${INSTALL_PATH} \
+  --prefix="$INSTALL_PATH" \
   --with-cpu=mips64vr4300 \
   --disable-threads \
   --disable-libssp \
   --disable-werror
-make -j$JOBS
-make install || sudo env PATH="$PATH" make install || su -c "env PATH=$PATH make install"
+make -j "$JOBS"
+make install || sudo env PATH="$PATH" make install || su -c "env PATH=\"$PATH\" make install"
 
-# Compile GCC for MIPS N64 (pass 2)
+# Compile GCC for MIPS N64 (pass 2) outside of the source tree
 cd ..
 rm -rf gcc_compile
 mkdir gcc_compile
 cd gcc_compile
-CFLAGS_FOR_TARGET="-G0 -O2" CXXFLAGS_FOR_TARGET="-G0 -O2" ../gcc-$GCC_V/configure \
-  --prefix=${INSTALL_PATH} \
+CFLAGS_FOR_TARGET="-G0 -O2" CXXFLAGS_FOR_TARGET="-G0 -O2" ../"gcc-$GCC_V"/configure \
+  --prefix="$INSTALL_PATH" \
   --target=mips64-elf \
   --with-arch=vr4300 \
   --with-tune=vr4300 \
@@ -111,5 +125,5 @@ CFLAGS_FOR_TARGET="-G0 -O2" CXXFLAGS_FOR_TARGET="-G0 -O2" ../gcc-$GCC_V/configur
   --disable-win32-registry \
   --disable-nls \
   --with-system-zlib
-make -j$JOBS
+make -j "$JOBS"
 make install || sudo make install || su -c "make install"


### PR DESCRIPTION
* Remove unnecessary exports
* Quote all variable expansions
* Remove unused `FORCE_DEFAULT_GCC` variable
* Fall-back to `curl` when `wget` is missing (some environments do not have `wget`, such as macOS)