### PR TITLE
Update the ucodetest example for compatibility with the new rsp crash screen

### DIFF
--- a/examples/ucodetest/ucodetest.c
+++ b/examples/ucodetest/ucodetest.c
@@ -41,28 +41,30 @@ int main(void)
     }
 
     printf("\n");
+    console_render();
 
     rsp_run_async();
 
     RSP_WAIT_LOOP(2000) {
         if (broke) {
-            printf("\nbroke");
-            printf("\n");
-            broke = false;
-
-            unsigned char* up = malloc(16);
-            rsp_read_data((void*)up, 16, 0);
-
-            i = 0;
-            while(i < 16)
-            {
-                printf("%02X ", up[i]);
-                if (i % 8 == 7) {
-                    printf("\n");
-                }
-                i++;
-            }
+            break;
         }
-        console_render();
     }
+
+    printf("\nbroke");
+    printf("\n");
+
+    unsigned char* up = malloc(16);
+    rsp_read_data((void*)up, 16, 0);
+
+    i = 0;
+    while(i < 16)
+    {
+        printf("%02X ", up[i]);
+        if (i % 8 == 7) {
+            printf("\n");
+        }
+        i++;
+    }
+    console_render();
 }


### PR DESCRIPTION
This example was causing the rsp crash screen to appear as the `RSP_WAIT_LOOP` was timing out. This PR reworks the example code to break out of the wait loop once the SP interrupt has been received, and moves the printing that was previously inside the wait loop to after the loop.
