### PR TITLE
rspq: disable INTR_BREAK without race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,15 @@ clean:
 	rm -f *.o *.a
 	rm -rf $(CURDIR)/build
 
-clobber: clean doxygen-clean examples-clean tools-clean
+test:
+	$(MAKE) -C tests
 
-.PHONY : clobber clean doxygen-clean doxygen doxygen-api examples examples-clean tools tools-clean tools-install
+test-clean:
+	$(MAKE) -C tests clean
+
+clobber: clean doxygen-clean examples-clean tools-clean test-clean
+
+.PHONY : clobber clean doxygen-clean doxygen doxygen-api examples examples-clean tools tools-clean tools-install test test-clean
 
 # Automatic dependency tracking
 -include $(wildcard $(BUILD_DIR)/*.d) $(wildcard $(BUILD_DIR)/*/*.d)

--- a/build.sh
+++ b/build.sh
@@ -56,4 +56,4 @@ rm -Rf $LIBMIKMOD_DIR
 # installed version rather than using local artifacts.
 makeWithParams clobber
 makeWithParams examples
-makeWithParams -C ./tests
+makeWithParams test

--- a/include/rsp.h
+++ b/include/rsp.h
@@ -375,7 +375,11 @@ void rsp_run(void);
  * This function starts running the RSP in background. Use rsp_wait() to
  * synchronize later.
  */
-void rsp_run_async(void);
+inline void rsp_run_async(void)
+{
+    extern void __rsp_run_async(uint32_t status_flags);
+    __rsp_run_async(SP_WSTATUS_SET_INTR_BREAK);
+}
 
 /** 
  * @brief Wait until RSP has finished processing. 

--- a/src/rsp.c
+++ b/src/rsp.c
@@ -142,12 +142,13 @@ void rsp_read_data(void* start, unsigned long size, unsigned int dmem_offset)
     enable_interrupts();
 }
 
-void rsp_run_async(void)
+/** @brief Internal implementation of #rsp_run_async */
+void __rsp_run_async(uint32_t status_flags)
 {
     // set RSP program counter
     *SP_PC = cur_ucode ? cur_ucode->start_pc : 0;
     MEMORY_BARRIER();
-    *SP_STATUS = SP_WSTATUS_CLEAR_HALT | SP_WSTATUS_CLEAR_BROKE | SP_WSTATUS_SET_INTR_BREAK;
+    *SP_STATUS = SP_WSTATUS_CLEAR_HALT | SP_WSTATUS_CLEAR_BROKE | status_flags;
 }
 
 void rsp_wait(void)
@@ -399,3 +400,5 @@ void __rsp_crash(const char *file, int line, const char *func, const char *msg, 
     abort();
 }
 /// @endcond
+
+extern inline void rsp_run_async(void);

--- a/src/rspq/rspq.c
+++ b/src/rspq/rspq.c
@@ -639,12 +639,9 @@ static void rspq_start(void)
     MEMORY_BARRIER();
 
     // Off we go!
-    rsp_run_async();
-
-    // Disable INTR_ON_BREAK as that it is not useful in the RSPQ engine, and
-    // might even cause excessive interrupts.
-    // It was turned on by rsp_run_async.
-    *SP_STATUS = SP_WSTATUS_CLEAR_INTR_BREAK;
+    // Do not turn on INTR_BREAK as we don't need it.
+    extern void __rsp_run_async(uint32_t status_flags);
+    __rsp_run_async(0);
 }
 
 /** @brief Initialize a rspq_ctx_t structure */


### PR DESCRIPTION
Currently, rspq starts the RSP via rsp_run_async which sets INTR_BREAK (and we can't change that), and then disable INTR_BREAK one split second later.

This can cause race conditions, especially on emulators, given that the RSP will actually hit the break just a few opcodes later, and if an interrupt is generated, it hits an assert because it is unexpected.

Fix it by avoiding the race window and disabling INTR_BREAK at start. We do that with an internal API for now.