### PR TITLE
Some changes and additions to cop0

### DIFF
--- a/include/cop0.h
+++ b/include/cop0.h
@@ -59,7 +59,7 @@
  *
  * @see #C0_GET_CAUSE_EXC_CODE, #C0_GET_CAUSE_CE and #C0_CAUSE_BD
  */
-#define C0_READ_CR() ({ \
+#define C0_CAUSE() ({ \
 	uint32_t x; \
 	asm volatile("mfc0 %0,$13" : "=r" (x) : ); \
 	x; \
@@ -70,9 +70,15 @@
  * 
  * Use this to update it for a custom exception handler.
  * */
-#define C0_WRITE_CR(x) ({ \
+#define C0_WRITE_CAUSE(x) ({ \
     asm volatile("mtc0 %0,$13"::"r"(x)); \
 })
+
+/** @cond */
+/* Alternative version with different naming */
+#define C0_CR()        C0_CAUSE()
+#define C0_WRITE_CR(x) C0_WRITE_CAUSE()
+/** @endcond */
 
 /**
  * @brief Returns the COP0 register $8 (BadVAddr)
@@ -81,7 +87,7 @@
  * only register holding the last virtual address to be translated which became
  * invalid, or a virtual address for which an addressing error occurred.
  */
-#define C0_READ_BADVADDR() ({ \
+#define C0_BADVADDR() ({ \
 	uint32_t x; \
 	asm volatile("mfc0 %0,$8" : "=r" (x) : ); \
 	x; \
@@ -97,11 +103,19 @@
  * needs correction in the exception handler. This macro is for reading its
  * value.
  */
-#define C0_READ_EPC() ({ \
+#define C0_EPC() ({ \
 	uint32_t x; \
 	asm volatile("mfc0 %0,$14" : "=r" (x) : ); \
 	x; \
 })
+
+/** @cond */
+/* Deprecated version of macros with wrong naming that include "READ" */
+#define C0_READ_CR()         C0_CAUSE()
+#define C0_READ_EPC()        C0_EPC()
+#define C0_READ_BADVADDR()   C0_BADVADDR()
+/** @endcond */
+
 
 /* COP0 Status bits definition. Please refer to MIPS R4300 manual. */
 #define C0_STATUS_IE        0x00000001      ///< Status: interrupt enable
@@ -116,12 +130,16 @@
 /* COP0 interrupt bits definition. These are compatible bothwith mask and pending bits. */
 #define C0_INTERRUPT_0      0x00000100      ///< Status/Cause: HW interrupt 0
 #define C0_INTERRUPT_1      0x00000200      ///< Status/Cause: HW interrupt 1
-#define C0_INTERRUPT_RCP    0x00000400      ///< Status/Cause: HW interrupt 2 (RCP)
+#define C0_INTERRUPT_2      0x00000400      ///< Status/Cause: HW interrupt 2 (RCP)
 #define C0_INTERRUPT_3      0x00000800      ///< Status/Cause: HW interrupt 3
-#define C0_INTERRUPT_4      0x00001000      ///< Status/Cause: HW interrupt 4
+#define C0_INTERRUPT_4      0x00001000      ///< Status/Cause: HW interrupt 4 (PRENMI)
 #define C0_INTERRUPT_5      0x00002000      ///< Status/Cause: HW interrupt 5
 #define C0_INTERRUPT_6      0x00004000      ///< Status/Cause: HW interrupt 6
-#define C0_INTERRUPT_TIMER  0x00008000      ///< Status/Cause: HW interrupt 7 (Timer)
+#define C0_INTERRUPT_7      0x00008000      ///< Status/Cause: HW interrupt 7 (Timer)
+
+#define C0_INTERRUPT_RCP    C0_INTERRUPT_2  ///< Status/Cause: HW interrupt 2 (RCP)
+#define C0_INTERRUPT_PRENMI C0_INTERRUPT_4  ///< Status/Cause: HW interrupt 4 (PRENMI)
+#define C0_INTERRUPT_TIMER  C0_INTERRUPT_7  ///< Status/Cause: HW interrupt 7 (Timer)
 
 /**
  * @brief Get the CE value from the COP0 status register

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -77,7 +77,7 @@
 /** @cond */
 /* Alternative version with different naming */
 #define C0_CR()        C0_CAUSE()
