### PR TITLE
Clean rsp_load cache when calling rsp_load_code directly

### DIFF
--- a/include/rsp.h
+++ b/include/rsp.h
@@ -136,8 +136,11 @@ void rsp_wait(void);
 /** @brief Do a DMA transfer to load a piece of code into RSP IMEM.
  * 
  * This is a lower-level function that actually executes a DMA transfer
- * from RDRAM to IMEM. Prefer using rsp_load instead.
+ * from RDRAM to IMEM. Prefer using #rsp_load instead.
  * 
+ * @note in order for this function to be interoperable with #rsp_load, it
+ * will reset the last loaded ucode cache.
+ *
  * @param[in]     code          Pointer to buffer in RDRAM containing code. 
  *                              Must be aligned to 8 bytes.
  * @param[in]     size          Size of the code to load. Must be a multiple of 8.

--- a/src/rsp.c
+++ b/src/rsp.c
@@ -41,6 +41,10 @@ void rsp_load_code(void* start, unsigned long size, unsigned int imem_offset)
     assert(((uint32_t)start % 8) == 0);
     assert((imem_offset % 8) == 0);
 
+    if (cur_ucode != NULL) {
+        cur_ucode = NULL;
+    }
+
     disable_interrupts();
     __SP_DMA_wait();
 


### PR DESCRIPTION
Consider a program which calls `rsp_load` first and `rsp_load_code` later; `rsp_load` keeps a cache of the last loaded ucode, for performance reasons: so in order for a later invocation to `rsp_load` to actually execute, `rsp_load_code` should always clear the cache.

Otherwise, `rsp_load` would erroneously assume that the ucode trying to be loaded was already up, while in fact it was the one loaded by `rsp_load_code`.