### PR TITLE
rsp.inc: unify support for e(x) syntax

### DIFF
--- a/include/rsp.inc
+++ b/include/rsp.inc
@@ -270,6 +270,349 @@ makeNotImplemented tnei
     .set $v31, 0x11F
 .endm
 
+# Encode vector elements for use in e(x) style syntax.
+.macro veVectorElements
+    .set VE_v,  0x0
+    .set VE_0q, 0x2
+    .set VE_1q, 0x3
+    .set VE_0h, 0x4
+    .set VE_1h, 0x5
+    .set VE_2h, 0x6
+    .set VE_3h, 0x7
+    .set VE_0,  0x8
+    .set VE_1,  0x9
+    .set VE_2,  0xA
+    .set VE_3,  0xB
+    .set VE_4,  0xC
+    .set VE_5,  0xD
+    .set VE_6,  0xE
+    .set VE_7,  0xF
+.endm
+
+# Encode byte offsets for use in e(x) style syntax.
+.macro byteVectorElements
+    .set VE_v,  -1
+    .set VE_0q, -1
+    .set VE_1q, -1
+    .set VE_0h, -1
+    .set VE_1h, -1
+    .set VE_2h, -1
+    .set VE_3h, -1
+    .set VE_0,  0x0
+    .set VE_1,  0x2
+    .set VE_2,  0x4
+    .set VE_3,  0x6
+    .set VE_4,  0x8
+    .set VE_5,  0xA
+    .set VE_6,  0xC
+    .set VE_7,  0xE
+.endm
+
+# Encode byte offsets for use in e(x) style syntax.
+.macro laneAsByteVectorElements
+    byteVectorElements
+.endm
+
+# Encode lane indices for use in e(x) style syntax.
+.macro laneVectorElements
+    .set VE_v,  -1
+    .set VE_0q, -1
+    .set VE_1q, -1
+    .set VE_0h, -1
+    .set VE_1h, -1
+    .set VE_2h, -1
+    .set VE_3h, -1
+    .set VE_0,  0x0
+    .set VE_1,  0x1
+    .set VE_2,  0x2
+    .set VE_3,  0x3
+    .set VE_4,  0x4
+    .set VE_5,  0x5
+    .set VE_6,  0x6
+    .set VE_7,  0x7
+.endm
+
+# This will encode element accessors for computational
+# opcodes, which interpret the element as either lane index + 8
+# or broadcast specifiers. For these, the .bN accessors are not valid.
+.macro veAccessorEncoder prefix, base
+    .set \prefix\().v,   (\base + 0x0)
+    .set \prefix\().q0,  (\base + 0x2)
+    .set \prefix\().q1,  (\base + 0x3)
+    .set \prefix\().h0,  (\base + 0x4)
+    .set \prefix\().h1,  (\base + 0x5)
+    .set \prefix\().h2,  (\base + 0x6)
+    .set \prefix\().h3,  (\base + 0x7)
+    .set \prefix\().e0,  (\base + 0x8)
+    .set \prefix\().e1,  (\base + 0x9)
+    .set \prefix\().e2,  (\base + 0xA)
+    .set \prefix\().e3,  (\base + 0xB)
+    .set \prefix\().e4,  (\base + 0xC)
+    .set \prefix\().e5,  (\base + 0xD)
+    .set \prefix\().e6,  (\base + 0xE)
+    .set \prefix\().e7,  (\base + 0xF)
+    .set \prefix\().b0,  -1
+    .set \prefix\().b1,  -1
+    .set \prefix\().b2,  -1
+    .set \prefix\().b3,  -1
+    .set \prefix\().b4,  -1
+    .set \prefix\().b5,  -1
+    .set \prefix\().b6,  -1
+    .set \prefix\().b7,  -1
+    .set \prefix\().b8,  -1
+    .set \prefix\().b9,  -1
+    .set \prefix\().b10, -1
+    .set \prefix\().b11, -1
+    .set \prefix\().b12, -1
+    .set \prefix\().b13, -1
+    .set \prefix\().b14, -1
+    .set \prefix\().b15, -1
+.endm
+
+# This will encode element accessors for opcodes which interpret
+# the element as lane index (only packed load/store ops).
+# For these, only the .eN accessors are valid.
+.macro laneAccessorEncoder prefix, base
+    .set \prefix\().v,   -1
+    .set \prefix\().q0,  -1
+    .set \prefix\().q1,  -1
+    .set \prefix\().h0,  -1
+    .set \prefix\().h1,  -1
+    .set \prefix\().h2,  -1
+    .set \prefix\().h3,  -1
+    .set \prefix\().e0,  (\base + 0x0)
+    .set \prefix\().e1,  (\base + 0x1)
+    .set \prefix\().e2,  (\base + 0x2)
+    .set \prefix\().e3,  (\base + 0x3)
+    .set \prefix\().e4,  (\base + 0x4)
+    .set \prefix\().e5,  (\base + 0x5)
+    .set \prefix\().e6,  (\base + 0x6)
+    .set \prefix\().e7,  (\base + 0x7)
+    .set \prefix\().b0,  -1
+    .set \prefix\().b1,  -1
+    .set \prefix\().b2,  -1
+    .set \prefix\().b3,  -1
+    .set \prefix\().b4,  -1
+    .set \prefix\().b5,  -1
+    .set \prefix\().b6,  -1
+    .set \prefix\().b7,  -1
+    .set \prefix\().b8,  -1
+    .set \prefix\().b9,  -1
+    .set \prefix\().b10, -1
+    .set \prefix\().b11, -1
+    .set \prefix\().b12, -1
+    .set \prefix\().b13, -1
+    .set \prefix\().b14, -1
+    .set \prefix\().b15, -1
+.endm
+
+# This will encode element accessors for opcodes which interpret
+# the element as byte offset (mtc2/mfc2 and most load/store ops).
+# For these, both .eN (lane index) and .bN (byte offset) accessors
+# are valid. The broadcast accessors are not.
+.macro byteAccessorEncoder prefix, base
+    .set \prefix\().v,   -1
+    .set \prefix\().q0,  -1
+    .set \prefix\().q1,  -1
+    .set \prefix\().h0,  -1
+    .set \prefix\().h1,  -1
+    .set \prefix\().h2,  -1
+    .set \prefix\().h3,  -1
+    .set \prefix\().e0,  (\base + 0x0)
+    .set \prefix\().e1,  (\base + 0x2)
+    .set \prefix\().e2,  (\base + 0x4)
+    .set \prefix\().e3,  (\base + 0x6)
+    .set \prefix\().e4,  (\base + 0x8)
+    .set \prefix\().e5,  (\base + 0xA)
+    .set \prefix\().e6,  (\base + 0xC)
+    .set \prefix\().e7,  (\base + 0xE)
+    .set \prefix\().b0,  (\base + 0x0)
+    .set \prefix\().b1,  (\base + 0x1)
+    .set \prefix\().b2,  (\base + 0x2)
+    .set \prefix\().b3,  (\base + 0x3)
+    .set \prefix\().b4,  (\base + 0x4)
+    .set \prefix\().b5,  (\base + 0x5)
+    .set \prefix\().b6,  (\base + 0x6)
+    .set \prefix\().b7,  (\base + 0x7)
+    .set \prefix\().b8,  (\base + 0x8)
+    .set \prefix\().b9,  (\base + 0x9)
+    .set \prefix\().b10, (\base + 0xA)
+    .set \prefix\().b11, (\base + 0xB)
+    .set \prefix\().b12, (\base + 0xC)
+    .set \prefix\().b13, (\base + 0xD)
+    .set \prefix\().b14, (\base + 0xE)
+    .set \prefix\().b15, (\base + 0xF)
+.endm
+
+# This will encode element accessors for opcodes which interpret
+# the element as byte offset, but only even offsets are valid
+# (so effectively they accept lane indices, but encoded as byte offset).
+# This applies to ltv and stv.
+.macro laneAsByteAccessorEncoder prefix, base
+    .set \prefix\().v,   -1
+    .set \prefix\().q0,  -1
+    .set \prefix\().q1,  -1
+    .set \prefix\().h0,  -1
+    .set \prefix\().h1,  -1
+    .set \prefix\().h2,  -1
+    .set \prefix\().h3,  -1
+    .set \prefix\().e0,  (\base + 0x0)
+    .set \prefix\().e1,  (\base + 0x2)
+    .set \prefix\().e2,  (\base + 0x4)
+    .set \prefix\().e3,  (\base + 0x6)
+    .set \prefix\().e4,  (\base + 0x8)
+    .set \prefix\().e5,  (\base + 0xA)
+    .set \prefix\().e6,  (\base + 0xC)
+    .set \prefix\().e7,  (\base + 0xE)
+    .set \prefix\().b0,  -1
+    .set \prefix\().b1,  -1
+    .set \prefix\().b2,  -1
+    .set \prefix\().b3,  -1
+    .set \prefix\().b4,  -1
+    .set \prefix\().b5,  -1
+    .set \prefix\().b6,  -1
+    .set \prefix\().b7,  -1
+    .set \prefix\().b8,  -1
+    .set \prefix\().b9,  -1
+    .set \prefix\().b10, -1
+    .set \prefix\().b11, -1
+    .set \prefix\().b12, -1
+    .set \prefix\().b13, -1
+    .set \prefix\().b14, -1
+    .set \prefix\().b15, -1
+.endm
+
+# This macro will encode all possible combinations of vector registers and
+# element accessors (dot-syntax) as numbers >= 0x200. The lower 4 bits
+# encode the element, the 5 bits above those encode the register number.
+.macro defineVectorAccessors encoder
+    \encoder $v00, 0x200
+    \encoder $v01, 0x210
+    \encoder $v02, 0x220
+    \encoder $v03, 0x230
+    \encoder $v04, 0x240
+    \encoder $v05, 0x250
+    \encoder $v06, 0x260
+    \encoder $v07, 0x270
+    \encoder $v08, 0x280
+    \encoder $v09, 0x290
+    \encoder $v10, 0x2A0
+    \encoder $v11, 0x2B0
+    \encoder $v12, 0x2C0
+    \encoder $v13, 0x2D0
+    \encoder $v14, 0x2E0
+    \encoder $v15, 0x2F0
+    \encoder $v16, 0x300
+    \encoder $v17, 0x310
+    \encoder $v18, 0x320
+    \encoder $v19, 0x330
+    \encoder $v20, 0x340
+    \encoder $v21, 0x350
+    \encoder $v22, 0x360
+    \encoder $v23, 0x370
+    \encoder $v24, 0x380
+    \encoder $v25, 0x390
+    \encoder $v26, 0x3A0
+    \encoder $v27, 0x3B0
+    \encoder $v28, 0x3C0
+    \encoder $v29, 0x3D0
+    \encoder $v30, 0x3E0
+    \encoder $v31, 0x3F0
+.endm
+
+.macro veVectorAccessors
+    defineVectorAccessors veAccessorEncoder
+.endm
+
+.macro laneVectorAccessors
+    defineVectorAccessors laneAccessorEncoder
+.endm
+
+.macro byteVectorAccessors
+    defineVectorAccessors byteAccessorEncoder
+.endm
+
+.macro laneAsByteVectorAccessors
+    defineVectorAccessors laneAsByteAccessorEncoder
+.endm
+
+# The following two macros are required for load/store instructions,
+# where we need to map back to GPR style syntax
+.macro regAccessorEncoder prefix, value
+    .set reg.\prefix\().v,   \value
+    .set reg.\prefix\().q0,  \value
+    .set reg.\prefix\().q1,  \value
+    .set reg.\prefix\().h0,  \value
+    .set reg.\prefix\().h1,  \value
+    .set reg.\prefix\().h2,  \value
+    .set reg.\prefix\().h3,  \value
+    .set reg.\prefix\().e0,  \value
+    .set reg.\prefix\().e1,  \value
+    .set reg.\prefix\().e2,  \value
+    .set reg.\prefix\().e3,  \value
+    .set reg.\prefix\().e4,  \value
+    .set reg.\prefix\().e5,  \value
+    .set reg.\prefix\().e6,  \value
+    .set reg.\prefix\().e7,  \value
+    .set reg.\prefix\().b0,  \value
+    .set reg.\prefix\().b1,  \value
+    .set reg.\prefix\().b2,  \value
+    .set reg.\prefix\().b3,  \value
+    .set reg.\prefix\().b4,  \value
+    .set reg.\prefix\().b5,  \value
+    .set reg.\prefix\().b6,  \value
+    .set reg.\prefix\().b7,  \value
+    .set reg.\prefix\().b8,  \value
+    .set reg.\prefix\().b9,  \value
+    .set reg.\prefix\().b10, \value
+    .set reg.\prefix\().b11, \value
+    .set reg.\prefix\().b12, \value
+    .set reg.\prefix\().b13, \value
+    .set reg.\prefix\().b14, \value
+    .set reg.\prefix\().b15, \value
+.endm
+
+.macro regVectorAccessors
+    regAccessorEncoder $v00, $0
+    regAccessorEncoder $v01, $1
+    regAccessorEncoder $v02, $2
+    regAccessorEncoder $v03, $3
+    regAccessorEncoder $v04, $4
+    regAccessorEncoder $v05, $5
+    regAccessorEncoder $v06, $6
+    regAccessorEncoder $v07, $7
+    regAccessorEncoder $v08, $8
+    regAccessorEncoder $v09, $9
+    regAccessorEncoder $v10, $10
+    regAccessorEncoder $v11, $11
+    regAccessorEncoder $v12, $12
+    regAccessorEncoder $v13, $13
+    regAccessorEncoder $v14, $14
+    regAccessorEncoder $v15, $15
+    regAccessorEncoder $v16, $16
+    regAccessorEncoder $v17, $17
+    regAccessorEncoder $v18, $18
+    regAccessorEncoder $v19, $19
+    regAccessorEncoder $v20, $20
+    regAccessorEncoder $v21, $21
+    regAccessorEncoder $v22, $22
+    regAccessorEncoder $v23, $23
+    regAccessorEncoder $v24, $24
+    regAccessorEncoder $v25, $25
+    regAccessorEncoder $v26, $26
+    regAccessorEncoder $v27, $27
+    regAccessorEncoder $v28, $28
+    regAccessorEncoder $v29, $29
+    regAccessorEncoder $v30, $30
+    regAccessorEncoder $v31, $31
+.endm
+
+# Instead of using the constants above, it is possible to use the syntax 'e(x)'
+# via the following macros.
+#define _PPCAT2(n,x) n ## x
+#define _PPCAT(n,x) _PPCAT2(n,x)
+#define e(xx) _PPCAT(VE_, xx)
+
 /** @brief Syntactic sugar for cop2 instuctions */
 .macro vectorOp opcode, vd, vs, vt, element
     .ifgt (\element >> 4)
