### PR TITLE
interrupt: add support for CART interrupts

### DIFF
--- a/include/cop0.h
+++ b/include/cop0.h
@@ -251,8 +251,8 @@
 #define C0_CAUSE_EXC_CODE   0x0000007C      ///< Cause: exception code
 
 /* COP0 interrupt bits definition. These are compatible bothwith mask and pending bits. */
-#define C0_INTERRUPT_0      0x00000100      ///< Status/Cause: HW interrupt 0
-#define C0_INTERRUPT_1      0x00000200      ///< Status/Cause: HW interrupt 1
+#define C0_INTERRUPT_0      0x00000100      ///< Status/Cause: SW interrupt 0
+#define C0_INTERRUPT_1      0x00000200      ///< Status/Cause: SW interrupt 1
 #define C0_INTERRUPT_2      0x00000400      ///< Status/Cause: HW interrupt 2 (RCP)
 #define C0_INTERRUPT_3      0x00000800      ///< Status/Cause: HW interrupt 3
 #define C0_INTERRUPT_4      0x00001000      ///< Status/Cause: HW interrupt 4 (PRENMI)
@@ -261,6 +261,7 @@
 #define C0_INTERRUPT_7      0x00008000      ///< Status/Cause: HW interrupt 7 (Timer)
 
 #define C0_INTERRUPT_RCP    C0_INTERRUPT_2  ///< Status/Cause: HW interrupt 2 (RCP)
+#define C0_INTERRUPT_CART   C0_INTERRUPT_3  ///< Status/Cause: HW interrupt 3 (CART)
 #define C0_INTERRUPT_PRENMI C0_INTERRUPT_4  ///< Status/Cause: HW interrupt 4 (PRENMI)
 #define C0_INTERRUPT_TIMER  C0_INTERRUPT_7  ///< Status/Cause: HW interrupt 7 (Timer)
 

--- a/include/interrupt.h
+++ b/include/interrupt.h
@@ -34,17 +34,19 @@ void register_AI_handler( void (*callback)() );
 void register_VI_handler( void (*callback)() );
 void register_PI_handler( void (*callback)() );
 void register_DP_handler( void (*callback)() );
-void register_TI_handler( void (*callback)() );
 void register_SI_handler( void (*callback)() );
 void register_SP_handler( void (*callback)() );
+void register_TI_handler( void (*callback)() );
+void register_CART_handler( void (*callback)() );
 
 void unregister_AI_handler( void (*callback)() );
 void unregister_VI_handler( void (*callback)() );
 void unregister_PI_handler( void (*callback)() );
 void unregister_DP_handler( void (*callback)() );
-void unregister_TI_handler( void (*callback)() );
 void unregister_SI_handler( void (*callback)() );
 void unregister_SP_handler( void (*callback)() );
+void unregister_TI_handler( void (*callback)() );
+void unregister_CART_handler( void (*callback)() );
 
 void set_AI_interrupt( int active );
 void set_VI_interrupt( int active, unsigned long line );
@@ -52,6 +54,8 @@ void set_PI_interrupt( int active );
 void set_DP_interrupt( int active );
 void set_SI_interrupt( int active );
 void set_SP_interrupt( int active );
+void set_TI_interrupt( int active );
+void set_CART_interrupt( int active );
 
 static inline __attribute__((deprecated("calling init_interrupts no longer required")))
 void init_interrupts() {}

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -152,12 +152,16 @@ struct callback_link * VI_callback = 0;
 struct callback_link * PI_callback = 0;
 /** @brief Linked list of DP callbacks */
 struct callback_link * DP_callback = 0;
-/** @brief Linked list of TI callbacks */
-struct callback_link * TI_callback = 0;
 /** @brief Linked list of SI callbacks */
 struct callback_link * SI_callback = 0;
 /** @brief Linked list of SP callbacks */
 struct callback_link * SP_callback = 0;
+/** @brief Linked list of TI callbacks */
+struct callback_link * TI_callback = 0;
+/** @brief Linked list of CART callbacks */
+struct callback_link * CART_callback = 0;
+
+static int last_cart_interrupt_count = 0;
 
 /** 
  * @brief Call each callback in a linked list of callbacks
@@ -314,9 +318,30 @@ void __MI_handler(void)
  */
 void __TI_handler(void)
 {
-	/* timer int cleared in int handler */
+	/* NOTE: the timer interrupt is already acknowledged in inthandler.S */
     __call_callback(TI_callback);
 }
