### PR TITLE
Misc batch of audio fixes

### DIFF
--- a/examples/audioplayer/Makefile
+++ b/examples/audioplayer/Makefile
@@ -21,20 +21,20 @@ all: audioplayer.z64
 filesystem/%.xm64: assets/%.xm
 	@mkdir -p $(dir $@)
 	@echo "    [AUDIO] $@"
-	@$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem $<
+	@$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem "$<"
 filesystem/%.xm64: assets/%.XM
 	@mkdir -p $(dir $@)
 	@echo "    [AUDIO] $@"
-	@$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem $<
+	@$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem "$<"
 
 filesystem/%.ym64: assets/%.ym
 	@mkdir -p $(dir $@)
 	@echo "    [AUDIO] $@"
-	$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem $<
+	$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem "$<"
 filesystem/%.ym64: assets/%.YM
 	@mkdir -p $(dir $@)
 	@echo "    [AUDIO] $@"
-	$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem $<
+	$(N64_AUDIOCONV) $(AUDIOCONV_FLAGS) -o filesystem "$<"
 
 # As an example, activate compression darkness.ym. The file will be smaller
 # but it will be impossible to seek it in the player.

--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -220,8 +220,6 @@ enum Page page_song(void) {
 
 	// Unmute all channels
 	memset(mute, 0, sizeof(mute));
-	for (int i=0;i<4;i++) // 4 audio buffers (see audio_init)
-		audio_write_silence();
 
 	while (true) {
 		display_context_t disp = display_lock();
@@ -392,8 +390,6 @@ enum Page page_song(void) {
 					xm64player_close(&xm);
 				else
 					ym64player_close(&ym);
-				for (int i=0;i<4;i++) // 4 audio buffers (see audio_init)
-					audio_write_silence();
 				return PAGE_MENU;
 			}
 		}

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -502,8 +502,8 @@ void mixer_exec(int32_t *out, int num_samples) {
 	rsp_load(&rsp_mixer);
 
 	volatile rsp_mixer_channel_t *rsp_wv = (volatile rsp_mixer_channel_t *)&SP_DMEM[36];
-	mixer_fx15_t lvol[MIXER_MAX_CHANNELS] __attribute__((aligned(8)));
-	mixer_fx15_t rvol[MIXER_MAX_CHANNELS] __attribute__((aligned(8)));
+	mixer_fx15_t lvol[MIXER_MAX_CHANNELS] __attribute__((aligned(8))) = {0};
+	mixer_fx15_t rvol[MIXER_MAX_CHANNELS] __attribute__((aligned(8))) = {0};
 
 	for (int ch=0;ch<Mixer.num_channels;ch++) {
 		mixer_channel_t *c = &Mixer.channels[ch];
@@ -582,7 +582,8 @@ void mixer_exec(int32_t *out, int num_samples) {
 
 	for (int i=0;i<Mixer.num_channels;i++) {
 		mixer_channel_t *ch = &Mixer.channels[i];
-		ch->pos += (uint64_t)rsp_wv[i].pos - (uint64_t)(ch->pos & 0x7FFFFFFF);
+		if (ch->ptr)
+			ch->pos += (uint64_t)rsp_wv[i].pos - (uint64_t)(ch->pos & 0x7FFFFFFF);
 	}
 
 	Mixer.ticks += num_samples;

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -32,6 +32,10 @@ static int tick(void *arg) {
 		// Seek was requested. Do it.
 		xm_seek(ctx, xmp->seek.patidx, xmp->seek.row, xmp->seek.tick);
 		xmp->seek.patidx = -1;
+		// Turn off all currently-playing samples, so that we don't risk keep
+		// playing them.
+		for (int i=0;i<ctx->module.num_channels;i++)
+			mixer_ch_stop(first_ch+i);
 	}
 
 	assert(ctx->remaining_samples_in_tick <= 0);

--- a/tools/audioconv64/audioconv64.c
+++ b/tools/audioconv64/audioconv64.c
@@ -111,6 +111,11 @@ void convert(char *infn, char *outfn1) {
 	}
 }
 
+bool exists(const char *path) {
+	struct stat st;
+	return stat(path, &st) == 0;
+}
+
 bool isfile(const char *path) {
 	struct stat st;
 	stat(path, &st);
@@ -232,7 +237,11 @@ int main(int argc, char *argv[]) {
 			}
 		} else {
 			// Positional argument. It's either a file or a directory. Convert it
-			walkdir(argv[i], outdir, convert);
+			if (!exists(argv[i])) {
+				fprintf(stderr, "ERROR: file %s does not exist\n", argv[i]);
+			} else {
+				walkdir(argv[i], outdir, convert);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR includes several commits that I've done over the past weeks to fix several bugs. It should be reviewed commit by commit, as they are mostly unrelated changes.

The most important is `audio: avoid allowing to overwrite a buffer that was currently played`, which fixes a historical bug in audio.c where the currently-played audio buffer could be overwritten because of race conditions, causing audio cracks or silence. This typically happened at the begin or end of an audio playback.

`mixer: fix two undefined behaviors` fixes an uninitialized data bug that triggers when the RSP mixer was used together with other RSP ucodes (alternating them) and could find random data in DMEM. This will turn useful as we grow more ucodes in libdragon.

`audioconv64: fix off-tune bug with short forward loops` is an important fix for some out-of-tune playback in chiptune XM modules that used very short 8-bit waveforms with loops.

The others are really minor stuff.