### PR TITLE
New interrupt handler

### DIFF
--- a/include/exception.h
+++ b/include/exception.h
@@ -19,33 +19,33 @@
 enum
 {
     /** @brief Unknown exception */
-	EXCEPTION_TYPE_UNKNOWN = 0,
+    EXCEPTION_TYPE_UNKNOWN = 0,
     /** @brief Reset exception */
-	EXCEPTION_TYPE_RESET,
+    EXCEPTION_TYPE_RESET,
     /** @brief Critical exception */
-	EXCEPTION_TYPE_CRITICAL
+    EXCEPTION_TYPE_CRITICAL
 };
 
 /**
  * @brief Exception codes
  */
 typedef enum {
-	EXCEPTION_CODE_INTERRUPT = 0,
-	EXCEPTION_CODE_TLB_MODIFICATION = 1,
-	EXCEPTION_CODE_TLB_LOAD_I_MISS = 2,
-	EXCEPTION_CODE_TLB_STORE_MISS = 3,
-	EXCEPTION_CODE_LOAD_I_ADDRESS_ERROR = 4,
-	EXCEPTION_CODE_STORE_ADDRESS_ERROR = 5,
-	EXCEPTION_CODE_I_BUS_ERROR = 6,
-	EXCEPTION_CODE_D_BUS_ERROR = 7,
-	EXCEPTION_CODE_SYS_CALL = 8,
-	EXCEPTION_CODE_BREAKPOINT = 9,
-	EXCEPTION_CODE_RESERVED_INSTRUCTION = 10,
-	EXCEPTION_CODE_COPROCESSOR_UNUSABLE = 11,
-	EXCEPTION_CODE_ARITHMETIC_OVERFLOW = 12,
-	EXCEPTION_CODE_TRAP = 13,
-	EXCEPTION_CODE_FLOATING_POINT = 15,
-	EXCEPTION_CODE_WATCH = 23,
+    EXCEPTION_CODE_INTERRUPT = 0,
+    EXCEPTION_CODE_TLB_MODIFICATION = 1,
+    EXCEPTION_CODE_TLB_LOAD_I_MISS = 2,
+    EXCEPTION_CODE_TLB_STORE_MISS = 3,
+    EXCEPTION_CODE_LOAD_I_ADDRESS_ERROR = 4,
+    EXCEPTION_CODE_STORE_ADDRESS_ERROR = 5,
+    EXCEPTION_CODE_I_BUS_ERROR = 6,
+    EXCEPTION_CODE_D_BUS_ERROR = 7,
+    EXCEPTION_CODE_SYS_CALL = 8,
+    EXCEPTION_CODE_BREAKPOINT = 9,
+    EXCEPTION_CODE_RESERVED_INSTRUCTION = 10,
+    EXCEPTION_CODE_COPROCESSOR_UNUSABLE = 11,
+    EXCEPTION_CODE_ARITHMETIC_OVERFLOW = 12,
+    EXCEPTION_CODE_TRAP = 13,
+    EXCEPTION_CODE_FLOATING_POINT = 15,
+    EXCEPTION_CODE_WATCH = 23,
 } exception_code_t;
 
 /**
@@ -53,34 +53,37 @@ typedef enum {
  *
  * DO NOT modify the order unless editing inthandler.S
  */
-typedef volatile struct
+typedef struct __attribute__((packed))
 {
     /** @brief General purpose registers 1-32 */
-	volatile uint64_t gpr[32];
-    /** @brief SR */
-	volatile uint32_t sr;
-    /** @brief CR */
-	volatile const uint32_t cr;
-    /**
-	 * @brief represents EPC - COP0 register $14
-	 *
-	 * The coprocessor 0 (system control coprocessor - COP0) register $14 is the
-	 * return from exception program counter. For asynchronous exceptions it points
-	 * to the place to continue execution whereas for synchronous (caused by code)
-	 * exceptions, point to the instruction causing the fault condition, which
-	 * needs correction in the exception handler. This member is for reading/writing
-	 * its value.
-	 * */
-	volatile uint32_t epc;
+    uint64_t gpr[32];
     /** @brief HI */
-	volatile uint64_t hi;
+    uint64_t hi;
     /** @brief LO */
-	volatile uint64_t lo;
+    uint64_t lo;
+    /** @brief SR */
+    uint32_t sr;
+    /** @brief CR (NOTE: can't modify this from an exception handler) */
+    uint32_t cr;
+    /**
+     * @brief represents EPC - COP0 register $14
+     *
+     * The coprocessor 0 (system control coprocessor - COP0) register $14 is the
+     * return from exception program counter. For asynchronous exceptions it points
+     * to the place to continue execution whereas for synchronous (caused by code)
+     * exceptions, point to the instruction causing the fault condition, which
+     * needs correction in the exception handler. This member is for reading/writing
+     * its value.
+     * */
+    uint32_t epc;
     /** @brief FC31 */
-	volatile uint32_t fc31;
+    uint32_t fc31;
     /** @brief Floating point registers 1-32 */
-	volatile uint64_t fpr[32];
+    uint64_t fpr[32];
 } reg_block_t;
+
+/* Make sure the structure has the right size. Please keep this in sync with inthandler.S */
+_Static_assert(sizeof(reg_block_t) == 544, "invalid reg_block_t size -- this must match inthandler.S");
 
 /**
  * @brief Structure representing an exception
@@ -91,15 +94,15 @@ typedef struct
      * @brief Exception type
      * @see #EXCEPTION_TYPE_RESET, #EXCEPTION_TYPE_CRITICAL
      */
-	int32_t type;
-	/**
-	 * @brief Underlying exception code
-	 */
-	exception_code_t code;
+    int32_t type;
+    /**
+     * @brief Underlying exception code
+     */
+    exception_code_t code;
     /** @brief String information of exception */
-	const char* info;
+    const char* info;
     /** @brief Registers at point of exception */
-	volatile reg_block_t* regs;
+    volatile reg_block_t* regs;
 } exception_t;
 
 /** @} */

