### PR TITLE
ym64: switch to requiring filesystem-prefix for filenames

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -209,7 +209,7 @@ enum Page page_song(void) {
 			song_ramsz += xm.ctx->ctx_size_stream_sample_buf[i];
 		#endif
 	} else {
-		ym64player_open(&ym, cur_rom+5, &yminfo);
+		ym64player_open(&ym, cur_rom, &yminfo);
 		ym64player_play(&ym, 0);
 		song_name = yminfo.name;
 		song_channels = 3;

--- a/include/ym64.h
+++ b/include/ym64.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 #include "mixer.h"
 #include "ay8910.h"
@@ -52,7 +53,7 @@ typedef struct _LHANewDecoder LHANewDecoder;
 typedef struct {
 	waveform_t wave;          ///< waveform for playback with the mixer
 
-	int fh;                   ///< Open file handle
+	FILE *f;                  ///< Open file handle
 	LHANewDecoder *decoder;   ///< Optional LHA decoder (compressed YM files)
 	int start_off;            ///< Starting offset of the first audio frame
 
@@ -77,7 +78,7 @@ typedef struct {
  * @brief Open a YM64 file for playback
  * 
  * @param[in]  	player 		YM64 player to initialize
- * @param[in] 	fn 			Filename to open
+ * @param[in] 	fn 			Filename of the XM64 (with filesystem prefix, e.g. `rom://`).
  * @param[out] 	info 		Optional structure to fill with information on the song
  *                          (pass NULL if not needed)
  */


### PR DESCRIPTION
Just like xm64, it's better to have public APIs to accept filenames
with filesystem prefix. In the case of ym64, it does also work on
all filesystems as the I/O is far from critical (while on xm64, we
currently only support rom://)