### PR TITLE
toolchain: compile newlib with optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
           ghcr.io/dragonminded/libdragon:latest \
           ./build.sh
 
+      - name: "Upload built ROMs to artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: roms
+          path: |
+            ${{ github.workspace }}/examples/**/*.z64
+            ${{ github.workspace }}/tests/*.z64
+
   Build-Tools-Windows:
     runs-on: windows-latest
     strategy:

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -95,7 +95,7 @@ make install-target-libgcc || sudo make install-target-libgcc || su -c "make ins
 
 # Compile newlib
 cd ../"newlib-$NEWLIB_V"
-CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC" ./configure \
+CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2" ./configure \
   --target=mips64-elf \
   --prefix="$INSTALL_PATH" \
   --with-cpu=mips64vr4300 \


### PR DESCRIPTION
Ooops...

I have broken it here:
https://github.com/DragonMinded/libdragon/commit/1c522f2da5928bb5bb79ac76436c2186091fef75#diff-4cdfece525412cfc651464566e6bc1e6a8c333a3d67831a751e8c78f3a82ab69L93-R93

but I had removed `CFLAGS="-O2"` because `CFLAGS` was being ignored in the compilation of Newlib (I knew because I had tried to add the `-DHAVE_ASSERT_FUNC` in `CFLAGS` and it was being ignored). So I moved to `CFLAGS_FOR_TARGET` and I assumed that nothing was necessary.

It looks like for unknown (to me) reasons, `CFLAGS="-O2"` was indeed having an effect.

I've also took the chance to modify the CI to upload all the built ROMs as artifacts, which costs nothing and since we build them, we can as well make them available for download from the CI.