### PR TITLE
Add HEAP_START_ADDR to n64sys.h

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -106,6 +106,14 @@ extern int __bbplayer;
     (((unsigned long)(_addrp))&~0xE0000000); \
 })
 
+/** @brief Symbol at the end of code, data, and sdata (set by the linker) */
+extern char __rom_end[];
+
+/**
+ * @brief Void pointer to the start of heap memory
+ */
+#define HEAP_START_ADDR ((void*)__rom_end)
+
 /**
  * @brief Memory barrier to ensure in-order execution
  *

--- a/n64.ld
+++ b/n64.ld
@@ -154,5 +154,8 @@ SECTIONS {
     } > mem
 
     . = ALIGN(8);
+    __rom_end = .;
+
+    /* Deprecated */
     end = .;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -987,10 +987,6 @@ int readlink( const char *path, char *buf, size_t bufsize )
     return -1;
 }
 
-/** @brief Symbol at the end of code, data, and sdata (set by the linker) */
-// Do not allow this in small data or it will seem larger than it actually is
-extern char end __attribute__((section (".data")));
-
 /**
  * @brief Return a new chunk of memory to be used as heap
  *
@@ -1009,7 +1005,7 @@ void *sbrk( int incr )
 
     if( heap_end == 0 )
     {
-        heap_end = &end;
+        heap_end = (char*)HEAP_START_ADDR;
         heap_top = (char*)KSEG0_START_ADDR + get_memory_size() - STACK_SIZE;
     }
 


### PR DESCRIPTION
Up until now the linker script defined the symbol `end` after the end of all .data and .bss sections which was used by sbrk to get the address to the start of heap memory. This PR gives the symbol a more appropriate name (while keeping the old one around for backwards compatibility) and makes its value available through a public macro in n64sys.h. Additionally, the symbol no longer uses an attribute to keep it from being added to small data. Instead, it is simply declared with an incomplete type. Credit to @depp for suggesting this change.