### PR TITLE
Improve example Makefiles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
-all: audioplayer cpptest ctest dfsdemo mixertest mptest mputest spritemap test timers vrutest vtest ucodetest
-clean: audioplayer-clean cpptest-clean ctest-clean dfsdemo-clean mixertest-clean mptest-clean mputest-clean spritemap-clean test-clean timers-clean vrutest-clean vtest-clean ucodetest-clean
+all: audioplayer cpptest ctest dfsdemo mixertest mptest mputest spritemap test timers vrutest vtest ucodetest eepromfstest
+clean: audioplayer-clean cpptest-clean ctest-clean dfsdemo-clean mixertest-clean mptest-clean mputest-clean spritemap-clean test-clean timers-clean vrutest-clean vtest-clean ucodetest-clean eepromfstest-clean
 
 audioplayer:
 	$(MAKE) -C audioplayer
@@ -21,6 +21,11 @@ dfsdemo:
 dfsdemo-clean:
 	$(MAKE) -C dfsdemo clean
 
+eepromfstest:
+	$(MAKE) -C eepromfstest
+eepromfstest-clean:
+	$(MAKE) -C eepromfstest clean
+
 mixertest:
 	$(MAKE) -C mixertest
 mixertest-clean:
@@ -35,6 +40,11 @@ mputest:
 	$(MAKE) -C mputest
 mputest-clean:
 	$(MAKE) -C mputest clean
+
+rtctest:
+	$(MAKE) -C rtctest
+rtctest-clean:
+	$(MAKE) -C rtctest clean
 
 spritemap:
 	$(MAKE) -C spritemap
@@ -67,4 +77,4 @@ ucodetest-clean:
 	$(MAKE) -C ucodetest clean
 
 .PHONY: audioplayer audioplayer-clean cpptest cpptest-clean ctest ctest-clean dfsdemo dfsdemo-clean mixertest mixertest-clean mptest mptest-clean mputest mputest-clean spritemap spritemap-clean
-.PHONY: test test-clean timers timers-clean vrutest vrutest-clean vtest vtest-clean ucodetest ucodetest-clean
+.PHONY: test test-clean timers timers-clean vrutest vrutest-clean vtest vtest-clean ucodetest ucodetest-clean eepromfstest eepromfstest-clean

--- a/examples/audioplayer/Makefile
+++ b/examples/audioplayer/Makefile
@@ -1,7 +1,8 @@
 BUILD_DIR=build
 include $(N64_INST)/include/n64.mk
 
