### PR TITLE
joybus: implement asynchronous API and use it to implement controller autoscan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o \
 			 $(BUILD_DIR)/audio.o $(BUILD_DIR)/display.o \
 			 $(BUILD_DIR)/console.o $(BUILD_DIR)/joybus.o \
 			 $(BUILD_DIR)/controller.o $(BUILD_DIR)/rtc.o \
-			 $(BUILD_DIR)/eepromfs.o $(BUILD_DIR)/mempak.o \
+			 $(BUILD_DIR)/eeprom.o $(BUILD_DIR)/eepromfs.o $(BUILD_DIR)/mempak.o \
 			 $(BUILD_DIR)/tpak.o $(BUILD_DIR)/graphics.o $(BUILD_DIR)/rdp.o \
 			 $(BUILD_DIR)/rsp.o $(BUILD_DIR)/dma.o $(BUILD_DIR)/timer.o \
 			 $(BUILD_DIR)/exception.o $(BUILD_DIR)/do_ctors.o \
@@ -84,6 +84,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/mempak.h $(INSTALLDIR)/mips64-elf/include/mempak.h
 	install -Cv -m 0644 include/controller.h $(INSTALLDIR)/mips64-elf/include/controller.h
 	install -Cv -m 0644 include/rtc.h $(INSTALLDIR)/mips64-elf/include/rtc.h
+	install -Cv -m 0644 include/eeprom.h $(INSTALLDIR)/mips64-elf/include/eeprom.h
 	install -Cv -m 0644 include/eepromfs.h $(INSTALLDIR)/mips64-elf/include/eepromfs.h
 	install -Cv -m 0644 include/tpak.h $(INSTALLDIR)/mips64-elf/include/tpak.h
 	install -Cv -m 0644 include/graphics.h $(INSTALLDIR)/mips64-elf/include/graphics.h

--- a/include/eeprom.h
+++ b/include/eeprom.h
@@ -1,0 +1,68 @@
+/**
+ * @file eeprom.h
+ * @brief EEPROM support
+ * @ingroup eeprom
+ */
+
+#ifndef __LIBDRAGON_EEPROM_H
+#define __LIBDRAGON_EEPROM_H
+
+/**
+ * @defgroup peripherals Peripherals subsystem
+ * @ingroup libdragon
+ * @brief Management of serial peripherals, reachable through Joybus
+ * 
+ * This module contains higher-level routine to access different peripherals
+ * that are accessible via the JoyBus protocol and the PIF serial chip.
+ */
+
+/**
+ * @defgroup eeprom EEPROM subsystem
+ * @ingroup peripherals
+ * @brief Management of EEPROM for saves
+ * 
+ * This subsytem is made of two different APIs:
+ * 
+ *  * A lower-level API (eeprom.h) for raw low-level access to EEPROM bytes
+ *  * A higher-level API (eepromfs.h) for higher-level access to EEPROM
+ *    with structured data.
+ *
+ */
+
+#include <stdint.h>
+
+/**
+ * @brief EEPROM Probe Values
+ * @see #eeprom_present
+ */
+typedef enum eeprom_type_t
+{
+    /** @brief No EEPROM present */
+    EEPROM_NONE = 0,
+    /** @brief 4 kilobit (64-block) EEPROM present */
+    EEPROM_4K   = 1,
+    /** @brief 16 kilobit (256-block) EEPROM present */
+    EEPROM_16K  = 2
+} eeprom_type_t; 
+
+/**
+ * @brief Size of an EEPROM save block in bytes.
+ */
+#define EEPROM_BLOCK_SIZE 8
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+eeprom_type_t eeprom_present( void );
+size_t eeprom_total_blocks( void );
+void eeprom_read( uint8_t block, uint8_t * dest );
+uint8_t eeprom_write( uint8_t block, const uint8_t * src );
+void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len );
+void eeprom_write_bytes( const uint8_t * src, size_t start, size_t len );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/eepromfs.h
+++ b/include/eepromfs.h
@@ -1,7 +1,7 @@
 /**
  * @file eepromfs.h
  * @brief EEPROM Filesystem
- * @ingroup eepfs
+ * @ingroup eeprom
  */
 #ifndef __LIBDRAGON_EEPROMFS_H
 #define __LIBDRAGON_EEPROMFS_H

--- a/include/joybus.h
+++ b/include/joybus.h
@@ -1,7 +1,7 @@
 /**
  * @file joybus.h
  * @brief Joybus Subsystem
- * @ingroup joybus
+ * @ingroup lowlevel
  */
 #ifndef __LIBDRAGON_JOYBUS_H
 #define __LIBDRAGON_JOYBUS_H
