### PR TITLE
Add infrastructure to handle reset button process

### DIFF
--- a/include/exception.h
+++ b/include/exception.h
@@ -105,6 +105,21 @@ typedef struct
     volatile reg_block_t* regs;
 } exception_t;
 
+
+/** 
+ * @brief Guaranteed length of the reset time.
+ * 
+ * This is the guaranteed length of the reset time, that is the time
+ * that goes between the user pressing the reset button, and the CPU actually
+ * resetting. See #exception_reset_time for more details.
+ * 
+ * @note The general knowledge about this is that the reset time should be
+ *       500 ms. Testing on different consoles show that, while most seem to
+ *       reset after 500 ms, a few EU models reset after 200ms. So we define
+ *       the timer shorter for greater compatibility.
+ */
+#define RESET_TIME_LENGTH      TICKS_FROM_MS(200)
+
 /** @} */
 
 #ifdef __cplusplus
@@ -113,6 +128,9 @@ extern "C" {
 
 void register_exception_handler( void (*cb)(exception_t *) );
 void exception_default_handler( exception_t* ex );
+
+void register_reset_handler( void (*cb)(void) );
+uint32_t exception_reset_time( void );
 
 #ifdef __cplusplus
 }

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -143,6 +143,9 @@ extern int __bbplayer;
  */
 #define TICKS_DISTANCE(from, to) ((int32_t)((uint32_t)(to) - (uint32_t)(from)))
 
+/** @brief Return how much time has passed since the instant t0. */
+#define TICKS_SINCE(t0)          TICKS_DISTANCE(t0, TICKS_READ())
+
 /**
  * @brief Returns true if "t1" is before "t2".
  *

--- a/src/exception.c
+++ b/src/exception.c
@@ -6,7 +6,8 @@
 #include "exception.h"
 #include "console.h"
 #include "n64sys.h"
-
+#include "debug.h"
+#include "regsinternal.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -26,10 +27,17 @@
  * @{
  */
 
+/** @brief Maximum number of reset handlers that can be registered. */
+#define MAX_RESET_HANDLERS 4
+
 /** @brief Unhandled exception handler currently registered with exception system */
 static void (*__exception_handler)(exception_t*) = exception_default_handler;
 /** @brief Base register offset as defined by the interrupt controller */
 extern volatile reg_block_t __baseRegAddr;
+/** @brief Pre-NMI exception handlers */
+static void (*__prenmi_handlers[MAX_RESET_HANDLERS])(void);
+/** @brief Tick at which the pre-NMI was triggered */
+static uint32_t __prenmi_tick;
 
 /**
  * @brief Register an exception handler to handle exceptions
@@ -281,16 +289,104 @@ void __onCriticalException(volatile reg_block_t* regs)
 }
 
 /**
- * @brief Respond to a reset exception
+ * @brief Register a handler that will be called when the user
+ *        presses the RESET button. 
+ * 
+ * The N64 sends an interrupt when the RESET button is pressed,
+ * and then actually resets the console after about ~500ms (but less
+ * on some models, see #RESET_TIME_LENGTH).
+ * 
+ * Registering a handler can be used to perform a clean reset.
+ * Technically, at the hardware level, it is important that the RCP
+ * is completely idle when the reset happens, or it might freeze
+ * and require a power-cycle to unfreeze. This means that any
+ * I/O, audio, video activity must cease before #RESET_TIME_LENGTH
+ * has elapsed.
+ * 
+ * This entry point can be used by the game code to basically
+ * halts itself and stops issuing commands. Libdragon itself will
+ * register handlers to halt internal modules so to provide a basic
+ * good reset experience.
+ * 
+ * Handlers can use #exception_reset_time to read how much has passed
+ * since the RESET button was pressed.
+ * 
+ * @param cb    Callback to invoke when the reset button is pressed.
+ * 
+ * @note  Reset handlers are called under interrupt.
+ * 
  */
-void __onResetException(volatile reg_block_t* regs)
+void register_reset_handler( void (*cb)(void) )
 {
-	exception_t e;
-	
-	if(!__exception_handler) { return; }
-
-	__fetch_regs(&e, EXCEPTION_TYPE_RESET, regs);
-	__exception_handler(&e);
+	for (int i=0;i<MAX_RESET_HANDLERS;i++)
+	{		
+		if (!__prenmi_handlers[i])
+		{
+			__prenmi_handlers[i] = cb;
+			return;
+		}
+	}
+	assertf(0, "Too many pre-NMI handlers\n");
 }