@@ -297,20 +640,17 @@ makeNotImplemented tnei
     cop2 (\element << 21 | \vt << 16 | \vs << 11 | \vd << 6 | \opcode)
 .endm
 
-/** @brief Syntactic sugar for lwc2 instuctions */
-.macro loadVector, opcode, vt, element, offset, base
-    renameRegisters
-    lwc2 \vt, (\opcode << 11 | \element << 7 | \offset) (\base)
-.endm
-
-/** @brief Syntactic sugar for swc2 instuctions */
-.macro storeVector opcode, vt, element, offset, base
-    renameRegisters
-    swc2 \vt, (\opcode << 11 | \element << 7 | \offset) (\base)
-.endm
-
 .macro makeOpInstruction name, opcode
+    # Overloads:
+    #   op vd, vs, vt, element
+    #   op vd, vs, vt
+    #   op vd, vs, vt.e
+    #   op vd, vt, element
+    #   op vd, vt
+    #   op vd, vt.e
     .macro \name vd, vsOrVt, vtOrElement, elementOrEmpty
+        veVectorElements
+
         # If the last argument is specified we can be sure that the full syntax is being used
         .ifnb \elementOrEmpty
             # All operands with element: op $v1, $v2, $v3, e(x)
@@ -318,77 +658,42 @@ makeNotImplemented tnei
             .exitm
         .endif
 