@@ -10,7 +10,7 @@
 #include <stdint.h>
 
 /**
- * @addtogroup joybus
+ * @addtogroup lowlevel
  * @{
  */
 
@@ -23,36 +23,12 @@
  */
 #define JOYBUS_BLOCK_DWORDS ( JOYBUS_BLOCK_SIZE / sizeof(uint64_t) )
 
-/**
- * @brief EEPROM Probe Values
- * @see #eeprom_present
- */
-typedef enum eeprom_type_t
-{
-    /** @brief No EEPROM present */
-    EEPROM_NONE = 0,
-    /** @brief 4 kilobit (64-block) EEPROM present */
-    EEPROM_4K   = 1,
-    /** @brief 16 kilobit (256-block) EEPROM present */
-    EEPROM_16K  = 2
-} eeprom_type_t; 
-
-/**
- * @brief Size of an EEPROM save block in bytes.
- */
-#define EEPROM_BLOCK_SIZE 8
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void joybus_exec( const void * inblock, void * outblock );
-eeprom_type_t eeprom_present( void );
-size_t eeprom_total_blocks( void );
-void eeprom_read( uint8_t block, uint8_t * dest );
-uint8_t eeprom_write( uint8_t block, const uint8_t * src );
-void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len );
-void eeprom_write_bytes( const uint8_t * src, size_t start, size_t len );
 
 #ifdef __cplusplus
 }

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -36,6 +36,7 @@
 #include "display.h"
 #include "dma.h"
 #include "dragonfs.h"
