### PR TITLE
controller: add assert if controller_init is not called

### DIFF
--- a/examples/test/test.c
+++ b/examples/test/test.c
@@ -40,6 +40,7 @@ int main(void)
     /* Initialize peripherals */
     display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
     dfs_init( DFS_DEFAULT_LOCATION );
+    controller_init();
 
     /* Read in sprite */
     sprite_t *mario = read_sprite( "rom://mario.sprite" );

--- a/src/controller.c
+++ b/src/controller.c
@@ -65,6 +65,8 @@ static struct controller_data current;
 static struct controller_data prev;
 /** @brief True if there is a pending controller autoscan */
 static volatile bool controller_autoscan_in_progress = false;
+/** @brief True if the module was initialized */
+static bool controller_inited = false;
 
 static void controller_interrupt_update(uint64_t *output, void *ctx)
 {
@@ -106,6 +108,7 @@ void controller_init( void )
     memset(&current, 0, sizeof(struct controller_data));
     memset((void*)&next, 0, sizeof(struct controller_data));
     register_VI_handler(controller_interrupt);
+    controller_inited = true;
 }
 
 /**
@@ -232,6 +235,7 @@ void controller_read_gc_origin( struct controller_origin_data * outdata )
  */
 void controller_scan( void )
 {
+    assertf(controller_inited, "controller_init() was not called");
     prev = current;
 
     disable_interrupts();


### PR DESCRIPTION
In #234, we changed the controller module to do the scanning in
background.

Before #234, controller_init was just a big glorified
nop as it was just clearing global variables which were already cleared
in BSS. So a ROM could get away forgetting to call controller_init.

After #234, controller_init registers the interrupt callback to do
the scanning. So not calling controller_init equals to never read
any controller, so input is broken.

Add an assert to catch this case, to help people porting their code
to latest libdragon.