### PR TITLE
Include the workflow name in the concurrency group

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -10,7 +10,7 @@ on:
 # It is ok to have parallel runs for push and PR events and from different branches.
 # We can cancel previous runs for non-trunk events.
 concurrency:
-  group: ${{ github.ref }}${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -10,7 +10,7 @@ on:
 # this. It is ok to have parallel runs for push and PR events and from different
 # branches. We can cancel previous runs for non-trunk events.
 concurrency:
-  group: ${{ github.ref }}${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:


### PR DESCRIPTION
Otherwise different workflows can occasionally cancel each other.