### PR TITLE
rsp: add rsp_crash with crash screen and RSP assert support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o \
 			 $(BUILD_DIR)/controller.o $(BUILD_DIR)/rtc.o \
 			 $(BUILD_DIR)/eeprom.o $(BUILD_DIR)/eepromfs.o $(BUILD_DIR)/mempak.o \
 			 $(BUILD_DIR)/tpak.o $(BUILD_DIR)/graphics.o $(BUILD_DIR)/rdp.o \
-			 $(BUILD_DIR)/rsp.o $(BUILD_DIR)/dma.o $(BUILD_DIR)/timer.o \
+			 $(BUILD_DIR)/rsp.o $(BUILD_DIR)/rsp_crash.o \
+			 $(BUILD_DIR)/dma.o $(BUILD_DIR)/timer.o \
 			 $(BUILD_DIR)/exception.o $(BUILD_DIR)/do_ctors.o \
 			 $(BUILD_DIR)/audio/mixer.o $(BUILD_DIR)/audio/samplebuffer.o \
 			 $(BUILD_DIR)/audio/rsp_mixer.o $(BUILD_DIR)/audio/wav64.o \
@@ -98,6 +99,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/ucode.S $(INSTALLDIR)/mips64-elf/include/ucode.S
 	install -Cv -m 0644 include/rsp.inc $(INSTALLDIR)/mips64-elf/include/rsp.inc
 	install -Cv -m 0644 include/rsp_dma.inc $(INSTALLDIR)/mips64-elf/include/rsp_dma.inc
+	install -Cv -m 0644 include/rsp_assert.inc $(INSTALLDIR)/mips64-elf/include/rsp_assert.inc
 	install -Cv -m 0644 include/mixer.h $(INSTALLDIR)/mips64-elf/include/mixer.h
 	install -Cv -m 0644 include/samplebuffer.h $(INSTALLDIR)/mips64-elf/include/samplebuffer.h
 	install -Cv -m 0644 include/wav64.h $(INSTALLDIR)/mips64-elf/include/wav64.h

--- a/examples/ucodetest/ucodetest.c
+++ b/examples/ucodetest/ucodetest.c
@@ -44,8 +44,7 @@ int main(void)
 
     rsp_run_async();
 