+#include "eeprom.h"
 #include "eepromfs.h"
 #include "graphics.h"
 #include "interrupt.h"

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -1,0 +1,242 @@
+/**
+ * @file eeprom.c
+ * @brief EEPROM support
+ * @ingroup eeprom
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include "eeprom.h"
+#include "joybus.h"
+
+/**
+ * @brief Read the status of the EEPROM.
+ *
+ * The EEPROM status response contains a byte-swapped identifier half-word that
+ * indicates which size EEPROM is present on the cartridge and a status byte.
+ *
+ * @return the normalized Joybus EEPROM status response data.
+ */
+static uint32_t eeprom_status( void )
+{
+    const uint64_t input[JOYBUS_BLOCK_DWORDS] =
+    {
+        0x00000000ff010300,
+        0xfffffffffe000000,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+    };
+    uint64_t output[JOYBUS_BLOCK_DWORDS];
+
+    joybus_exec( input, output );
+
+    uint8_t * recv_bytes = (uint8_t *)&output[1];
+
+    return (
+        /* Intentional un-swap of identifier bytes */
+        ((uint32_t)recv_bytes[1] << 16) |
+        ((uint32_t)recv_bytes[0] << 8)  |
+        recv_bytes[2]
+    );
+}
+
+/**
+ * @brief Probe the EEPROM interface on the cartridge.
+ *
+ * Inspect the identifier half-word of the EEPROM status response to
+ * determine which EEPROM save type is available (if any).
+ *
+ * @return which EEPROM type was detected on the cartridge.
+ */
+eeprom_type_t eeprom_present( void )
+{
+    switch( eeprom_status() >> 8 )
+    {
+        case 0xC000: return EEPROM_16K;
+        case 0x8000: return EEPROM_4K;
+        default: return EEPROM_NONE;
+    }
+}
+
+/**
+ * @brief Determine how many blocks of EEPROM exist on the cartridge.
+ *
+ * @return 0 if EEPROM was not detected
+ *         or the number of EEPROM 8-byte save blocks available.
+ */
+size_t eeprom_total_blocks( void )
+{
+    switch ( eeprom_present() )
+    {
+        case EEPROM_16K: return 256;
+        case EEPROM_4K: return 64;
+        default: return 0;
+    }
+}
+
+/**
+ * @brief Read a block from EEPROM.
+ *
+ * @param[in]  block
+ *             Block to read data from. Joybus accesses EEPROM in 8-byte blocks.
+ *
+ * @param[out] dest
+ *             Destination buffer for the eight bytes read from EEPROM.
+ */
+void eeprom_read( uint8_t block, uint8_t * dest )
+{
+    const uint64_t input[JOYBUS_BLOCK_DWORDS] =
+    {
+        0x0000000002080400 | block,
+        0xffffffffffffffff,
+        0xfe00000000000000,
+        0,
+        0,
+        0,
+        0,
+        1
+    };
+    uint64_t output[JOYBUS_BLOCK_DWORDS];
+
+    joybus_exec( input, output );
+
+    memcpy( dest, &output[1], EEPROM_BLOCK_SIZE );
+}
+
+/**
+ * @brief Write a block to EEPROM.
+ *
+ * @param[in] block
+ *            Block to write data to. Joybus accesses EEPROM in 8-byte blocks.
+ *
+ * @param[in] src
+ *            Source buffer for the eight bytes of data to write to EEPROM.
+ *
+ * @return the EEPROM status byte
+ */
+uint8_t eeprom_write( uint8_t block, const uint8_t * src )
+{
+    uint64_t input[JOYBUS_BLOCK_DWORDS] =
+    {
+        0x000000000a010500 | block,
+        0x0000000000000000,
+        0xfffe000000000000,
+        0,
+        0,
+        0,
+        0,
+        1
+    };
+    uint64_t output[JOYBUS_BLOCK_DWORDS];
+
+    memcpy( &input[1], src, EEPROM_BLOCK_SIZE );
+
+    joybus_exec( input, output );
+
+    return output[2] >> 56;
+}
+
+/**
+ * @brief Read a buffer of bytes from EEPROM.
+ *
+ * This is a high-level convenience helper that abstracts away the
+ * one-at-a-time EEPROM block access pattern.
+ *
+ * @param[out] dest
+ *             Destination buffer to read data into
+ * @param[in]  start
+ *             Byte offset in EEPROM to start reading data from
+ * @param[in]  len
+ *             Byte length of data to read into buffer
+ */
+void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len )
+{
+    size_t bytes_left = len;
+    uint8_t buf[EEPROM_BLOCK_SIZE];
+    uint8_t current_block = start / EEPROM_BLOCK_SIZE;
+    // If we need to read a partial block to start off...
+    size_t block_offset = start % EEPROM_BLOCK_SIZE;
+    if (block_offset)
+    {
+        eeprom_read( current_block++, buf );
+        bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
+        while (block_offset < EEPROM_BLOCK_SIZE)
+        {
+            *dest++ = buf[block_offset++];
+        }
+    }
+    // Read whole blocks at a time
+    while ( bytes_left >= EEPROM_BLOCK_SIZE )
+    {
+        eeprom_read( current_block++, dest );
+        dest += EEPROM_BLOCK_SIZE;
+        bytes_left -= EEPROM_BLOCK_SIZE;
+    }
+    // If we need to read a partial block at the end...
+    if (bytes_left)
+    {
+        eeprom_read( current_block, buf );
+        memcpy( dest, buf, bytes_left );
+    }
+}
+
+/**
+ * @brief Write a buffer of bytes to EEPROM.
+ *
+ * This is a high-level convenience helper that abstracts away the
+ * one-at-a-time EEPROM block access pattern.
+ *
+ * Each EEPROM block write takes approximately 15 milliseconds;
+ * this operation may block for a while with large buffer sizes:
+ *
+ * * 4k EEPROM: 64 blocks * 15ms = 960ms!
+ * * 16k EEPROM: 256 blocks * 15ms = 3840ms!
+ *
+ * You may want to pause audio before calling this.
+ *
+ * @param[in] src
+ *            Source buffer containing data to write
+ *
+ * @param[in] start
+ *            Byte offset in EEPROM to start writing data to
+ *
+ * @param[in] len
+ *            Byte length of the src buffer
+ */
+void eeprom_write_bytes( const uint8_t * src, size_t start, size_t len )
+{
+    size_t bytes_left = len;
+    uint8_t buf[EEPROM_BLOCK_SIZE];
+    uint8_t current_block = start / EEPROM_BLOCK_SIZE;
+    // If we need to write a partial block to start off...
+    size_t block_offset = start % EEPROM_BLOCK_SIZE;
+    if (block_offset)
+    {
+        eeprom_read( current_block, buf );
+        bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
+        while (block_offset < EEPROM_BLOCK_SIZE)
+        {
+            buf[block_offset++] = *src++;
+        }
+        eeprom_write( current_block++, buf );
+    }
+    // Write whole blocks at a time
+    while (bytes_left >= EEPROM_BLOCK_SIZE)
+    {
+        memcpy( buf, src, EEPROM_BLOCK_SIZE );
+        eeprom_write( current_block++, buf );
+        src += EEPROM_BLOCK_SIZE;
+        bytes_left -= EEPROM_BLOCK_SIZE;
+    }
+    // If we need to write a partial block at the end...
+    if (bytes_left)
+    {
+        eeprom_read( current_block, buf );
+        memcpy( buf, src, bytes_left );
+        eeprom_write( current_block, buf );
+    }
+}

