### PR TITLE
examples: don't call display_init before console_init

### DIFF
--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -4,9 +4,6 @@
 #include <stdint.h>
 #include <libdragon.h>
 
-static resolution_t res = RESOLUTION_320x240;
-static bitdepth_t bit = DEPTH_32_BPP;
-
 class TestClass
 {
     private:
@@ -31,10 +28,7 @@ int main(void)
     TestClass* localClass = new TestClass();
 
     console_init();
-
     console_set_render_mode(RENDER_MANUAL);
-
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
 
     while(1)
     {

--- a/examples/ctest/ctest.c
+++ b/examples/ctest/ctest.c
@@ -5,9 +5,6 @@
 #include <time.h>
 #include <libdragon.h>
 
-static resolution_t res = RESOLUTION_320x240;
-static bitdepth_t bit = DEPTH_32_BPP;
-
 char *format_type( int accessory )
 {
     switch( accessory )
@@ -26,7 +23,6 @@ char *format_type( int accessory )
 int main(void)
 {
     /* Initialize peripherals */
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
     console_init();
     controller_init();
     timer_init();

--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -4,9 +4,6 @@
 #include <stdint.h>
 #include <libdragon.h>
 
-static resolution_t res = RESOLUTION_320x240;
-static bitdepth_t bit = DEPTH_32_BPP;
-
 typedef struct
 {
     char initials[3];
@@ -456,7 +453,6 @@ static int validate_eeprom(eeprom_type_t eeprom_type)
 int main(void)
 {
     /* Initialize peripherals */
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
     console_init();
     controller_init();
 

--- a/examples/timers/timers.c
+++ b/examples/timers/timers.c
@@ -4,9 +4,6 @@
 #include <stdint.h>
 #include <libdragon.h>
 
-static resolution_t res = RESOLUTION_320x240;
-static bitdepth_t bit = DEPTH_32_BPP;
-
 static volatile double t1 = 0.0; // increment every ms
 static volatile double t2 = 0.0; // increment every .5 sec
 static volatile double t3 = 0.0; // increment every 1 sec
@@ -39,7 +36,6 @@ int main(void)
     long long start, end;
 
     /* Initialize peripherals */
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
     console_init();
 
     console_set_render_mode(RENDER_MANUAL);

--- a/examples/vrutest/vrutest.c
+++ b/examples/vrutest/vrutest.c
@@ -4,9 +4,6 @@
 #include <stdint.h>
 #include <libdragon.h>
 
-static resolution_t res = RESOLUTION_320x240;
-static bitdepth_t bit = DEPTH_32_BPP;
-
 void print_request( int len, uint8_t *res )
 {
     for( int i = 0; i < len; i++ )
@@ -30,7 +27,6 @@ void print_result( int len, uint8_t *res )
 int main(void)
 {
     /* Initialize peripherals */
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
     console_init();
     controller_init();
 

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -230,7 +230,6 @@ static const struct Testsuite
 };
 
 int main() {
-	display_init(RESOLUTION_320x240, DEPTH_32_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
 	console_init();
 	console_set_debug(false);
 	debug_init_isviewer();


### PR DESCRIPTION
This is bad practice as console_init will initialize the display by
itself. Maybe it didn't do ages ago, but it does now.