### PR TITLE
exception.c: Do not acknowledge FP exceptions

### DIFF
--- a/src/exception.c
+++ b/src/exception.c
@@ -85,18 +85,7 @@ void exception_default_handler(exception_t* ex) {
 		case EXCEPTION_CODE_TLB_STORE_MISS:
 		case EXCEPTION_CODE_TLB_LOAD_I_MISS:
 		case EXCEPTION_CODE_COPROCESSOR_UNUSABLE:
-		break;
 		case EXCEPTION_CODE_FLOATING_POINT:
-			// Clear FP interrupt cause bits so that it is not retriggered when we return to exception_halt
-			ex->regs->fc31 &= ~(
-				C1_CAUSE_INEXACT_OP |
-				C1_CAUSE_UNDERFLOW |
-				C1_CAUSE_OVERFLOW |
-				C1_CAUSE_DIV_BY_0 |
-				C1_CAUSE_INVALID_OP |
-				C1_CAUSE_NOT_IMPLEMENTED
-			);
-		break;
 		case EXCEPTION_CODE_WATCH:
 		case EXCEPTION_CODE_ARITHMETIC_OVERFLOW:
 		case EXCEPTION_CODE_TRAP:


### PR DESCRIPTION
With the latest changes to the console, it is not necessary to acknowledge
FP exceptions in the default exception handler. Previously it was necessary to
return from the exception handler.