--- a/src/eepromfs.c
+++ b/src/eepromfs.c
@@ -1,7 +1,7 @@
 /**
  * @file eepromfs.c
  * @brief EEPROM Filesystem
- * @ingroup eepfs
+ * @ingroup eeprom
  */
 #include <string.h>
 #include <stdint.h>

--- a/src/joybus.c
+++ b/src/joybus.c
@@ -1,7 +1,7 @@
 /**
  * @file joybus.c
  * @brief Joybus Subsystem
- * @ingroup joybus
+ * @ingroup lowlevel
  */
 
 #include <string.h>
@@ -10,7 +10,7 @@
 
 /**
  * @defgroup joybus Joybus Subsystem
- * @ingroup libdragon
+ * @ingroup lowlevel
  * @brief Joybus peripheral interface.
  *
  * The Joybus subsystem is in charge of communication with all controllers,
@@ -19,18 +19,32 @@
  * for communicating with the serial interface (SI) registers to send commands
  * to controllers (including Controller Paks, Rumble Paks, and Transfer Paks),
  * the VRU, EEPROM save memory, and the cartridge-based real-time clock.
+ * 
+ * This module implements just the low-level protocol. You should use it
+ * only to implement an unsupported peripherals. Otherwise, refer to the
+ * higher-level modules such as:
  *
- * For Controller Pak functions, refer to the
- * @ref mempak "Mempak Filesystem Routines".
- *
- * For Transfer Pak functions, refer to the
- * @ref transferpak "Transfer Pak Interface".
- *
- * For all other controller-related functions, refer to the
+ * For controllers:
  * @ref controller "Controller Subsystem".
  *
- * For real-time clock functions, refer to the
- * @ref rtc "Real-time Clock Subsystem".
+ * For EEPROM, RTC and other peripherals:
+ * @ref peripherals "Peripherals Subsystem".
+ *
+ * Internally, the JoyBus subsystem communicates with the PIF controller via
+ * the SI DMA, via the JoyBus protocol which is a standard master/slave
+ * binary protocol. Each message of the protocol is a block of 64 bytes, and
+ * can contain multiple commands. Currently, there are no macros or functions
+ * to help composing a JoyBus message, so higher-level libraries currently
+ * hard code the binary messages. 
+ * 
+ * All communications is made asynchronously because SI DMA is quite slow:
+ * its completion is bound to the PIF actually processing the data, rather than
+ * just being the memory transfer. A queue of pending JoyBus messages is kept
+ * in a ring buffer, and is then executed under interrupt when the previous SI DMA
+ * completes. The internal entry point is #joybus_exec_async, that schedules
+ * a message to be sent to PIF, and calls a callback with the reply whenever
+ * it is available. A blocking API (#joybus_exec) is made available for
+ * simpler usage.
  *
  * @{
  */
@@ -112,238 +126,6 @@ void joybus_exec( const void * input, void * output )
     enable_interrupts();
 
     memcpy(output, UncachedAddr(output_aligned), JOYBUS_BLOCK_SIZE);