-    while(1)
-    {
+    RSP_WAIT_LOOP(2000) {
         if (broke) {
             printf("\nbroke");
             printf("\n");

--- a/include/rsp.h
+++ b/include/rsp.h
@@ -1,10 +1,147 @@
 /**
  * @file rsp.h
- * @brief RSP - Programmable vector coprocessor
+ * @brief Low-level RSP hardware library
  * @ingroup rsp
  */
+
+/**
+ * @defgroup rsp RSP interface
+ * @ingroup lowlevel
+ * @brief RSP basic library
+ * 
+ * This library offers very low-level support for RSP programming. The goal
+ * is to provide access to the hardware by exposing macros for all
+ * hardware registers, provide a few simple helpers to load and run RSP
+ * ucode (without any constraint or limitation on how the ucode should
+ * be designed, how it should communicate with the CPU, etc.), and a few
+ * debugging helpers to aid during development.
+ * 
+ * This documentation is not a guide to become a RSP programmer. It assumes
+ * familiarity with RSP programming concepts and focus on explaining 
+ * libdragon RSP support.
+ * 
+ * ## Ucode definition and loading
+ * 
+ * To define a RSP ucode, assuming you are using the n64.mk build system,
+ * it is sufficient to do the following:
+ * 
+ *   1. Write your ucode in a file with extension `.S` and whose name starts
+ *      with `rsp`. For instance `rsp_math.S`.
+ *   2. Add the corresponding object file (`rsp_math.o`) in your Makefile in
+ *      the list of dependencies for building your ROM, like all the other
+ *      object files that come from C files.
+ *   3. Declare the existence of the ucode in the source using #DEFINE_RSP_UCODE,
+ *      for instance `DEFINE_RSP_UCODE(rsp_math)`.
+ *      
+ * At this point, you can load the ucode using #rsp_load and run it using
+ * either #rsp_run, or #rsp_run_async (and later synchronize with #rsp_wait).
+ * You can look at the `ucodetest` example which is a very minimal program
+ * that does some RSP programming.
+ * 
+ * If you don't use n64.mk, you will have to come up with your own way to
+ * load the ucode text and data segment into the ROM, and then either
+ * define your own #rsp_ucode_t structure, or manually call the lower level
+ * functions #rsp_load_code and #rsp_load_data.
+ * 
+ * ## Reading and writing data to RSP
+ * 
+ * To provide input and read output from the RSP, there are a few possible ways:
+ * 
+ *   1. Directly access RSP DMEM using the #SP_DMEM macro. The DMEM is memory
+ *      mapped into the CPU address space, so it can be accessed directly.
+ *      Only 32-bit reads and writes are supported. Note that you can only
+ *      access DMEM while the RSP is not running.
+ *   2. Run a DMA transfer using #rsp_load_data or #rsp_read_data. This is
+ *      generally faster then accessing DMEM especially for larger transfers,
+ *      but like all DMA transfers it requires the RDRAM buffer to be 8-byte
+ *      aligned.
+ *   3. Have the RSP do DMA transfers to and from RDRAM. This needs to be
+ *      part of the ucode program.
+ *  
+ * ## RSP crashes
+ * 
+ * RSP does not have any concept of exception. So in general it is not possible
+ * to tell whether something went wrong while running the ucode.
+ * 
+ * We define "RSP crash" any situation in which the RSP is behaving in an
+ * unexpected way. For instance, it may have returned corrupted data, or have
+ * stopped responding (eg: it is in an infinite loop), or has interrupted its
+ * execution before providing a result (eg: a signal has not been set in the
+ * status register).
+ * 
+ * When the CPU notices that the RSP may have crashed, it can invoke the
+ * #rsp_crash function. This function interrupts the program showing a
+ * crash screen that contains a full register dump, and then aborts execution,
+ * so it must be used in non-recoverable situations. A even more complete dump
+ * that includes also a full DMEM dump is sent via #debugf on the debugging spew
+ * (see the debugging library to check how to hook up to it). A function
+ * #rsp_crashf is also available in case the CPU wants to provide a message
+ * on the symptom that was used to detect the RSP crash (eg:
+ * `rsp_crashf("computed data is corrupted")`).
+ * 
+ * To help detect RSP crashes that involve timeouts, a macro #RSP_WAIT_LOOP
+ * is available that can be used to implement CPU busy loops where the CPU
+ * waits for the RSP to do something. The macro just simplifies the creation
+ * of a loop with a timeout that calls #rsp_crash, the actual condition to
+ * wait for is left to the caller for the maximum programming flexibility.
+ * Notice that #rsp_wait and #rsp_run use #RSP_WAIT_LOOP internally with
+ * a timeout of 500ms to wait for the RSP to finish execution of the ucode,
+ * so using those APIs is enough to detect infinite loops in ucode execution
+ * and trigger a RSP crash screen.
+ * 
+ * ## Custom ucode crash handlers
+ * 
+ * It may be useful to also dump ucode-specific information when the crash
+ * screen is triggered. For instance, a ucode might want to dump on the
+ * screen some important variable or buffers taken from DMEM, or even
+ * reconstruct some state by looking at the registers. To do so, it is
+ * possible to register a ucode-specific crash handler by filling the
+ * `crash_handler` field in the #rsp_ucode_t structure (it can be done
+ * either at runtime, or at compile-time when using the #DEFINE_RSP_UCODE
+ * macro).
+ * 
+ * The crash handler will be called by the RSP crash screen and can either
+ * add information on the screen (via printf) or dump them to the debugging
+ * log (via debugf). It receives a #rsp_snapshot_t, which is a full snapshot
+ * of the whole RSP state at the moment of crash, including all registers
+ * (scalars and vectors), all COP0/COP2 registers, and the full IMEM and DMEM
+ * contents.
+ * 
+ * ## RSP asserts
+ * 
+ * Since RSP debugging is quite complex due to the limited available
+ * communication channels, it is advised to adopt defensive programming
+ * while writing RSP ucode. The header file rsp.inc provides a set of 
+ * assert macros that can be used in the RSP ucode to check for assumptions
+ * and invariants, similar to the C assert. To use them, also include
+ * the file rsp_assert.inc in your text segment.
+ * 
+ * When the RSP hits an assert, it enters an infinite loop, that will be
+ * eventually detected by the CPU, triggering the RSP crash screen. Each
+ * assertion can define a numeric assert code that will be shown in the
+ * crash screen.
+ * 
+ * To further help with debugging, it is possible to register a custom
+ * assert manager in the ucode. Similar to the crash handler, the assert
+ * handler will be called when an assert is triggered and will be provided
+ * with a #rsp_snapshot_t, and the assert code. The assert handler can be
+ * used to parse the assert code and display a proper assert message (about
+ * two lines of text). Since each assert is placed in a specific point in the
+ * code, the assert handler can inspect the register contents at the point of
+ * assertion to provide further information on the crash. Notice that the crash
+ * handler will still be called also for asserts and remains the best place
+ * where display a dump of the main internal data structures of the overlay.
+ * 
+ * The RSP assert macros are compiled away when NDEBUG is defined (just like
+ * the C assert), so that it is possible to remove them from the final build
+ * in case of memory constraints.
+ * 
+ */
+
 #ifndef __LIBDRAGON_RSP_H
 #define __LIBDRAGON_RSP_H
+
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,14 +159,45 @@ extern "C" {
 /** @brief SP status register */
 #define SP_STATUS     ((volatile uint32_t*)0xA4040010)
 
+/** @brief SP DMA full register */
+#define SP_DMA_FULL   ((volatile uint32_t*)0xA4040014)
+
+/** @brief SP DMA busy register */
+#define SP_DMA_BUSY   ((volatile uint32_t*)0xA4040018)
+
+/** @brief SP semaphore register */
+#define SP_SEMAPHORE  ((volatile uint32_t*)0xA404001C)
+
 /** @brief SP halted */
 #define SP_STATUS_HALTED                (1 << 0)
+/** @brief SP executed a break instruction */
+#define SP_STATUS_BROKE                 (1 << 1)
 /** @brief SP DMA busy */
 #define SP_STATUS_DMA_BUSY              (1 << 2)
+/** @brief SP DMA full */
+#define SP_STATUS_DMA_FULL              (1 << 3)
 /** @brief SP IO busy */
 #define SP_STATUS_IO_BUSY               (1 << 4)
+/** @brief SP is in single step mode */
+#define SP_STATUS_SSTEP                 (1 << 5)
 /** @brief SP generate interrupt when hit a break instruction */
 #define SP_STATUS_INTERRUPT_ON_BREAK    (1 << 6)
+/** @brief SP signal 0 is set */
+#define SP_STATUS_SIG0                  (1 << 7)
+/** @brief SP signal 1 is set */
+#define SP_STATUS_SIG1                  (1 << 8)
+/** @brief SP signal 2 is set */
+#define SP_STATUS_SIG2                  (1 << 9)
+/** @brief SP signal 3 is set */
+#define SP_STATUS_SIG3                  (1 << 10)
+/** @brief SP signal 4 is set */
+#define SP_STATUS_SIG4                  (1 << 11)
+/** @brief SP signal 5 is set */
+#define SP_STATUS_SIG5                  (1 << 12)
+/** @brief SP signal 6 is set */
+#define SP_STATUS_SIG6                  (1 << 13)
+/** @brief SP signal 7 is set */
+#define SP_STATUS_SIG7                  (1 << 14)
 
 #define SP_WSTATUS_CLEAR_HALT        0x00001   ///< SP_STATUS write mask: clear #SP_STATUS_HALTED bit
 #define SP_WSTATUS_SET_HALT          0x00002   ///< SP_STATUS write mask: set #SP_STATUS_HALTED bit
@@ -58,6 +226,22 @@ extern "C" {
 #define SP_WSTATUS_SET_SIG7          0x1000000 ///< SP_STATUS write mask: set SIG7 bit
 
 /**
+ * @brief Snapshot of the register status of the RSP.
+ * 
+ * This structure is used in the crash handler.
+ */
+typedef struct {
+    uint32_t gpr[32];           ///< General purpose registers
+    uint16_t vpr[32][8];        ///< Vector registers
+    uint16_t vaccum[3][8];      ///< Vector accumulator
+    uint32_t cop0[16];          ///< COP0 registers (note: reg 4 is SP_STATUS)
+    uint32_t cop2[3];           ///< COP2 control registers
+    uint32_t pc;                ///< Program counter
+    uint8_t dmem[4096] __attribute__((aligned(8)));  ///< Contents of DMEM
+    uint8_t imem[4096] __attribute__((aligned(8)));  ///< Contents of IMEM
+} rsp_snapshot_t;
+
+/**
  * @brief RSP ucode definition.
  * 
  * This small structure holds the text/data pointers to a RSP ucode program
@@ -75,6 +259,40 @@ typedef struct {
 
     const char *name;      ///< Name of the ucode
     uint32_t start_pc;     ///< Initial RSP PC
+
+    /**
+     * @brief Custom crash handler. 
+     * 
+     * If specified, this function is invoked when a RSP crash happens,
+     * while filling the information screen. It can be used to dump
+     * custom ucode-specific information.
+     * 
+     * @note DO NOT ACCESS RSP hardware registers in the crash handler.
+     *       To dump information, access the state provided as argument
+     *       that contains a full snapshot of the RSP state at the point
+     *       of crash.
+     */
+    void (*crash_handler)(rsp_snapshot_t *state);
+
+    /**
+     * @brief Custom assert handler.
+     * 
+     * If specified, this function is invoked when a RSP crash caused
+     * by an assert is triggered. This function should display information
+     * related to the assert using `printf` (max 2 lines).
+     * 
+     * Normally, the first line will be the assert message associated with
+     * the code (eg: "Invalid buffer pointer"), while the optional second line 
+     * can contain a dump of a few important variables, maybe extracted from
+     * the register state (eg: "bufptr=0x00000000 prevptr=0x8003F780").
+     * The assert handler will now which registers to inspect to extract
+     * information, given the exact position of the assert in the code.
+     * 
+     * @note The crash handler, if specified, is called for all crashes,
+     * including asserts. That is the correct place where dump information
+     * on the ucode state in general.
+     */
+    void (*assert_handler)(rsp_snapshot_t *state, uint16_t assert_code);
 } rsp_ucode_t;
 
 /**
@@ -85,8 +303,20 @@ typedef struct {
  * and compiled a ucode called rsp_math.S, you can use DEFINE_RSP_UCODE(rsp_math)
  * to define it at the global level. You can then use rsp_load(&rsp_math) 
  * to load it.
+ * 
+ * To statically define attributes of the ucode, you can use the C designated
+ * initializer syntax.
+ * 
+* @code{.c}
+ *      // Define the RSP ucode stored in file rsp_math.S.
+ *      // For the sake of this example, we also show how to set the member
+ *      // start_pc at definition time. You normally don't need to change this
+ *      // as most ucode will start at 0x0 anyway (which is the default).
+ *      DEFINE_RSP_UCODE(&rsp_math, .start_pc = 0x100);
+ * @endcode
+  * 
  */
-#define DEFINE_RSP_UCODE(ucode_name) \
+#define DEFINE_RSP_UCODE(ucode_name, ...) \
     extern uint8_t ucode_name ## _text_start[]; \
     extern uint8_t ucode_name ## _data_start[]; \
     extern uint8_t ucode_name ## _text_end[0]; \
@@ -97,6 +327,8 @@ typedef struct {
         .code_end = ucode_name ## _text_end, \
         .data_end = ucode_name ## _data_end, \
         .name = #ucode_name, .start_pc = 0, \
+        .crash_handler = 0, .assert_handler = 0, \
+        __VA_ARGS__ \
     }
 
 /** @brief Initialize the RSP subsytem. */
@@ -130,7 +362,12 @@ void rsp_run(void);
  */
 void rsp_run_async(void);
 
-/** @brief Wait until RSP has finished processing. */
+/** 
+ * @brief Wait until RSP has finished processing. 
+ *
+ * This function will wait until the RSP is halted. It contains a fixed
+ * timeout of 500 ms, after which #rsp_crash is invoked to abort the program.
+ */
 void rsp_wait(void);
 
 /** @brief Do a DMA transfer to load a piece of code into RSP IMEM.
@@ -186,6 +423,82 @@ void rsp_read_code(void* code, unsigned long size, unsigned int imem_offset);
  */
 void rsp_read_data(void* data, unsigned long size, unsigned int dmem_offset);
 
+/**
+ * @brief Abort the program showing a RSP crash screen
+ * 
+ * This function aborts the execution of the program, and shows an exception
+ * screen which contains the RSP status. 
+ * 
+ * This function (and its sibling #rsp_crashf) should be invoked whenever the
+ * CPU realizes that the RSP is severely misbehaving, as it provides useful
+ * information on the RSP status that can help tracking down the bug. It is
+ * invoked automatically by this library (and others RSP libraries that build upon)
+ * whenever internal consistency checks fail. It is also invoked as part
+ * of `RSP_WAIT_LOOP` when the timeout is reached, which is the most common
+ * way of detecting RSP misbehavior.
+ * 
+ * If the RSP has hit an assert, the crash screen will display the assert-
+ * specific information (like assert code and assert message).
+ * 
+ * To display ucode-specific information (like structural decoding of DMEM data),
+ * this function will call the function crash_handler in the current #rsp_ucode_t,
+ * if it is defined. 
+ * 
+ * @see #rsp_crashf
+ */
+#define rsp_crash()  ({ \
+    __rsp_crash(__FILE__, __LINE__, __func__, NULL); \
+}) 
+
+/**
+ * @brief Abort the program showing a RSP crash screen with a symptom message.
+ * 
+ * This function is similar to #rsp_crash, but also allows to specify a message
+ * that will be displayed in the crash screen. Since the CPU is normally
+ * unaware of the exact reason why the RSP has crashed, the message is
+ * possibly just a symptom as observed by the CPU (eg: "timeout reached",
+ * "signal was not set"), and is in fact referred as "symptom" in the RSP crash
+ * screen.
+ * 
+ * See #rsp_crash for more information on when to call this function and how
+ * it can be useful.
+ * 
+ * @see #rsp_crash
+ */
+#define rsp_crashf(msg, ...) ({ \
+    __rsp_crash(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__); \
+})
+
+/**
+ * @brief Create a loop that waits for some condition that is related to RSP,
+ *        aborting with a RSP crash after a timeout.
+ *
+ * This macro simplifies the creation of a loop that busy-waits for operations
+ * performed by the RSP. If the condition is not reached within a timeout,
+ * it is assumed that the RSP has crashed or otherwise stalled and
+ * #rsp_crash is invoked to abort the program showing a debugging screen.
+ * 
+ * @code{.c}
+ *      // This example shows a loop that waits for the RSP to set signal 2
+ *      // in the status register. It is just an example on how to use the
+ *      // macro.
+ *      
+ *      RSP_WAIT_LOOP(150) {
+ *          if (*SP_STATUS & SP_STATUS_SIG_2)
+ *              break;
+ *      }
+ * @endcode
+ *
+ * @param[in]  timeout_ms  Allowed timeout in milliseconds. Normally a value
+ *                         like 150 is good enough because it is unlikely that
+ *                         the application should wait for such a long time.
+ * 
+ */
+#define RSP_WAIT_LOOP(timeout_ms) \
+    for (uint32_t __t = TICKS_READ() + TICKS_FROM_MS(timeout_ms); \
+         TICKS_BEFORE(TICKS_READ(), __t) || (rsp_crashf("wait loop timed out (%d ms)", timeout_ms), false); \
+         __rsp_check_assert(__FILE__, __LINE__, __func__))
+
 static inline __attribute__((deprecated("use rsp_load_code instead")))
 void load_ucode(void * start, unsigned long size) {
     rsp_load_code(start, size, 0);
@@ -210,6 +523,14 @@ static inline __attribute__((deprecated("use rsp_run_async instead")))
 void run_ucode(void) {
     rsp_run_async();
 }
+
+// Internal function used by rsp_crash and rsp_crashf. These are not part
+// of the public API of rsp.h. Do not call them directly.
+/// @cond
+void __rsp_crash(const char *file, int line, const char *func, const char *msg, ...)
+   __attribute__((noreturn, format(printf, 4, 5)));
+void __rsp_check_assert(const char *file, int line, const char *func);
+/// @endcond
 
 #ifdef __cplusplus
 }

