### PR TITLE
Optimize joybus_exec callback, remove nested function

### DIFF
--- a/src/joybusinternal.h
+++ b/src/joybusinternal.h
@@ -1,6 +1,9 @@
 #ifndef __LIBDRAGON_JOYBUSINTERNAL_H
 #define __LIBDRAGON_JOYBUSINTERNAL_H
 
-void joybus_exec_async(const void * input, void (*callback)(uint64_t *output, void *ctx), void *ctx);
+/** @brief Joybus execution callback pointer */
+typedef void (*joybus_callback_t)(uint64_t *out_dwords, void *ctx);
+
+void joybus_exec_async(const void * input, joybus_callback_t callback, void *ctx);
 
 #endif


### PR DESCRIPTION
Use `joybus_callback_t` to unify usage of callback function pointer