### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,28 +47,36 @@ programming and debugging. These are the main features:
 See [the libdragon CLI](https://github.com/anacierdem/libdragon-docker) to
 quickly get libdragon up and running. Basically:
 
-1. Download the CLI (as a pre-built binary, or build from source)
-2. Run `libdragon init` to create a skeleton project
-3. Run `libdragon make` to compile a build a ROM
+1. Make sure that you have Docker installed correctly (on Windows and Mac, use
+   Docker Desktop). You can run `docker system info` to check that it is working
+   correctly.
+2. Install the [the libdragon CLI](https://github.com/anacierdem/libdragon-docker).
+   You have two options:
+
+   1. Download the [pre-built binary](https://github.com/anacierdem/libdragon-docker/releases/tag/v10.8.0), 
+      and copy it into some directory which is part of your system PATH.
+   2. If you have `npm` installed (at least verstion 14), run `npm install -g libdragon`.
+3. Run `libdragon init` to create a skeleton project
+4. Run `libdragon make` to compile a build a ROM
 
 If you want, you can also compile and run one of the examples that will
 be found in `libdragon/examples` in the skeleton project.
 
 ### Option 2: Compile the toolchain (Linux only)
 
-1. Create a directory and copy the `build-toolchain.sh` script there from the `tools/` directory.
-2. Read the comments in the build script to see what additional packages are needed.
-3. Run `./build-toolchain.sh` from the created directory, let it build and install the toolchain.
-4. Install libpng-dev if not already installed.
+1. Export the environment variable N64_INST to the path where you want your
+   toolchain to be installed. For instance: `export N64_INST=/opt/n64` or
+   `export N64_INST=/usr/local`.
+2. Create an empty directory and copy the `tools/build-toolchain.sh` script there
+3. Read the comments in the build script to see what additional packages are needed.
+4. Run `./build-toolchain.sh` from the created directory, let it build and install the toolchain.
+5. Install libpng-dev if not already installed.
+6. Make sure that you still have the `N64_INST` variable pointing to the correct
+   directory where the toolchain was installed (`echo $N64_INST`).
+6. Run `./build.sh` at the top-level. This will install libdragon, its tools,
+   and also build all examples.
 
-*Below steps can also be executed by running `build.sh` at the top level.*
-
-5. Install libdragon by typing `make install` at the top level.
-6. Install the tools by typing `make tools-install` at the top level.
-7. Install libmikmod for the examples using it. See `build.sh` at the top level for details.
-8. Compile the examples by typing `make examples` at the top level.
-
-You are now ready to run the examples on your N64.
+You are now ready to run the examples on your N64 or emulator.
 
 ## Getting started: how to run a ROM
 

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Set N64_INST before calling the script to change the default installation directory path
-INSTALL_PATH="${N64_INST:-/usr/local}"
+INSTALL_PATH="${N64_INST}"
 # Set PATH for newlib to compile using GCC for MIPS N64 (pass 1)
 export PATH="$PATH:$INSTALL_PATH/bin"
 


### PR DESCRIPTION
The instructions did not mention the N64_INST environment variable which
is mandatory for the build system. Moreover, the build-toolchain.sh
was still allowing to be run without it, giving it a default PATH, even
though the build system doesn't know of this default.

Change build-toolchain.sh to make N64_INST mandatory to run, and then
update the README accordingly. Since we are at it, improve also the
instructions by being more detailed.