+        veVectorAccessors
+        encodeVectorRegs
+
         # If only the last argument was omitted, we need to check which syntax is being used
         .ifnb \vtOrElement
-            encodeVectorRegs
+            .iflt (\vtOrElement)
+                .error "Invalid element"
+                .exitm
+            .endif
+
+            # Dot-style syntax is encoded as numbers >= 0x200
+            .if (\vtOrElement >= 0x200)
+                # All operands with vt and element combined into accessor syntax: op $v1, $v2, $v3.e
+                vectorOp \opcode, \vd, \vsOrVt, ((\vtOrElement >> 4) & 0x1F), (\vtOrElement & 0xF)
             # Because we encode vector registers as numbers >= 0x100, we can check if 
             # the third argument is vt or the vector element (which are < 0x10):
-            .if (\vtOrElement < 0x100)
-                # vs omitted with element: op $v1, $v2, e(x)
-                vectorOp \opcode, \vd, \vd, \vsOrVt, \vtOrElement
-            .else
+            .elseif (\vtOrElement >= 0x100)
                 # All operands without element: op $v1, $v2, $v3
                 vectorOp \opcode, \vd, \vsOrVt, \vtOrElement, 0
+            .else
+                # vs omitted with element: op $v1, $v2, e(x)
+                vectorOp \opcode, \vd, \vd, \vsOrVt, \vtOrElement
             .endif
             .exitm
         .endif
 
-        # Otherwise it is the 2 parameter form
-        # vs omitted without element: op $v1, $v2
-        vectorOp \opcode, \vd, \vd, \vsOrVt, 0
-    .endm
-.endm
-
-.macro makeLsInstruction mode, name, opcode, size, rangemin, rangemax
-    .macro \name vt, element, offset, base
-        .ifgt (\element >> 4)
-            .error "Invalid element"
-            .exitm
-        .endif
-
-        .ifne ((\offset) % \size)
-            .error "Invalid offset - must be multiple of \size"
-            .exitm
-        .endif
-
-        .ifge (\offset)
-            .ifgt ((\offset) - \rangemax)
-                .error "Invalid offset - valid range: [\rangemin, \rangemax]"
-                .exitm
-            .endif
-
-            \mode\()Vector \opcode, \vt, \element, ((\offset) / \size), \base
+        # Dot-style syntax is encoded as numbers >= 0x200
+        .if (\vsOrVt >= 0x200)
+            # vs omitted with vt and element combined into accessor syntax: op $v1, $v2.e
+            vectorOp \opcode, \vd, \vd, ((\vsOrVt >> 4) & 0x1F), (\vsOrVt & 0xF)
         .else
-            .iflt ((\offset) - \rangemin)
-                .error "Invalid offset - valid range: [\rangemin, \rangemax]"
-                .exitm
-            .endif
-
-            \mode\()Vector \opcode, \vt, \element, (128 + ((\offset) / \size)), \base
+            # vs omitted without element: op $v1, $v2
+            vectorOp \opcode, \vd, \vd, \vsOrVt, 0
         .endif
     .endm
 .endm
-
-.macro makeLsInstructionQuad mode, name, opcode
-    makeLsInstruction \mode, \name, \opcode, 16, -1024, 1008
-.endm
-
-.macro makeLsInstructionDouble mode, name, opcode
-    makeLsInstruction \mode, \name, \opcode, 8, -512, 504
-.endm
-
-.macro makeLsInstructionLong mode, name, opcode
-    makeLsInstruction \mode, \name, \opcode, 4, -256, 252
-.endm
-
-.macro makeLsInstructionShort mode, name, opcode
-    makeLsInstruction \mode, \name, \opcode, 2, -128, 126
-.endm
-
-.macro makeLsInstructionByte mode, name, opcode
-    makeLsInstruction \mode, \name, \opcode, 1, -64, 63
-.endm
-
 
 /** @brief Vector Absolute Value of Short Elements */
 makeOpInstruction vabs, 0b010011
@@ -464,8 +769,6 @@ makeOpInstruction vrsq, 0b110100
 makeOpInstruction vrsqh, 0b110110
 /** @brief Vector Element Scalar SQRT Reciprocal (Double Prec. Low) */
 makeOpInstruction vrsql, 0b110101