-#define C0_WRITE_CR(x) C0_WRITE_CAUSE()
+#define C0_WRITE_CR(x) C0_WRITE_CAUSE(x)
 /** @endcond */
 
 /**
@@ -109,13 +109,136 @@
 	x; \
 })
 
+/**
+ * @brief Read the COP0 INDEX register
+ * 
+ * This register is used during TLB programming. It holds the index of the TLB
+ * entry being accessed (0-31).
+ */
+#define C0_INDEX() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$0":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Write the COP0 INDEX register
+ * 
+ * This register is used during TLB programming. It holds the index of the TLB
+ * entry being accessed (0-31).
+ */
+#define C0_WRITE_INDEX(x)    asm volatile("mtc0 %0,$0; nop; nop"::"r"(x))
+
+
+/**
+ * @brief Read the COP0 ENTRYHI register
+ * 
+ * This register is used during TLB programming. It holds the configuration
+ * of the virtual memory entry for the TLB slot being accessed.
+ */
+#define C0_ENTRYHI() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$10":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Write the COP0 ENTRYHI register
+ * 
+ * This register is used during TLB programming.
+ */
+#define C0_WRITE_ENTRYHI(x)  asm volatile("mtc0 %0,$10; nop; nop"::"r"(x))
+
+/**
+ * @brief Read the COP0 ENTRYLO0 register
+ * 
+ * This register is used during TLB programming. It holds the configuration
+ * of the physical memory entry (even bank) for the TLB slot being accessed.
+ */
+#define C0_ENTRYLO0() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$2":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Write the COP0 ENTRYLO0 register
+ * 
+ * This register is used during TLB programming. It holds the configuration
+ * of the physical memory entry (even bank) for the TLB slot being accessed.
+ */
+#define C0_WRITE_ENTRYLO0(x) asm volatile("mtc0 %0,$2; nop; nop"::"r"(x))
+
+/**
+ * @brief Read the COP0 ENTRYLO1 register
+ * 
+ * This register is used during TLB programming. It holds the configuration
+ * of the physical memory entry (odd bank) for the TLB slot being accessed.
+ */
+#define C0_ENTRYLO1() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$3":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Write the COP0 ENTRYLO1 register
+ * 
+ * This register is used during TLB programming. It holds the configuration
+ * of the physical memory entry (even bank) for the TLB slot being accessed.
+ */
+#define C0_WRITE_ENTRYLO1(x) asm volatile("mtc0 %0,$3; nop; nop"::"r"(x))
+
+
+/**
+ * @brief Read the COP0 PAGEMASK register
+ * 
+ * This register is used during TLB programming. It holds the bitmask that
+ * configures the page size of the TLB slot being accessed.
+ */
+#define C0_PAGEMASK() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$5":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Write the COP0 PAGEMASK register
+ * 
+ * This register is used during TLB programming. It holds the bitmask that
+ * configures the page size of the TLB slot being accessed.
+ */
+#define C0_WRITE_PAGEMASK(x) asm volatile("mtc0 %0,$5; nop; nop"::"r"(x))
+
+
+/**
+ * @brief Read the COP0 WIRED register
+ * 
+ * This register is used during TLB programming. It allows to partition TLB
+ * slots between fixed slots and random slots. The fixed slot pool is the
+ * range [0..WIRED[ and the random pool is the range [WIRED..32[
+ */
+#define C0_WIRED() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$6":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Write the COP0 WIRED register
+ * 
+ * This register is used during TLB programming. It allows to partition TLB
+ * slots between fixed slots and random slots. The fixed slot pool is the
+ * range [0..WIRED[ and the random pool is the range [WIRED..32[
+ */
+#define C0_WRITE_WIRED(x) asm volatile("mtc0 %0,$6; nop; nop"::"r"(x))
+
 /** @cond */
 /* Deprecated version of macros with wrong naming that include "READ" */
 #define C0_READ_CR()         C0_CAUSE()
 #define C0_READ_EPC()        C0_EPC()
 #define C0_READ_BADVADDR()   C0_BADVADDR()
 /** @endcond */
-
 
 /* COP0 Status bits definition. Please refer to MIPS R4300 manual. */
 #define C0_STATUS_IE        0x00000001      ///< Status: interrupt enable
@@ -153,6 +276,51 @@
  * @brief Get the exception code value from the COP0 status register value
  */
 #define C0_GET_CAUSE_EXC_CODE(sr) (((sr) & C0_CAUSE_EXC_CODE) >> 2)
+
+/* Flag bits valid for COP0 ENTRYLO0/ENTRYLO1 registers */
+#define C0_ENTRYLO_GLOBAL      (1<<0)       ///< ENTRYLO: mapping is global (all ASIDs)
+#define C0_ENTRYLO_VALID       (1<<1)       ///< ENTRYLO: mapping is active (not disabled)
+#define C0_ENTRYLO_DIRTY       (1<<2)       ///< ENTRYLO: mapping is writable
+
+/* Flag bits valid for COP0 INDEX register */
+#define C0_INDEX_PROBE_FAILED  (1<<31)      ///< INDEX: set when a TLBP probe failed to find a match
+
+
+/**
+ * @brief COP0 TLBWI opcode.
+ * 
+ * This opcode is used during TLB programming. It writes the TLB slot referenced
+ * by INDEX with the contents of PAGEMASK, ENTRYHI, ENTRYLO0, ENTRYLO1.
+ */
+#define C0_TLBWI()           asm volatile("tlbwi; nop; nop; nop; nop")
+
+/**
+ * @brief COP0 TLBWR opcode.
+ * 
+ * This opcode is used during TLB programming. It writes a random TLB slot with
+ * the contents of PAGEMASK, ENTRYHI, ENTRYLO0, ENTRYLO1. THe slot is selected
+ * in the random pool (slots in the range from WIRED to 31).
+ */
+#define C0_TLBWR()           asm volatile("tlbwr; nop; nop; nop; nop")
+
+/**
+ * @brief COP0 TLBR opcode.
+ * 
+ * This opcode is used during TLB programming. It reads the contents of the TLB
+ * slot referenced by INDEX into the registers PAGEMASK, ENTRYHI, ENTRYLO0 and
+ * ENTRYLO1.
+ */
+#define C0_TLBR()            asm volatile("tlbr; nop; nop; nop; nop")
+
+/**
+ * @brief COP0 TLBP opcode.
+ * 
+ * This opcode is used during TLB programming. It probes the current TLB slots
+ * using ENTRYHI (virtual address) to find a matching slot. If it finds, it
+ * loads its index into INDEX. Otherwise, it sets the C0_INDEX_PROBE_FAILED bit
+ * in INDEX.
+ */
+#define C0_TLBP()            asm volatile("tlbp; nop; nop; nop; nop")
 
 /** @} */
 

--- a/src/exception.c
+++ b/src/exception.c
@@ -116,7 +116,7 @@ void exception_default_handler(exception_t* ex) {
 	fprintf(stdout, "%s exception at PC:%08lX\n", ex->info, (uint32_t)(ex->regs->epc + ((cr & C0_CAUSE_BD) ? 4 : 0)));
 
 	fprintf(stdout, "CR:%08lX (COP:%1lu BD:%u)\n", cr, C0_GET_CAUSE_CE(cr), (bool)(cr & C0_CAUSE_BD));
-	fprintf(stdout, "SR:%08lX FCR31:%08X BVAdr:%08lX \n", sr, (unsigned int)fcr31, C0_READ_BADVADDR());
+	fprintf(stdout, "SR:%08lX FCR31:%08X BVAdr:%08lX \n", sr, (unsigned int)fcr31, C0_BADVADDR());
 	fprintf(stdout, "----------------------------------------------------------------");
 	fprintf(stdout, "FPU IOP UND OVE DV0 INV NI | INT sw0 sw1 ex0 ex1 ex2 ex3 ex4 tmr");
 	fprintf(stdout, "Cause%2u %3u %3u %3u %3u%3u | Cause%2u %3u %3u %3u %3u %3u %3u %3u",


### PR DESCRIPTION
First commit: apply a more consistent naming to existing macros. Some were called C0_READ_REG and others C0_REG.

Second commit: add macros for TLB registers and opcodes.