--- a/include/rsp.inc
+++ b/include/rsp.inc
@@ -807,4 +807,37 @@ makeLsInstructionQuad store, swv, 0b00111
 #define DMA_OUT          (DMA_OUT_ASYNC | SP_STATUS_DMA_BUSY | SP_STATUS_DMA_FULL)
 
 
+##################################################
+# RSP_ASSERT.INC macros
+##################################################
+
+#ifndef NDEBUG
+    .macro assert code
+        j assertion_failed
+        .set noat
+        lui $1, \code
+        .set at
+    .endm
+    .macro assert_eq v0, v1, code
+        bne \v0, \v1, assertion_failed
+        .set noat
+        lui $1, \code
+        .set at
+    .endm
+    .macro assert_ne v0, v1, code
+        beq \v0, \v1, assertion_failed
+        .set noat
+        lui $1, \code
+        .set at
+    .endm
+
+#else
+    .macro assert code
+    .endm
+    .macro assert_eq v0, v1, code
+    .endm
+    .macro assert_ne v0, v1, code
+    .endm
+#endif
+
 #endif /* RSP_INC */

--- a/include/rsp_assert.inc
+++ b/include/rsp_assert.inc
@@ -1,0 +1,19 @@
+########################################################
+# Include this file wherever you prefer in your text segment
+########################################################
+
+########################################################
+# RSP Assert support
+#
+# Define a function called "assertion_failed" that is
+# used as jump target by assert macros. 
+#
+########################################################
+
+	.func assertion_failed
+assertion_failed:
+	# Infinite loop. Use a special break opcode to
+	# be able to tell it from standard "break".
+	b assertion_failed
+	break 0xBA
+	.endfunc