-/** @brief Vector Accumulator Read (and Write) */
-makeOpInstruction vsar, 0b011101
 /** @brief Vector Subtraction of Short Elements */
 makeOpInstruction vsub, 0b010001
 /** @brief Vector Subtraction of Short Elements With Carry */
@@ -473,53 +776,39 @@ makeOpInstruction vsubc, 0b010101
 /** @brief Vector XOR of Short Elements */
 makeOpInstruction vxor, 0b101100
 
-/** @brief Load Byte into Vector Register */
-makeLsInstructionByte load, lbv, 0b00000
-/** @brief Load Double into Vector Register */
-makeLsInstructionDouble load, ldv, 0b00011
-/** @brief Load Packed Fourth into Vector Register */
-makeLsInstructionQuad load, lfv, 0b01001
-/** @brief Load Packed Half into Vector Register */
-makeLsInstructionQuad load, lhv, 0b01000
-/** @brief Load Long into Vector Register */
-makeLsInstructionLong load, llv, 0b00010
-/** @brief Load Packed Bytes into Vector Register */
-makeLsInstructionDouble load, lpv, 0b00110
-/** @brief Load Quad into Vector Register */
-makeLsInstructionQuad load, lqv, 0b00100
-/** @brief Load Quad (Rest) into Vector Register */
-makeLsInstructionQuad load, lrv, 0b00101
-/** @brief Load Short into Vector Register */
-makeLsInstructionShort load, lsv, 0b00001
-/** @brief Load Transpose into Vector Register */
-makeLsInstructionQuad load, ltv, 0b01011
-/** @brief Load Unsigned Packed into Vector Register */
-makeLsInstructionDouble load, luv, 0b00111
+#define COP2_ACC_HI             0x8
+#define COP2_ACC_MD             0x9
+#define COP2_ACC_LO             0xA
 
-/** @brief Store Byte from Vector Register */
-makeLsInstructionByte store, sbv, 0b00000
-/** @brief Store Double from Vector Register */
-makeLsInstructionDouble store, sdv, 0b00011
-/** @brief Store Packed Fourth from Vector Register */
-makeLsInstructionQuad store, sfv, 0b01001
-/** @brief Store Packed Half from Vector Register */
-makeLsInstructionQuad store, shv, 0b01000
-/** @brief Store Long from Vector Register */
-makeLsInstructionLong store, slv, 0b00010
-/** @brief Store Packed Bytes from Vector Register */
-makeLsInstructionDouble store, spv, 0b00110
-/** @brief Store Quad from Vector Register */
-makeLsInstructionQuad store, sqv, 0b00100
-/** @brief Store Quad (Rest) from Vector Register */
-makeLsInstructionQuad store, srv, 0b00101
-/** @brief Store Short from Vector Register */
-makeLsInstructionShort store, ssv, 0b00001
-/** @brief Store Transpose from Vector Register */
-makeLsInstructionQuad store, stv, 0b01011
-/** @brief Store Unsigned Packed from Vector Register */
-makeLsInstructionDouble store, suv, 0b00111
-/** @brief Store Wrapped vector from Vector Register */
-makeLsInstructionQuad store, swv, 0b00111
+.macro vsarInternal vd, element
+    .if (\element == COP2_ACC_HI || \element == COP2_ACC_MD || \element == COP2_ACC_LO)
+        vectorOp 0b011101, \vd, 0, 0, \element
+    .else
+        .error "Invalid element"
+    .endif
+.endm
+
+/** @brief Vector Accumulator Read (and Write) */
+.macro vsar vd, vs, vt, element
+    .ifnb \element
+        # 4-arg syntax (Deprecated)
+        vsarInternal \vd, \element
+        .exitm
+    .endif
+
+    .ifnb \vt
+        .error "Wrong number of arguments. Use syntax: vsar <vd> <element>"
+        .exitm
+    .endif
+
+    .ifnb \vs
+        # \vs is element
+        vsarInternal \vd, \vs
+        .exitm
+    .endif
+
+    .error "Wrong number of arguments. Use syntax: vsar <vd> <element>"
+.endm
 
 /** @brief Vector Accumulator DCT Rounding (Positive/Negative) 
   *
@@ -529,34 +818,33 @@ makeLsInstructionQuad store, swv, 0b00111
   * Export them as vrndn16 / vrndp16, so that they can be
   * used without making mistakes.
   */
-.macro vrndn vd, vt, element=0
-    .ifgt (\element >> 4)
-        .error "Invalid element"
-        .exitm
-    .endif
-    vectorOp 0b001010, \vd, 0, \vt, \element
+.macro makeVrndpOp name, opcode, flag
+    # Overloads:
+    #   op vd, vt, element
+    #   op vd, vt
+    #   op vd, vt.e
+    .macro \name vd, vt, element=0
+        veVectorElements
+        veVectorAccessors
+
+        .iflt (\vt)
+            .error "Invalid element"
+            .exitm
+        .endif
+
+        # Dot-style syntax is encoded as numbers >= 0x200
+        .if (\vt >= 0x200)
+            vectorOp \opcode, \vd, \flag, ((\vt >> 4) & 0x1F), (\element & 0xF)
+        .else
+            vectorOp \opcode, \vd, \flag, \vt, \element
+        .endif
+    .endm
 .endm
-.macro vrndn16 vd, vt, element=0
-    .ifgt (\element >> 4)
-        .error "Invalid element"
-        .exitm
-    .endif
-    vectorOp 0b001010, \vd, 1, \vt, \element
-.endm
-.macro vrndp vd, vt, element=0
-    .ifgt (\element >> 4)
-        .error "Invalid element"
-        .exitm
-    .endif
-    vectorOp 0b000010, \vd, 0, \vt, \element
-.endm
-.macro vrndp16 vd, vt, element=0
-    .ifgt (\element >> 4)
-        .error "Invalid element"
-        .exitm
-    .endif
-    vectorOp 0b000010, \vd, 1, \vt, \element
-.endm
+
+makeVrndpOp vrndn,   0b001010, 0
+makeVrndpOp vrndn16, 0b001010, 1
+makeVrndpOp vrndp,   0b000010, 0
+makeVrndpOp vrndp16, 0b000010, 1
 
 /** 
  * @brief Vector Accumulator Oddification
@@ -571,40 +859,180 @@ makeLsInstructionQuad store, swv, 0b00111
 .endm
 
 
-.macro mtc2 reg, vreg, element
-    hexRegisters
-    hexGeneralRegisters
-    .long (0x12 << 26 | 0x4 << 21 | \vreg << 11 | hex.\reg << 16 | \element << 7)
+/** @brief Syntactic sugar for lwc2 instuctions */
+.macro loadVector, opcode, vt, element, offset, base
+    renameRegisters
+    lwc2 \vt, (\opcode << 11 | \element << 7 | \offset) (\base)
 .endm
 