-}
-
-/**
- * @brief Read the status of the EEPROM.
- *
- * The EEPROM status response contains a byte-swapped identifier half-word that
- * indicates which size EEPROM is present on the cartridge and a status byte.
- *
- * @return the normalized Joybus EEPROM status response data.
- */
-static uint32_t eeprom_status( void )
-{
-    const uint64_t input[JOYBUS_BLOCK_DWORDS] =
-    {
-        0x00000000ff010300,
-        0xfffffffffe000000,
-        0,
-        0,
-        0,
-        0,
-        0,
-        1
-    };
-    uint64_t output[JOYBUS_BLOCK_DWORDS];
-
-    joybus_exec( input, output );
-
-    uint8_t * recv_bytes = (uint8_t *)&output[1];
-
-    return (
-        /* Intentional un-swap of identifier bytes */
-        ((uint32_t)recv_bytes[1] << 16) |
-        ((uint32_t)recv_bytes[0] << 8)  |
-        recv_bytes[2]
-    );
-}
-
-/**
- * @brief Probe the EEPROM interface on the cartridge.
- *
- * Inspect the identifier half-word of the EEPROM status response to
- * determine which EEPROM save type is available (if any).
- *
- * @return which EEPROM type was detected on the cartridge.
- */
-eeprom_type_t eeprom_present( void )
-{
-    switch( eeprom_status() >> 8 )
-    {
-        case 0xC000: return EEPROM_16K;
-        case 0x8000: return EEPROM_4K;
-        default: return EEPROM_NONE;
-    }
-}
-
-/**
- * @brief Determine how many blocks of EEPROM exist on the cartridge.
- *
- * @return 0 if EEPROM was not detected
- *         or the number of EEPROM 8-byte save blocks available.
- */
-size_t eeprom_total_blocks( void )
-{
-    switch ( eeprom_present() )
-    {
-        case EEPROM_16K: return 256;
-        case EEPROM_4K: return 64;
-        default: return 0;
-    }
-}
-
-/**
- * @brief Read a block from EEPROM.
- *
- * @param[in]  block
- *             Block to read data from. Joybus accesses EEPROM in 8-byte blocks.
- *
- * @param[out] dest
- *             Destination buffer for the eight bytes read from EEPROM.
- */
-void eeprom_read( uint8_t block, uint8_t * dest )
-{
-    const uint64_t input[JOYBUS_BLOCK_DWORDS] =
-    {
-        0x0000000002080400 | block,
-        0xffffffffffffffff,
-        0xfe00000000000000,
-        0,
-        0,
-        0,
-        0,
-        1
-    };
-    uint64_t output[JOYBUS_BLOCK_DWORDS];
-
-    joybus_exec( input, output );
-
-    memcpy( dest, &output[1], EEPROM_BLOCK_SIZE );
-}
-
-/**
- * @brief Write a block to EEPROM.
- *
- * @param[in] block
- *            Block to write data to. Joybus accesses EEPROM in 8-byte blocks.
- *
- * @param[in] src
- *            Source buffer for the eight bytes of data to write to EEPROM.
- *
- * @return the EEPROM status byte
- */
-uint8_t eeprom_write( uint8_t block, const uint8_t * src )
-{
-    uint64_t input[JOYBUS_BLOCK_DWORDS] =
-    {
-        0x000000000a010500 | block,
-        0x0000000000000000,
-        0xfffe000000000000,
-        0,
-        0,
-        0,
-        0,
-        1
-    };
-    uint64_t output[JOYBUS_BLOCK_DWORDS];
-
-    memcpy( &input[1], src, EEPROM_BLOCK_SIZE );
-
-    joybus_exec( input, output );
-
-    return output[2] >> 56;
-}
-
-/**
- * @brief Read a buffer of bytes from EEPROM.
- *
- * This is a high-level convenience helper that abstracts away the
- * one-at-a-time EEPROM block access pattern.
- *
- * @param[out] dest
- *             Destination buffer to read data into
- * @param[in]  start
- *             Byte offset in EEPROM to start reading data from
- * @param[in]  len
- *             Byte length of data to read into buffer
- */
-void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len )
-{
-    size_t bytes_left = len;
-	uint8_t buf[EEPROM_BLOCK_SIZE];
-	uint8_t current_block = start / EEPROM_BLOCK_SIZE;
-	// If we need to read a partial block to start off...
-	size_t block_offset = start % EEPROM_BLOCK_SIZE;
-	if (block_offset)
-	{
-		eeprom_read( current_block++, buf );
-		bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
-		while (block_offset < EEPROM_BLOCK_SIZE)
-		{
-			*dest++ = buf[block_offset++];
-		}
-	}
-	// Read whole blocks at a time
-	while ( bytes_left >= EEPROM_BLOCK_SIZE )
-	{
-		eeprom_read( current_block++, dest );
-		dest += EEPROM_BLOCK_SIZE;
-		bytes_left -= EEPROM_BLOCK_SIZE;
-	}
-	// If we need to read a partial block at the end...
-	if (bytes_left)
-	{
-		eeprom_read( current_block, buf );
-		memcpy( dest, buf, bytes_left );
-	}
-}
-
-/**
- * @brief Write a buffer of bytes to EEPROM.
- *
- * This is a high-level convenience helper that abstracts away the
- * one-at-a-time EEPROM block access pattern.
- *
- * Each EEPROM block write takes approximately 15 milliseconds;
- * this operation may block for a while with large buffer sizes:
- *
- * * 4k EEPROM: 64 blocks * 15ms = 960ms!
- * * 16k EEPROM: 256 blocks * 15ms = 3840ms!
- *
- * You may want to pause audio before calling this.
- *
- * @param[in] src
- *            Source buffer containing data to write
- *
- * @param[in] start
- *            Byte offset in EEPROM to start writing data to
- *
- * @param[in] len
- *            Byte length of the src buffer
- */
-void eeprom_write_bytes( const uint8_t * src, size_t start, size_t len )
-{
-    size_t bytes_left = len;
-	uint8_t buf[EEPROM_BLOCK_SIZE];
-	uint8_t current_block = start / EEPROM_BLOCK_SIZE;
-	// If we need to write a partial block to start off...
-	size_t block_offset = start % EEPROM_BLOCK_SIZE;
-	if (block_offset)
-	{
-		eeprom_read( current_block, buf );
-		bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
-		while (block_offset < EEPROM_BLOCK_SIZE)
-		{
-			buf[block_offset++] = *src++;
-		}
-		eeprom_write( current_block++, buf );
-	}
-	// Write whole blocks at a time
-	while (bytes_left >= EEPROM_BLOCK_SIZE)
-	{
-		memcpy( buf, src, EEPROM_BLOCK_SIZE );
-		eeprom_write( current_block++, buf );
-		src += EEPROM_BLOCK_SIZE;
-		bytes_left -= EEPROM_BLOCK_SIZE;
-	}
-	// If we need to write a partial block at the end...
-	if (bytes_left)
-	{
-		eeprom_read( current_block, buf );
-		memcpy( buf, src, bytes_left );
-		eeprom_write( current_block, buf );
-	}
 }
 
 /** @} */ /* joybus */

