### PR TITLE
Add malloc_uncached API

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -7,6 +7,7 @@
 #define __LIBDRAGON_N64SYS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <assert.h>
 #include "cop0.h"
 #include "cop1.h"
@@ -224,6 +225,8 @@ void inst_cache_invalidate_all(void);
 
 int get_memory_size();
 bool is_memory_expanded();
+void *malloc_uncached(size_t size);
+void free_uncached(void *buf);
 
 /** @brief Type of TV video output */
 typedef enum {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -164,7 +164,7 @@ static void mixer_init_samplebuffers(void) {
 
 	// Do one large allocations for all sample buffers
 	assert(Mixer.ch_buf_mem == NULL);
-	Mixer.ch_buf_mem = malloc(totsize);
+	Mixer.ch_buf_mem = malloc_uncached(totsize);
 	assert(Mixer.ch_buf_mem != NULL);
 	uint8_t *cur = Mixer.ch_buf_mem;
 
@@ -185,7 +185,7 @@ void mixer_close(void) {
 	assert(mixer_initialized());
 
 	if (Mixer.ch_buf_mem) {
-		free(Mixer.ch_buf_mem);
+		free_uncached(Mixer.ch_buf_mem);
 		Mixer.ch_buf_mem = NULL;
 	}
 
@@ -397,7 +397,7 @@ void mixer_ch_set_limits(int ch, int max_bits, float max_frequency, int max_buf_
 	if (Mixer.ch_buf_mem) {
 		for (int i=0;i<Mixer.num_channels;i++)
 			samplebuffer_close(&Mixer.ch_buf[i]);
-		free(Mixer.ch_buf_mem);
+		free_uncached(Mixer.ch_buf_mem);
 		Mixer.ch_buf_mem = NULL;
 	}
 }
@@ -532,7 +532,7 @@ void mixer_exec(int32_t *out, int num_samples) {
 		// Convert to RSP mixer channel structure truncating 64-bit values to 32-bit.
 		// We don't need full absolute position on the RSP, so 32-bit is more
 		// than enough. In fact, we only expose 31 bits, so that we can use the
-		// 32th bit later to correctly update the position without overflow bugs.
+		// 32nd bit later to correctly update the position without overflow bugs.
 		rsp_wv[ch].pos = (uint32_t)c->pos & 0x7FFFFFFF;
 		rsp_wv[ch].step = (uint32_t)c->step & 0x7FFFFFFF;
 		rsp_wv[ch].ptr = c->ptr + ((c->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);


### PR DESCRIPTION
Co-developed with @snacchus.

This PR adds a new `malloc_uncached` API to allocate a buffer that is meant to use only via uncached memory accesses. This kind of programming pattern is useful for buffers that are either (almost) never touched by the CPU (like audio buffers) or even in the case that the CPU only use them as write only / append only, and somebody else consumes them (eg: a RSP display list).

The second commit uses the new API in the mixer, where there was similar code though incomplete and thus potentially buggy.