+
+/**
+ * @brief Handle a CART interrupt
+ */
+void __CART_handler(void)
+{
+    /* Call the registered callbacks */
+    __call_callback(CART_callback);
+
+    #ifndef NDEBUG
+     /* CART interrupts must be acknowledged by handlers. If the handler fails
+       to do so, the console freezes because the interrupt will retrigger
+       continuously. Since a freeze is always bad for debugging, try to 
+       detect it, and show a proper assertion screen. */
+    if (!(C0_CAUSE() & C0_INTERRUPT_CART))
+        last_cart_interrupt_count = 0;
+    else
+        assertf(++last_cart_interrupt_count < 128, "CART interrupt deadlock: a CART interrupt is continuously triggering, with no ack");
+    #endif
+}
+
 
 /**
  * @brief Register an AI callback
@@ -407,28 +432,6 @@ void unregister_DP_handler( void (*callback)() )
 }
 
 /**
- * @brief Register a TI callback
- *
- * @param[in] callback
- *            Function to call when a TI interrupt occurs
- */
-void register_TI_handler( void (*callback)() )
-{
-    __register_callback(&TI_callback,callback);
-}
-
-/**
- * @brief Unegister a TI callback
- *
- * @param[in] callback
- *            Function that should no longer be called on TI interrupts
- */
-void unregister_TI_handler( void (*callback)() )
-{
-    __unregister_callback(&TI_callback,callback);
-}
-
-/**
  * @brief Register a SI callback
  *
  * @param[in] callback
@@ -472,11 +475,84 @@ void unregister_SP_handler( void (*callback)() )
     __unregister_callback(&SP_callback,callback);
 }
 
+
+/**
+ * @brief Register a timer callback
+ * 
+ * The callback will be used when the timer interrupt is triggered by the CPU.
+ * This happens when the COP0 COUNT register reaches the same value of the
+ * COP0 COMPARE register.
+ * 
+ * This function is useful only if you want to do your own low level programming
+ * of the internal CPU timer and handle the interrupt yourself. In this case,
+ * also remember to activate the timer interrupt using #set_TI_interrupt.
+ * 
+ * @note If you use the timer library (#timer_init and #new_timer), you do not
+ * need to call this function, as timer interrupt are already handled by the timer
+ * library.
+ *
+ * @param[in] callback
+ *            Function to call when a timer interrupt occurs
+ */
+void register_TI_handler( void (*callback)() )
+{
+    __register_callback(&TI_callback,callback);
+}
+
+/**
+ * @brief Unregister a timer callback
+ *
+ * @note If you use the timer library (#timer_init and #new_timer), you do not
+ * need to call this function, as timer interrupt are already handled by the timer
+ * library.
+ *
+ * @param[in] callback
+ *            Function that should no longer be called on timer interrupts
+ */
+void unregister_TI_handler( void (*callback)() )
+{
+    __unregister_callback(&TI_callback,callback);
+}
+
+/**
+ * @brief Register a CART interrupt callback.
+ * 
+ * The callback will be called when a CART interrupt is triggered. CART interrupts
+ * are interrupts triggered by devices attached to the PI bus (aka CART bus),
+ * for instance the 64DD, or the modem cassette.
+ * 
+ * CART interrupts are disabled by default in libdragon. Use #set_CART_interrupt
+ * to enable/disable them.
+ * 
+ * Notice that there is no generic way to acknowledge those interrupts, so if
+ * you activate CART interrupts, make also sure to register an handler that
+ * acknowledge them, otherwise the interrupt will deadlock the console.
+ * 
+ * @param[in] callback
+ *            Function that should no longer be called on CART interrupts
+ */
+void register_CART_handler( void (*callback)() )
+{
+    __register_callback(&CART_callback,callback);
+}
+
+/**
+ * @brief Unregister a CART interrupt callback
+ *
+ * @param[in] callback
+ *            Function that should no longer be called on CART interrupts
+ */
+void unregister_CART_handler( void (*callback)() )
+{
+    __unregister_callback(&CART_callback,callback);
+}
+
+
 /**
  * @brief Enable or disable the AI interrupt
  *
  * @param[in] active
- *            Flag to specify whether the AI interupt should be active
+ *            Flag to specify whether the AI interrupt should be active
  */
 void set_AI_interrupt(int active)
 {
@@ -494,7 +570,7 @@ void set_AI_interrupt(int active)
  * @brief Enable or disable the VI interrupt
  *
  * @param[in] active
- *            Flag to specify whether the VI interupt should be active
+ *            Flag to specify whether the VI interrupt should be active
  * @param[in] line
  *            The vertical line that causes this interrupt to fire.  Ignored
  *            when setting the interrupt inactive
@@ -516,7 +592,7 @@ void set_VI_interrupt(int active, unsigned long line)
  * @brief Enable or disable the PI interrupt
  *
  * @param[in] active
- *            Flag to specify whether the PI interupt should be active
+ *            Flag to specify whether the PI interrupt should be active
  */
 void set_PI_interrupt(int active)
 {
@@ -534,7 +610,7 @@ void set_PI_interrupt(int active)
  * @brief Enable or disable the DP interrupt
  *
  * @param[in] active
- *            Flag to specify whether the DP interupt should be active
+ *            Flag to specify whether the DP interrupt should be active
  */
 void set_DP_interrupt(int active)
 {
@@ -552,7 +628,7 @@ void set_DP_interrupt(int active)
  * @brief Enable or disable the SI interrupt
  *
  * @param[in] active
- *            Flag to specify whether the SI interupt should be active
+ *            Flag to specify whether the SI interrupt should be active
  */
 void set_SI_interrupt(int active)
 {
@@ -570,7 +646,7 @@ void set_SI_interrupt(int active)
  * @brief Enable or disable the SP interrupt
  *
  * @param[in] active
- *            Flag to specify whether the SP interupt should be active
+ *            Flag to specify whether the SP interrupt should be active
  */
 void set_SP_interrupt(int active)
 {
@@ -583,6 +659,51 @@ void set_SP_interrupt(int active)
         MI_regs->mask=MI_MASK_CLR_SP;
     }
 }
+
+/**
+ * @brief Enable the timer interrupt
+ * 
+ * @note If you use the timer library (#timer_init and #new_timer), you do not
+ * need to call this function, as timer interrupt is already handled by the timer
+ * library.
+ *
+ * @param[in] active
+ *            Flag to specify whether the timer interrupt should be active
+ *
+ * @see #register_TI_handler
+ */
+void set_TI_interrupt(int active)
+{
+    if( active )
+    {
+        C0_WRITE_STATUS(C0_STATUS() | C0_INTERRUPT_TIMER);
+    }
+    else
+    {
+        C0_WRITE_STATUS(C0_STATUS() & ~C0_INTERRUPT_TIMER);
+    }
+}
+
+/**
+ * @brief Enable the CART interrupt
+ * 
+ * @param[in] active
+ *            Flag to specify whether the CART interrupt should be active
+ * 
+ * @see #register_CART_handler
+ */
+void set_CART_interrupt(int active)
+{
+    if( active )
+    {
+        C0_WRITE_STATUS(C0_STATUS() | C0_INTERRUPT_CART);
+    }
+    else
+    {
+        C0_WRITE_STATUS(C0_STATUS() & ~C0_INTERRUPT_CART);
+    }
+}
+
 
 /**
  * @brief Initialize the interrupt controller

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -196,15 +196,26 @@ notprenmi:
 	mfc0 t0,C0_COMPARE
 	mtc0 t0,C0_COMPARE
 
-	/* handle timer exception */
+	/* handle timer interrupt */
 	jal __TI_handler
 	nop
 
 	j end_interrupt
 	nop
 notcount:
+	and t0, cause, 0x800
+	beqz t0, notcart
+	nop
 
-	/* pass anything else along to handler */
+	/* handle CART interrupt */
+	jal __CART_handler
+	nop
+
+	j end_interrupt
+	nop
+
+notcart:
+	/* pass anything else along to MI (RCP) handler */
 	jal __MI_handler
 	addiu a0, sp, 32
 	j end_interrupt

--- a/src/timer.c
+++ b/src/timer.c
@@ -231,7 +231,7 @@ void timer_init(void)
 	ticks64_high = 0;
 	C0_WRITE_COUNT(1);
 	C0_WRITE_COMPARE(0);
-	C0_WRITE_STATUS(C0_STATUS() | C0_INTERRUPT_TIMER);
+	set_TI_interrupt(1);
 	register_TI_handler(timer_interrupt_callback);
 	enable_interrupts();
 }
@@ -490,8 +490,7 @@ void timer_close(void)
 	disable_interrupts();
 	
 	/* Disable generation of timer interrupt. */
-	C0_WRITE_STATUS(C0_STATUS() & ~C0_INTERRUPT_TIMER);
-
+	set_TI_interrupt(0);
 	unregister_TI_handler(timer_interrupt_callback);
 
 	timer_link_t *head = TI_timers;


### PR DESCRIPTION
This PR allows to enable the CART interrupt and connect handlers to it. This is used by 64DD but in general peripherals on the cartridge bus can trigger it.