### PR TITLE
Add rspqdemo

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
-all: audioplayer cpptest ctest dfsdemo mixertest mptest mputest spritemap test timers vrutest vtest ucodetest eepromfstest
-clean: audioplayer-clean cpptest-clean ctest-clean dfsdemo-clean mixertest-clean mptest-clean mputest-clean spritemap-clean test-clean timers-clean vrutest-clean vtest-clean ucodetest-clean eepromfstest-clean
+all: audioplayer cpptest ctest dfsdemo mixertest mptest mputest rspqdemo spritemap test timers vrutest vtest ucodetest eepromfstest
+clean: audioplayer-clean cpptest-clean ctest-clean dfsdemo-clean mixertest-clean mptest-clean mputest-clean rspqdemo-clean spritemap-clean test-clean timers-clean vrutest-clean vtest-clean ucodetest-clean eepromfstest-clean
 
 audioplayer:
 	$(MAKE) -C audioplayer
@@ -41,6 +41,11 @@ mputest:
 mputest-clean:
 	$(MAKE) -C mputest clean
 
+rspqdemo:
+	$(MAKE) -C rspqdemo
+rspqdemo-clean:
+	$(MAKE) -C rspqdemo clean
+
 rtctest:
 	$(MAKE) -C rtctest
 rtctest-clean:
@@ -77,4 +82,4 @@ ucodetest-clean:
 	$(MAKE) -C ucodetest clean
 
 .PHONY: audioplayer audioplayer-clean cpptest cpptest-clean ctest ctest-clean dfsdemo dfsdemo-clean mixertest mixertest-clean mptest mptest-clean mputest mputest-clean spritemap spritemap-clean
-.PHONY: test test-clean timers timers-clean vrutest vrutest-clean vtest vtest-clean ucodetest ucodetest-clean eepromfstest eepromfstest-clean
+.PHONY: rspqdemo rspqdemo-clean test test-clean timers timers-clean vrutest vrutest-clean vtest vtest-clean ucodetest ucodetest-clean eepromfstest eepromfstest-clean