--- a/src/rsp.c
+++ b/src/rsp.c
@@ -1,11 +1,27 @@
 /**
  * @file rsp.c
- * @brief Hardware Vector Interface
+ * @brief Low-level RSP hardware library
  * @ingroup rsp
  */
 
-#include "libdragon.h"
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "rsp.h"
+#include "debug.h"
+#include "console.h"
 #include "regsinternal.h"
+#include "n64sys.h"
+#include "interrupt.h"
+
+/**
+ * RSP crash handler ucode (rsp_crash.S)
+ */
+DEFINE_RSP_UCODE(rsp_crash);
 
 /** @brief Static structure to address SP registers */
 static volatile struct SP_regs_s * const SP_regs = (struct SP_regs_s *)0xa4040000;
@@ -21,11 +37,18 @@ static void __SP_DMA_wait(void)
     while (SP_regs->status & (SP_STATUS_DMA_BUSY | SP_STATUS_IO_BUSY)) ;
 }
 
+static void rsp_interrupt(void)
+{
+    __rsp_check_assert(__FILE__, __LINE__, __func__);
+}
+
 void rsp_init(void)
 {
     /* Make sure RSP is halted */
     *SP_PC = 0x1000;
     SP_regs->status = SP_WSTATUS_SET_HALT;
+    set_SP_interrupt(1);
+    register_SP_handler(rsp_interrupt);
 }
 
 void rsp_load(rsp_ucode_t *ucode) {
@@ -120,12 +143,18 @@ void rsp_run_async(void)
     // set RSP program counter
     *SP_PC = cur_ucode ? cur_ucode->start_pc : 0;
     MEMORY_BARRIER();
-    *SP_STATUS = SP_WSTATUS_CLEAR_HALT | SP_WSTATUS_SET_INTR_BREAK;
+    *SP_STATUS = SP_WSTATUS_CLEAR_HALT | SP_WSTATUS_CLEAR_BROKE | SP_WSTATUS_SET_INTR_BREAK;
 }
 
 void rsp_wait(void)
 {
-    while (!(*SP_STATUS & SP_STATUS_HALTED)) {}
+    RSP_WAIT_LOOP(500) {
+        // Wait for the RSP to halt and the DMA engine to be idle.
+        uint32_t status = *SP_STATUS;
+        if (status & SP_STATUS_HALTED && 
+            !(status & (SP_STATUS_DMA_BUSY|SP_STATUS_DMA_FULL)))
+            break;
+    }
 }
 
 void rsp_run(void)