+
+/** 
+ * @brief Check whether the RESET button was pressed and how long we are into
+ *        the reset process.
+ * 
+ * This function returns how many ticks have elapsed since the user has pressed
+ * the RESET button, or 0 if the user has not pressed it.
+ * 
+ * It can be used by user code to perform actions during the RESET
+ * process (see #register_reset_handler). It is also possible to simply
+ * poll this value to check at any time if the button has been pressed or not.
+ * 
+ * The reset process takes about 500ms between the user pressing the
+ * RESET button and the CPU being actually reset, though on some consoles
+ * it seems to be much less. See #RESET_TIME_LENGTH for more information.
+ * For the broadest compatibility, please use #RESET_TIME_LENGTH to implement
+ * the reset logic.
+ * 
+ * Notice also that the reset process is initiated when the user presses the
+ * button, but the reset will not happen until the user releases the button.
+ * So keeping the button pressed is a good way to check if the application
+ * actually winds down correctly.
+ * 
+ * @return Ticks elapsed since RESET button was pressed, or 0 if the RESET button
+ *         was not pressed.
+ * 
+ * @see register_reset_handler
+ * @see #RESET_TIME_LENGTH
+ */
+uint32_t exception_reset_time( void )
+{
+	if (!__prenmi_tick) return 0;
+	return TICKS_SINCE(__prenmi_tick);
+}
+
+
+/**
+ * @brief Respond to a reset exception.
+ * 
+ * Calls the handlers registered by #register_reset_handler.
+ */
+void __onResetException( volatile reg_block_t* regs )
+{
+	/* This function will be called many times becuase there is no way
+	   to acknowledge the pre-NMI interrupt. So make sure it does nothing
+	   after the first call. */
+	if (__prenmi_tick) return;
+
+	/* Store the tick at which we saw the exception. Make sure
+	 * we never store 0 as we use that for "no reset happened". */
+	__prenmi_tick = TICKS_READ() | 1;
+
+	/* Call the registered handlers. */
+	for (int i=0;i<MAX_RESET_HANDLERS;i++)
+	{
+		if (__prenmi_handlers[i])
+			__prenmi_handlers[i]();
+	}
+}
+
 
 /** @} */

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -722,7 +722,7 @@ __attribute__((constructor)) void __init_interrupts()
         /* Enable interrupts systemwide. We set the global interrupt enable,
            and then specifically enable RCP interrupts. */
         uint32_t sr = C0_STATUS();
-        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_INTERRUPT_RCP);
+        C0_WRITE_STATUS(sr | C0_STATUS_IE | C0_INTERRUPT_RCP | C0_INTERRUPT_PRENMI);
     }
 }
 

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -177,9 +177,18 @@ interrupt:
 	nop
 
 	/* handle reset */
-	addiu a0, sp, 32
 	jal __onResetException
-	nop
+	addiu a0, sp, 32
+
+	# There is no way to ack the pre-NMI interrupt, so it will
+	# stay pending in CR. Let's disable it in SR to avoid
+	# looping here. If another unrelated interrupt triggers, 
+	# CR will still have 0x1000 set, but __onResetException will
+	# do nothing after the first call.
+	li t0, ~0x1000
+	lw t1, STACK_SR(sp)
+	and t1, t0
+	sw t1, STACK_SR(sp)
 
 	# Reload cause register and test for other interrupts
 	lw cause, STACK_CR(sp)

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -190,7 +190,7 @@ interrupt:
 	and t1, t0
 	sw t1, STACK_SR(sp)
 
-	# Reload cause register and test for other interrupts
+	# Reload cause register (might be reused by C code) and test for other interrupts
 	lw cause, STACK_CR(sp)
 notprenmi:
 
@@ -208,7 +208,7 @@ notprenmi:
 	jal __TI_handler
 	nop
 
-	# Reload cause register and test for other interrupts
+	# Reload cause register (might be reused by C code) and test for other interrupts
 	lw cause, STACK_CR(sp)
 
 notcount:
@@ -220,7 +220,7 @@ notcount:
 	jal __CART_handler
 	nop
 
-	# Reload cause register and test for other interrupts
+	# Reload cause register (might be reused by C code) and test for other interrupts
 	lw cause, STACK_CR(sp)
 
 notcart:

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -181,9 +181,8 @@ interrupt:
 	jal __onResetException
 	nop
 
-	j end_interrupt
-	nop
-
+	# Reload cause register and test for other interrupts
+	lw cause, STACK_CR(sp)
 notprenmi:
 
 	/* check for count=compare */
@@ -200,8 +199,9 @@ notprenmi:
 	jal __TI_handler
 	nop
 
-	j end_interrupt
-	nop
+	# Reload cause register and test for other interrupts
+	lw cause, STACK_CR(sp)
+
 notcount:
 	and t0, cause, 0x800
 	beqz t0, notcart
@@ -211,15 +211,16 @@ notcount:
 	jal __CART_handler
 	nop
 
-	j end_interrupt
-	nop
+	# Reload cause register and test for other interrupts
+	lw cause, STACK_CR(sp)
 
 notcart:
 	/* pass anything else along to MI (RCP) handler */
 	jal __MI_handler
 	addiu a0, sp, 32
-	j end_interrupt
-	nop
+
+	# No more interrupts to process, we can exit
+	# (fallthrough)
 
 end_interrupt:
 	mfc0 t0, C0_SR

--- a/tests/test_exception.c
+++ b/tests/test_exception.c
@@ -316,7 +316,7 @@ void test_exception(TestContext *ctx) {
     ASSERT_EQUAL_HEX(exception_regs.epc, (uint32_t)&test_break_label, "EPC not available to the handler");
 
     // If the other tests change SR these may fail unnecessarily, but we expect tests to do proper cleanup
-    ASSERT_EQUAL_HEX(exception_regs.sr, 0x241004E3, "SR not available to the handler");
+    ASSERT_EQUAL_HEX(exception_regs.sr, 0x241014E3, "SR not available to the handler");
     ASSERT_EQUAL_HEX(exception_regs.cr, 0x24, "CR not available to the handler");
     ASSERT_EQUAL_HEX(exception_regs.fc31, 0x0, "FCR31 not available to the handler");
 }


### PR DESCRIPTION
Currently, libdragon just shows a crash screen as soon as the reset button is pressed.

This PR implements a general infrastructure to handle reset button handling:

  * Ability to register a handler when the reset is triggered (register_reset_handler)
  * Ability to just poll for the reset button (exception_reset_time)

Moreover, it hooks this up in the audio system as follows:

 * audio.c: avoid scheduling new buffers if they'd be truncated by the reset signal
 * mixer.c: perform a fadeout during reset
