### PR TITLE
Two small changes in wav64

### DIFF
--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -51,16 +51,16 @@ int main(void) {
 		struct controller_data ckeys = get_keys_down();
 
 		if (ckeys.c[0].A) {
-			mixer_ch_play(CHANNEL_SFX1, &sfx_cannon.wave);
+			wav64_play(&sfx_cannon, CHANNEL_SFX1);
 		}
 		if (ckeys.c[0].B) {
-			mixer_ch_play(CHANNEL_SFX2, &sfx_laser.wave);
+			wav64_play(&sfx_laser, CHANNEL_SFX2);
 			mixer_ch_set_vol(CHANNEL_SFX2, 0.25f, 0.25f);
 		}
 		if (ckeys.c[0].Z) {
 			music = !music;
 			if (music) {
-				mixer_ch_play(CHANNEL_MUSIC, &sfx_monosample.wave);
+				wav64_play(&sfx_monosample, CHANNEL_MUSIC);
 				music_frequency = sfx_monosample.wave.frequency;
 			}
 			else

--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -24,12 +24,12 @@ int main(void) {
 
 	wav64_t sfx_cannon, sfx_laser, sfx_monosample;
 
-	wav64_open(&sfx_cannon, "cannon.wav64");
+	wav64_open(&sfx_cannon, "rom:/cannon.wav64");
 	
-	wav64_open(&sfx_laser, "laser.wav64");
+	wav64_open(&sfx_laser, "rom:/laser.wav64");
 	wav64_set_loop(&sfx_laser, true);
 
-	wav64_open(&sfx_monosample, "monosample8.wav64");
+	wav64_open(&sfx_monosample, "rom:/monosample8.wav64");
 	wav64_set_loop(&sfx_monosample, true);
 
 	bool music = false;

--- a/include/wav64.h
+++ b/include/wav64.h
@@ -32,13 +32,14 @@ typedef struct {
 	uint32_t rom_addr;
 } wav64_t;
 
-/** @brief Open a WAV64 file for playback from the DragonFS filesystem.  
+/** @brief Open a WAV64 file for playback.
  * 
  * This function opens the file, parses the header, and initializes for
  * playing back through the audio mixer.
  * 
- * @param 	wav       	Pointer to wav64_t structure
- * @param   fn          Filename of the wav64 (on DragonFS).
+ * @param   wav         Pointer to wav64_t structure
+ * @param   fn          Filename of the wav64 (with filesystem prefix). Currently,
+ *                      only files on DFS ("rom:/") are supported.
  */ 
 void wav64_open(wav64_t *wav, const char *fn);
 
@@ -51,8 +52,8 @@ void wav64_set_loop(wav64_t *wav, bool loop);
  * waveform (#wav64_t::wave). For advanced usages, please call directly the
  * mixer functions.
  * 
- * @param   wav 		Pointer to wav64_t structure
- * @param   ch  		Channel of the mixer to use for playback.
+ * @param   wav         Pointer to wav64_t structure
+ * @param   ch          Channel of the mixer to use for playback.
  */
 void wav64_play(wav64_t *wav, int ch);
 

--- a/include/wav64.h
+++ b/include/wav64.h
@@ -1,7 +1,7 @@
 /**
  * @file wav64.h
  * @brief Support for WAV64 audio files
- * @ingroup audio
+ * @ingroup mixer
  */
 
 #ifndef __LIBDRAGON_WAV64_H

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -39,6 +39,14 @@ static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, b
 void wav64_open(wav64_t *wav, const char *fn) {
 	memset(wav, 0, sizeof(*wav));
 
+	// Currently, we only support streaming WAVs from DFS (ROMs). Any other
+	// filesystem is unsupported.
+	// For backward compatibility, we also silently accept a non-prefixed path.
+	if (strstr(fn, ":/")) {
+		assertf(strncmp(fn, "rom:/", 5) == 0, "Cannot open %s: wav64 only supports files in ROM (rom:/)", fn);
+		fn += 5;
+	}
+
 	int fh = dfs_open(fn);
 	assertf(fh >= 0, "file does not exist: %s", fn);
 

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -1,7 +1,7 @@
 /**
  * @file wav64.c
  * @brief Support for WAV64 audio files
- * @ingroup audio
+ * @ingroup mixer
  */
 
 #include "libdragon.h"
@@ -66,6 +66,11 @@ void wav64_open(wav64_t *wav, const char *fn) {
 
 	wav->wave.read = waveform_read;
 	wav->wave.ctx = wav;
+}
+
+void wav64_play(wav64_t *wav, int ch)
+{
+    mixer_ch_play(ch, &wav->wave);
 }
 
 void wav64_set_loop(wav64_t *wav, bool loop) {


### PR DESCRIPTION
 * Add missing `wav64_play` (was documented in header file, but non existing)
 * Align `wav64_open` to the new convention of requesting filesystem-qualified filenames. Keep the bare filenames working for backward compatibility
