### PR TITLE
display: avoid configuring ANTIALIAS_OFF when it triggers a hw bug

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -339,6 +339,21 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     switch( aa )
     {
         case ANTIALIAS_OFF:
+            /* Disabling antialias hits a hardware bug on NTSC consoles on
+               low resolutions (see issue #66). We do not know the exact
+               horizontal scale minimum, but among libdragon's supported
+               resolutions the bug appears on 256x240x16 and 320x240x16. It would
+               work on PAL consoles, but we think users are better served by
+               prohibiting it altogether. 
+
+               For people that absolutely need this on PAL consoles, it can
+               be enabled with *(volatile uint32_t*)0xA4400000 |= 0x300 just
+               after the display_init call. */
+            if (bit == DEPTH_16_BPP)
+                assertf(res != RESOLUTION_256x240 && res != RESOLUTION_320x240,
+                    "ANTIALIAS_OFF is not supported by the hardware on 256x240x16 and 320x240x16.\n"
+                    "Please use ANTIALIAS_RESAMPLE instead.");
+
             /* Set AA off flag */
             control |= 0x300;
 


### PR DESCRIPTION
On NTSC consoles, disabling antialias/resample on low resolutions
triggers a hardware bug. The bug does not appear to be present on PAL
consoles though.

We assume that most users will want to build an application that works
on all consoles, so we assert with an explicit error message in case
ANTIALIAS_OFF is selected, suggesting to use ANTIALIAS_RESAMPLE which
should be acceptable in most use cases and works on all consoles.

Fixes #66