### PR TITLE
rspq: fix command size not being decoded correctly

### DIFF
--- a/include/rsp_queue.inc
+++ b/include/rsp_queue.inc
@@ -360,6 +360,7 @@ rspq_execute_command:
     # NOTE: Could be optimised either by doubling the size of command descriptors (so that the command size can be loaded directly instead of having to decode it),
     #       or by storing the command size in the overlay header instead. The latter would mean that all commands in an overlay need to be the same size though.
     srl cmd_size, cmd_desc, 10
+    andi cmd_size, 0x3C
 
     # Check if the command is truncated because of buffer overflow (that is,
     # it finishes beyond the buffer end). If so, we must refetch the buffer


### PR DESCRIPTION
This adds a missing bitmask to rsp_queue.inc where the command size
is being decoded. The bug would manifest whenever the command address
had any of the 2 most significant bits set.