-.macro mfc2 reg, vreg, element
-    hexRegisters
-    hexGeneralRegisters
-    .long (0x12 << 26 | 0x0 << 21 | \vreg << 11 | hex.\reg << 16 | \element << 7)
+/** @brief Syntactic sugar for swc2 instuctions */
+.macro storeVector opcode, vt, element, offset, base
+    renameRegisters
+    swc2 \vt, (\opcode << 11 | \element << 7 | \offset) (\base)
 .endm
 
-# Vector element macros
-#define VE_v  0
-#define VE_0q 2
-#define VE_1q 3
-#define VE_0h 4
-#define VE_1h 5
-#define VE_2h 6
-#define VE_3h 7
-#define VE_0  8
-#define VE_1  9
-#define VE_2  10
-#define VE_3  11
-#define VE_4  12
-#define VE_5  13
-#define VE_6  14
-#define VE_7  15
+.macro lsInstruction mode, opcode, vt, element, offset, base, size, rangemin, rangemax
+    .ifgt (\element >> 4)
+        .error "Invalid element"
+        .exitm
+    .endif
 
-# Instead of using the constants above, it is possible to use the syntax 'e(x)'
-# via the following macros.
-#define _PPCAT2(n,x) n ## x
-#define _PPCAT(n,x) _PPCAT2(n,x)
-#define e(xx) _PPCAT(VE_, xx)
+    .ifne ((\offset) % \size)
+        .error "Invalid offset - must be multiple of \size"
+        .exitm
+    .endif
+
+    .ifge (\offset)
+        .ifgt ((\offset) - \rangemax)
+            .error "Invalid offset - valid range: [\rangemin, \rangemax]"
+            .exitm
+        .endif
+
+        \mode\()Vector \opcode, \vt, \element, ((\offset) / \size), \base
+    .else
+        .iflt ((\offset) - \rangemin)
+            .error "Invalid offset - valid range: [\rangemin, \rangemax]"
+            .exitm
+        .endif
+
+        \mode\()Vector \opcode, \vt, \element, (128 + ((\offset) / \size)), \base
+    .endif
+.endm
+
+.macro makeLsInstruction mode, elMode, name, opcode, size, rangemin, rangemax
+    # Overloads:
+    #   op vt, element, offset, base
+    #   op vt, offset, base
+    #   op vt.e, offset, base
+    .macro \name vt, elementOrOffset, offsetOrBase, baseOrEmpty
+        \elMode\()VectorElements
+
+        .ifnb \baseOrEmpty
+            lsInstruction \mode, \opcode, \vt, \elementOrOffset, \offsetOrBase, \baseOrEmpty, \size, \rangemin, \rangemax
+            .exitm
+        .endif
+
+        \elMode\()VectorAccessors
+        encodeVectorRegs
+
+        .iflt (\vt)
+            .error "Invalid element"
+            .exitm
+        .endif
+
+        # Dot-style syntax is encoded as numbers >= 0x200
+        .if (\vt >= 0x200)
+            regVectorAccessors
+            lsInstruction \mode, \opcode, reg.\vt, (\vt & 0xF), \elementOrOffset, \offsetOrBase, \size, \rangemin, \rangemax
+        .else
+            lsInstruction \mode, \opcode, \vt, 0, \elementOrOffset, \offsetOrBase, \size, \rangemin, \rangemax
+        .endif
+    .endm
+.endm
+
+.macro makeLsInstructionQuad mode, elMode, name, opcode
+    makeLsInstruction \mode, \elMode, \name, \opcode, 16, -1024, 1008
+.endm
+
+.macro makeLsInstructionDouble mode, elMode, name, opcode
+    makeLsInstruction \mode, \elMode, \name, \opcode, 8, -512, 504
+.endm
+
+.macro makeLsInstructionLong mode, elMode, name, opcode
+    makeLsInstruction \mode, \elMode, \name, \opcode, 4, -256, 252
+.endm
+
+.macro makeLsInstructionShort mode, elMode, name, opcode
+    makeLsInstruction \mode, \elMode, \name, \opcode, 2, -128, 126
+.endm
+
+.macro makeLsInstructionByte mode, elMode, name, opcode
+    makeLsInstruction \mode, \elMode, \name, \opcode, 1, -64, 63
+.endm
+
+/** @brief Load Byte into Vector Register */
+makeLsInstructionByte load, byte, lbv, 0b00000
+/** @brief Load Double into Vector Register */
+makeLsInstructionDouble load, byte, ldv, 0b00011
+/** @brief Load Packed Fourth into Vector Register */
+makeLsInstructionQuad load, byte, lfv, 0b01001
+/** @brief Load Packed Half into Vector Register */
+makeLsInstructionQuad load, byte, lhv, 0b01000
+/** @brief Load Long into Vector Register */
+makeLsInstructionLong load, byte, llv, 0b00010
+/** @brief Load Packed Bytes into Vector Register */
+makeLsInstructionDouble load, lane, lpv, 0b00110
+/** @brief Load Quad into Vector Register */
+makeLsInstructionQuad load, byte, lqv, 0b00100
+/** @brief Load Quad (Rest) into Vector Register */
+makeLsInstructionQuad load, byte, lrv, 0b00101
+/** @brief Load Short into Vector Register */
+makeLsInstructionShort load, byte, lsv, 0b00001
+/** @brief Load Transpose into Vector Register */
+makeLsInstructionQuad load, laneAsByte, ltv, 0b01011
+/** @brief Load Unsigned Packed into Vector Register */
+makeLsInstructionDouble load, lane, luv, 0b00111
+
+/** @brief Store Byte from Vector Register */
+makeLsInstructionByte store, byte, sbv, 0b00000
+/** @brief Store Double from Vector Register */
+makeLsInstructionDouble store, byte, sdv, 0b00011
+/** @brief Store Packed Fourth from Vector Register */
+makeLsInstructionQuad store, byte, sfv, 0b01001
+/** @brief Store Packed Half from Vector Register */
+makeLsInstructionQuad store, byte, shv, 0b01000
+/** @brief Store Long from Vector Register */
+makeLsInstructionLong store, byte, slv, 0b00010
+/** @brief Store Packed Bytes from Vector Register */
+makeLsInstructionDouble store, lane, spv, 0b00110
+/** @brief Store Quad from Vector Register */
+makeLsInstructionQuad store, byte, sqv, 0b00100
+/** @brief Store Quad (Rest) from Vector Register */
+makeLsInstructionQuad store, byte, srv, 0b00101
+/** @brief Store Short from Vector Register */
+makeLsInstructionShort store, byte, ssv, 0b00001
+/** @brief Store Transpose from Vector Register */
+makeLsInstructionQuad store, laneAsByte, stv, 0b01011
+/** @brief Store Unsigned Packed from Vector Register */
+makeLsInstructionDouble store, lane, suv, 0b00111
+/** @brief Store Wrapped vector from Vector Register */
+makeLsInstructionQuad store, byte, swv, 0b00111
+
+.macro mxc2 opcode, reg, vreg, element
+    .ifgt (\element >> 4)
+        .error "Invalid element"
+        .exitm
+    .endif
+    .long (0x12 << 26 | \opcode << 21 | \vreg << 11 | \reg << 16 | \element << 7)
+.endm
+
+.macro makeMxc2Op name, opcode
+    # Overloads:
+    #   op reg, vreg, element
+    #   op reg, vreg
+    #   op reg, vreg.e
+    .macro \name reg, vreg, element=0
+        hexRegisters
+        hexGeneralRegisters
+        byteVectorElements
+        byteVectorAccessors
+
+        .iflt (\vreg)
+            .error "Invalid element"
+            .exitm
+        .endif
+
+        # Dot-style syntax is encoded as numbers >= 0x200
+        .if (\vreg >= 0x200)
+            mxc2 \opcode, hex.\reg, ((\vreg >> 4) & 0x1F), (\vreg & 0xF)
+        .else
+            mxc2 \opcode, hex.\reg, \vreg, \element
+        .endif
+    .endm
+.endm
+
+makeMxc2Op mtc2, 0x4
+makeMxc2Op mfc2, 0x0
 
 ##################################################
 # Vector shift pseudo-opcodes

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -167,8 +167,8 @@
 	# Misc constants
 	#define v_const1      $v31
 
