### PR TITLE
Initial support for iQue/BBPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ programming and debugging. These are the main features:
   to use 64-bit registers and opcodes with it)
 * Can be developed with newer-generation emulators (cen64, Ares, Dillonb's n64,
   m64p) or development cartridges (64drive, EverDrive64).
+* Support both vanilla N64 and iQue Player (chinese variant). The support is
+  experimental and done fully at runtime, so it is possible to run ROMs built
+  with libdragon on iQue without modifying the source code.
 * In-ROM filesystem implementation for assets. Assets can be loaded with
   `fopen("rom://asset.dat")` without having to do complex things to link them in.
 * Efficient interrupt-based timer library (also features a monotone 64-bit

--- a/examples/timers/timers.c
+++ b/examples/timers/timers.c
@@ -15,28 +15,28 @@ static volatile int running = 1; // clear by one-shot after 30 sec
 
 void one_msec(int ovfl)
 {
-	t1 += 0.001;
+    t1 += 0.001;
 }
 
 void half_sec(int ovfl)
 {
-	t2 += 0.5;
+    t2 += 0.5;
 }
 
 void one_sec(int ovfl)
 {
-	t3 += 1.0;
+    t3 += 1.0;
 }
 
 void one_shot(int ovfl)
 {
-	running = 0;
+    running = 0;
 }
 
 int main(void)
 {
-	timer_link_t *one_shot_t;
-	long long start, end;
+    timer_link_t *one_shot_t;
+    long long start, end;
 
     /* Initialize peripherals */
     display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
@@ -44,31 +44,33 @@ int main(void)
 
     console_set_render_mode(RENDER_MANUAL);
 
-	timer_init();
-	start = timer_ticks();
-	new_timer(TIMER_TICKS(1000), TF_CONTINUOUS, one_msec);
-	new_timer(TIMER_TICKS(500000), TF_CONTINUOUS, half_sec);
-	new_timer(TIMER_TICKS(1000000), TF_CONTINUOUS, one_sec);
-	one_shot_t = new_timer(TIMER_TICKS(30000000), TF_ONE_SHOT, one_shot); // the only one we have to keep track of
+    timer_init();
+    start = timer_ticks();
+    new_timer(TIMER_TICKS(1000), TF_CONTINUOUS, one_msec);
+    new_timer(TIMER_TICKS(500000), TF_CONTINUOUS, half_sec);
+    new_timer(TIMER_TICKS(1000000), TF_CONTINUOUS, one_sec);
+    one_shot_t = new_timer(TIMER_TICKS(30000000), TF_ONE_SHOT, one_shot); // the only one we have to keep track of
 
     /* Main loop test */
     while(running)
     {
         console_clear();
 
+        printf("Running on: %s\n", sys_bbplayer() ? "iQue" : "N64");
         printf( "\n Every msec    : %f", t1 );
         printf( "\n Every half sec: %f", t2 );
         printf( "\n Every sec     : %f", t3 );
 
         console_render();
     }
-	end = timer_ticks();
-	// one-shot timers have to be explicitly freed
-	delete_timer(one_shot_t);
-	timer_close();
+    end = timer_ticks();
+    // one-shot timers have to be explicitly freed
+    delete_timer(one_shot_t);
+    timer_close();
 
     console_clear();
 
+    printf("Running on: %s\n", sys_bbplayer() ? "iQue" : "N64");
     printf( "\n Every msec    : %f", t1 );
     printf( "\n Every half sec: %f", t2 );
     printf( "\n Every sec     : %f", t3 );
@@ -76,5 +78,5 @@ int main(void)
 
     console_render();
 
-	while (1) ;
+    while (1) ;
 }

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -17,9 +17,14 @@
  */
 
 /**
+ * @brief Indicates whether we are running on a vanilla N64 or a iQue player
+ */
+extern int __bbplayer;
+
+/**
  * @brief Frequency of the MIPS R4300 CPU
  */
-#define CPU_FREQUENCY    93750000 
+#define CPU_FREQUENCY    (__bbplayer ? 140625000 : 93750000)
 
 
 /**
@@ -142,6 +147,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+bool sys_bbplayer(void);
 
 int sys_get_boot_cic();
 void sys_set_boot_cic(int bc);

--- a/src/debug.c
+++ b/src/debug.c
@@ -372,7 +372,12 @@ static bool usb_initialize_once(void) {
 	if (!once)
 	{
 		once = true;
-		ok = usb_initialize();
+		if (!sys_bbplayer())
+			ok = usb_initialize();
+		else
+			/* 64drive autodetection makes iQue player crash; disable USB
+			   support altogether for now. */
+			ok = false;
 	}
 	return ok;
 }

