### PR TITLE
Explicitly set C++ version in cpptest example

### DIFF
--- a/examples/cpptest/Makefile
+++ b/examples/cpptest/Makefile
@@ -2,6 +2,8 @@ BUILD_DIR=build
 SOURCE_DIR=.
 include $(N64_INST)/include/n64.mk
 
+N64_CXXFLAGS += -std=c++14
+
 all: cpptest.z64
 
 OBJS = $(BUILD_DIR)/*.o

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -1,8 +1,7 @@
-#include <stdio.h>
-#include <malloc.h>
-#include <string.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdint>
 #include <libdragon.h>
+#include <memory>
 
 class TestClass
 {
@@ -25,7 +24,7 @@ TestClass globalClass;
 
 int main(void)
 {
-    TestClass* localClass = new TestClass();
+    auto localClass = std::make_unique<TestClass>();
 
     console_init();
     console_set_render_mode(RENDER_MANUAL);
@@ -38,5 +37,4 @@ int main(void)
         console_render();
     }
 
-    delete localClass;
 }

--- a/n64.mk
+++ b/n64.mk
@@ -52,7 +52,7 @@ CFLAGS+=-MMD     # automatic .d dependency generationc
 CXXFLAGS+=-MMD     # automatic .d dependency generationc
 ASFLAGS+=-MMD    # automatic .d dependency generation
 
-N64_CXXFLAGS := $(N64_CFLAGS) -std=c++11
+N64_CXXFLAGS := $(N64_CFLAGS)
 N64_CFLAGS += -std=gnu99
 
 # Change all the dependency chain of z64 ROMs to use the N64 toolchain.


### PR DESCRIPTION
Also modernize cpptest code a bit to use smart pointers and make_unique in order to showcase modern C++ support.