--- a/src/exception.c
+++ b/src/exception.c
@@ -26,7 +26,7 @@
  * @{
  */
 
-/** @brief Exception handler currently registered with exception system */
+/** @brief Unhandled exception handler currently registered with exception system */
 static void (*__exception_handler)(exception_t*) = exception_default_handler;
 /** @brief Base register offset as defined by the interrupt controller */
 extern volatile reg_block_t __baseRegAddr;
@@ -256,10 +256,12 @@ static const char* __get_exception_name(exception_code_t code)
  * @param[in]  type
  *             Exception type.  Either #EXCEPTION_TYPE_CRITICAL or 
  *             #EXCEPTION_TYPE_RESET
+ * @param[in]  regs
+ *             CPU register status at exception time
  */
-static void __fetch_regs(exception_t* e,int32_t type)
+static void __fetch_regs(exception_t* e, int32_t type, volatile reg_block_t *regs)
 {
-	e->regs = &__baseRegAddr;
+	e->regs = regs;
 	e->type = type;
 	e->code = C0_GET_CAUSE_EXC_CODE(e->regs->cr);
 	e->info = __get_exception_name(e->code);
@@ -268,26 +270,26 @@ static void __fetch_regs(exception_t* e,int32_t type)
 /**
  * @brief Respond to a critical exception
  */
-void __onCriticalException()
+void __onCriticalException(volatile reg_block_t* regs)
 {
 	exception_t e;
 
 	if(!__exception_handler) { return; }
 
-	__fetch_regs(&e,EXCEPTION_TYPE_CRITICAL);
+	__fetch_regs(&e, EXCEPTION_TYPE_CRITICAL, regs);
 	__exception_handler(&e);
 }
 
 /**
  * @brief Respond to a reset exception
  */
-void __onResetException()
+void __onResetException(volatile reg_block_t* regs)
 {
 	exception_t e;
 	
 	if(!__exception_handler) { return; }
 
-	__fetch_regs(&e,EXCEPTION_TYPE_RESET);
+	__fetch_regs(&e, EXCEPTION_TYPE_RESET, regs);
 	__exception_handler(&e);
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -112,6 +112,11 @@
  */
 static int __interrupt_depth = -1;
 
+/** @brief Value of the status register at the moment interrupts
+ *         got disabled.
+ */
+static int __interrupt_sr = 0;
+
 /** @brief tick at which interrupts were disabled. */
 uint32_t interrupt_disabled_tick = 0;
 
@@ -613,8 +618,19 @@ void disable_interrupts()
 
     if( __interrupt_depth == 0 )
     {
-        /* Interrupts are enabled, so its safe to disable them */
-        C0_WRITE_STATUS(C0_STATUS() & ~C0_STATUS_IE);
+        /* We must disable the interrupts now. */
+        uint32_t sr = C0_STATUS();
+        C0_WRITE_STATUS(sr & ~C0_STATUS_IE);
+
+        /* Save the original SR value away, so that we now if
+           interrupts were enabled and whether to restore them.
+           NOTE: this memory write must happen now that interrupts
+           are disabled, otherwise it could cause a race condition
+           because an interrupt could trigger and overwrite it.
+           So put an explicit barrier. */
+        MEMORY_BARRIER();
+        __interrupt_sr = sr;
+
         interrupt_disabled_tick = TICKS_READ();
     }
 
@@ -642,7 +658,11 @@ void enable_interrupts()
 
     if( __interrupt_depth == 0 )
     {
-        C0_WRITE_STATUS(C0_STATUS() | C0_STATUS_IE);
+        /* Restore the interrupt state that was active when interrupts got
+           disabled. This is important because, within an interrupt handler,
+           we don't want here to force-enable interrupts, or we would allow
+           reentrant interrupts which are not supported. */
+        C0_WRITE_STATUS(C0_STATUS() | (__interrupt_sr & C0_STATUS_IE));
     }
 }
 

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -80,10 +80,15 @@ inthandler:
 	and k1, ~(SR_IE | SR_EXL)
 	mtc0 k1, C0_SR
 
-	mfc0 k1, C0_CAUSE
-	sw k1, STACK_CR(sp)
+	# WARNING: it is now possible to trigger reentrant exceptions (and not only
+	# crashing one. Avoid using k0/k1 from now on, as they would get corrupted
+	# by a reentrant exception.
+	#define cause t8
 
-	andi t0, k1, 0xff
+	mfc0 cause, C0_CAUSE
+	sw cause, STACK_CR(sp)
+
+	andi t0, cause, 0xff
 	beqz t0, interrupt
 	nop
 
@@ -98,7 +103,7 @@ exception:
 
 	# Save the callee-saved FPU regs
 	jal save_fpu_regs
-	move k0, sp
+	move a0, sp
 
 	# Save all the CPU+FPU caller-saved regs, which are normally
 	# not saved for an interrupt.
@@ -106,14 +111,13 @@ exception:
 	nop
 
 	# Check the exception type
-	mfc0 k1, C0_CAUSE
-	andi t0, k1, CAUSE_EXC_MASK
+	andi t0, cause, CAUSE_EXC_MASK
 	bne t0, CAUSE_EXC_COPROCESSOR, critical_exception
 	nop
 
 exception_coprocessor:
 	# Extract CE bits (28..29) from CR
-	srl t0, k1, 28
+	srl t0, cause, 28
 	andi t0, 3
 	# If == 1 (COP1), it is an FPU exception
 	bne t0, 1, critical_exception
@@ -134,7 +138,7 @@ exception_coprocessor_fpu:
 	# That is, we want to make sure that they get restored when the
 	# underlying interrupt exits.
 	jal save_fpu_regs
-	lw k0, interrupt_exception_frame
+	lw a0, interrupt_exception_frame
 
 	# OK we are done. We can now exit the exception
 	j end_interrupt
@@ -168,7 +172,7 @@ interrupt:
 	sw sp, interrupt_exception_frame
 
 	/* check for "pre-NMI" (reset) */
-	andi t0,k1,0x1000
+	andi t0, cause, 0x1000
 	beqz t0, notprenmi
 	nop
 
@@ -183,7 +187,7 @@ interrupt:
 notprenmi:
 
 	/* check for count=compare */
-	and t0,k1,0x8000
+	and t0, cause, 0x8000
 	beqz t0,notcount
 	nop
 	/* Writing C0_COMPARE acknowledges the timer interrupt (clear the interrupt
@@ -202,7 +206,7 @@ notcount:
 
 	/* pass anything else along to handler */
 	jal __MI_handler
-	nop
+	addiu a0, sp, 32
 	j end_interrupt
 	nop
 
@@ -233,11 +237,26 @@ end_interrupt:
 	ldc1 $f18,(STACK_FPR+18*8)(sp)
 	ldc1 $f19,(STACK_FPR+19*8)(sp)
 
-	lw k1, STACK_FC31(sp)
-	ctc1 k1, $f31
+	lw t0, STACK_FC31(sp)
+	ctc1 t0, $f31
 
 end_interrupt_gpr:
+
+	# Restore SR. This also disables reentrant exceptions by
+	# restoring the EXL bit into SR
+	.set noat
+	lw t0, STACK_SR(sp)
+	mtc0 t0, C0_SR
+
+	ld t0, STACK_LO(sp)
+	ld t1, STACK_HI(sp)
+	lw t2, STACK_EPC(sp)
+	mtlo t0
+	mthi t1
+	mtc0 t2, C0_EPC
+
 	/* restore GPRs */
+	ld $1,(STACK_GPR + 1*8)(sp)
 	ld $2,(STACK_GPR + 2*8)(sp)
 	ld $3,(STACK_GPR + 3*8)(sp)
 	ld $4,(STACK_GPR + 4*8)(sp)
@@ -255,19 +274,6 @@ end_interrupt_gpr:
 	ld $24,(STACK_GPR+24*8)(sp)
 	ld $25,(STACK_GPR+25*8)(sp)
 	ld $31,(STACK_GPR+31*8)(sp)
-
-	lw k0,STACK_EPC(sp)
-	lw k1,STACK_SR(sp)
-	mtc0 k0,C0_EPC
-	mtc0 k1,C0_SR
-
-	ld k0,STACK_LO(sp)
-	ld k1,STACK_HI(sp)
-	mtlo k0
-	mthi k1
-
-	.set noat
-	ld $1,(STACK_GPR+1*8)(sp)
 	addiu sp, EXC_STACK_SIZE
 	eret
 
@@ -305,27 +311,27 @@ finalize_exception_frame:
 	.align 5
 save_fpu_regs:
 	cfc1 $1, $f31
-	sw $1, STACK_FC31(k0)
-	sdc1 $f0, (STACK_FPR+ 0*8)(k0)
-	sdc1 $f1, (STACK_FPR+ 1*8)(k0)
-	sdc1 $f2, (STACK_FPR+ 2*8)(k0)
-	sdc1 $f3, (STACK_FPR+ 3*8)(k0)
-	sdc1 $f4, (STACK_FPR+ 4*8)(k0)
-	sdc1 $f5, (STACK_FPR+ 5*8)(k0)
-	sdc1 $f6, (STACK_FPR+ 6*8)(k0)
-	sdc1 $f7, (STACK_FPR+ 7*8)(k0)
-	sdc1 $f8, (STACK_FPR+ 8*8)(k0)
-	sdc1 $f9, (STACK_FPR+ 9*8)(k0)
-	sdc1 $f10,(STACK_FPR+10*8)(k0)
-	sdc1 $f11,(STACK_FPR+11*8)(k0)
-	sdc1 $f12,(STACK_FPR+12*8)(k0)
-	sdc1 $f13,(STACK_FPR+13*8)(k0)
-	sdc1 $f14,(STACK_FPR+14*8)(k0)
-	sdc1 $f15,(STACK_FPR+15*8)(k0)
-	sdc1 $f16,(STACK_FPR+16*8)(k0)
-	sdc1 $f17,(STACK_FPR+17*8)(k0)
-	sdc1 $f18,(STACK_FPR+18*8)(k0)
-	sdc1 $f19,(STACK_FPR+19*8)(k0)
+	sw $1, STACK_FC31(a0)
+	sdc1 $f0, (STACK_FPR+ 0*8)(a0)
+	sdc1 $f1, (STACK_FPR+ 1*8)(a0)
+	sdc1 $f2, (STACK_FPR+ 2*8)(a0)
+	sdc1 $f3, (STACK_FPR+ 3*8)(a0)
+	sdc1 $f4, (STACK_FPR+ 4*8)(a0)
+	sdc1 $f5, (STACK_FPR+ 5*8)(a0)
+	sdc1 $f6, (STACK_FPR+ 6*8)(a0)
+	sdc1 $f7, (STACK_FPR+ 7*8)(a0)
+	sdc1 $f8, (STACK_FPR+ 8*8)(a0)
+	sdc1 $f9, (STACK_FPR+ 9*8)(a0)
+	sdc1 $f10,(STACK_FPR+10*8)(a0)
+	sdc1 $f11,(STACK_FPR+11*8)(a0)
+	sdc1 $f12,(STACK_FPR+12*8)(a0)
+	sdc1 $f13,(STACK_FPR+13*8)(a0)
+	sdc1 $f14,(STACK_FPR+14*8)(a0)
+	sdc1 $f15,(STACK_FPR+15*8)(a0)
+	sdc1 $f16,(STACK_FPR+16*8)(a0)
+	sdc1 $f17,(STACK_FPR+17*8)(a0)
+	sdc1 $f18,(STACK_FPR+18*8)(a0)
+	sdc1 $f19,(STACK_FPR+19*8)(a0)
 	jr ra
 	nop
 

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -98,6 +98,14 @@ inthandler:
 	mfc0 k1, C0_SR
 	sw k1, STACK_SR(k0)
 
+	# Since all critical information about current exception has been saved,
+	# we can now turn off EXL. This allows a reentrant exception to save its
+	# own full context for operating. At the same time, it is better to keep
+	# interrupts disabled so that we don't risk triggering recursive interrupts,
+	# so disable IE as well.
+	and k1, ~(SR_IE | SR_EXL)
+	mtc0 k1, C0_SR
+
 	mfc0 k1, C0_CAUSE
 	sw k1, STACK_CR(k0)
 

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -11,134 +11,165 @@
 inthandler:
 	.global inthandler
 
-	/*Save $2 before using*/
-	sd $2,save02
-
 	.set noat
-	/*Fetch exception pc off cop#0*/
-	mfc0 $2,C0_EPC
+	.set noreorder
 
-	la k1,save01
-	sd $1,(k1)
+#define EXCEPTION_CODE_SYS_CALL      (8<<2)
+#define EXCEPTION_CODE_BREAKPOINT    (9<<2)
 
-	mfc0 k1,C0_SR
-	la $1,saveSR
-	sw k1,($1)
-	la $1, ~1
-	and k1,$1
-	mtc0 k1,C0_SR
-	.set at
+# The exception stack contains a dump of all GPRs/FPRs. This requires 544 bytes.
+# On top of that, we need 32 bytes of empty space at offset 0-31, because
+# that is required by MIPS ABI when calling C functions (it's a space called
+# "argument slots" -- even if the function takes no arguments, or are only passed in 
+# registers, the ABI requires reserving that space and called functions might
+# use it to store local variables).
+# So we keep 0-31 empty, and we start saving GPRs from 32, and then FPR. See
+# the other macros to see the actual layout.
+#
+# *NOTE*: this layout is also exposed in C via regblock_t in exception.h
+# Please keep in sync!
+#define EXC_STACK_SIZE (544+32)
+#define STACK_GPR      32
+#define STACK_HI     (STACK_GPR+(32*8))
+#define STACK_LO     (STACK_HI+8)
+#define STACK_SR     (STACK_LO+8)
+#define STACK_CR     (STACK_SR+4)
+#define STACK_EPC    (STACK_CR+4)
+#define STACK_FC31   (STACK_EPC+4)
+#define STACK_FPR    (STACK_FC31+4)
 
-	/*Save EPC now*/
-	sw $2,saveEPC
+	addiu k0, sp, -EXC_STACK_SIZE
+	srl k0, 3
+	sll k0, 3
 
 	/* save GPRs */
-	/*sd $2,save02 - removed , saved already.At this point it contains epc*/
-	sd $3,save03
-	sd $4,save04
-	sd $5,save05
-	sd $6,save06
-	sd $7,save07
-	sd $8,save08
-	sd $9,save09
-	sd $10,save10
-	sd $11,save11
-	sd $12,save12
-	sd $13,save13
-	sd $14,save14
-	sd $15,save15
-	sd $16,save16
-	sd $17,save17
-	sd $18,save18
-	sd $19,save19
-	sd $20,save20
-	sd $21,save21
-	sd $22,save22
-	sd $23,save23
-	sd $24,save24
-	sd $25,save25
+	# No need to save $0, as it is always zero
+	sd $1,(STACK_GPR+1*8)(k0)
+	.set at
+	sd $2,(STACK_GPR+2*8)(k0)
+	sd $3,(STACK_GPR+3*8)(k0)
+	sd $4,(STACK_GPR+4*8)(k0)
+	sd $5,(STACK_GPR+5*8)(k0)
+	sd $6,(STACK_GPR+6*8)(k0)
+	sd $7,(STACK_GPR+7*8)(k0)
+	sd $8,(STACK_GPR+8*8)(k0)
+	sd $9,(STACK_GPR+9*8)(k0)
+	sd $10,(STACK_GPR+10*8)(k0)
+	sd $11,(STACK_GPR+11*8)(k0)
+	sd $12,(STACK_GPR+12*8)(k0)
+	sd $13,(STACK_GPR+13*8)(k0)
+	sd $14,(STACK_GPR+14*8)(k0)
+	sd $15,(STACK_GPR+15*8)(k0)
+	sd $16,(STACK_GPR+16*8)(k0)
+	sd $17,(STACK_GPR+17*8)(k0)
+	sd $18,(STACK_GPR+18*8)(k0)
+	sd $19,(STACK_GPR+19*8)(k0)
+	sd $20,(STACK_GPR+20*8)(k0)
+	sd $21,(STACK_GPR+21*8)(k0)
+	sd $22,(STACK_GPR+22*8)(k0)
+	sd $23,(STACK_GPR+23*8)(k0)
+	sd $24,(STACK_GPR+24*8)(k0)
+	sd $25,(STACK_GPR+25*8)(k0)
 	# No need to save $26 (k0) & $27 (k1), the int handler is free to use them
-	sd $28,save28
-	sd $29,save29
-	sd $30,save30
-	sd $31,save31
-	mflo $30
-	sd $30,saveLO
-	mfhi $30
-	sd $30,saveHI
-	cfc1 $30,$f31
-	sw $30,saveFC31
+	sd $28,(STACK_GPR+28*8)(k0)
+	sd $29,(STACK_GPR+29*8)(k0)
+	sd $30,(STACK_GPR+30*8)(k0)
+	sd $31,(STACK_GPR+31*8)(k0)
 
-	sdc1 $f0,saveFR00
-	sdc1 $f1,saveFR01
-	sdc1 $f2,saveFR02
-	sdc1 $f3,saveFR03
-	sdc1 $f4,saveFR04
-	sdc1 $f5,saveFR05
-	sdc1 $f6,saveFR06
-	sdc1 $f7,saveFR07
-	sdc1 $f8,saveFR08
-	sdc1 $f9,saveFR09
-	sdc1 $f10,saveFR10
-	sdc1 $f11,saveFR11
-	sdc1 $f12,saveFR12
-	sdc1 $f13,saveFR13
-	sdc1 $f14,saveFR14
-	sdc1 $f15,saveFR15
-	sdc1 $f16,saveFR16
-	sdc1 $f17,saveFR17
-	sdc1 $f18,saveFR18
-	sdc1 $f19,saveFR19
-	sdc1 $f20,saveFR20
-	sdc1 $f21,saveFR21
-	sdc1 $f22,saveFR22
-	sdc1 $f23,saveFR23
-	sdc1 $f24,saveFR24
-	sdc1 $f25,saveFR25
-	sdc1 $f26,saveFR26
-	sdc1 $f27,saveFR27
-	sdc1 $f28,saveFR28
-	sdc1 $f29,saveFR29
-	sdc1 $f30,saveFR30
-	sdc1 $f31,saveFR31
+	mflo k1
+	sd k1,STACK_LO(k0)
+	mfhi k1
+	sd k1,STACK_HI(k0)
+	cfc1 k1,$f31
+	sw k1,STACK_FC31(k0)
 
-	la sp,(exception_stack+65*1024-8)
+	sdc1 $f0,(STACK_FPR+0*8)(k0)
+	sdc1 $f1,(STACK_FPR+1*8)(k0)
+	sdc1 $f2,(STACK_FPR+2*8)(k0)
+	sdc1 $f3,(STACK_FPR+3*8)(k0)
+	sdc1 $f4,(STACK_FPR+4*8)(k0)
+	sdc1 $f5,(STACK_FPR+5*8)(k0)
+	sdc1 $f6,(STACK_FPR+6*8)(k0)
+	sdc1 $f7,(STACK_FPR+7*8)(k0)
+	sdc1 $f8,(STACK_FPR+8*8)(k0)
+	sdc1 $f9,(STACK_FPR+9*8)(k0)
+	sdc1 $f10,(STACK_FPR+10*8)(k0)
+	sdc1 $f11,(STACK_FPR+11*8)(k0)
+	sdc1 $f12,(STACK_FPR+12*8)(k0)
+	sdc1 $f13,(STACK_FPR+13*8)(k0)
+	sdc1 $f14,(STACK_FPR+14*8)(k0)
+	sdc1 $f15,(STACK_FPR+15*8)(k0)
+	sdc1 $f16,(STACK_FPR+16*8)(k0)
+	sdc1 $f17,(STACK_FPR+17*8)(k0)
+	sdc1 $f18,(STACK_FPR+18*8)(k0)
+	sdc1 $f19,(STACK_FPR+19*8)(k0)
+	sdc1 $f20,(STACK_FPR+20*8)(k0)
+	sdc1 $f21,(STACK_FPR+21*8)(k0)
+	sdc1 $f22,(STACK_FPR+22*8)(k0)
+	sdc1 $f23,(STACK_FPR+23*8)(k0)
+	sdc1 $f24,(STACK_FPR+24*8)(k0)
+	sdc1 $f25,(STACK_FPR+25*8)(k0)
+	sdc1 $f26,(STACK_FPR+26*8)(k0)
+	sdc1 $f27,(STACK_FPR+27*8)(k0)
+	sdc1 $f28,(STACK_FPR+28*8)(k0)
+	sdc1 $f29,(STACK_FPR+29*8)(k0)
+	sdc1 $f30,(STACK_FPR+30*8)(k0)
+	sdc1 $f31,(STACK_FPR+31*8)(k0)
+
+	/* Fetch exception pc off cop0 */
+	mfc0 k1, C0_EPC
+	sw k1, STACK_EPC(k0)
+
+	/* Mark interrupts as disabled. TODO: is this really required? */
+	mfc0 k1, C0_SR
+	sw k1, STACK_SR(k0)
+	li t0, ~1
+	and k1, t0
+	mtc0 k1, C0_SR
 
 	mfc0 k1, C0_CAUSE
-	sw k1, saveCR
-	andi $30,k1,0xff
-	beqz $30, justaninterrupt
+	sw k1, STACK_CR(k0)
+
+	move sp, k0
+
+	andi t0, k1, 0xff
+	beqz t0, justaninterrupt
 	nop
 
-	/*:(*/
+critical_exception:
+	/* Exception not specially handled. */
+	addiu a0, sp, 32
 	jal __onCriticalException
 	nop
+
 	j endint
 	nop
 
 justaninterrupt:
 	/* check for "pre-NMI" (reset) */
-	andi $30,k1,0x1000
-	beqz $30, notprenmi
+	andi t0,k1,0x1000
+	beqz t0, notprenmi
 	nop
 
 	/* handle reset */
+	addiu a0, sp, 32
 	jal __onResetException
 	nop
 
 	j endint
 	nop
+
 notprenmi:
 
 	/* check for count=compare */
-	and $30,k1,0x8000
-	beqz $30,notcount
+	and t0,k1,0x8000
+	beqz t0,notcount
 	nop
 	/* Writing C0_COMPARE acknowledges the timer interrupt (clear the interrupt
 	   bit in C0_CAUSE, otherwise the interrupt would retrigger). We write
 	   the current value so that we don't destroy it in case it's needed. */
-	mfc0 k0,C0_COMPARE
-	mtc0 k0,C0_COMPARE
+	mfc0 t0,C0_COMPARE
+	mtc0 t0,C0_COMPARE
 
 	/* handle timer exception */
 	jal __TI_handler
@@ -154,162 +185,86 @@ notcount:
 
 endint:
 	/* restore GPRs */
-	ld $2,save02
-	ld $3,save03
-	ld $4,save04
-	ld $5,save05
-	ld $6,save06
-	ld $7,save07
-	ld $8,save08
-	ld $9,save09
-	ld $10,save10
-	ld $11,save11
-	ld $12,save12
-	ld $13,save13
-	ld $14,save14
-	ld $15,save15
-	ld $16,save16
-	ld $17,save17
-	ld $18,save18
-	ld $19,save19
-	ld $20,save20
-	ld $21,save21
-	ld $22,save22
-	ld $23,save23
-	ld $24,save24
-	ld $25,save25
+	move k0, sp
+	ld $2,(STACK_GPR+2*8)(k0)
+	ld $3,(STACK_GPR+3*8)(k0)
+	ld $4,(STACK_GPR+4*8)(k0)
+	ld $5,(STACK_GPR+5*8)(k0)
+	ld $6,(STACK_GPR+6*8)(k0)
+	ld $7,(STACK_GPR+7*8)(k0)
+	ld $8,(STACK_GPR+8*8)(k0)
+	ld $9,(STACK_GPR+9*8)(k0)
+	ld $10,(STACK_GPR+10*8)(k0)
+	ld $11,(STACK_GPR+11*8)(k0)
+	ld $12,(STACK_GPR+12*8)(k0)
+	ld $13,(STACK_GPR+13*8)(k0)
+	ld $14,(STACK_GPR+14*8)(k0)
+	ld $15,(STACK_GPR+15*8)(k0)
+	ld $16,(STACK_GPR+16*8)(k0)
+	ld $17,(STACK_GPR+17*8)(k0)
+	ld $18,(STACK_GPR+18*8)(k0)
+	ld $19,(STACK_GPR+19*8)(k0)
+	ld $20,(STACK_GPR+20*8)(k0)
+	ld $21,(STACK_GPR+21*8)(k0)
+	ld $22,(STACK_GPR+22*8)(k0)
+	ld $23,(STACK_GPR+23*8)(k0)
+	ld $24,(STACK_GPR+24*8)(k0)
+	ld $25,(STACK_GPR+25*8)(k0)
 	# No need to restore $26 (k0) & $27 (k1), the int handler is free to use them
-	ld $28,save28
-	ld $29,save29
-	ld $31,save31
-	lw $30,saveEPC
-	mtc0 $30,C0_EPC
-	lw $30,saveSR
-	mtc0 $30,C0_SR
-	ld $30,saveLO
-	mtlo $30
-	ld $30,saveHI
-	mthi $30
+	ld $28,(STACK_GPR+28*8)(k0)
+	ld $29,(STACK_GPR+29*8)(k0)
+	ld $30,(STACK_GPR+30*8)(k0)
+	ld $31,(STACK_GPR+31*8)(k0)
 
-	ldc1 $f0,saveFR00
-	ldc1 $f1,saveFR01
-	ldc1 $f2,saveFR02
-	ldc1 $f3,saveFR03
-	ldc1 $f4,saveFR04
-	ldc1 $f5,saveFR05
-	ldc1 $f6,saveFR06
-	ldc1 $f7,saveFR07
-	ldc1 $f8,saveFR08
-	ldc1 $f9,saveFR09
-	ldc1 $f10,saveFR10
-	ldc1 $f11,saveFR11
-	ldc1 $f12,saveFR12
-	ldc1 $f13,saveFR13
-	ldc1 $f14,saveFR14
-	ldc1 $f15,saveFR15
-	ldc1 $f16,saveFR16
-	ldc1 $f17,saveFR17
-	ldc1 $f18,saveFR18
-	ldc1 $f19,saveFR19
-	ldc1 $f20,saveFR20
-	ldc1 $f21,saveFR21
-	ldc1 $f22,saveFR22
-	ldc1 $f23,saveFR23
-	ldc1 $f24,saveFR24
-	ldc1 $f25,saveFR25
-	ldc1 $f26,saveFR26
-	ldc1 $f27,saveFR27
-	ldc1 $f28,saveFR28
-	ldc1 $f29,saveFR29
-	ldc1 $f30,saveFR30
+	lw k1,STACK_EPC(k0)
+	mtc0 k1,C0_EPC
 
-	lw $30,saveFC31
-	ldc1 $f31,saveFR31
-	ctc1 $30,$f31
+	lw k1,STACK_SR(k0)
+	mtc0 k1,C0_SR
 
-	ld $30,save30
+	ld k1,STACK_LO(k0)
+	mtlo k1
+
+	ld k1,STACK_HI(k0)
+	mthi k1
+
+	ldc1 $f0,(STACK_FPR+0*8)(k0)
+	ldc1 $f1,(STACK_FPR+1*8)(k0)
+	ldc1 $f2,(STACK_FPR+2*8)(k0)
+	ldc1 $f3,(STACK_FPR+3*8)(k0)
+	ldc1 $f4,(STACK_FPR+4*8)(k0)
+	ldc1 $f5,(STACK_FPR+5*8)(k0)
+	ldc1 $f6,(STACK_FPR+6*8)(k0)
+	ldc1 $f7,(STACK_FPR+7*8)(k0)
+	ldc1 $f8,(STACK_FPR+8*8)(k0)
+	ldc1 $f9,(STACK_FPR+9*8)(k0)
+	ldc1 $f10,(STACK_FPR+10*8)(k0)
+	ldc1 $f11,(STACK_FPR+11*8)(k0)
+	ldc1 $f12,(STACK_FPR+12*8)(k0)
+	ldc1 $f13,(STACK_FPR+13*8)(k0)
+	ldc1 $f14,(STACK_FPR+14*8)(k0)
+	ldc1 $f15,(STACK_FPR+15*8)(k0)
+	ldc1 $f16,(STACK_FPR+16*8)(k0)
+	ldc1 $f17,(STACK_FPR+17*8)(k0)
+	ldc1 $f18,(STACK_FPR+18*8)(k0)
+	ldc1 $f19,(STACK_FPR+19*8)(k0)
+	ldc1 $f20,(STACK_FPR+20*8)(k0)
+	ldc1 $f21,(STACK_FPR+21*8)(k0)
+	ldc1 $f22,(STACK_FPR+22*8)(k0)
+	ldc1 $f23,(STACK_FPR+23*8)(k0)
+	ldc1 $f24,(STACK_FPR+24*8)(k0)
+	ldc1 $f25,(STACK_FPR+25*8)(k0)
+	ldc1 $f26,(STACK_FPR+26*8)(k0)
+	ldc1 $f27,(STACK_FPR+27*8)(k0)
+	ldc1 $f28,(STACK_FPR+28*8)(k0)
+	ldc1 $f29,(STACK_FPR+29*8)(k0)
+	ldc1 $f30,(STACK_FPR+30*8)(k0)
+	ldc1 $f31,(STACK_FPR+31*8)(k0)
+
+	lw k1, STACK_FC31(k0)
+	ctc1 k1, $f31
+
 	.set noat
-	la $1,save01
-	ld $1,($1)
-
+	ld $1,(STACK_GPR+1*8)(k0)
 	eret
 	nop
-	.set at
-
-	.section .bss
-	.global __baseRegAddr
-
-	.align 8
-	# A label does not work here. The first save slot is unused so we are naming it to mark this data block.
-	.lcomm __baseRegAddr, 8
-	.lcomm save01, 8
-	.lcomm save02, 8
-	.lcomm save03, 8
-	.lcomm save04, 8
-	.lcomm save05, 8
-	.lcomm save06, 8
-	.lcomm save07, 8
-	.lcomm save08, 8
-	.lcomm save09, 8
-	.lcomm save10, 8
-	.lcomm save11, 8
-	.lcomm save12, 8
-	.lcomm save13, 8
-	.lcomm save14, 8
-	.lcomm save15, 8
-	.lcomm save16, 8
-	.lcomm save17, 8
-	.lcomm save18, 8
-	.lcomm save19, 8
-	.lcomm save20, 8
-	.lcomm save21, 8
-	.lcomm save22, 8
-	.lcomm save23, 8
-	.lcomm save24, 8
-	.lcomm save25, 8
-	.lcomm save26, 8
-	.lcomm save27, 8
-	.lcomm save28, 8
-	.lcomm save29, 8
-	.lcomm save30, 8
-	.lcomm save31, 8
-	.lcomm saveSR, 4
-	.lcomm saveCR, 4
-	.lcomm saveEPC, 4
-	.lcomm saveHI, 8
-	.lcomm saveLO, 8
-	.lcomm saveFC31, 4
-	.lcomm saveFR00, 8
-	.lcomm saveFR01, 8
-	.lcomm saveFR02, 8
-	.lcomm saveFR03, 8
-	.lcomm saveFR04, 8
-	.lcomm saveFR05, 8
-	.lcomm saveFR06, 8
-	.lcomm saveFR07, 8
-	.lcomm saveFR08, 8
-	.lcomm saveFR09, 8
-	.lcomm saveFR10, 8
-	.lcomm saveFR11, 8
-	.lcomm saveFR12, 8
-	.lcomm saveFR13, 8
-	.lcomm saveFR14, 8
-	.lcomm saveFR15, 8
-	.lcomm saveFR16, 8
-	.lcomm saveFR17, 8
-	.lcomm saveFR18, 8
-	.lcomm saveFR19, 8
-	.lcomm saveFR20, 8
-	.lcomm saveFR21, 8
-	.lcomm saveFR22, 8
-	.lcomm saveFR23, 8
-	.lcomm saveFR24, 8
-	.lcomm saveFR25, 8
-	.lcomm saveFR26, 8
-	.lcomm saveFR27, 8
-	.lcomm saveFR28, 8
-	.lcomm saveFR29, 8
-	.lcomm saveFR30, 8
-	.lcomm saveFR31, 8
-	.lcomm exception_stack, 65*1024
-

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -8,6 +8,7 @@
 
 #include "regs.S"
 
+	.align 5
 inthandler:
 	.global inthandler
 
@@ -35,44 +36,41 @@ inthandler:
 #define STACK_FC31   (STACK_EPC+4)
 #define STACK_FPR    (STACK_FC31+4)
 
-	addiu k0, sp, -EXC_STACK_SIZE
-	srl k0, 3
-	sll k0, 3
+	addiu sp, -EXC_STACK_SIZE
 
 	# Save caller-saved GPRs only. These are the only
 	# ones required to call a C function from assembly, as the
 	# others (callee-saved) would be preserved by the function 
 	# itself, if modified.
-	sd $1, (STACK_GPR+ 1*8)(k0) # AT
+	sd $1, (STACK_GPR+ 1*8)(sp) # AT
 	.set at
-	sd $2, (STACK_GPR+ 2*8)(k0) # V0
-	sd $3, (STACK_GPR+ 3*8)(k0) # V1
-	sd $4, (STACK_GPR+ 4*8)(k0) # A0
-	sd $5, (STACK_GPR+ 5*8)(k0) # A1
-	sd $6, (STACK_GPR+ 6*8)(k0) # A2
-	sd $7, (STACK_GPR+ 7*8)(k0) # A3
-	sd $8, (STACK_GPR+ 8*8)(k0) # T0
-	sd $9, (STACK_GPR+ 9*8)(k0) # T1
-	sd $10,(STACK_GPR+10*8)(k0) # T2
-	sd $11,(STACK_GPR+11*8)(k0) # T3 
-	sd $12,(STACK_GPR+12*8)(k0) # T4
-	sd $13,(STACK_GPR+13*8)(k0) # T5
-	sd $14,(STACK_GPR+14*8)(k0) # T6
-	sd $15,(STACK_GPR+15*8)(k0) # T7
-	sd $24,(STACK_GPR+24*8)(k0) # T8
-	sd $25,(STACK_GPR+25*8)(k0) # T9
-	sd $31,(STACK_GPR+31*8)(k0) # RA
+	sd $2, (STACK_GPR+ 2*8)(sp) # V0
+	sd $3, (STACK_GPR+ 3*8)(sp) # V1
+	sd $4, (STACK_GPR+ 4*8)(sp) # A0
+	sd $5, (STACK_GPR+ 5*8)(sp) # A1
+	sd $6, (STACK_GPR+ 6*8)(sp) # A2
+	sd $7, (STACK_GPR+ 7*8)(sp) # A3
+	sd $8, (STACK_GPR+ 8*8)(sp) # T0
+	sd $9, (STACK_GPR+ 9*8)(sp) # T1
+	sd $10,(STACK_GPR+10*8)(sp) # T2
+	sd $11,(STACK_GPR+11*8)(sp) # T3 
+	sd $12,(STACK_GPR+12*8)(sp) # T4
+	sd $13,(STACK_GPR+13*8)(sp) # T5
+	sd $14,(STACK_GPR+14*8)(sp) # T6
+	sd $15,(STACK_GPR+15*8)(sp) # T7
+	sd $24,(STACK_GPR+24*8)(sp) # T8
+	sd $25,(STACK_GPR+25*8)(sp) # T9
+	sd $31,(STACK_GPR+31*8)(sp) # RA
 
-	mflo k1
-	sd k1,STACK_LO(k0)
+	mflo k0
 	mfhi k1
-	sd k1,STACK_HI(k0)
+	sd k0,STACK_LO(sp)
+	sd k1,STACK_HI(sp)
 
-	mfc0 k1, C0_EPC
-	sw k1, STACK_EPC(k0)
-
+	mfc0 k0, C0_EPC
 	mfc0 k1, C0_SR
-	sw k1, STACK_SR(k0)
+	sw k0, STACK_EPC(sp)
+	sw k1, STACK_SR(sp)
 
 	# Since all critical information about current exception has been saved,
 	# we can now turn off EXL. This allows a reentrant exception to save its
@@ -83,9 +81,7 @@ inthandler:
 	mtc0 k1, C0_SR
 
 	mfc0 k1, C0_CAUSE
-	sw k1, STACK_CR(k0)
-
-	move sp, k0
+	sw k1, STACK_CR(sp)
 
 	andi t0, k1, 0xff
 	beqz t0, interrupt
@@ -102,7 +98,7 @@ exception:
 
 	# Save the callee-saved FPU regs
 	jal save_fpu_regs
-	nop
+	move k0, sp
 
 	# Save all the CPU+FPU caller-saved regs, which are normally
 	# not saved for an interrupt.
@@ -211,105 +207,102 @@ notcount:
 	nop
 
 end_interrupt:
-	move k0, sp
-	addiu sp, EXC_STACK_SIZE
-
 	mfc0 t0, C0_SR
 	and t0, SR_CU1
 	beqz t0, end_interrupt_gpr
 	nop
 
-	ldc1 $f0, (STACK_FPR+ 0*8)(k0)
-	ldc1 $f1, (STACK_FPR+ 1*8)(k0)
-	ldc1 $f2, (STACK_FPR+ 2*8)(k0)
-	ldc1 $f3, (STACK_FPR+ 3*8)(k0)
-	ldc1 $f4, (STACK_FPR+ 4*8)(k0)
-	ldc1 $f5, (STACK_FPR+ 5*8)(k0)
-	ldc1 $f6, (STACK_FPR+ 6*8)(k0)
-	ldc1 $f7, (STACK_FPR+ 7*8)(k0)
-	ldc1 $f8, (STACK_FPR+ 8*8)(k0)
-	ldc1 $f9, (STACK_FPR+ 9*8)(k0)
-	ldc1 $f10,(STACK_FPR+10*8)(k0)
-	ldc1 $f11,(STACK_FPR+11*8)(k0)
-	ldc1 $f12,(STACK_FPR+12*8)(k0)
-	ldc1 $f13,(STACK_FPR+13*8)(k0)
-	ldc1 $f14,(STACK_FPR+14*8)(k0)
-	ldc1 $f15,(STACK_FPR+15*8)(k0)
-	ldc1 $f16,(STACK_FPR+16*8)(k0)
-	ldc1 $f17,(STACK_FPR+17*8)(k0)
-	ldc1 $f18,(STACK_FPR+18*8)(k0)
-	ldc1 $f19,(STACK_FPR+19*8)(k0)
+	ldc1 $f0, (STACK_FPR+ 0*8)(sp)
+	ldc1 $f1, (STACK_FPR+ 1*8)(sp)
+	ldc1 $f2, (STACK_FPR+ 2*8)(sp)
+	ldc1 $f3, (STACK_FPR+ 3*8)(sp)
+	ldc1 $f4, (STACK_FPR+ 4*8)(sp)
+	ldc1 $f5, (STACK_FPR+ 5*8)(sp)
+	ldc1 $f6, (STACK_FPR+ 6*8)(sp)
+	ldc1 $f7, (STACK_FPR+ 7*8)(sp)
+	ldc1 $f8, (STACK_FPR+ 8*8)(sp)
+	ldc1 $f9, (STACK_FPR+ 9*8)(sp)
+	ldc1 $f10,(STACK_FPR+10*8)(sp)
+	ldc1 $f11,(STACK_FPR+11*8)(sp)
+	ldc1 $f12,(STACK_FPR+12*8)(sp)
+	ldc1 $f13,(STACK_FPR+13*8)(sp)
+	ldc1 $f14,(STACK_FPR+14*8)(sp)
+	ldc1 $f15,(STACK_FPR+15*8)(sp)
+	ldc1 $f16,(STACK_FPR+16*8)(sp)
+	ldc1 $f17,(STACK_FPR+17*8)(sp)
+	ldc1 $f18,(STACK_FPR+18*8)(sp)
+	ldc1 $f19,(STACK_FPR+19*8)(sp)
 
-	lw k1, STACK_FC31(k0)
+	lw k1, STACK_FC31(sp)
 	ctc1 k1, $f31
 
 end_interrupt_gpr:
 	/* restore GPRs */
-	ld $2,(STACK_GPR + 2*8)(k0)
-	ld $3,(STACK_GPR + 3*8)(k0)
-	ld $4,(STACK_GPR + 4*8)(k0)
-	ld $5,(STACK_GPR + 5*8)(k0)
-	ld $6,(STACK_GPR + 6*8)(k0)
-	ld $7,(STACK_GPR + 7*8)(k0)
-	ld $8,(STACK_GPR + 8*8)(k0)
-	ld $9,(STACK_GPR + 9*8)(k0)
-	ld $10,(STACK_GPR+10*8)(k0)
-	ld $11,(STACK_GPR+11*8)(k0)
-	ld $12,(STACK_GPR+12*8)(k0)
-	ld $13,(STACK_GPR+13*8)(k0)
-	ld $14,(STACK_GPR+14*8)(k0)
-	ld $15,(STACK_GPR+15*8)(k0)
-	ld $24,(STACK_GPR+24*8)(k0)
-	ld $25,(STACK_GPR+25*8)(k0)
-	ld $31,(STACK_GPR+31*8)(k0)
+	ld $2,(STACK_GPR + 2*8)(sp)
+	ld $3,(STACK_GPR + 3*8)(sp)
+	ld $4,(STACK_GPR + 4*8)(sp)
+	ld $5,(STACK_GPR + 5*8)(sp)
+	ld $6,(STACK_GPR + 6*8)(sp)
+	ld $7,(STACK_GPR + 7*8)(sp)
+	ld $8,(STACK_GPR + 8*8)(sp)
+	ld $9,(STACK_GPR + 9*8)(sp)
+	ld $10,(STACK_GPR+10*8)(sp)
+	ld $11,(STACK_GPR+11*8)(sp)
+	ld $12,(STACK_GPR+12*8)(sp)
+	ld $13,(STACK_GPR+13*8)(sp)
+	ld $14,(STACK_GPR+14*8)(sp)
+	ld $15,(STACK_GPR+15*8)(sp)
+	ld $24,(STACK_GPR+24*8)(sp)
+	ld $25,(STACK_GPR+25*8)(sp)
+	ld $31,(STACK_GPR+31*8)(sp)
 
-	lw k1,STACK_EPC(k0)
-	mtc0 k1,C0_EPC
-
-	lw k1,STACK_SR(k0)
+	lw k0,STACK_EPC(sp)
+	lw k1,STACK_SR(sp)
+	mtc0 k0,C0_EPC
 	mtc0 k1,C0_SR
 
-	ld k1,STACK_LO(k0)
-	mtlo k1
-
-	ld k1,STACK_HI(k0)
+	ld k0,STACK_LO(sp)
+	ld k1,STACK_HI(sp)
+	mtlo k0
 	mthi k1
 
 	.set noat
-	ld $1,(STACK_GPR+1*8)(k0)
+	ld $1,(STACK_GPR+1*8)(sp)
+	addiu sp, EXC_STACK_SIZE
 	eret
-	nop
 
+	.align 5
 finalize_exception_frame:
-	sd $16,(STACK_GPR+16*8)(k0)   # S0
-	sd $17,(STACK_GPR+17*8)(k0)   # S1
-	sd $18,(STACK_GPR+18*8)(k0)   # S2
-	sd $19,(STACK_GPR+19*8)(k0)   # S3
-	sd $20,(STACK_GPR+20*8)(k0)   # S4
-	sd $21,(STACK_GPR+21*8)(k0)   # S5
-	sd $22,(STACK_GPR+22*8)(k0)   # S6
-	sd $23,(STACK_GPR+23*8)(k0)   # S7
-	sd $28,(STACK_GPR+28*8)(k0)   # GP
+	sd $16,(STACK_GPR+16*8)(sp)   # S0
+	sd $17,(STACK_GPR+17*8)(sp)   # S1
+	sd $18,(STACK_GPR+18*8)(sp)   # S2
+	sd $19,(STACK_GPR+19*8)(sp)   # S3
+	sd $20,(STACK_GPR+20*8)(sp)   # S4
+	sd $21,(STACK_GPR+21*8)(sp)   # S5
+	sd $22,(STACK_GPR+22*8)(sp)   # S6
+	sd $23,(STACK_GPR+23*8)(sp)   # S7
+	sd $28,(STACK_GPR+28*8)(sp)   # GP
 	# SP has been modified to make space for the exception frame,
 	# but we want to save the previous value in the exception frame itself.
 	addiu $1, sp, EXC_STACK_SIZE
-	sd $1, (STACK_GPR+29*8)(k0)   # SP
-	sd $30,(STACK_GPR+30*8)(k0)   # FP
-	sdc1 $f20,(STACK_FPR+20*8)(k0)
-	sdc1 $f21,(STACK_FPR+21*8)(k0)
-	sdc1 $f22,(STACK_FPR+22*8)(k0)
-	sdc1 $f23,(STACK_FPR+23*8)(k0)
-	sdc1 $f24,(STACK_FPR+24*8)(k0)
-	sdc1 $f25,(STACK_FPR+25*8)(k0)
-	sdc1 $f26,(STACK_FPR+26*8)(k0)
-	sdc1 $f27,(STACK_FPR+27*8)(k0)
-	sdc1 $f28,(STACK_FPR+28*8)(k0)
-	sdc1 $f29,(STACK_FPR+29*8)(k0)
-	sdc1 $f30,(STACK_FPR+30*8)(k0)
-	sdc1 $f31,(STACK_FPR+31*8)(k0)
+	sd $1, (STACK_GPR+29*8)(sp)   # SP
+	sd $30,(STACK_GPR+30*8)(sp)   # FP
+	sdc1 $f20,(STACK_FPR+20*8)(sp)
+	sdc1 $f21,(STACK_FPR+21*8)(sp)
+	sdc1 $f22,(STACK_FPR+22*8)(sp)
+	sdc1 $f23,(STACK_FPR+23*8)(sp)
+	sdc1 $f24,(STACK_FPR+24*8)(sp)
+	sdc1 $f25,(STACK_FPR+25*8)(sp)
+	sdc1 $f26,(STACK_FPR+26*8)(sp)
+	sdc1 $f27,(STACK_FPR+27*8)(sp)
+	sdc1 $f28,(STACK_FPR+28*8)(sp)
+	sdc1 $f29,(STACK_FPR+29*8)(sp)
+	sdc1 $f30,(STACK_FPR+30*8)(sp)
+	sdc1 $f31,(STACK_FPR+31*8)(sp)
 	jr ra
 	nop
 
+	.align 5
 save_fpu_regs:
 	cfc1 $1, $f31
 	sw $1, STACK_FC31(k0)

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -14,9 +14,6 @@ inthandler:
 	.set noat
 	.set noreorder
 
-#define EXCEPTION_CODE_SYS_CALL      (8<<2)
-#define EXCEPTION_CODE_BREAKPOINT    (9<<2)
-
 # The exception stack contains a dump of all GPRs/FPRs. This requires 544 bytes.
 # On top of that, we need 32 bytes of empty space at offset 0-31, because
 # that is required by MIPS ABI when calling C functions (it's a space called
@@ -70,29 +67,6 @@ inthandler:
 	sd k1,STACK_LO(k0)
 	mfhi k1
 	sd k1,STACK_HI(k0)
-	cfc1 k1,$f31
-	sw k1,STACK_FC31(k0)
-
-	sdc1 $f0,(STACK_FPR+0*8)(k0)
-	sdc1 $f1,(STACK_FPR+1*8)(k0)
-	sdc1 $f2,(STACK_FPR+2*8)(k0)
-	sdc1 $f3,(STACK_FPR+3*8)(k0)
-	sdc1 $f4,(STACK_FPR+4*8)(k0)
-	sdc1 $f5,(STACK_FPR+5*8)(k0)
-	sdc1 $f6,(STACK_FPR+6*8)(k0)
-	sdc1 $f7,(STACK_FPR+7*8)(k0)
-	sdc1 $f8,(STACK_FPR+8*8)(k0)
-	sdc1 $f9,(STACK_FPR+9*8)(k0)
-	sdc1 $f10,(STACK_FPR+10*8)(k0)
-	sdc1 $f11,(STACK_FPR+11*8)(k0)
-	sdc1 $f12,(STACK_FPR+12*8)(k0)
-	sdc1 $f13,(STACK_FPR+13*8)(k0)
-	sdc1 $f14,(STACK_FPR+14*8)(k0)
-	sdc1 $f15,(STACK_FPR+15*8)(k0)
-	sdc1 $f16,(STACK_FPR+16*8)(k0)
-	sdc1 $f17,(STACK_FPR+17*8)(k0)
-	sdc1 $f18,(STACK_FPR+18*8)(k0)
-	sdc1 $f19,(STACK_FPR+19*8)(k0)
 
 	mfc0 k1, C0_EPC
 	sw k1, STACK_EPC(k0)
@@ -117,10 +91,60 @@ inthandler:
 	beqz t0, interrupt
 	nop
 
-critical_exception:
-	# Make sure that all registers are saved in the exception frame
+exception:
+	# This is an exception, not an interrupt. We want to save the full processor
+	# state in the exception frame, so all registers including FPU regs.
+	# Make sure FPU is activated in this context. It could be deactivated if
+	# this exception happened within an interrupt (where FPU is disabled by default).
+	mfc0 t0, C0_SR
+	or t0, SR_CU1
+	mtc0 t0, C0_SR
+
+	# Save the callee-saved FPU regs
+	jal save_fpu_regs
+	nop
+
+	# Save all the CPU+FPU caller-saved regs, which are normally
+	# not saved for an interrupt.
 	jal finalize_exception_frame
 	nop
+
+	# Check the exception type
+	mfc0 k1, C0_CAUSE
+	andi t0, k1, CAUSE_EXC_MASK
+	bne t0, CAUSE_EXC_COPROCESSOR, critical_exception
+	nop
+
+exception_coprocessor:
+	# Extract CE bits (28..29) from CR
+	srl t0, k1, 28
+	andi t0, 3
+	# If == 1 (COP1), it is an FPU exception
+	bne t0, 1, critical_exception
+	nop
+
+exception_coprocessor_fpu:
+	# FPU exception. This happened because of the use of FPU in an interrupt handler,
+	# where it is disabled by default. We must save the full FPU context,
+	# reactivate the FPU, and then return from exception, so that the FPU instruction
+	# is executed again and this time it will work.
+
+	# Make sure that FPU will also be enabled when we exit this exception
+	lw t0, STACK_SR(sp)
+	or t0, SR_CU1
+	sw t0, STACK_SR(sp)
+
+	# Save the FPU registers into the *underlying* interrupt context.
+	# That is, we want to make sure that they get restored when the
+	# underlying interrupt exits.
+	jal save_fpu_regs
+	lw k0, interrupt_exception_frame
+
+	# OK we are done. We can now exit the exception
+	j end_interrupt
+	nop
+
+critical_exception:
 
 	/* Exception not specially handled. */
 	addiu a0, sp, 32
@@ -131,6 +155,22 @@ critical_exception:
 	nop
 
 interrupt:
+	# This is an interrupt. 
+	# First of all, disable FPU coprocessor so that we can avoid saving FPU
+	# registers altogether.
+	mfc0 t0, C0_SR
+	and t0, ~SR_CU1
+	mtc0 t0, C0_SR
+
+	# If a FPU instruction is executed during the interrupt handler, a nested
+	# exception will trigger. The nested handler will enable the FPU and save
+	# the FPU registers into the interrupt exception frame. To do so, it needs
+	# to know *where* the interrupt exception frame is. That is, we need
+	# to store the current stack pointer somewhere.
+	# Notice that interrupts cannot be reentrant (only exceptions are), so
+	# a single variable will suffice.
+	sw sp, interrupt_exception_frame
+
 	/* check for "pre-NMI" (reset) */
 	andi t0,k1,0x1000
 	beqz t0, notprenmi
@@ -173,6 +213,37 @@ notcount:
 end_interrupt:
 	move k0, sp
 	addiu sp, EXC_STACK_SIZE
+
+	mfc0 t0, C0_SR
+	and t0, SR_CU1
+	beqz t0, end_interrupt_gpr
+	nop
+
+	ldc1 $f0, (STACK_FPR+ 0*8)(k0)
+	ldc1 $f1, (STACK_FPR+ 1*8)(k0)
+	ldc1 $f2, (STACK_FPR+ 2*8)(k0)
+	ldc1 $f3, (STACK_FPR+ 3*8)(k0)
+	ldc1 $f4, (STACK_FPR+ 4*8)(k0)
+	ldc1 $f5, (STACK_FPR+ 5*8)(k0)
+	ldc1 $f6, (STACK_FPR+ 6*8)(k0)
+	ldc1 $f7, (STACK_FPR+ 7*8)(k0)
+	ldc1 $f8, (STACK_FPR+ 8*8)(k0)
+	ldc1 $f9, (STACK_FPR+ 9*8)(k0)
+	ldc1 $f10,(STACK_FPR+10*8)(k0)
+	ldc1 $f11,(STACK_FPR+11*8)(k0)
+	ldc1 $f12,(STACK_FPR+12*8)(k0)
+	ldc1 $f13,(STACK_FPR+13*8)(k0)
+	ldc1 $f14,(STACK_FPR+14*8)(k0)
+	ldc1 $f15,(STACK_FPR+15*8)(k0)
+	ldc1 $f16,(STACK_FPR+16*8)(k0)
+	ldc1 $f17,(STACK_FPR+17*8)(k0)
+	ldc1 $f18,(STACK_FPR+18*8)(k0)
+	ldc1 $f19,(STACK_FPR+19*8)(k0)
+
+	lw k1, STACK_FC31(k0)
+	ctc1 k1, $f31
+
+end_interrupt_gpr:
 	/* restore GPRs */
 	ld $2,(STACK_GPR + 2*8)(k0)
 	ld $3,(STACK_GPR + 3*8)(k0)
@@ -203,30 +274,6 @@ end_interrupt:
 
 	ld k1,STACK_HI(k0)
 	mthi k1
-
-	ldc1 $f0,(STACK_FPR+0*8)(k0)
-	ldc1 $f1,(STACK_FPR+1*8)(k0)
-	ldc1 $f2,(STACK_FPR+2*8)(k0)
-	ldc1 $f3,(STACK_FPR+3*8)(k0)
-	ldc1 $f4,(STACK_FPR+4*8)(k0)
-	ldc1 $f5,(STACK_FPR+5*8)(k0)
-	ldc1 $f6,(STACK_FPR+6*8)(k0)
-	ldc1 $f7,(STACK_FPR+7*8)(k0)
-	ldc1 $f8,(STACK_FPR+8*8)(k0)
-	ldc1 $f9,(STACK_FPR+9*8)(k0)
-	ldc1 $f10,(STACK_FPR+10*8)(k0)
-	ldc1 $f11,(STACK_FPR+11*8)(k0)
-	ldc1 $f12,(STACK_FPR+12*8)(k0)
-	ldc1 $f13,(STACK_FPR+13*8)(k0)
-	ldc1 $f14,(STACK_FPR+14*8)(k0)
-	ldc1 $f15,(STACK_FPR+15*8)(k0)
-	ldc1 $f16,(STACK_FPR+16*8)(k0)
-	ldc1 $f17,(STACK_FPR+17*8)(k0)
-	ldc1 $f18,(STACK_FPR+18*8)(k0)
-	ldc1 $f19,(STACK_FPR+19*8)(k0)
-
-	lw k1, STACK_FC31(k0)
-	ctc1 k1, $f31
 
 	.set noat
 	ld $1,(STACK_GPR+1*8)(k0)
@@ -262,3 +309,35 @@ finalize_exception_frame:
 	sdc1 $f31,(STACK_FPR+31*8)(k0)
 	jr ra
 	nop
+
+save_fpu_regs:
+	cfc1 $1, $f31
+	sw $1, STACK_FC31(k0)
+	sdc1 $f0, (STACK_FPR+ 0*8)(k0)
+	sdc1 $f1, (STACK_FPR+ 1*8)(k0)
+	sdc1 $f2, (STACK_FPR+ 2*8)(k0)
+	sdc1 $f3, (STACK_FPR+ 3*8)(k0)
+	sdc1 $f4, (STACK_FPR+ 4*8)(k0)
+	sdc1 $f5, (STACK_FPR+ 5*8)(k0)
+	sdc1 $f6, (STACK_FPR+ 6*8)(k0)
+	sdc1 $f7, (STACK_FPR+ 7*8)(k0)
+	sdc1 $f8, (STACK_FPR+ 8*8)(k0)
+	sdc1 $f9, (STACK_FPR+ 9*8)(k0)
+	sdc1 $f10,(STACK_FPR+10*8)(k0)
+	sdc1 $f11,(STACK_FPR+11*8)(k0)
+	sdc1 $f12,(STACK_FPR+12*8)(k0)
+	sdc1 $f13,(STACK_FPR+13*8)(k0)
+	sdc1 $f14,(STACK_FPR+14*8)(k0)
+	sdc1 $f15,(STACK_FPR+15*8)(k0)
+	sdc1 $f16,(STACK_FPR+16*8)(k0)
+	sdc1 $f17,(STACK_FPR+17*8)(k0)
+	sdc1 $f18,(STACK_FPR+18*8)(k0)
+	sdc1 $f19,(STACK_FPR+19*8)(k0)
+	jr ra
+	nop
+
+
+	.section .bss
+ 	.align 8
+	.lcomm interrupt_exception_frame, 4
+

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -60,20 +60,8 @@ inthandler:
 	sd $13,(STACK_GPR+13*8)(k0)
 	sd $14,(STACK_GPR+14*8)(k0)
 	sd $15,(STACK_GPR+15*8)(k0)
-	sd $16,(STACK_GPR+16*8)(k0)
-	sd $17,(STACK_GPR+17*8)(k0)
-	sd $18,(STACK_GPR+18*8)(k0)
-	sd $19,(STACK_GPR+19*8)(k0)
-	sd $20,(STACK_GPR+20*8)(k0)
-	sd $21,(STACK_GPR+21*8)(k0)
-	sd $22,(STACK_GPR+22*8)(k0)
-	sd $23,(STACK_GPR+23*8)(k0)
 	sd $24,(STACK_GPR+24*8)(k0)
 	sd $25,(STACK_GPR+25*8)(k0)
-	# No need to save $26 (k0) & $27 (k1), the int handler is free to use them
-	sd $28,(STACK_GPR+28*8)(k0)
-	sd $29,(STACK_GPR+29*8)(k0)
-	sd $30,(STACK_GPR+30*8)(k0)
 	sd $31,(STACK_GPR+31*8)(k0)
 
 	mflo k1
@@ -137,6 +125,10 @@ inthandler:
 	nop
 
 critical_exception:
+	# Make sure that all registers are saved in the exception frame
+	jal finalize_exception_frame
+	nop
+
 	/* Exception not specially handled. */
 	addiu a0, sp, 32
 	jal __onCriticalException
@@ -186,6 +178,7 @@ notcount:
 endint:
 	/* restore GPRs */
 	move k0, sp
+	addiu sp, EXC_STACK_SIZE
 	ld $2,(STACK_GPR+2*8)(k0)
 	ld $3,(STACK_GPR+3*8)(k0)
 	ld $4,(STACK_GPR+4*8)(k0)
@@ -200,20 +193,8 @@ endint:
 	ld $13,(STACK_GPR+13*8)(k0)
 	ld $14,(STACK_GPR+14*8)(k0)
 	ld $15,(STACK_GPR+15*8)(k0)
-	ld $16,(STACK_GPR+16*8)(k0)
-	ld $17,(STACK_GPR+17*8)(k0)
-	ld $18,(STACK_GPR+18*8)(k0)
-	ld $19,(STACK_GPR+19*8)(k0)
-	ld $20,(STACK_GPR+20*8)(k0)
-	ld $21,(STACK_GPR+21*8)(k0)
-	ld $22,(STACK_GPR+22*8)(k0)
-	ld $23,(STACK_GPR+23*8)(k0)
 	ld $24,(STACK_GPR+24*8)(k0)
 	ld $25,(STACK_GPR+25*8)(k0)
-	# No need to restore $26 (k0) & $27 (k1), the int handler is free to use them
-	ld $28,(STACK_GPR+28*8)(k0)
-	ld $29,(STACK_GPR+29*8)(k0)
-	ld $30,(STACK_GPR+30*8)(k0)
 	ld $31,(STACK_GPR+31*8)(k0)
 
 	lw k1,STACK_EPC(k0)
@@ -267,4 +248,22 @@ endint:
 	.set noat
 	ld $1,(STACK_GPR+1*8)(k0)
 	eret
+	nop
+
+finalize_exception_frame:
+	sd $16,(STACK_GPR+16*8)(k0)   # S0
+	sd $17,(STACK_GPR+17*8)(k0)   # S1
+	sd $18,(STACK_GPR+18*8)(k0)   # S2
+	sd $19,(STACK_GPR+19*8)(k0)   # S3
+	sd $20,(STACK_GPR+20*8)(k0)   # S4
+	sd $21,(STACK_GPR+21*8)(k0)   # S5
+	sd $22,(STACK_GPR+22*8)(k0)   # S6
+	sd $23,(STACK_GPR+23*8)(k0)   # S7
+	sd $28,(STACK_GPR+28*8)(k0)   # GP
+	# SP has been modified to make space for the exception frame,
+	# but we want to save the previous value in the exception frame itself.
+	addiu $1, sp, EXC_STACK_SIZE
+	sd $1,(STACK_GPR+29*8)(k0)    # SP
+	sd $30,(STACK_GPR+30*8)(k0)   # FP
+	jr ra
 	nop

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -42,27 +42,29 @@ inthandler:
 	srl k0, 3
 	sll k0, 3
 
-	/* save GPRs */
-	# No need to save $0, as it is always zero
-	sd $1,(STACK_GPR+1*8)(k0)
+	# Save caller-saved GPRs only. These are the only
+	# ones required to call a C function from assembly, as the
+	# others (callee-saved) would be preserved by the function 
+	# itself, if modified.
+	sd $1, (STACK_GPR+ 1*8)(k0) # AT
 	.set at
-	sd $2,(STACK_GPR+2*8)(k0)
-	sd $3,(STACK_GPR+3*8)(k0)
-	sd $4,(STACK_GPR+4*8)(k0)
-	sd $5,(STACK_GPR+5*8)(k0)
-	sd $6,(STACK_GPR+6*8)(k0)
-	sd $7,(STACK_GPR+7*8)(k0)
-	sd $8,(STACK_GPR+8*8)(k0)
-	sd $9,(STACK_GPR+9*8)(k0)
-	sd $10,(STACK_GPR+10*8)(k0)
-	sd $11,(STACK_GPR+11*8)(k0)
-	sd $12,(STACK_GPR+12*8)(k0)
-	sd $13,(STACK_GPR+13*8)(k0)
-	sd $14,(STACK_GPR+14*8)(k0)
-	sd $15,(STACK_GPR+15*8)(k0)
-	sd $24,(STACK_GPR+24*8)(k0)
-	sd $25,(STACK_GPR+25*8)(k0)
-	sd $31,(STACK_GPR+31*8)(k0)
+	sd $2, (STACK_GPR+ 2*8)(k0) # V0
+	sd $3, (STACK_GPR+ 3*8)(k0) # V1
+	sd $4, (STACK_GPR+ 4*8)(k0) # A0
+	sd $5, (STACK_GPR+ 5*8)(k0) # A1
+	sd $6, (STACK_GPR+ 6*8)(k0) # A2
+	sd $7, (STACK_GPR+ 7*8)(k0) # A3
+	sd $8, (STACK_GPR+ 8*8)(k0) # T0
+	sd $9, (STACK_GPR+ 9*8)(k0) # T1
+	sd $10,(STACK_GPR+10*8)(k0) # T2
+	sd $11,(STACK_GPR+11*8)(k0) # T3 
+	sd $12,(STACK_GPR+12*8)(k0) # T4
+	sd $13,(STACK_GPR+13*8)(k0) # T5
+	sd $14,(STACK_GPR+14*8)(k0) # T6
+	sd $15,(STACK_GPR+15*8)(k0) # T7
+	sd $24,(STACK_GPR+24*8)(k0) # T8
+	sd $25,(STACK_GPR+25*8)(k0) # T9
+	sd $31,(STACK_GPR+31*8)(k0) # RA
 
 	mflo k1
 	sd k1,STACK_LO(k0)
@@ -112,7 +114,7 @@ inthandler:
 	move sp, k0
 
 	andi t0, k1, 0xff
-	beqz t0, justaninterrupt
+	beqz t0, interrupt
 	nop
 
 critical_exception:
@@ -125,10 +127,10 @@ critical_exception:
 	jal __onCriticalException
 	nop
 
-	j endint
+	j end_interrupt
 	nop
 
-justaninterrupt:
+interrupt:
 	/* check for "pre-NMI" (reset) */
 	andi t0,k1,0x1000
 	beqz t0, notprenmi
@@ -139,7 +141,7 @@ justaninterrupt:
 	jal __onResetException
 	nop
 
-	j endint
+	j end_interrupt
 	nop
 
 notprenmi:
@@ -158,26 +160,28 @@ notprenmi:
 	jal __TI_handler
 	nop
 
-	j endint
+	j end_interrupt
 	nop
 notcount:
 
 	/* pass anything else along to handler */
 	jal __MI_handler
 	nop
+	j end_interrupt
+	nop
 
-endint:
-	/* restore GPRs */
+end_interrupt:
 	move k0, sp
 	addiu sp, EXC_STACK_SIZE
-	ld $2,(STACK_GPR+2*8)(k0)
-	ld $3,(STACK_GPR+3*8)(k0)
-	ld $4,(STACK_GPR+4*8)(k0)
-	ld $5,(STACK_GPR+5*8)(k0)
-	ld $6,(STACK_GPR+6*8)(k0)
-	ld $7,(STACK_GPR+7*8)(k0)
-	ld $8,(STACK_GPR+8*8)(k0)
-	ld $9,(STACK_GPR+9*8)(k0)
+	/* restore GPRs */
+	ld $2,(STACK_GPR + 2*8)(k0)
+	ld $3,(STACK_GPR + 3*8)(k0)
+	ld $4,(STACK_GPR + 4*8)(k0)
+	ld $5,(STACK_GPR + 5*8)(k0)
+	ld $6,(STACK_GPR + 6*8)(k0)
+	ld $7,(STACK_GPR + 7*8)(k0)
+	ld $8,(STACK_GPR + 8*8)(k0)
+	ld $9,(STACK_GPR + 9*8)(k0)
 	ld $10,(STACK_GPR+10*8)(k0)
 	ld $11,(STACK_GPR+11*8)(k0)
 	ld $12,(STACK_GPR+12*8)(k0)
@@ -242,7 +246,7 @@ finalize_exception_frame:
 	# SP has been modified to make space for the exception frame,
 	# but we want to save the previous value in the exception frame itself.
 	addiu $1, sp, EXC_STACK_SIZE
-	sd $1,(STACK_GPR+29*8)(k0)    # SP
+	sd $1, (STACK_GPR+29*8)(k0)   # SP
 	sd $30,(STACK_GPR+30*8)(k0)   # FP
 	sdc1 $f20,(STACK_FPR+20*8)(k0)
 	sdc1 $f21,(STACK_FPR+21*8)(k0)

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -92,16 +92,11 @@ inthandler:
 	sdc1 $f18,(STACK_FPR+18*8)(k0)
 	sdc1 $f19,(STACK_FPR+19*8)(k0)
 
-	/* Fetch exception pc off cop0 */
 	mfc0 k1, C0_EPC
 	sw k1, STACK_EPC(k0)
 
-	/* Mark interrupts as disabled. TODO: is this really required? */
 	mfc0 k1, C0_SR
 	sw k1, STACK_SR(k0)
-	li t0, ~1
-	and k1, t0
-	mtc0 k1, C0_SR
 
 	mfc0 k1, C0_CAUSE
 	sw k1, STACK_CR(k0)

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -91,18 +91,6 @@ inthandler:
 	sdc1 $f17,(STACK_FPR+17*8)(k0)
 	sdc1 $f18,(STACK_FPR+18*8)(k0)
 	sdc1 $f19,(STACK_FPR+19*8)(k0)
-	sdc1 $f20,(STACK_FPR+20*8)(k0)
-	sdc1 $f21,(STACK_FPR+21*8)(k0)
-	sdc1 $f22,(STACK_FPR+22*8)(k0)
-	sdc1 $f23,(STACK_FPR+23*8)(k0)
-	sdc1 $f24,(STACK_FPR+24*8)(k0)
-	sdc1 $f25,(STACK_FPR+25*8)(k0)
-	sdc1 $f26,(STACK_FPR+26*8)(k0)
-	sdc1 $f27,(STACK_FPR+27*8)(k0)
-	sdc1 $f28,(STACK_FPR+28*8)(k0)
-	sdc1 $f29,(STACK_FPR+29*8)(k0)
-	sdc1 $f30,(STACK_FPR+30*8)(k0)
-	sdc1 $f31,(STACK_FPR+31*8)(k0)
 
 	/* Fetch exception pc off cop0 */
 	mfc0 k1, C0_EPC
@@ -229,18 +217,6 @@ endint:
 	ldc1 $f17,(STACK_FPR+17*8)(k0)
 	ldc1 $f18,(STACK_FPR+18*8)(k0)
 	ldc1 $f19,(STACK_FPR+19*8)(k0)
-	ldc1 $f20,(STACK_FPR+20*8)(k0)
-	ldc1 $f21,(STACK_FPR+21*8)(k0)
-	ldc1 $f22,(STACK_FPR+22*8)(k0)
-	ldc1 $f23,(STACK_FPR+23*8)(k0)
-	ldc1 $f24,(STACK_FPR+24*8)(k0)
-	ldc1 $f25,(STACK_FPR+25*8)(k0)
-	ldc1 $f26,(STACK_FPR+26*8)(k0)
-	ldc1 $f27,(STACK_FPR+27*8)(k0)
-	ldc1 $f28,(STACK_FPR+28*8)(k0)
-	ldc1 $f29,(STACK_FPR+29*8)(k0)
-	ldc1 $f30,(STACK_FPR+30*8)(k0)
-	ldc1 $f31,(STACK_FPR+31*8)(k0)
 
 	lw k1, STACK_FC31(k0)
 	ctc1 k1, $f31
@@ -265,5 +241,17 @@ finalize_exception_frame:
 	addiu $1, sp, EXC_STACK_SIZE
 	sd $1,(STACK_GPR+29*8)(k0)    # SP
 	sd $30,(STACK_GPR+30*8)(k0)   # FP
+	sdc1 $f20,(STACK_FPR+20*8)(k0)
+	sdc1 $f21,(STACK_FPR+21*8)(k0)
+	sdc1 $f22,(STACK_FPR+22*8)(k0)
+	sdc1 $f23,(STACK_FPR+23*8)(k0)
+	sdc1 $f24,(STACK_FPR+24*8)(k0)
+	sdc1 $f25,(STACK_FPR+25*8)(k0)
+	sdc1 $f26,(STACK_FPR+26*8)(k0)
+	sdc1 $f27,(STACK_FPR+27*8)(k0)
+	sdc1 $f28,(STACK_FPR+28*8)(k0)
+	sdc1 $f29,(STACK_FPR+29*8)(k0)
+	sdc1 $f30,(STACK_FPR+30*8)(k0)
+	sdc1 $f31,(STACK_FPR+31*8)(k0)
 	jr ra
 	nop

--- a/src/regs.S
+++ b/src/regs.S
@@ -102,6 +102,12 @@
 #define SR_EXL      0x00000002  /* Exception level */
 #define SR_IE       0x00000001  /* Interrupts enabled */
 
+/* Standard Cause Register bitmasks: */
+#define CAUSE_EXC_MASK             (0x1F << 2)
+#define CAUSE_EXC_SYSCALL          (8    << 2)
+#define CAUSE_EXC_BREAKPOINT       (9    << 2)
+#define CAUSE_EXC_COPROCESSOR      (11   << 2)
+
 /* Standard (R4000) cache operations. Taken from "MIPS R4000
    Microprocessor User's Manual" 2nd edition: */
 

--- a/src/regs.S
+++ b/src/regs.S
@@ -98,6 +98,10 @@
 #define SR_SX		0x00000040	/* Supervisor extended addressing enabled */
 #define SR_UX		0x00000020	/* User extended addressing enabled */
 
+#define SR_ERL      0x00000004  /* Error level */
+#define SR_EXL      0x00000002  /* Exception level */
+#define SR_IE       0x00000001  /* Interrupts enabled */
+
 /* Standard (R4000) cache operations. Taken from "MIPS R4000
    Microprocessor User's Manual" 2nd edition: */
 

--- a/tests/test_cop1.c
+++ b/tests/test_cop1.c
@@ -11,3 +11,31 @@ void test_cop1_denormalized_float(TestContext *ctx) {
        "not implemented" exception was not raised */
     ASSERT(x == 0.0f, "Denormalized float was not flushed to zero");
 }
+
+void test_cop1_interrupts(TestContext *ctx) {
+   // Test that we can use FPUs in the context of an interrupt handler.
+   // This is useful because in general interrupt handlers save FPU registers
+   // only "on demand" when needed.
+   timer_init();
+   DEFER(timer_close());
+
+   volatile float float_value = 1234.0f;
+   void cb1(int ovlf) {
+      disable_interrupts();
+      float_value *= 2;
+      enable_interrupts();
+   }
+
+   void cb2(int ovlf) {
+      float_value *= 2;
+   }
+
+   timer_link_t *tt1 = new_timer(TICKS_FROM_MS(2), TF_ONE_SHOT, cb1);
+   DEFER(delete_timer(tt1));
+   timer_link_t *tt2 = new_timer(TICKS_FROM_MS(2), TF_ONE_SHOT, cb2);
+   DEFER(delete_timer(tt2));
+
+   wait_ms(3);
+
+   ASSERT_EQUAL_SIGNED((int)float_value, 4936, "invalid floating point value");
+}


### PR DESCRIPTION
This commit series introduces a big refactoring of the interrupt handler, with the following benefits:

* It is much faster because fewer registers are saved (18 now vs 60 before). The fixed cost of an interrupt (before invoking the registered handler) is ~50% less now, so the interrupts are 2x faster.
* FPU registers are saved optimistically. If interrupt handlers don't touch FPU, they are not saved at all; otherwise, as soon as a handler does a COP1 operation, and exception is triggered that saves the registers on the stack and resumes execution. This is a good tradeoff because interrupt handles rarely need FPU anyway.
* The context is saved on the user stack, rather than a dedicated interrupt stack. This is required for the kernel anyway (and the implementation was in fact taken from the kernel branch), and it saves ~64K of RDRAM that was previously allocated for interrupt stack.

Possible future work in this area:

 * More micro-optimization in the code, like improving icache usage.
 * Introduce the concept of a interrupt handler, with a specific ABI, so that even fewer registers are saved when only interrupt handlers need to be saved.