@@ -133,3 +162,245 @@ void rsp_run(void)
     rsp_run_async();
     rsp_wait();
 }
+
+/// @cond
+// Check if the RSP has hit an internal assert, and call rsp_crash if so.
+// This function is invoked by #RSP_WAIT_LOOP while waiting for the RSP
+// to finish a task, so that we immediately show a crash screen if the RSP
+// has hit an assert.
+void __rsp_check_assert(const char *file, int line, const char *func)
+{
+    // If it's running, it has not asserted
+    if (!(*SP_STATUS & (SP_STATUS_HALTED | SP_STATUS_BROKE)))
+        return;
+
+    // We need to check if the RSP has reached the assert loop. We do
+    // this by inspecting IMEM, which cannot be done while a DMA is in
+    // progress. Since this is a best-effort fast-path to a RSP crash,
+    // we can simply punt if a DMA is in progress.
+    // TODO: figure out a better way to know the PC address of the RSP
+    // assert loop.
+    if (*SP_STATUS & (SP_STATUS_DMA_BUSY | SP_STATUS_IO_BUSY))
+        return;
+
+    // Detect infinite break loop
+    if (SP_IMEM[(*SP_PC >> 2) + 1] == 0x00BA000D) {
+        __rsp_crash(file, line, func, NULL);
+    }
+}
+/// @endcond
+
+/// @cond
+// RSP crash handler implementation
+__attribute__((noreturn, format(printf, 4, 5)))
+void __rsp_crash(const char *file, int line, const char *func, const char *msg, ...)
+{
+    volatile uint32_t *DP_STATUS = (volatile uint32_t*)0xA410000C;
+
+    rsp_snapshot_t state __attribute__((aligned(8)));
+    rsp_ucode_t *uc = cur_ucode;
+
+    // Disable interrupts right away. We're going to abort soon, so let's
+    // avoid being preempted for any reason.
+    disable_interrupts();
+
+    // Read the status registers right away. Its value can mutate at any time
+    // so the earlier the better.
+    uint32_t sp_status = *SP_STATUS;
+    uint32_t dp_status = *DP_STATUS;
+    MEMORY_BARRIER();
+
+    // Freeze the RDP
+    *DP_STATUS = 1<<3;
+
+    // Initialize the console
+    console_init();
+    console_set_debug(true);
+    console_set_render_mode(RENDER_MANUAL);
+
+    // Forcibly halt the RSP, and wait also for the DMA engine to be idle
+    *SP_STATUS = SP_WSTATUS_SET_HALT;
+    while (!(*SP_STATUS & SP_STATUS_HALTED)) {}
+    while (*SP_STATUS & (SP_STATUS_DMA_BUSY | SP_STATUS_DMA_FULL)) {}
+    MEMORY_BARRIER();
+
+    // Read the current PC. This can only be read after the RSP is halted.
+    uint32_t pc = *SP_PC;
+    MEMORY_BARRIER();
+
+    // Fetch DMEM, as we are going to modify it to read the register contents
+    rsp_read_code(state.imem, 4096, 0);
+    rsp_read_data(state.dmem, 4096, 0);
+
+    // Load the crash handler into RSP, and run it. It will read all the
+    // registers and save them into DMEM.
+    rsp_load(&rsp_crash);
+    rsp_run();
+    rsp_read_data(&state, 764, 0);
+ 
+    // Overwrite the status register information with the read we did at
+    // the beginning of the handler
+    state.cop0[4] = sp_status;
+    state.cop0[11] = dp_status;
+
+    // Write the PC now so it doesn't get overwritten by the DMA
+    state.pc = pc;
+
+    // Dump information on the current ucode name and CPU point of crash
+    const char *uc_name = uc ? uc->name : "???";
+    char pcpos[120];
+    snprintf(pcpos, 120, "%s (%s:%d)", func, file, line);
+    pcpos[119] = 0;
+
+    printf("RSP CRASH | %s | %.*s\n", uc_name, 48-strlen(uc_name), pcpos);
+
+    // Display the optional message coming from the C code
+    if (msg)
+    {
+        printf("Crash symptom: ");
+        va_list args;
+        va_start(args, msg);
+        vprintf(msg, args);
+        va_end(args);
+        printf("\n");
+    }
+
+    // Check if a RSP assert triggered. We check that we reached an
+    // infinite loop with the break instruction in the delay slot.
+    if (*(uint32_t*)(&state.imem[pc+4]) == 0x00BA000D) {
+        // The at register ($1) contains the assert code in the top 16 bits.
+        uint16_t code = state.gpr[1] >> 16;
+        printf("RSP ASSERTION FAILED (0x%x)", code);
+
+        if (uc->assert_handler) {
+            printf(" - ");
+            uc->assert_handler(&state, code);
+        } else {
+            printf("\n");
+        }
+    }
+
+    printf("PC:%03lx | STATUS:%4lx [", state.pc, sp_status);
+    if (sp_status & (1<<0))  printf("halt ");
+    if (sp_status & (1<<1))  printf("broke ");
+    if (sp_status & (1<<2))  printf("dma_busy ");
+    if (sp_status & (1<<3))  printf("dma_full ");
+    if (sp_status & (1<<4))  printf("io_full ");
+    if (sp_status & (1<<5))  printf("sstep ");
+    if (sp_status & (1<<6))  printf("irqbreak ");
+    if (sp_status & (1<<7))  printf("sig0 ");
+    if (sp_status & (1<<8))  printf("sig1 ");
+    if (sp_status & (1<<9))  printf("sig2 ");
+    if (sp_status & (1<<10)) printf("sig3 ");
+    if (sp_status & (1<<11)) printf("sig4 ");
+    if (sp_status & (1<<12)) printf("sig5 ");
+    if (sp_status & (1<<13)) printf("sig6 ");
+    if (sp_status & (1<<14)) printf("sig7 ");
+    printf("] | DP_STATUS:%4lx [", dp_status);
+    if (dp_status & (1<<0))  printf("xbus ");
+    if (dp_status & (1<<1))  printf("freeze ");
+    if (dp_status & (1<<2))  printf("flush ");
+    if (dp_status & (1<<3))  printf("gclk ");
+    if (dp_status & (1<<4))  printf("tmem ");
+    if (dp_status & (1<<5))  printf("pipe ");
+    if (dp_status & (1<<6))  printf("busy ");
+    if (dp_status & (1<<7))  printf("ready ");
+    if (dp_status & (1<<8))  printf("dma ");
+    if (dp_status & (1<<9))  printf("start ");
+    if (dp_status & (1<<10)) printf("end ");
+    printf("]\n");
+
+    // Dump GPRs
+    printf("-------------------------------------------------GP Registers--\n");
+    printf("zr:%08lX ",  state.gpr[0]);  printf("at:%08lX ",  state.gpr[1]);
+    printf("v0:%08lX ",  state.gpr[2]);  printf("v1:%08lX ",  state.gpr[3]);
+    printf("a0:%08lX\n", state.gpr[4]);  printf("a1:%08lX ",  state.gpr[5]);
+    printf("a2:%08lX ",  state.gpr[6]);  printf("a3:%08lX ",  state.gpr[7]);
+    printf("t0:%08lX ",  state.gpr[8]);  printf("t1:%08lX\n", state.gpr[9]);
+    printf("t2:%08lX ",  state.gpr[10]); printf("t3:%08lX ",  state.gpr[11]);
+    printf("t4:%08lX ",  state.gpr[12]); printf("t5:%08lX ",  state.gpr[13]);
+    printf("t6:%08lX\n", state.gpr[14]); printf("t7:%08lX ",  state.gpr[15]);
+    printf("t8:%08lX ",  state.gpr[24]); printf("t9:%08lX ",  state.gpr[25]);
+    printf("s0:%08lX ",  state.gpr[16]); printf("s1:%08lX\n", state.gpr[17]);
+    printf("s2:%08lX ",  state.gpr[18]); printf("s3:%08lX ",  state.gpr[19]);
+    printf("s4:%08lX ",  state.gpr[20]); printf("s5:%08lX ",  state.gpr[21]);
+    printf("s6:%08lX\n", state.gpr[22]); printf("s7:%08lX ",  state.gpr[23]);
+    printf("gp:%08lX ",  state.gpr[28]); printf("sp:%08lX ",  state.gpr[29]);
+    printf("fp:%08lX ",  state.gpr[30]); printf("ra:%08lX\n", state.gpr[31]);
+
+    // Dump VPRs, only to the debug log (no space on screen)
+    debugf("-------------------------------------------------VP Registers--\n");
+    for (int i=0;i<16;i++) {
+        uint16_t *r = state.vpr[i];
+        debugf("$v%02d:%04x %04x %04x %04x %04x %04x %04x %04x   ",
+            i, r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]);
+        r += 16*8;
+        debugf("$v%02d:%04x %04x %04x %04x %04x %04x %04x %04x\n",
+            i+16, r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]);
+    }
+    {        
+        uint16_t *r = state.vaccum[0];
+        debugf("acc_hi:%04x %04x %04x %04x %04x %04x %04x %04x\n",
+            r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]);
+        r += 8;
+        debugf("acc_md:%04x %04x %04x %04x %04x %04x %04x %04x\n",
+            r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]);
+        r += 8;
+        debugf("acc_lo:%04x %04x %04x %04x %04x %04x %04x %04x\n",
+            r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]);
+    }
+
+    // Dump COP0 registers
+    printf("-----------------------------------------------COP0 Registers--\n");
+    printf("$c0  DMA_SPADDR    %08lx    |  ", state.cop0[0]);
+    printf("$c8  DP_START      %08lx\n",      state.cop0[8]);
+    printf("$c1  DMA_RAMADDR   %08lx    |  ", state.cop0[1]);
+    printf("$c9  DP_END        %08lx\n",      state.cop0[9]);
+    printf("$c2  DMA_READ      %08lx    |  ", state.cop0[2]);
+    printf("$c10 DP_CURRENT    %08lx\n",      state.cop0[10]);
+    printf("$c3  DMA_WRITE     %08lx    |  ", state.cop0[3]);
+    printf("$c11 DP_STATUS     %08lx\n",      state.cop0[11]);
+    printf("$c4  SP_STATUS     %08lx    |  ", state.cop0[4]);
+    printf("$c12 DP_CLOCK      %08lx\n",      state.cop0[12]);
+    printf("$c5  DMA_FULL      %08lx    |  ", state.cop0[5]);
+    printf("$c13 DP_BUSY       %08lx\n",      state.cop0[13]);
+    printf("$c6  DMA_BUSY      %08lx    |  ", state.cop0[6]);
+    printf("$c14 DP_PIPE_BUSY  %08lx\n",      state.cop0[14]);
+    printf("$c7  SEMAPHORE     %08lx    |  ", state.cop0[7]);
+    printf("$c15 DP_TMEM_BUSY  %08lx\n",      state.cop0[15]);
+
+    // Invoke ucode-specific crash handler, if defined. This will dump ucode-specific
+    // information (possibly decoded from DMEM).
+    if (uc->crash_handler) {
+        printf("-----------------------------------------------Ucode data------\n");
+        uc->crash_handler(&state);
+    }
+
+    // Full dump of DMEM into the debug log.
+    bool lineskip = false;
+    debugf("DMEM:\n");
+    for (int i = 0; i < 4096/16; i++) {
+        uint8_t *d = state.dmem + i*16;
+        // If the current line of data is identical to the previous one,
+        // just dump one "*" and skip all other similar lines
+        if (i!=0 && memcmp(d, d-16, 16) == 0) {
+            if (!lineskip) debugf("*\n");
+            lineskip = true;
+        } else {
+            lineskip = false;
+            debugf("%04x  ", i*16);
+            for (int j=0;j<16;j++) {
+                debugf("%02x ", d[j]);
+                if (j==7) debugf(" ");
+            }
+            debugf("  |");
+            for (int j=0;j<16;j++) debugf("%c", d[j] >= 32 && d[j] < 127 ? d[j] : '.');
+            debugf("|\n");
+        }
+    }
+
+    // OK we're done. Render on the screen and abort
+    console_render();
+    abort();
+}
+/// @endcond

