### PR TITLE
mixer: improve documentation of C files

### DIFF
--- a/doxygen-public.conf
+++ b/doxygen-public.conf
@@ -896,7 +896,7 @@ FILE_PATTERNS          =
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -905,7 +905,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = ./src/audio/libxm/ ./src/audio/lzh5.h ./src/fatfs/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -1,6 +1,6 @@
 /**
  * @file mixer.h
- * @brief Audio mixer 
+ * @brief RSP Audio mixer 
  * @ingroup mixer
  */
 

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -4,18 +4,23 @@
  * @ingroup mixer
  */
 
-#include "libdragon.h"
+#include "mixer.h"
+#include "samplebuffer.h"
+#include "n64sys.h"
+#include "utils.h"
+#include "debug.h"
 #include <string.h>
 
+/** @brief Set to 1 to activate debug logs */
 #define MIXER_TRACE   0
 
 #if MIXER_TRACE
+/** @brief like debugf(), but writes only if #MIXER_TRACE is not 0 */
 #define tracef(fmt, ...)  debugf(fmt, ##__VA_ARGS__)
 #else
+/** @brief like debugf(), but writes only if #MIXER_TRACE is not 0 */
 #define tracef(fmt, ...)  ({ })
 #endif
-
-#define ROUND_UP(n, d)  (((n) + (d) - 1) / (d) * (d))
 
 void samplebuffer_init(samplebuffer_t *buf, uint8_t* uncached_mem, int nbytes) {
 	memset(buf, 0, sizeof(samplebuffer_t));
@@ -60,8 +65,10 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 	// This is not strictly required because dma_read() can do wonders,
 	// but it results in slightly faster DMA transfers and its almost free
 	// to do here.
+	/// @cond
 	#define ROUNDUP8_BPS(nsamples, bps) \
 		(((nsamples)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps)))
+	/// @endcond
 
 	int bps = SAMPLES_BPS_SHIFT(buf);
 

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -1,16 +1,24 @@
 /**
  * @file wav64.c
  * @brief Support for WAV64 audio files
- * @ingroup audio
+ * @ingroup mixer
  */
 
-#include "libdragon.h"
+#include "wav64.h"
 #include "wav64internal.h"
+#include "mixer.h"
+#include "dragonfs.h"
+#include "n64sys.h"
+#include "dma.h"
+#include "samplebuffer.h"
+#include "debug.h"
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 
+/** ID of a standard WAV file */
 #define WAV_RIFF_ID   "RIFF"
+/** ID of a WAVX file (big-endian WAV) */
 #define WAV_RIFX_ID   "RIFX"
 
 /** @brief Profile of DMA usage by WAV64, used for debugging purposes. */

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -1,3 +1,9 @@
+/**
+ * @file xm64.c
+ * @brief Efficient XM module player
+ * @ingroup mixer
+ */
+
 #include <libdragon.h>
 #include "wav64internal.h"
 #include "libxm/xm.h"

--- a/src/audio/ym64.c
+++ b/src/audio/ym64.c
@@ -1,20 +1,28 @@
+/**
+ * @file ym64.c
+ * @brief Player for the .YM64 module format (Arkos Tracker 2)
+ * @ingroup mixer
+ */
+
 #include "ym64.h"
 #include "ay8910.h"
+#include "lzh5.h"
+#include "samplebuffer.h"
+#include "debug.h"
+#include "utils.h"
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
-#include <libdragon.h>
-#include "lzh5.h"
-#include "utils.h"
 
+/** @brief Header of a YM5 file */
 typedef struct __attribute__((packed)) {
-	uint32_t nframes;
-	uint32_t attrs;
-	uint16_t ndigidrums;
-	uint32_t chipfreq;
-	uint16_t playfreq;
-	uint32_t loop;
-	uint16_t sizeext;
+	uint32_t nframes;         ///< Number of audioframes
+	uint32_t attrs;           ///< Attributes (bit 0: interleaved format)
+	uint16_t ndigidrums;      ///< Number of digital samples
+	uint32_t chipfreq;        ///< Frequency of the emulated chip
+	uint16_t playfreq;        ///< Playback frequency in audioframes per seconds (eg: 50)
+	uint32_t loop;            ///< Audioframe where the loop starts
+	uint16_t sizeext;         ///< Extension (always 0)
 } ym5header;
 
 _Static_assert(sizeof(ym5header) == 22, "invalid header size");


### PR DESCRIPTION
Activate generation of source-level documentation for src/audio/*.c.
Skip vendored files, and write the missing comments.