-	#define k_0000        v_zero,0
-	#define k_8000        v_shift8,8
+	#define k_0000        v_zero
+	#define k_8000        v_shift8.e0
 
 
 	.data
@@ -186,9 +186,9 @@ VCONST_1:
 	.half 0xe076      #   (0.9837**8) fixed 0.16
 	.half 0x1f8a      # 1-(0.9837**8) fixed 0.16
 
-	#define k_ffff      v_const1,e(0)
-	#define k_alpha     v_const1,e(1)
-	#define k_1malpha   v_const1,e(2)
+	#define k_ffff      v_const1.e0
+	#define k_alpha     v_const1.e1
+	#define k_1malpha   v_const1.e2
 
 	vsll_data
 	vsll8_data
@@ -276,9 +276,9 @@ command_exec:
 	#define samples_left    t4
 	#define outptr          s8
 
-	vxor v_zero, v_zero, v_zero,0
+	vxor v_zero, v_zero, v_zero
 	li t0, %lo(VCONST_1)
-	lqv v_const1,0, 0,t0
+	lqv v_const1, 0,t0
 
 	# Extract command parameters
 	andi a0, 0xFFFF
@@ -441,10 +441,10 @@ UpdateAndFetch:
 	li out_ptr, %lo(CHANNEL_BUFFER)
 	li t0, (MAX_SAMPLES_PER_LOOP * MAX_CHANNELS * 2) / 64 - 1
 ClearLoop:
-	sqv v_zero,0, 0x00,out_ptr
-	sqv v_zero,0, 0x10,out_ptr
-	sqv v_zero,0, 0x20,out_ptr
-	sqv v_zero,0, 0x30,out_ptr
+	sqv v_zero, 0x00,out_ptr
+	sqv v_zero, 0x10,out_ptr
+	sqv v_zero, 0x20,out_ptr
+	sqv v_zero, 0x30,out_ptr
 	addi out_ptr, 64
 	bnez t0, ClearLoop
 	addi t0, -1
@@ -930,22 +930,22 @@ WaveLoopEpilog2:
 SetupMixer:
 	# Load global volume (into all lanes)
 	lh t0, %lo(GLOBAL_VOLUME)
-	mtc2 t0, v_glvol,0
-	vor v_glvol, v_zero, v_glvol,8
+	mtc2 t0, v_glvol.e0
+	vor v_glvol, v_zero, v_glvol.e0
 
 	li s0, %lo(CHANNEL_VOLUMES_L)
 	li s1, %lo(XVOL_L)
 
 	# Load channel volumes (left / right)
-	lqv v_chvol_l_0,0,     0*MAX_CHANNELS_VOFF+0x00,s0
-	lqv v_chvol_l_1,0,     0*MAX_CHANNELS_VOFF+0x10,s0
-	lqv v_chvol_l_2,0,     0*MAX_CHANNELS_VOFF+0x20,s0
-	lqv v_chvol_l_3,0,     0*MAX_CHANNELS_VOFF+0x30,s0
+	lqv v_chvol_l_0,     0*MAX_CHANNELS_VOFF+0x00,s0
+	lqv v_chvol_l_1,     0*MAX_CHANNELS_VOFF+0x10,s0
+	lqv v_chvol_l_2,     0*MAX_CHANNELS_VOFF+0x20,s0
+	lqv v_chvol_l_3,     0*MAX_CHANNELS_VOFF+0x30,s0
 
-	lqv v_chvol_r_0,0,     1*MAX_CHANNELS_VOFF+0x00,s0
-	lqv v_chvol_r_1,0,     1*MAX_CHANNELS_VOFF+0x10,s0
-	lqv v_chvol_r_2,0,     1*MAX_CHANNELS_VOFF+0x20,s0
-	lqv v_chvol_r_3,0,     1*MAX_CHANNELS_VOFF+0x30,s0
+	lqv v_chvol_r_0,     1*MAX_CHANNELS_VOFF+0x00,s0
+	lqv v_chvol_r_1,     1*MAX_CHANNELS_VOFF+0x10,s0
+	lqv v_chvol_r_2,     1*MAX_CHANNELS_VOFF+0x20,s0
+	lqv v_chvol_r_3,     1*MAX_CHANNELS_VOFF+0x30,s0
 
 	# Apply global volume to obtain the final volume for each channel
 	vmudl v_chvol_l_0, v_chvol_l_0, v_glvol
@@ -959,15 +959,15 @@ SetupMixer:
 
 #if VOLUME_FILTER
 	# Load actual volumes levels
-	lqv v_xvol_l_0,0,      0*MAX_CHANNELS_VOFF+0x00,s1
-	lqv v_xvol_l_1,0,      0*MAX_CHANNELS_VOFF+0x10,s1
-	lqv v_xvol_l_2,0,      0*MAX_CHANNELS_VOFF+0x20,s1
-	lqv v_xvol_l_3,0,      0*MAX_CHANNELS_VOFF+0x30,s1
+	lqv v_xvol_l_0,      0*MAX_CHANNELS_VOFF+0x00,s1
+	lqv v_xvol_l_1,      0*MAX_CHANNELS_VOFF+0x10,s1
+	lqv v_xvol_l_2,      0*MAX_CHANNELS_VOFF+0x20,s1
+	lqv v_xvol_l_3,      0*MAX_CHANNELS_VOFF+0x30,s1
 