--- a/examples/rspqdemo/Makefile
+++ b/examples/rspqdemo/Makefile
@@ -1,0 +1,15 @@
+BUILD_DIR=build
+include $(N64_INST)/include/n64.mk
+
+all: rspqdemo.z64
+
+$(BUILD_DIR)/rspqdemo.elf: $(BUILD_DIR)/rspqdemo.o $(BUILD_DIR)/rsp_vec.o $(BUILD_DIR)/vec.o
+
+rspqdemo.z64: N64_ROM_TITLE="RSPQ Demo"
+
+clean:
+	rm -rf $(BUILD_DIR) rspqdemo.z64
+
+-include $(wildcard $(BUILD_DIR)/*.d)
+
+.PHONY: all clean

--- a/examples/rspqdemo/rsp_vec.S
+++ b/examples/rspqdemo/rsp_vec.S
@@ -1,0 +1,132 @@
+#include <rsp_queue.inc>
+
+#define SLOT_SIZE 0x20
+#define NUM_SLOTS 0x20
+
+    .set noreorder
+    .set at
+
+    .data
+
+RSPQ_BeginOverlayHeader
+    RSPQ_DefineCommand VecCmd_Load,         8
+    RSPQ_DefineCommand VecCmd_Store,        8
+    RSPQ_DefineCommand VecCmd_Transform,    8
+RSPQ_EndOverlayHeader
+
+RSPQ_BeginSavedState
+    .align 4
+VEC_SLOTS: .ds.b NUM_SLOTS * SLOT_SIZE
+RSPQ_EndSavedState
+
+    .text
+
+VecCmd_Load:
+    j Vec_DMA
+    li t2, DMA_IN
+    
+VecCmd_Store:
+    li t2, DMA_OUT
+
+Vec_DMA:
+    andi s4, a1, 0xFFF0
+    addiu s4, %lo(VEC_SLOTS)
+    srl t0, a1, 16
+    j DMAExec
+    move s0, a0
+
+VecCmd_Transform:
+    #define trans_mtx t0
+    #define trans_vec t1
+    #define trans_out t2
+    #define m0i $v01
+    #define m0f $v02
+    #define m1i $v03
+    #define m1f $v04
+    #define m2i $v05
+    #define m2f $v06
+    #define m3i $v07
+    #define m3f $v08
+    #define v01i $v09
+    #define v01f $v10
+    #define o01i $v13
+    #define o01f $v14
+    #define vtemp $v17
+
+    srl trans_mtx, a1, 16
+    andi trans_mtx, 0xFF0
+    andi trans_vec, a1, 0xFF0
+    andi trans_out, a0, 0xFF0
+
+    addiu trans_mtx, %lo(VEC_SLOTS)
+    addiu trans_vec, %lo(VEC_SLOTS)
+    addiu trans_out, %lo(VEC_SLOTS)
+
+    # Load matrix columns, repeating each column twice in a register
+    ldv m0i,0x0,  0x00,trans_mtx
+    ldv m0i,0x8,  0x00,trans_mtx
+    ldv m0f,0x0,  0x10,trans_mtx
+    ldv m0f,0x8,  0x10,trans_mtx
+    ldv m1i,0x0,  0x08,trans_mtx
+    ldv m1i,0x8,  0x08,trans_mtx
+    ldv m1f,0x0,  0x18,trans_mtx
+    ldv m1f,0x8,  0x18,trans_mtx
+    ldv m2i,0x0,  0x20,trans_mtx
+    ldv m2i,0x8,  0x20,trans_mtx
+    ldv m2f,0x0,  0x30,trans_mtx
+    ldv m2f,0x8,  0x30,trans_mtx
+    ldv m3i,0x0,  0x28,trans_mtx
+    ldv m3i,0x8,  0x28,trans_mtx
+    ldv m3f,0x0,  0x38,trans_mtx
+    ldv m3f,0x8,  0x38,trans_mtx
+
+    # Load vector (a slot always contains two vectors)
+    lqv v01i,0x0,  0x00,trans_vec
+    lqv v01f,0x0,  0x10,trans_vec
+
+    # Perform transformation by computing the dot products of the matrix rows with the vector.
+    # We take advantage of the accumulator by letting it perform the addition automatically
+    # with each multiplication.
+
+    vmudl vtemp, m0f, v01f,e(0h) #   m(x,0) * v(0)
+    vmadm vtemp, m0i, v01f,e(0h)
+    vmadn vtemp, m0f, v01i,e(0h)
+    vmadh vtemp, m0i, v01i,e(0h)
+
+    vmadl vtemp, m1f, v01f,e(1h) # + m(x,1) * v(1)
+    vmadm vtemp, m1i, v01f,e(1h)
+    vmadn vtemp, m1f, v01i,e(1h)
+    vmadh vtemp, m1i, v01i,e(1h)
+
+    vmadl vtemp, m2f, v01f,e(2h) # + m(x,2) * v(2)
+    vmadm vtemp, m2i, v01f,e(2h)
+    vmadn vtemp, m2f, v01i,e(2h)
+    vmadh vtemp, m2i, v01i,e(2h)
+
+    vmadl vtemp, m3f, v01f,e(3h) # + m(x,3) * v(3)
+    vmadm vtemp, m3i, v01f,e(3h)
+    vmadn o01f,  m3f, v01i,e(3h)
+    vmadh o01i,  m3i, v01i,e(3h)
+
+    # Write result
+    sqv o01i,0x0,  0x00,trans_out
+    jr ra
+    sqv o01f,0x0,  0x10,trans_out
+    
+    #undef trans_mtx
+    #undef trans_vec
+    #undef trans_out
+    #undef m0i
+    #undef m0f
+    #undef m1i
+    #undef m1f
+    #undef m2i
+    #undef m2f
+    #undef m3i
+    #undef m3f
+    #undef v01i
+    #undef v01f
+    #undef o01i
+    #undef o01f
+    #undef vtemp
+

--- a/examples/rspqdemo/rspqdemo.c
+++ b/examples/rspqdemo/rspqdemo.c
@@ -1,0 +1,140 @@
+#include <libdragon.h>
+#include <string.h>
+
+#include "vec.h"
+#include "vector_helper.h"
+
+#define NUM_VECTOR_SLOTS  16
+#define NUM_VECTORS       (NUM_VECTOR_SLOTS*2)
+#define NUM_MATRICES      4
+#define MTX_SLOT          30
+
+vec4_t vectors[NUM_VECTORS];
+mtx4x4_t identity, scale, rotation, translation;
+
+vec_slot_t *input_vectors;
+vec_slot_t *output_vectors;
+vec_mtx_t *matrices;
+
+rspq_block_t *transform_vectors_block;
+
+void print_vectors(vec4_t *v, uint32_t count)
+{
+    for (uint32_t i = 0; i < count; i++)
+    {
+        printf("%11.4f  %11.4f  %11.4f  %11.4f\n", v[i].v[0], v[i].v[1], v[i].v[2], v[i].v[3]);
+    }
+    printf("\n");
+}
+
+void print_output(const char* header)
+{
+    rspq_wait();
+    printf("%s\n", header);
+    vectors_to_floats(vectors[0].v, output_vectors, NUM_VECTORS*4);
+    print_vectors(vectors, NUM_VECTORS);
+}
+
+int main()
+{
+    // Initialize systems
+    console_init();
+    console_set_debug(true);
+	debug_init_isviewer();
+	debug_init_usblog();
+
+    // Initialize the "vec" library that this example is based on (see vec.h)
+    vec_init();
+
+    // Allocate memory for DMA transfers
+    input_vectors = malloc_uncached(sizeof(vec_slot_t)*NUM_VECTOR_SLOTS);
+    output_vectors = malloc_uncached(sizeof(vec_slot_t)*NUM_VECTOR_SLOTS);
+    matrices = malloc_uncached(sizeof(vec_mtx_t)*NUM_MATRICES);
+
+    memset(input_vectors, 0, sizeof(vec_slot_t)*NUM_VECTOR_SLOTS);
+    memset(output_vectors, 0, sizeof(vec_slot_t)*NUM_VECTOR_SLOTS);
+    memset(matrices, 0, sizeof(vec_slot_t)*NUM_MATRICES);
+
+    // Initialize input vectors
+    for (uint32_t z = 0; z < 2; z++)
+    {
+        for (uint32_t y = 0; y < 4; y++)
+        {
+            for (uint32_t x = 0; x < 4; x++)
+            {
+                vectors[z*4*4 + y*4 + x] = (vec4_t){ .v={
+                    x, y, z, 1.f
+                }};
+            }
+        }
+    }
+    // Convert to fixed point format required by the overlay
+    floats_to_vectors(input_vectors, vectors[0].v, NUM_VECTORS*4);
+
+    // Initialize matrices
+    matrix_identity(&identity);
+    matrix_scale(&scale, 0.5f, 2.0f, 1.1f);
+    matrix_rotate_y(&rotation, 4.f);
+    matrix_translate(&translation, 0.f, -3.1f, 8.f);
+
+    // Convert to fixed point format required by the overlay
+    floats_to_vectors(matrices[0].c, identity.m[0],    16);
+    floats_to_vectors(matrices[1].c, scale.m[0],       16);
+    floats_to_vectors(matrices[2].c, rotation.m[0],    16);
+    floats_to_vectors(matrices[3].c, translation.m[0], 16);
+
+    // This block defines a reusable sequence of commands that could
+    // be understood as a "function" that will transform the vectors
+    // in slots 0-15 with the matrix in slots 30-31.
+    // It is repeatedly called further down to transform an array of vectors with
+    // different matrices.
+    rspq_block_begin();
+    vec_load(0, input_vectors, NUM_VECTOR_SLOTS);
+    for (uint32_t i = 0; i < NUM_VECTOR_SLOTS; i++)
+    {
+        vec_transform(i, MTX_SLOT, i);
+    }
+    vec_store(output_vectors, 0, NUM_VECTOR_SLOTS);
+    transform_vectors_block = rspq_block_end();
+
+    // Print inputs first for reference
+    printf("Input vectors:\n");
+    print_vectors(vectors, NUM_VECTORS);
+
+    // Scale
+    vec_load(MTX_SLOT, matrices[1].c, 2);
+    rspq_block_run(transform_vectors_block);
+    print_output("Scaled:");
+
+    // Rotate
+    vec_load(MTX_SLOT, matrices[2].c, 2);
+    rspq_block_run(transform_vectors_block);
+    print_output("Rotated:");
+
+    // Translate
+    vec_load(MTX_SLOT, matrices[3].c, 2);
+    rspq_block_run(transform_vectors_block);
+    print_output("Translated:");
+
+    // Typical affine matrix: first scale, then rotate, then translate
+    // Load 3 matrices starting at slot 16
+    vec_load(16, matrices[1].c, 6);
+    // Perform matrix composition by multiplying them together (transforming column vectors)
+    // The resulting matrix is written to MTX_SLOT
+    vec_transform(22, 18, 16);         // Rotation * scale (first two columns)
+    vec_transform(23, 18, 17);         // Rotation * scale (last two columns)
+    vec_transform(MTX_SLOT+0, 20, 22); // Translation * rotation * scale (first two columns)
+    vec_transform(MTX_SLOT+1, 20, 23); // Translation * rotation * scale (last two columns)
+    rspq_block_run(transform_vectors_block);
+    print_output("Combined:");
+
+    // Clean up
+    rspq_block_free(transform_vectors_block);
+    free_uncached(matrices);
+    free_uncached(output_vectors);
+    free_uncached(input_vectors);
+
+    vec_close();
+
+    return 0;
+}

--- a/examples/rspqdemo/vec.c
+++ b/examples/rspqdemo/vec.c
@@ -1,0 +1,51 @@
+#include "vec.h"
+#include <string.h>
+
+DEFINE_RSP_UCODE(rsp_vec);
+
+uint32_t vec_id;
+
+void vec_init()
+{
+    rspq_init();
+
+    // Initialize the saved state
+    void* state = UncachedAddr(rspq_overlay_get_state(&rsp_vec));
+    memset(state, 0, 0x400);
+
+    // Register the overlay
+    vec_id = rspq_overlay_register(&rsp_vec);
+}
+
+void vec_close()
+{
+    rspq_overlay_unregister(vec_id);
+}
+
+void floats_to_vectors(vec_slot_t *dest, const float *source, uint32_t source_length)
+{
+    for (uint32_t i = 0; i < source_length; ++i)
+    {
+        int32_t fixed = source[i]*(1<<16);
+        uint32_t dest_idx = i/8;
+        uint32_t lane_idx = i%8;
+        dest[dest_idx].i[lane_idx] = (uint16_t)((fixed & 0xFFFF0000) >> 16);
+        dest[dest_idx].f[lane_idx] = (uint16_t)(fixed & 0x0000FFFF);
+    }
+}
+
+void vectors_to_floats(float *dest, const vec_slot_t *source, uint32_t dest_length)
+{
+    for (uint32_t i = 0; i < dest_length; ++i)
+    {
+        uint32_t src_idx = i/8;
+        uint32_t lane_idx = i%8;
+        int32_t integer = source[src_idx].i[lane_idx];
+        uint32_t fraction = source[src_idx].f[lane_idx];
+
+        int32_t fixed = integer << 16 | fraction;
+
+        dest[i] = ((float)fixed) / (1<<16);
+    }
+}
+

--- a/examples/rspqdemo/vec.h
+++ b/examples/rspqdemo/vec.h
@@ -1,0 +1,89 @@
+/**
+ * This is an example of how to create a library that sits on top of rspq.
+ * 
+ * The "vec" library is a very simple vector transformation tool that
+ * takes advantage of the RSP's vector opcodes. This is done by creating
+ * an rspq overlay (see "rsp_vec.S") which implements the vector math on the RSP
+ * side, and defining some helper functions that serve as the CPU-side
+ * interface to that overlay.
+ * 
+ * Note that this is purely meant to show off the features of the rspq system
+ * and is *not* meant to be an optimal vector math implementation. In reality,
+ * such a system would likely be implemented very differently.
+ * 
+ * The overlay offers three commands: load, store, and transform.
+ * The load/store commands will basically just perform a DMA that transfers
+ * vector data between RDRAM and DMEM.
+ * 
+ * Vectors are organized into "slots". A single slot consists of 8 vector components
+ * (which can be interpreted as two 4-component vectors), each of which has an 
+ * integer and a fractional part. The #vec_slot_t struct shows the memory layout of such a slot.
+ * 
+ * The overlay can hold up to 16 slots in DMEM. The load and store commands work
+ * on the basis of slots, so you specify at which slot to start the transfer, and
+ * how many slots should be transferred.
+ * 
+ * The heart of the system is the "transform" command. It takes the slot index of
+ * a "matrix" and that of a vector and will transform that vector with the matrix,
+ * storing the output to another slot. This works by interpreting two slots as the
+ * columns of a 4x4 matrix, which will act on two 4 component vectors. Multiplying
+ * two matrices together can also be done by transforming the columns of the right
+ * hand side matrix with the left hand matrix in two steps: columns 0 and 1 first,
+ * then columnds 2 and 3.
+ * 
+ * This header also offers some convenience functions that will convert float arrays
+ * to and from the slot format.
+ */
+
+#ifndef VEC_H
+#define VEC_H
+
+#include <stdint.h>
+#include <libdragon.h>
+
+enum {
+    VEC_CMD_LOAD  = 0x0,
+    VEC_CMD_STORE = 0x1,
+    VEC_CMD_TRANS = 0x2,
+};
+
+typedef struct {
+    int16_t i[8];
+    uint16_t f[8];
+} __attribute__((aligned(16))) vec_slot_t;
+
+typedef struct {
+    vec_slot_t c[2];
+} __attribute__((aligned(16))) vec_mtx_t;
+
+void vec_init();
+void vec_close();
+
+static inline void vec_load(uint32_t slot, vec_slot_t *src, uint32_t num)
+{
+    extern uint32_t vec_id;
+    rspq_write(vec_id, VEC_CMD_LOAD,
+        PhysicalAddr(src) & 0xFFFFFF,
+        (((num*sizeof(vec_slot_t)-1)&0xFFF)<<16) | ((slot*sizeof(vec_slot_t))&0xFF0));
+}
+
+static inline void vec_store(vec_slot_t *dest, uint32_t slot, uint32_t num)
+{
+    extern uint32_t vec_id;
+    rspq_write(vec_id, VEC_CMD_STORE,
+        PhysicalAddr(dest) & 0xFFFFFF,
+        (((num*sizeof(vec_slot_t)-1)&0xFFF)<<16) | ((slot*sizeof(vec_slot_t))&0xFF0));
+}
+
+static inline void vec_transform(uint32_t dest, uint32_t mtx, uint32_t vec)
+{
+    extern uint32_t vec_id;
+    rspq_write(vec_id, VEC_CMD_TRANS,
+        (dest*sizeof(vec_slot_t))&0xFF0,
+        (((mtx*sizeof(vec_slot_t))&0xFF0)<<16) | ((vec*sizeof(vec_slot_t))&0xFF0));
+}
+
+void floats_to_vectors(vec_slot_t *dest, const float *source, uint32_t source_length);
+void vectors_to_floats(float *dest, const vec_slot_t *source, uint32_t dest_length);
+
+#endif

--- a/examples/rspqdemo/vector_helper.h
+++ b/examples/rspqdemo/vector_helper.h
@@ -1,0 +1,87 @@
+/**
+ * Some helper structs and functions for common vector/matrix operations.
+ */
+
+#ifndef VECTOR_HELPER_H
+#define VECTOR_HELPER_H
+
+#include <math.h>
+
+typedef struct {
+    float v[4];
+} vec4_t;
+
+typedef struct {
+    float m[4][4];
+} mtx4x4_t;
+
+void matrix_identity(mtx4x4_t *dest)
+{
+    *dest = (mtx4x4_t){ .m={
+        {1.f, 0.f, 0.f, 0.f},
+        {0.f, 1.f, 0.f, 0.f},
+        {0.f, 0.f, 1.f, 0.f},
+        {0.f, 0.f, 0.f, 1.f},
+    }};
+}
+
+void matrix_translate(mtx4x4_t *dest, float x, float y, float z)
+{
+    *dest = (mtx4x4_t){ .m={
+        {1.f, 0.f, 0.f, 0.f},
+        {0.f, 1.f, 0.f, 0.f},
+        {0.f, 0.f, 1.f, 0.f},
+        {x,   y,   z,   1.f},
+    }};
+}
+
+void matrix_scale(mtx4x4_t *dest, float x, float y, float z)
+{
+    *dest = (mtx4x4_t){ .m={
+        {x,   0.f, 0.f, 0.f},
+        {0.f, y,   0.f, 0.f},
+        {0.f, 0.f, z,   0.f},
+        {0.f, 0.f, 0.f, 1.f},
+    }};
+}
+
+void matrix_rotate_x(mtx4x4_t *dest, float angle)
+{
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    *dest = (mtx4x4_t){ .m={
+        {1.f, 0.f, 0.f, 0.f},
+        {0.f, c,   s,   0.f},
+        {0.f, -s,  c,   0.f},
+        {0.f, 0.f, 0.f, 1.f},
+    }};
+}
+
+void matrix_rotate_y(mtx4x4_t *dest, float angle)
+{
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    *dest = (mtx4x4_t){ .m={
+        {c,   0.f, -s,  0.f},
+        {0.f, 1.f, 0.f, 0.f},
+        {s,   0.f, c,   0.f},
+        {0.f, 0.f, 0.f, 1.f},
+    }};
+}
+
+void matrix_rotate_z(mtx4x4_t *dest, float angle)
+{
+    float c = cosf(angle);
+    float s = sinf(angle);
+
+    *dest = (mtx4x4_t){ .m={
+        {c,   s,   0.f, 0.f},
+        {-s,  c,   0.f, 0.f},
+        {0.f, 0.f, 1.f, 0.f},
+        {0.f, 0.f, 0.f, 1.f},
+    }};
+}
+
+#endif


### PR DESCRIPTION
This demo contains an example of how to create a library that sits on top of rspq, as well as the usage of the most important rspq features.

The "vec" library is a very simple vector transformation tool that takes advantage of the RSP's vector opcodes. This is done by creating an rspq overlay which implements the vector math on the RSP side, and defining some helper functions that serve as the CPU-side interface to that overlay.

The example ROM itself uses that library to perform some simple vector transformations and matrix multiplications, and prints the results to the console.