### PR TITLE
Fix `mixer_remove_event` entry identity matching

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -608,7 +608,7 @@ void mixer_add_event(int64_t delay, MixerEvent cb, void *ctx) {
 
 void mixer_remove_event(MixerEvent cb, void *ctx) {
 	for (int i=0;i<Mixer.num_events;i++) {
-		if (Mixer.events[i].cb == cb) {
+		if (Mixer.events[i].cb == cb && Mixer.events[i].ctx == ctx) {
 			memmove(&Mixer.events[i], &Mixer.events[i+1], sizeof(mixer_event_t) * (Mixer.num_events-i-1));
 			Mixer.num_events--;
 			return;


### PR DESCRIPTION
This allows mixer events to use a single callback function with multiple contexts.

Previously, if the same callback was added multiple times with different contexts, attempting to remove a specific event context would only remove the first entry (for that callback) in the event list, which may not actually be the entry associated with the context provided.

This is especially problematic in C++ where:
1. GCC's nested function syntax is not available
2. C++ Lambdas require lifecycle management for asynchronous callbacks
3. `std::function` is not compatible with function pointers
4. Trampolines are the easiest way to interact with C-style APIs

This is not an API change, but is definitely a behavior change that may cause breakage, however I consider the old behavior to be a bug. The API implies that the identifying values of an event should be both the callback and the context, otherwise there would be no point in providing the context to `mixer_remove_event`.

@rasky 