### PR TITLE
Hard-code concurrency groups

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -10,8 +10,7 @@ on:
 # It is ok to have parallel runs for push and PR events and from different branches.
 # We can cancel previous runs for non-trunk events.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  group: build-documentation-${{ github.ref }}-${{ github.event_name }}
 
 jobs:
   Build-Documentation:

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -10,8 +10,7 @@ on:
 # this. It is ok to have parallel runs for push and PR events and from different
 # branches. We can cancel previous runs for non-trunk events.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  group: build-toolchain-library-and-roms-${{ github.ref }}-${{ github.event_name }}
 
 jobs:
   Build-Toolchain-Library-And-Examples:


### PR DESCRIPTION
They seem to be always based on the root worflow name. Also remove the cancel-in-progress flag as it does not seem to work.