--- a/src/joybus.c
+++ b/src/joybus.c
@@ -71,11 +71,198 @@ static volatile struct SI_regs_s * const SI_regs = (struct SI_regs_s *)0xa480000
 static void * const PIF_RAM = (void *)0x1fc007c0;
 
 /**
- * @brief Wait until the SI is finished with a DMA request
+ * @brief A message to be sent to JoyBus, with its completion callback. 
  */
-static void __SI_DMA_wait( void )
+typedef struct {
+    uint64_t input[JOYBUS_BLOCK_DWORDS] __attribute__((aligned(16)));  ///< input message
+    void (*callback)(uint64_t* output);                                ///< callback for completion
+} joybus_msg_t;
+
+#define MAX_JOYBUS_MSGS            8    ///< Maximum number of pending joybus messages
+#define JOYBUS_STATE_IDLE          0    ///< Joybus state: idle (no pending messages)
+#define JOYBUS_STATE_SENDING       1    ///< JoyBus state: sending a message to PIF
+#define JOYBUS_STATE_RECEIVING     2    ///< JoyBus state: receiving a reply from PIF
+
+/** @brief Joybus temporary output buffer */
+static uint64_t joybus_outbuf[JOYBUS_BLOCK_DWORDS] __attribute__((aligned(16)));
+/** @brief Joybus current state (either #JOYBUS_STATE_IDLE, #JOYBUS_STATE_SENDING or #JOYBUS_STATE_RECEIVING) */
+static volatile int joybus_state;
+/** @brief Joybus pending messages (ring buffer) */
+static joybus_msg_t joybus_msgs[MAX_JOYBUS_MSGS];
+/** @brief Pending messages write index */
+static volatile int msgs_widx;
+/** @brief Pending messages read index */
+static volatile int msgs_ridx;
+
+static void si_interrupt(void);
+
+/**
+ * @brief Initialize the joybus subsystem
+ */
+__attribute__((constructor))
+void __joybus_init(void)
 {
-    while (SI_regs->status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) ;
+    // FIXME: this constructor requires the __init_interrupts constructor to be
+    // already run. Since we are not 100% sure of how GCC handles constructor
+    // ordering, we call it explicitly here (there's no harm in calling it
+    // multiple times anyway). Revisit this after gathering more information
+    // on constructor ordering.
+    extern void __init_interrupts(void);
+    __init_interrupts();
+
+    // Initialize the message ring buffer
+    msgs_widx = 0;
+    msgs_ridx = 0;
+    joybus_state = JOYBUS_STATE_IDLE;
+
+    // Acknowledge any pending SI interrupt
+    SI_regs->status = 0;
+
+    // Register our internal interrupt handler
+    register_SI_handler(si_interrupt);
+    set_SI_interrupt(1);
+}
+
+
+/**
+ * @brief Send a joybus messages to the PIF
+ * 
+ * @note This function must be called with interrupts disabled and SI must be idle
+ *
+ * @param      msg    Message to send
+ */
+static void joybus_msg_send(joybus_msg_t *msg) {
+    assert((SI_regs->status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) == 0);
+
+    data_cache_hit_writeback(msg->input, JOYBUS_BLOCK_SIZE);
+    SI_regs->DRAM_addr = msg->input;
+    MEMORY_BARRIER();
+    SI_regs->PIF_addr_write = PIF_RAM;
+    MEMORY_BARRIER();
+    joybus_state = JOYBUS_STATE_SENDING;
+}
+
+/**
+ * @brief Receive a joybus reply from the PIF
+ * 
+ * @note This function must be called with interrupts disabled and SI must be idle
+ *
+ * @param      msg    Message for which a reply is pending
+ */
+static void joybus_msg_recv(joybus_msg_t *msg) {
+    assert((SI_regs->status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) == 0);
+
+    // Start a DMA transfer into the global temporary buffer. We just need
+    // one buffer for all messages as there can be only one ongoing joybus
+    // message at a time (it is a master/slave protocol).
+    data_cache_hit_invalidate(joybus_outbuf, JOYBUS_BLOCK_SIZE);
+    SI_regs->DRAM_addr = joybus_outbuf;
+    MEMORY_BARRIER();
+    SI_regs->PIF_addr_read = PIF_RAM;
+    MEMORY_BARRIER();
+    joybus_state = JOYBUS_STATE_RECEIVING;
+}
+
+/**
+ * @brief Check where there are new messages to send
+ * 
+ * @note This function must be called with interrupts disabled.
+ */
+static void joybus_poll(void) {
+    // If the ring buffer is not empty, fetch the first message and send it
+    if (msgs_ridx != msgs_widx) {
+        joybus_msg_t *msg = &joybus_msgs[msgs_ridx];
+        joybus_msg_send(msg);
+        return;
+    }
+
+    // Queue is empty, switch to idle state
+    joybus_state = JOYBUS_STATE_IDLE;
+}
+
+/**
+ * @brief SI interrupt handler
+ */
+static void si_interrupt(void) {
+    joybus_msg_t *msg;
+
+    switch (joybus_state) {
+    case JOYBUS_STATE_SENDING:
+        // Message sending complete. Start receiving the reply
+        msg = &joybus_msgs[msgs_ridx];
+        joybus_msg_recv(msg);
+        return;
+
+    case JOYBUS_STATE_RECEIVING:
+        // Reply received. Call the callback
+        msg = &joybus_msgs[msgs_ridx];
+        if (msg->callback)
+            msg->callback(joybus_outbuf);
+
+        // Increment read pointer and poll for new messages
+        msgs_ridx = (msgs_ridx + 1) % MAX_JOYBUS_MSGS;
+        joybus_poll();
+        return;
+
+    case JOYBUS_STATE_IDLE:
+        // This should never happen! It's a bug in our state machine, or
+        // somebody is using the SI interface bypassing the joybus message list,
+        // which can cause havoc because they can intermix commands with us
+        assertf(false, "Internal error: SI interrupt while joybus state is idle");
+        return;
+    }
+}
+
+
+/**
+ * @brief Execute an asynchronous joybus message.
+ * 
+ * This function executes an asynchronous joybus protocol exchange, sending
+ * a message block (input), and receiving a reply (output). The message is
+ * sent in background and a completion function "callback" is called when
+ * the output is ready to be processed.
+ * 
+ * It is possible to schedule multiple joybus messages by calling this
+ * function multiple times. They will be automatically executed in order.
+ * The maximum number of pending messages at any given time is #MAX_JOYBUS_MSGS.
+ * 
+ * @note The callback function will be called under interrupt. 
+ * 
+ * @note This function is not part of the public API yet because we want
+ *       to evaluate the use of threading rather than asynchronous programming.
+ *       It should only be used internally without exposing a asynchronous
+ *       API externally.
+ * 
+ * @param[in]   input       The input block (must be of JOYBUS_BLOCK_SIZE bytes).
+ *                          No specific alignment is required for this data block.
+ * @param[in]   callback    A callback completion function that will be called
+ *                          when the joybus command is finished. The function
+ *                          will receive a pointer to the output buffer.
+ *                          Can be NULL if no callback is required.
+ */
+void joybus_exec_async(const void * input, void (*callback)(uint64_t *output))
+{
+    // Make sure that the task queue is not full. If it is, just assert for now.
+    // It is not easy to understand what we should do when the queue is full;
+    // blocking would be an option, but if we are under interrupt, we would be
+    // deadlocking. So punt for now: we can revisit this later.
+    assertf((msgs_widx + 1) % MAX_JOYBUS_MSGS != msgs_ridx,
+        "joybus task queue is full");
+
+    disable_interrupts();
+
+    // Write the new task into the ring buffer.
+    joybus_msg_t *msg = &joybus_msgs[msgs_widx];
+    memcpy(msg->input, input, JOYBUS_BLOCK_SIZE);
+    msg->callback = callback;
+
+    // Increment the write index. If the joybus subsystem is idle, poll immediately
+    // so that we can begin sending the message.
+    msgs_widx = (msgs_widx + 1) % MAX_JOYBUS_MSGS;
+    if (joybus_state == JOYBUS_STATE_IDLE)
+        joybus_poll();
+
+    enable_interrupts();
 }
 
 /**
@@ -95,37 +282,15 @@ static void __SI_DMA_wait( void )
  */
 void joybus_exec( const void * input, void * output )
 {
-    volatile uint64_t input_aligned[JOYBUS_BLOCK_DWORDS] __attribute__((aligned(16)));
-    volatile uint64_t output_aligned[JOYBUS_BLOCK_DWORDS] __attribute__((aligned(16)));
+    volatile bool done = false;
 
-    data_cache_hit_writeback_invalidate(input_aligned, JOYBUS_BLOCK_SIZE);
-    memcpy(UncachedAddr(input_aligned), input, JOYBUS_BLOCK_SIZE);
+    void callback(uint64_t *out) {
+        memcpy(output, out, JOYBUS_BLOCK_SIZE);
+        done = true;
+    }
 
-    /* Be sure another thread doesn't get into a resource fight */
-    disable_interrupts();
-
-    __SI_DMA_wait();
-
-    SI_regs->DRAM_addr = input_aligned; // only cares about 23:0
-    MEMORY_BARRIER();
-    SI_regs->PIF_addr_write = PIF_RAM;
-    MEMORY_BARRIER();
-
-    __SI_DMA_wait();
-
-    data_cache_hit_writeback_invalidate(output_aligned, JOYBUS_BLOCK_SIZE);
-
-    SI_regs->DRAM_addr = output_aligned;
-    MEMORY_BARRIER();
-    SI_regs->PIF_addr_read = PIF_RAM;
-    MEMORY_BARRIER();
-
-    __SI_DMA_wait();
-
-    /* Now that we've copied, its safe to let other threads go */
-    enable_interrupts();
-
-    memcpy(output, UncachedAddr(output_aligned), JOYBUS_BLOCK_SIZE);
+    joybus_exec_async(input, callback);
+    while (!done) {}
 }
 
 /** @} */ /* joybus */