--- a/src/display.c
+++ b/src/display.c
@@ -268,7 +268,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
 {
     uint32_t registers[REGISTER_COUNT];
     uint32_t tv_type = get_tv_type();
-    uint32_t control = 0x3000;
+    uint32_t control = !sys_bbplayer() ? 0x3000 : 0x1000;
 
     /* Can't have the video interrupt happening here */
     disable_interrupts();

--- a/src/dma.c
+++ b/src/dma.c
@@ -243,8 +243,10 @@ void dma_read_async(void *ram_address, unsigned long pi_address, unsigned long l
         if ((misalign&1) == 0 && len < 0x7F-misalign*2) {
             // Fast-path: RDRAM even-misaligned addresses work correctly
             // for small transfers (up to some magic value), though they transfer
-            // less then requested. Tweak the length accordingly and do the transfer.
-            len += misalign;
+            // less then requested on vanilla N64 (not on iQue). Tweak the length
+            // accordingly and do the transfer.
+            if (!sys_bbplayer())
+                len += misalign;
         } else {        
             // Manually transfer the first bytes, up to creating a 8-byte
             // alignment. The code is complicated by the fact that we can

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -10,6 +10,27 @@
 	.global _start
 _start:
 	lw t0, 0x80000318			/* memory size */
+
+	/* Check whether we are running on iQue or N64. Use the MI version register
+	   which has LSB set to 0xB0 on iQue. We assume 0xBn was meant for BBPlayer.
+	   Notice that we want this test to be hard for emulators to pass by mistake,
+	   so checking for a specific value while reading seems solid enough. */
+	lw t1, 0xA4300004
+	andi t1, 0xF0
+	bne t1, 0xB0, set_sp
+	li fp, 0                    /* fp=0 -> vanilla N64 */
+
+	/* In iQue player, memory allocated to game can be configured and it appears
+	   in 0x80000318. On the other hand, the top 8Mb of RDRAM is reserved to
+	   savegames. So avoid putting the stack there, capping the size to 0x7C0000.
+	   See also get_memory_size. */
+	li fp, 1                    /* fp=1 -> iQue player */
+	li t1, 0x800000
+	blt t0, t1, set_sp
+	nop
+	li t0, 0x7C0000
+
+set_sp:
 	li t1, 0x7FFFFFF0
 	addu sp,t0,t1				/* init stack */
 	la gp, _gp					/* init data pointer */
@@ -57,6 +78,9 @@ bss_init:
 	sub a1,a0
 	jal data_cache_hit_writeback_invalidate
 	nop
+
+	/* Store the bbplayer flag now that BSS has been cleared */
+	sw fp, __bbplayer
 
 	/* load interrupt vector */
 	la t0,intvector

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-BUILD_DIR=build/
+BUILD_DIR=build
 include $(N64_INST)/include/n64.mk
 
 all: testrom.z64 testrom_emu.z64

--- a/tests/test_dma.c
+++ b/tests/test_dma.c
@@ -22,6 +22,8 @@ void test_dma_read_misalign(TestContext *ctx) {
 	for (int i=56; i<64; i++) {
 		for (int j=1;j<256;j++) {
 			run(i, i&1, j);
+			if (ctx->result == TEST_FAILED)
+				return;
 		}
 	}
 }

--- a/tests/test_ticks.c
+++ b/tests/test_ticks.c
@@ -123,13 +123,18 @@ void test_ticks(TestContext *ctx) {
 	register_VI_handler(frame_callback);
 	enable_interrupts();
 
-	ASSERT(ticks_0 == 0 && ticks_1 == 45812, "not reading correct register or function not inlined. Received %lu and %lu", ticks_0, ticks_1);
+	ASSERT(ticks_0 == 0 && ticks_1 == (!sys_bbplayer() ? 45812 : 30542), "not reading correct register or function not inlined. Received %lu and %lu", ticks_0, ticks_1);
 
 	// Sync to nearest video frame to use as an interval
 	while (state < Start);
 
 	test_ticks_func(ctx, wait_ticks, "wait_ticks", test_ticks_cases, sizeof(test_ticks_cases) / sizeof(test_ticks_cases[0]));
-	test_ticks_func(ctx, wait_ms, "wait_ms", test_ticks_ms_cases, sizeof(test_ticks_ms_cases) / sizeof(test_ticks_ms_cases[0]));
+
+	// The wait_ms test contains hardcoded tick values that refer to the conversion
+	// between milliseconds and ticks, as computed on a N64. It won't work on
+	// iQue, so just skip this part.
+	if (!sys_bbplayer())
+		test_ticks_func(ctx, wait_ms, "wait_ms", test_ticks_ms_cases, sizeof(test_ticks_ms_cases) / sizeof(test_ticks_ms_cases[0]));
 
 	// Cleanup
 	unregister_VI_handler(frame_callback);

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -221,7 +221,7 @@ int main() {
 		return 0;
 	}
 
-	printf("libdragon testsuite\n\n");
+	printf("libdragon testsuite (%s)\n\n", sys_bbplayer() ? "iQue" : "N64");
 	int failures = 0;
 	int successes = 0;
 	int skipped = 0;
@@ -293,7 +293,7 @@ int main() {
 		// happened and we need to double check this.
 		// In general, this benchmarking is extremely hard to get right for
 		// emulators, so don't even attempt it because we would get too many failures.
-		else if (!IN_EMULATOR &&
+		else if (!IN_EMULATOR && !sys_bbplayer() &&
 			!(tests[i].flags & TEST_FLAGS_NO_BENCHMARK) &&
 			((float)test_diff / (float)test_duration > ((tests[i].flags & TEST_FLAGS_IO) ? 0.1f : 0.05f))
 		) {


### PR DESCRIPTION
iQue / BBPlayer is a Chinese variant of Nintendo 64 which has a slightly different hardware and operating system. This PR adds some basic support to libdragon so that it is possible to at least boot the ROMs. ~~The macro N64_BBPLAYER is introduced, and it must be changed to 1 at compile-time to build a iQue-compatible version of libdragon~~. Detection is made at boot time, and at runtime it is possible to call `sys_bbplayer()` to check whether we are running on an iQue Player or not.

The CPU frequency is higher compared to a stock N64, so timers run faster. In this patch, the CPU_FREQUENCY is adjusted so that the timers example pass. Notice that `wait_ticks` is not changed, so games using `wait_ticks` and hardcoding a fixed number of ticks might break with iQue as the delay would be shorter there. We must decide whether to keep this approach, or rather transparently scale all timer-related functions to the original N64 frequency.

A bit is also changed in the display registers otherwise display is garbled. A change is also made to n64tool, to create ROMs which are 16Kb-padded by default, which makes them compatible with iQue. This doesn't affect people explicitly specifying a size (that is still respected), but it is the new default behavior.

This is just the beginning, there are many other differences, but we have to start somewhere.

This PR has been tested on real hardware.