### PR TITLE
mixer: add mixer_throttle

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -99,8 +99,9 @@ typedef struct {
 struct {
 	uint32_t sample_rate;
 	int num_channels;
-	float divider;
 	float vol;
+	float max_samples;
+	bool throttled;
 
 	int64_t ticks;
 	int num_events;
@@ -617,6 +618,16 @@ void mixer_remove_event(MixerEvent cb, void *ctx) {
 	assertf("mixer_remove_event: specified event does not exist\ncb:%p ctx:%p", (void*)cb, ctx);
 }
 
+void mixer_throttle(float num_samples) {
+	Mixer.max_samples += num_samples;
+	Mixer.throttled = true;
+}
+
+void mixer_unthrottle(void) {
+	Mixer.max_samples = 0;
+	Mixer.throttled = false;
+}
+
 void mixer_poll(int16_t *out16, int num_samples) {
 	int32_t *out = (int32_t*)out16;
 
@@ -624,6 +635,18 @@ void mixer_poll(int16_t *out16, int num_samples) {
 	// it's not possible to call this function with an odd number,
 	// otherwise buffering might become complicated / impossible.
 	assert(num_samples % 2 == 0);
+
+	// Check if the mixer is throttled. If so, do not produce more
+	// than the allowance (with a small extra equal to a full audio buffer,
+	// to avoid issues with fixed-size buffers like those provided by audio.c),
+	// and silence after it.
+	if (Mixer.throttled) {
+		int extra = Mixer.sample_rate / MIXER_POLL_PER_SECOND;
+		int total = num_samples;
+		num_samples = MIN(num_samples, Mixer.max_samples+extra);
+		Mixer.max_samples -= num_samples;
+		memset(out + num_samples, 0, (total - num_samples) * sizeof(int32_t));
+	}
 
 	while (num_samples > 0) {
 		mixer_event_t *e = mixer_next_event();


### PR DESCRIPTION
This function allows to throttle the mixer to a specific pace, to help
implementing correct syncing with a video.

Normally, once the mixer is initiated and assuming mixer_poll is called
frequently enough, the audio will playback uninterrupted, irrespective of
any slow down in the main loop. This is the expected behavior for background
music for instance, but it does not work for video players or cut-scenes in
which the music must be perfectly synchronized with the video. If the video
happens to slowdown, the music will desynchronize.

mixer_throttle sets a budget of samples that the mixer is allowed to
generate. Every time the function is called, the specified number of samples
is added to the budget. Every time the mixer playbacks the channel, the
budget is decreased. If the budget reaches zero, the mixer will automatically
pause playback until the budget is increased again, possibly creating
audio cracks.