### PR TITLE
Allow context parameter for `joybus_exec_async`

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -66,7 +66,7 @@ static struct controller_data prev;
 /** @brief True if there is a pending controller autoscan */
 static volatile bool controller_autoscan_in_progress = false;
 
-static void controller_interrupt_update(uint64_t *output)
+static void controller_interrupt_update(uint64_t *output, void *ctx)
 {
     memcpy((void*)&next, output, sizeof(struct controller_data));
     controller_autoscan_in_progress = false;
@@ -88,7 +88,7 @@ static void controller_interrupt(void)
     
     if (!controller_autoscan_in_progress) {    
         controller_autoscan_in_progress = true;
-        joybus_exec_async(SI_read_con_block, controller_interrupt_update);
+        joybus_exec_async(SI_read_con_block, controller_interrupt_update, NULL);
     }
 }
 

--- a/src/joybusinternal.h
+++ b/src/joybusinternal.h
@@ -1,6 +1,6 @@
 #ifndef __LIBDRAGON_JOYBUSINTERNAL_H
 #define __LIBDRAGON_JOYBUSINTERNAL_H
 
-void joybus_exec_async(const void * input, void (*callback)(uint64_t *output));
+void joybus_exec_async(const void * input, void (*callback)(uint64_t *output, void *ctx), void *ctx);
 
 #endif


### PR DESCRIPTION
Needed for wrangling chains of async Joybus callbacks, such as detecting/toggling a Rumble Pak.

Used by my work-in-progress Joypad Subsystem library: https://github.com/meeq/JoypadTest-N64/blob/main/joypad.c

@rasky 