--- a/src/joybusinternal.h
+++ b/src/joybusinternal.h
@@ -1,0 +1,6 @@
+#ifndef __LIBDRAGON_JOYBUSINTERNAL_H
+#define __LIBDRAGON_JOYBUSINTERNAL_H
+
+void joybus_exec_async(const void * input, void (*callback)(uint64_t *output));
+
+#endif

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -11,7 +11,7 @@
 
 /**
  * @defgroup rtc Real-Time Clock Subsystem
- * @ingroup libdragon
+ * @ingroup peripherals
  * @brief Real-time clock interface.
  * @author Christopher Bonhage
  *


### PR DESCRIPTION
This PR has two goals:

 * Improve interrupt latency during Joybus operations. Joybus operations are very slow and they currently run with interrupts fully disabled, which means that it's impossible for the application to implement background graphic/audio update as they are running. This would be the same also with the multithreading kernel, as disabling interrupts prevents scheduling a different thread.
 * `controller_scan()` currently takes 10% (!) of CPU frame time. Since it's a blocking function and there is no multithreading support, all applications are wasting 10% of their CPU frame budget on this.

To fix both issues, we rework Joybus support to use an asynchronous queue of messages. The messages are stored in a ring buffer and the buffer is executed under interrupt, using the SI DMA interrupt to synchronize with PIF. This is done via a new API called `joybus_exec_async`, which is private for now. `joybus_exec` is rewritten on top of `joybus_exec_async` so that all existing code continues to work (be it controller pak, EEPROM, RTC or whatever else), but waiting for the reply to arrive cam now be done with interrupts enabled without risking race conditions.

Then, we change `controller.c` to use the new internal API to implement a autoscan feature: controllers are scanned in background every frame (at vsync). `controller_scan()` is now used only to copy the state updated into interrupt
into a frozen state, to be able to inspect it without risking race conditions. This effectively fixes the performance issue, at the cost of a little (sub-frame) controller latency (as the game accesses a cache refreshed at each vsync, rather than reading the stata at the moment it is ready to process). If the latency proves to be a problem, we can add a API to ask to autoscan controllers multiple times per frame, or the application can still use the alternative blocking API `controller_read` which still works of course (and still wastes 10% of CPU frame time).

The PR is a bit noisy because I took the chance of moving EEPROM functions into their own file. Reviewing commit by commit might be easier.