--- a/src/rsp_crash.S
+++ b/src/rsp_crash.S
@@ -1,0 +1,141 @@
+# RSP ucode that is used as part of the crash handler.
+# It extracts the value of all registers into DMEM so that they can be
+# shown in the exception screen.
+
+#include <rsp.inc>
+
+	.data
+
+EMPTY: .long 0
+
+	.text
+
+	.globl _start
+_start:
+	.set noat
+	sw $0,  0*4(zero)
+	sw $1,  1*4(zero)
+	sw $2,  2*4(zero)
+	sw $3,  3*4(zero)
+	sw $4,  4*4(zero)
+	sw $5,  5*4(zero)
+	sw $6,  6*4(zero)
+	sw $7,  7*4(zero)
+	sw $8,  8*4(zero)
+	sw $9,  9*4(zero)
+	sw $10, 10*4(zero)
+	sw $11, 11*4(zero)
+	sw $12, 12*4(zero)
+	sw $13, 13*4(zero)
+	sw $14, 14*4(zero)
+	sw $15, 15*4(zero)
+	sw $16, 16*4(zero)
+	sw $17, 17*4(zero)
+	sw $18, 18*4(zero)
+	sw $19, 19*4(zero)
+	sw $20, 20*4(zero)
+	sw $21, 21*4(zero)
+	sw $22, 22*4(zero)
+	sw $23, 23*4(zero)
+	sw $24, 24*4(zero)
+	sw $25, 25*4(zero)
+	sw $26, 26*4(zero)
+	sw $27, 27*4(zero)
+	sw $28, 28*4(zero)
+	sw $29, 29*4(zero)
+	sw $30, 30*4(zero)
+	sw $31, 31*4(zero)
+
+	li s0, 32*4
+	sqv $v00,0,  0*16,s0
+	sqv $v01,0,  1*16,s0
+	sqv $v02,0,  2*16,s0
+	sqv $v03,0,  3*16,s0
+	sqv $v04,0,  4*16,s0
+	sqv $v05,0,  5*16,s0
+	sqv $v06,0,  6*16,s0
+	sqv $v07,0,  7*16,s0
+	sqv $v08,0,  8*16,s0
+	sqv $v09,0,  9*16,s0
+	sqv $v10,0, 10*16,s0
+	sqv $v11,0, 11*16,s0
+	sqv $v12,0, 12*16,s0
+	sqv $v13,0, 13*16,s0
+	sqv $v14,0, 14*16,s0
+	sqv $v15,0, 15*16,s0
+	sqv $v16,0, 16*16,s0
+	sqv $v17,0, 17*16,s0
+	sqv $v18,0, 18*16,s0
+	sqv $v19,0, 19*16,s0
+	sqv $v20,0, 20*16,s0
+	sqv $v21,0, 21*16,s0
+	sqv $v22,0, 22*16,s0
+	sqv $v23,0, 23*16,s0
+	sqv $v24,0, 24*16,s0
+	sqv $v25,0, 25*16,s0
+	sqv $v26,0, 26*16,s0
+	sqv $v27,0, 27*16,s0
+	sqv $v28,0, 28*16,s0
+	sqv $v29,0, 29*16,s0
+	sqv $v30,0, 30*16,s0
+	sqv $v31,0, 31*16,s0
+
+    vsar $v00, $v00, $v00,e(0)
+    vsar $v01, $v01, $v02,e(1)
+    vsar $v02, $v01, $v02,e(2)
+
+	sqv $v00,0,  32*16,s0
+	sqv $v01,0,  33*16,s0
+	sqv $v02,0,  34*16,s0
+
+	add s0, 35*16
+
+	mfc0 t0, $0
+	mfc0 t1, $1
+	mfc0 t2, $2
+	mfc0 t3, $3
+	mfc0 t4, $4
+	mfc0 t5, $5
+	mfc0 t6, $6
+	mfc0 t7, $7
+
+	sw t0, 0*4(s0)
+	sw t1, 1*4(s0)
+	sw t2, 2*4(s0)
+	sw t3, 3*4(s0)
+	sw t4, 4*4(s0)
+	sw t5, 5*4(s0)
+	sw t6, 6*4(s0)
+	sw t7, 7*4(s0)
+
+	mfc0 t0, $8
+	mfc0 t1, $9
+	mfc0 t2, $10
+	mfc0 t3, $11
+	mfc0 t4, $12
+	mfc0 t5, $13
+	mfc0 t6, $14
+	mfc0 t7, $15
+
+	sw t0, 8*4(s0)
+	sw t1, 9*4(s0)
+	sw t2, 10*4(s0)
+	sw t3, 11*4(s0)
+	sw t4, 12*4(s0)
+	sw t5, 13*4(s0)
+	sw t6, 14*4(s0)
+	sw t7, 15*4(s0)
+
+	add s0, 16*4
+
+	cfc2 t0, $0
+	cfc2 t1, $1
+	cfc2 t2, $2
+
+	sw t0, 0*4(s0)
+	sw t1, 1*4(s0)
+	sw t2, 2*4(s0)
+
+	break
+
+


