### PR TITLE
Adding bit depth check on 'graphics_draw_character'

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -681,7 +681,7 @@ void graphics_draw_character( display_context_t disp, int x, int y, char ch )
     int depth = __bitdepth;
 
     // setting default font if none was set previously
-    if( sprite_font.sprite == NULL )
+    if( sprite_font.sprite == NULL || __bitdepth != sprite_font.sprite->bitdepth )
     {
         graphics_set_default_font();
     }


### PR DESCRIPTION
This PR fixes an issue where changing the bit depth after initializing the console would cause the font used to still be on the previous bit depth.

This should fix any problem on changing bit depth after setting a font (it will also revert back to the default font if it was changed to a custom).

This also fixes the garbage drawing on the `cpptest` example.