-	lqv v_xvol_r_0,0,      1*MAX_CHANNELS_VOFF+0x00,s1
-	lqv v_xvol_r_1,0,      1*MAX_CHANNELS_VOFF+0x10,s1
-	lqv v_xvol_r_2,0,      1*MAX_CHANNELS_VOFF+0x20,s1
-	lqv v_xvol_r_3,0,      1*MAX_CHANNELS_VOFF+0x30,s1
+	lqv v_xvol_r_0,      1*MAX_CHANNELS_VOFF+0x00,s1
+	lqv v_xvol_r_1,      1*MAX_CHANNELS_VOFF+0x10,s1
+	lqv v_xvol_r_2,      1*MAX_CHANNELS_VOFF+0x20,s1
+	lqv v_xvol_r_3,      1*MAX_CHANNELS_VOFF+0x30,s1
 #else
 	vor v_xvol_l_0, v_chvol_l_0, v_zero
 	vor v_xvol_l_1, v_chvol_l_1, v_zero
@@ -991,15 +991,15 @@ SetupMixer:
 EndMixer:
 	li s1, %lo(XVOL_L)
 
-	sqv v_xvol_l_0,0,      0*MAX_CHANNELS_VOFF+0x00,s1
-	sqv v_xvol_l_1,0,      0*MAX_CHANNELS_VOFF+0x10,s1
-	sqv v_xvol_l_2,0,      0*MAX_CHANNELS_VOFF+0x20,s1
-	sqv v_xvol_l_3,0,      0*MAX_CHANNELS_VOFF+0x30,s1
+	sqv v_xvol_l_0,      0*MAX_CHANNELS_VOFF+0x00,s1
+	sqv v_xvol_l_1,      0*MAX_CHANNELS_VOFF+0x10,s1
+	sqv v_xvol_l_2,      0*MAX_CHANNELS_VOFF+0x20,s1
+	sqv v_xvol_l_3,      0*MAX_CHANNELS_VOFF+0x30,s1
 
-	sqv v_xvol_r_0,0,      1*MAX_CHANNELS_VOFF+0x00,s1
-	sqv v_xvol_r_1,0,      1*MAX_CHANNELS_VOFF+0x10,s1
-	sqv v_xvol_r_2,0,      1*MAX_CHANNELS_VOFF+0x20,s1
-	sqv v_xvol_r_3,0,      1*MAX_CHANNELS_VOFF+0x30,s1
+	sqv v_xvol_r_0,      1*MAX_CHANNELS_VOFF+0x00,s1
+	sqv v_xvol_r_1,      1*MAX_CHANNELS_VOFF+0x10,s1
+	sqv v_xvol_r_2,      1*MAX_CHANNELS_VOFF+0x20,s1
+	sqv v_xvol_r_3,      1*MAX_CHANNELS_VOFF+0x30,s1
 
 	jr ra
 	nop
@@ -1034,16 +1034,16 @@ Mixer:
 	move t1, num_samples
 
 	# Load initial samples
-	lqv v_sample_0,0, 0x00,s0
-	lqv v_sample_1,0, 0x10,s0
-	lqv v_sample_2,0, 0x20,s0
-	lqv v_sample_3,0, 0x30,s0
+	lqv v_sample_0, 0x00,s0
+	lqv v_sample_1, 0x10,s0
+	lqv v_sample_2, 0x20,s0
+	lqv v_sample_3, 0x30,s0
 
 	# For optimal pipelining, output is stored at the beginning of the loop. To avoid
 	# corrupting memory, load the output register with whatever is there now.
-	lsv v_out_l,0, -4,s4
+	lsv v_out_l.e0, -4,s4
 	ble k0, 8, Mix8Start    # Optimized mixing loop for <= 8 channels
-	lsv v_out_r,0, -2,s4
+	lsv v_out_r.e0, -2,s4
 
 Mix32Start:
 	blt t1, 8, Mix32Loop
@@ -1059,8 +1059,8 @@ Mix32Loop:
 	# left channel:
 	vmulf v_mix_l, v_sample_0, v_xvol_l_0;
 	vmacf v_mix_l, v_sample_1, v_xvol_l_1;             # Store previous loop's output
-	vmacf v_mix_l, v_sample_2, v_xvol_l_2;             ssv v_out_l,0, -4,s4
-	vmacf v_mix_l, v_sample_3, v_xvol_l_3;             ssv v_out_r,0, -2,s4
+	vmacf v_mix_l, v_sample_2, v_xvol_l_2;             ssv v_out_l.e0, -4,s4
+	vmacf v_mix_l, v_sample_3, v_xvol_l_3;             ssv v_out_r.e0, -2,s4
 	# right channel:                                   # Updated counters
 	vmulf v_mix_r, v_sample_0, v_xvol_r_0;             add s0, 32*2
 	vmacf v_mix_r, v_sample_1, v_xvol_r_1;             addi t0, -1
@@ -1068,14 +1068,14 @@ Mix32Loop:
 	vmacf v_mix_r, v_sample_3, v_xvol_r_3;
 
 	# Mix all lanes together into the first lane       # Load next loop's samples
-	vaddc v_out_l, v_mix_l, v_mix_l,e(1q);             lqv v_sample_0,0, 0x00,s0
-	vaddc v_out_r, v_mix_r, v_mix_r,e(1q);             lqv v_sample_1,0, 0x10,s0
+	vaddc v_out_l, v_mix_l, v_mix_l.q1;                lqv v_sample_0.e0, 0x00,s0
+	vaddc v_out_r, v_mix_r, v_mix_r.q1;                lqv v_sample_1.e0, 0x10,s0
 	  # 1 cycle stall here
-	vaddc v_out_l, v_out_l, v_out_l,e(2h);             lqv v_sample_2,0, 0x20,s0
-	vaddc v_out_r, v_out_r, v_out_r,e(2h);             lqv v_sample_3,0, 0x30,s0
+	vaddc v_out_l, v_out_l, v_out_l.h2;                lqv v_sample_2.e0, 0x20,s0
+	vaddc v_out_r, v_out_r, v_out_r.h2;                lqv v_sample_3.e0, 0x30,s0
 	  # 1 cycle stall here
-	vaddc v_out_l, v_out_l, v_out_l,e(4);                bnez t0, Mix32Loop
-	vaddc v_out_r, v_out_r, v_out_r,e(4);
+	vaddc v_out_l, v_out_l, v_out_l.e4;                bnez t0, Mix32Loop
+	vaddc v_out_r, v_out_r, v_out_r.e4;
 
 #if VOLUME_FILTER
 	# Apply volume ramp
