### PR TITLE
mkdfs: skip empty subdirs instead of erroring out

### DIFF
--- a/tools/mkdfs/mkdfs.c
+++ b/tools/mkdfs/mkdfs.c
@@ -221,8 +221,9 @@ uint32_t add_directory(const char * const path)
 
                     if(!new_directory)
                     {
+                        fprintf(stderr, "Skipping empty directory: %s\n", file);
                         free(file);
-                        return 0;
+                        continue;
                     }
 
                     tmp_entry = sector_to_memory(new_entry);


### PR DESCRIPTION
Currently, mkdfs errors out when it finds an empty subdirectory. This
is very harsh, and there is no technical reason. Moreover, it does not
match the expectation of a standard directory-walking tool.

Change to simply ignore the subdirectory, adding a message on stderr.