### PR TITLE
build.sh: fix error with missing environment variables on Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,10 +13,13 @@ fi
 if [[ $OSTYPE == 'darwin'* ]]; then
   if command -v brew >/dev/null; then
     brew install libpng
-    CFLAGS="-I$(brew --prefix)/include"; export CFLAGS
-    LDFLAGS="-L$(brew --prefix)/lib"; export LDFLAGS
+    CFLAGS="-I$(brew --prefix)/include"
+    LDFLAGS="-L$(brew --prefix)/lib"
   fi
 fi
+
+CFLAGS=${CFLAGS:-}; export CFLAGS
+LDFLAGS=${LDFLAGS:-}; export LDFLAGS
 
 makeWithParams(){
   make -j"${JOBS}" "$@" || \


### PR DESCRIPTION
Introduced with the Mac refactoring. Looks like it was broken on Linux when `CFLAGS` is undefined because it is mentioned by the sudo line.