@@ -1109,9 +1109,9 @@ Mix32Loop:
 #endif
 
 	# Store last loop's output and exit
-	ssv v_out_l,0, -4,s4
+	ssv v_out_l.e0, -4,s4
 	jr ra
-	ssv v_out_r,0, -2,s4
+	ssv v_out_r.e0, -2,s4
 
 
 Mix8Start:
@@ -1124,17 +1124,17 @@ Mix8Start:
 	############################################################################
 	.align 3
 Mix8Loop:
-	vmulf v_mix_l, v_sample_0, v_xvol_l_0;             ssv v_out_l,0, -4,s4
-	vmulf v_mix_r, v_sample_0, v_xvol_r_0;             ssv v_out_r,0, -2,s4
+	vmulf v_mix_l, v_sample_0, v_xvol_l_0;             ssv v_out_l.e0, -4,s4
+	vmulf v_mix_r, v_sample_0, v_xvol_r_0;             ssv v_out_r.e0, -2,s4
 	  # pipeline stall
-	vaddc v_out_l, v_mix_l, v_mix_l,e(1q);             addi t0, -1
-	vaddc v_out_r, v_mix_r, v_mix_r,e(1q);             add s0, 32*2
+	vaddc v_out_l, v_mix_l, v_mix_l.q1;                addi t0, -1
+	vaddc v_out_r, v_mix_r, v_mix_r.q1;                add s0, 32*2
 	  # pipeline stall
-	vaddc v_out_l, v_out_l, v_out_l,e(2h);             addi s4, 4
-	vaddc v_out_r, v_out_r, v_out_r,e(2h);             lqv v_sample_0,0, 0,s0
+	vaddc v_out_l, v_out_l, v_out_l.h2;                addi s4, 4
+	vaddc v_out_r, v_out_r, v_out_r.h2;                lqv v_sample_0, 0,s0
 	  # pipeline stall
-	vaddc v_out_l, v_out_l, v_out_l,e(4);              bnez t0, Mix8Loop
-	vaddc v_out_r, v_out_r, v_out_r,e(4);
+	vaddc v_out_l, v_out_l, v_out_l.e4;                bnez t0, Mix8Loop
+	vaddc v_out_r, v_out_r, v_out_r.e4;
 
 #if VOLUME_FILTER
 	# Apply volume ramp
@@ -1149,7 +1149,7 @@ Mix8Loop:
 	nop 
 #endif
 
-	ssv v_out_l,0, -4,s4
+	ssv v_out_l.e0, -4,s4
 	jr ra
-	ssv v_out_r,0, -2,s4
+	ssv v_out_r.e0, -2,s4
 	.endfunc

--- a/src/rsp_crash.S
+++ b/src/rsp_crash.S
@@ -47,46 +47,46 @@ _start:
 	sw $31, 31*4(zero)
 
 	li s0, 32*4
-	sqv $v00,0,  0*16,s0
-	sqv $v01,0,  1*16,s0
-	sqv $v02,0,  2*16,s0
-	sqv $v03,0,  3*16,s0
-	sqv $v04,0,  4*16,s0
-	sqv $v05,0,  5*16,s0
-	sqv $v06,0,  6*16,s0
-	sqv $v07,0,  7*16,s0
-	sqv $v08,0,  8*16,s0
-	sqv $v09,0,  9*16,s0
-	sqv $v10,0, 10*16,s0
-	sqv $v11,0, 11*16,s0
-	sqv $v12,0, 12*16,s0
-	sqv $v13,0, 13*16,s0
-	sqv $v14,0, 14*16,s0
-	sqv $v15,0, 15*16,s0
-	sqv $v16,0, 16*16,s0
-	sqv $v17,0, 17*16,s0
-	sqv $v18,0, 18*16,s0
-	sqv $v19,0, 19*16,s0
-	sqv $v20,0, 20*16,s0
-	sqv $v21,0, 21*16,s0
-	sqv $v22,0, 22*16,s0
-	sqv $v23,0, 23*16,s0
-	sqv $v24,0, 24*16,s0
-	sqv $v25,0, 25*16,s0
-	sqv $v26,0, 26*16,s0
-	sqv $v27,0, 27*16,s0
-	sqv $v28,0, 28*16,s0
-	sqv $v29,0, 29*16,s0
-	sqv $v30,0, 30*16,s0
-	sqv $v31,0, 31*16,s0
+	sqv $v00,  0*16,s0
+	sqv $v01,  1*16,s0
+	sqv $v02,  2*16,s0
+	sqv $v03,  3*16,s0
+	sqv $v04,  4*16,s0
+	sqv $v05,  5*16,s0
+	sqv $v06,  6*16,s0
+	sqv $v07,  7*16,s0
+	sqv $v08,  8*16,s0
+	sqv $v09,  9*16,s0
+	sqv $v10, 10*16,s0
+	sqv $v11, 11*16,s0
+	sqv $v12, 12*16,s0
+	sqv $v13, 13*16,s0
+	sqv $v14, 14*16,s0
+	sqv $v15, 15*16,s0
+	sqv $v16, 16*16,s0
+	sqv $v17, 17*16,s0
+	sqv $v18, 18*16,s0
+	sqv $v19, 19*16,s0
+	sqv $v20, 20*16,s0
+	sqv $v21, 21*16,s0
+	sqv $v22, 22*16,s0
+	sqv $v23, 23*16,s0
+	sqv $v24, 24*16,s0
+	sqv $v25, 25*16,s0
+	sqv $v26, 26*16,s0
+	sqv $v27, 27*16,s0
+	sqv $v28, 28*16,s0
+	sqv $v29, 29*16,s0
+	sqv $v30, 30*16,s0
+	sqv $v31, 31*16,s0
 
-    vsar $v00, $v00, $v00,e(0)
-    vsar $v01, $v01, $v02,e(1)
-    vsar $v02, $v01, $v02,e(2)
+    vsar $v00, COP2_ACC_HI
+    vsar $v01, COP2_ACC_MD
+    vsar $v02, COP2_ACC_LO
 
-	sqv $v00,0,  32*16,s0
-	sqv $v01,0,  33*16,s0
-	sqv $v02,0,  34*16,s0
+	sqv $v00,  32*16,s0
+	sqv $v01,  33*16,s0
+	sqv $v02,  34*16,s0
 
 	add s0, 35*16
 


### PR DESCRIPTION
The vector element syntax that was introduced for computational vector opcodes is now supported in `mtc2`/`mfc2` and vector load/store opcodes as well. Until now, you had to specify the element as the byte offset into the vector register for those opcodes. Now it is possible to specify the lane index directly instead. For example:
```
# Before:
lsv $v00,4,  0x10,s4
mfc2 t0, $v01,6

# After:
lsv $v00,e(2),  0x10,s4
mfc2 t0, $v01,e(3)
```