-src = audioplayer.c
+OBJS = $(BUILD_DIR)/audioplayer.o
+
 assets_xm1 = $(wildcard assets/*.xm)
 assets_xm2 = $(wildcard assets/*.XM)
 assets_ym1 = $(wildcard assets/*.ym)
@@ -41,7 +42,7 @@ filesystem/%.ym64: assets/%.YM
 filesystem/darkness.ym64: AUDIOCONV_FLAGS += --ym-compress true
 
 $(BUILD_DIR)/audioplayer.dfs: $(assets_conv)
-$(BUILD_DIR)/audioplayer.elf: $(src:%.c=$(BUILD_DIR)/%.o)
+$(BUILD_DIR)/audioplayer.elf: $(OBJS)
 
 audioplayer.z64: N64_ROM_TITLE="Audio Player"
 audioplayer.z64: $(BUILD_DIR)/audioplayer.dfs

--- a/examples/cpptest/Makefile
+++ b/examples/cpptest/Makefile
@@ -4,8 +4,9 @@ include $(N64_INST)/include/n64.mk
 
 all: cpptest.z64
 
-$(BUILD_DIR)/cpptest.elf: \
-	$(BUILD_DIR)/cpptest.o
+OBJS = $(BUILD_DIR)/*.o
+
+$(BUILD_DIR)/cpptest.elf: $(OBJS)
 
 cpptest.z64: N64_ROM_TITLE="C++ test"
 

--- a/examples/ctest/Makefile
+++ b/examples/ctest/Makefile
@@ -4,9 +4,7 @@ all: ctest.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
-SRC = ctest.c
-OBJS = $(SRC:%.c=$(BUILD_DIR)/%.o)
-DEPS = $(SRC:%.c=$(BUILD_DIR)/%.d)
+OBJS = $(BUILD_DIR)/ctest.o
 
 ctest.z64: N64_ROM_TITLE = "Controller Test"
 
@@ -16,4 +14,4 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d)

--- a/examples/eepromfstest/Makefile
+++ b/examples/eepromfstest/Makefile
@@ -4,9 +4,7 @@ all: eepromfstest_4k.z64 eepromfstest_16k.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
-SRC = eepromfstest.c
-OBJS = $(SRC:%.c=$(BUILD_DIR)/%.o)
-DEPS = $(SRC:%.c=$(BUILD_DIR)/%.d)
+OBJS = $(BUILD_DIR)/eepromfstest.o
 
 eepromfstest_4k.z64: N64_ROM_TITLE = "EEPROMFS Test 4k"
 eepromfstest_4k.z64: N64_ROM_SAVETYPE = eeprom4k
@@ -21,4 +19,5 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64 *.v64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d)
+

--- a/examples/mixertest/Makefile
+++ b/examples/mixertest/Makefile
@@ -1,7 +1,8 @@
 BUILD_DIR=build
 include $(N64_INST)/include/n64.mk
 
-src = mixertest.c
+OBJS = $(BUILD_DIR)/mixertest.o
+
 assets = $(wildcard assets/*.wav)
 assets_conv = $(addprefix filesystem/,$(notdir $(assets:%.wav=%.wav64)))
 
@@ -16,10 +17,10 @@ filesystem/%.wav64: assets/%.wav
 	@$(N64_AUDIOCONV) -o filesystem $<
 
 $(BUILD_DIR)/mixertest.dfs: $(assets_conv)
-$(BUILD_DIR)/mixertest.elf: $(src:%.c=$(BUILD_DIR)/%.o)
+$(BUILD_DIR)/mixertest.elf: $(OBJS)
 
 mixertest.z64: N64_ROM_TITLE="Mixer Test"
-mixertest.z64: $(BUILD_DIR)/mixertest.dfs 
+mixertest.z64: $(BUILD_DIR)/mixertest.dfs
 
 clean:
 	rm -f $(BUILD_DIR)/* mixertest.z64 $(assets_conv)

--- a/examples/rtctest/Makefile
+++ b/examples/rtctest/Makefile
@@ -4,9 +4,7 @@ all: rtctest.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
-SRC = rtctest.c
-OBJS = $(SRC:%.c=$(BUILD_DIR)/%.o)
-DEPS = $(SRC:%.c=$(BUILD_DIR)/%.d)
+OBJS = $(BUILD_DIR)/rtctest.o
 
 rtctest.z64: N64_ROM_TITLE = "RTC Test"
 rtctest.z64: N64_ROM_RTC = true
@@ -17,4 +15,4 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d)

--- a/examples/spritemap/Makefile
+++ b/examples/spritemap/Makefile
@@ -4,9 +4,7 @@ all: spritemap.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
-SRC = spritemap.c
-OBJS = $(SRC:%.c=$(BUILD_DIR)/%.o)
-DEPS = $(SRC:%.c=$(BUILD_DIR)/%.d)
+OBJS = $(BUILD_DIR)/spritemap.o
 
 spritemap.z64: N64_ROM_TITLE = "Spritemap"
 spritemap.z64: $(BUILD_DIR)/spritemap.dfs
@@ -18,4 +16,4 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d)

--- a/examples/test/Makefile
+++ b/examples/test/Makefile
@@ -4,9 +4,7 @@ all: test.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
-SRC = test.c
-OBJS = $(SRC:%.c=$(BUILD_DIR)/%.o)
-DEPS = $(SRC:%.c=$(BUILD_DIR)/%.d)
+OBJS = $(BUILD_DIR)/test.o
 
 test.z64: N64_ROM_TITLE = "Video Test"
 test.z64: $(BUILD_DIR)/test.dfs
@@ -18,4 +16,4 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d))

--- a/examples/timers/Makefile
+++ b/examples/timers/Makefile
@@ -4,9 +4,7 @@ all: timers.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
-SRC = timers.c
-OBJS = $(SRC:%.c=$(BUILD_DIR)/%.o)
-DEPS = $(SRC:%.c=$(BUILD_DIR)/%.d)
+OBJS = $(BUILD_DIR)/timers.o
 
 timers.z64: N64_ROM_TITLE = "Timer Test"
 
@@ -16,4 +14,4 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d))

--- a/examples/ucodetest/Makefile
+++ b/examples/ucodetest/Makefile
@@ -5,7 +5,6 @@ BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
 OBJS = $(BUILD_DIR)/ucodetest.o $(BUILD_DIR)/rsp_basic.o
-DEPS = $(OBJS:$(BUILD_DIR)/%.o=$(BUILD_DIR)/%.d)
 
 ucodetest.z64: N64_ROM_TITLE = "UCode Test"
 
@@ -15,4 +14,4 @@ clean:
 	rm -rf $(BUILD_DIR) *.z64
 .PHONY: clean
 
--include $(DEPS)
+-include $(wildcard $(BUILD_DIR)/*.d))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,15 +5,15 @@ all: testrom.z64 testrom_emu.z64
 
 $(BUILD_DIR)/testrom.dfs: $(wildcard filesystem/*)
 
-$(BUILD_DIR)/testrom.elf: ${BUILD_DIR}/testrom.o ${BUILD_DIR}/test_constructors_cpp.o
+$(BUILD_DIR)/testrom.elf: $(BUILD_DIR)/testrom.o $(BUILD_DIR)/test_constructors_cpp.o
 testrom.z64: N64_ROM_TITLE="Libdragon Test ROM"
 testrom.z64: $(BUILD_DIR)/testrom.dfs
 
-$(BUILD_DIR)/testrom_emu.elf: ${BUILD_DIR}/testrom_emu.o ${BUILD_DIR}/test_constructors_cpp.o
+$(BUILD_DIR)/testrom_emu.elf: $(BUILD_DIR)/testrom_emu.o $(BUILD_DIR)/test_constructors_cpp.o
 testrom_emu.z64: N64_ROM_TITLE="Libdragon Test ROM"
 testrom_emu.z64: $(BUILD_DIR)/testrom.dfs
 
-${BUILD_DIR}/testrom_emu.o: testrom.c
+$(BUILD_DIR)/testrom_emu.o: $(SOURCE_DIR)/testrom.c
 	@mkdir -p $(dir $@)
 	@echo "    [CC] $<"
 	$(CC) -c $(CFLAGS) -DIN_EMULATOR=1 -o $@ $<


### PR DESCRIPTION
- Add missing builds for eepromfs and rtc examples
- Add `$(SOURCE_DIR)` prefix for `testrom_emu.o` recipe in test Makefile.
Without this the paths for the two sources become inconsistent when building
with a `SOURCE_DIR` override. Providing it is useful when using tools that parse
the build output. You can provide `SOURCE_DIR=../tests` to make such that the
build output looks like;
`[CC] ../tests/testrom.c`
This makes it possible to discriminate which error output is coming from which
path. Without consistent paths, there will be a second `[CC] testrom.c`.
- To be able to benefit from the same path consistency, changed the input list
to object files for all examples. When provided like `$(BUILD_DIR)/object.o`, it
ensures they all use the same `SOURCE_DIR` prefix and makes the Makefile a
little less verbose.
- We dont need to manually create a list of `.d` files. Start using a wildcard
instead.