### PR TITLE
do_ctors: fix (again) constructors when using ld linker

### DIFF
--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -35,7 +35,9 @@ void __do_global_ctors()
 {
 	func_ptr * ctor_addr = &__CTOR_END__ - 1;
 	func_ptr * ctor_sentinel = &__CTOR_LIST__;
-	while (ctor_addr > ctor_sentinel) {
+	assertf((uint32_t)*ctor_sentinel != 0xFFFFFFFF,
+		"Invalid constructor sentinel.\nWhen linking with g++, please specify:\n   --wrap __do_global_ctors");
+	while (ctor_addr >= ctor_sentinel) {
 		if (*ctor_addr) (*ctor_addr)();
 		ctor_addr--;
 	}


### PR DESCRIPTION
In #195, we fixed a bug (off-by-one) in __do_global_ctors that caused
the last constructor not to be called in C programs (using ld linker).

This in turn broke C++ software, that uses g++ as linker. We found out
that ld and g++ creates different constructor tables. We attempted a
first fix in #197 by switching n64.mk to use g++, but this broke the
usage of ld linker; so we fixed it again in #201 by separating the
codebase for ld (__do_global_ctors) vs g++ (__wrap___do_global_ctors).

Unfortunately, in doing so in #201, we reverted to the version of
__do_global_ctors that had the initial bug, effectively reverting #195.
So, all in all, we still have code built by ld broken because the
last constructor (eg: init_interrupts) is not called.

So this PR introduces again the fix in #195, hopefully fixing it finally
for good.