### PR TITLE
Build Docker images for linux/arm64 as well

### DIFF
--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -51,6 +51,9 @@ jobs:
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
+      - name: Set up QEMU
+        if: ${{ steps.path_diff.outputs.changed == 1 }}
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Build
         if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v1
@@ -75,12 +78,13 @@ jobs:
 
       - name: Build and push image
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           # Only push image if this is a push event. Otherwise it will fail because
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
@@ -93,10 +97,11 @@ jobs:
       # cached, it should not take long to build.
       - name: Load image for libdragon build
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           # Do not push the image yet, we also want to make sure libdragon builds
           # with the fresh image.
+          platforms: linux/amd64,linux/arm64
           push: false
           load: true
           tags: ghcr.io/${{ steps.vars.outputs.repository_name }}:latest
@@ -127,8 +132,9 @@ jobs:
       # build with this freshly built image.
       - name: Push latest image
         if: ${{ steps.path_diff.outputs.changed == 1 && github.ref == steps.vars.outputs.default_ref }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ steps.vars.outputs.repository_name }}:latest
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV N64_INST=${N64_INST}
 
 # install dependencies
 RUN apt-get update
-RUN apt-get install -yq wget bzip2 gcc g++ make file libmpfr-dev libmpc-dev zlib1g-dev texinfo git gcc-multilib
+RUN apt-get install -yq wget bzip2 gcc g++ make file libmpfr-dev libmpc-dev zlib1g-dev texinfo git
 
 # Build
 COPY ./tools/build-toolchain.sh /tmp/tools/build-toolchain.sh


### PR DESCRIPTION
While Macbooks with M1 can run linux/amd64 images, it is unbearably
slow. Building and publishing a linux/arm64 image provides a much
better experience.