### PR DESCRIPTION
Co-developed with @snacchus.

This PR starts adding some debugging facility for RSP ucode writers.

 * A RSP crash screen, that is shown anytime the RSP "crashes" (as detected or inferred by the CPU)
 * A `rsp_crash` / `rsp_crashf` macro that the CPU can use to trigger the RSP crash screen and abort.
 * A `RSP_WAIT_LOOP` macro, to help writing loops that trigger a RSP crash screen after a certain timeout.
 * A RSP assertion support, to let ucode writers add assertions in their code, that will trigger a RSP crash screen when hit.
 * The ability to complement the crash screen with ucode-specific information and dumps by registering "crash handlers" either generic or assert-specific.

In its most basic form, this PR is immediately useful with no code changes, because rsp_run and rsp_wait will now timeout with a RSP crash screen after 500ms (they now use the RSP_WAIT_LOOP macro).

The more advanced debugging features will instead require libraries to start using RSP_WAIT_LOOP, rsp_crash, and the RSP assert macros.

This screenshots shows a RSP crash screen triggered by a RSP assertion.

<img width="752" alt="Schermata 2022-01-05 alle 02 30 10" src="https://user-images.githubusercontent.com/1014109/148146400-bb87b946-1747-44a3-abad-217ddb6fd169.png">

It contains:
 
 * The ucode name (rsp_queue).
 * The C function and source file/line where the crash was detected
 * The assertion code `0x1` and description `Invalid overlay`
 * A custom crash handler for this assertion has inspected the RSP state and added a custom message that tells us that overlay 0xF was not registered (this was decoded by the top 4 bits of `a0` -- the custom assert handler knows that it has to look the information in `a0` because it is bound to this specific exception in a specific point of the code).
 * A dump of PC and STATUS register (including textual decoding of status bits)
 * A dump of all GPRs and COP0 registers. Vector registers and COP2 control registers are sent via `debugf` on the debugging log (with emulators or USB cartridges), together with a full DMEM dump at the moment of crash.
 * A custom ucode crash handler has decoded a few important information by extracting them from DMEM and registers, which again can be helpful to provide context.
