### PR TITLE
Add surface_t and use it in graphics.c and rdp.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o \
 			 $(BUILD_DIR)/inthandler.o $(BUILD_DIR)/entrypoint.o \
 			 $(BUILD_DIR)/debug.o $(BUILD_DIR)/usb.o $(BUILD_DIR)/fatfs/ff.o \
 			 $(BUILD_DIR)/fatfs/ffunicode.o $(BUILD_DIR)/dragonfs.o \
-			 $(BUILD_DIR)/audio.o $(BUILD_DIR)/display.o \
+			 $(BUILD_DIR)/audio.o $(BUILD_DIR)/display.o $(BUILD_DIR)/surface.o \
 			 $(BUILD_DIR)/console.o $(BUILD_DIR)/joybus.o \
 			 $(BUILD_DIR)/controller.o $(BUILD_DIR)/rtc.o \
 			 $(BUILD_DIR)/eeprom.o $(BUILD_DIR)/eepromfs.o $(BUILD_DIR)/mempak.o \
@@ -80,6 +80,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/dma.h $(INSTALLDIR)/mips64-elf/include/dma.h
 	install -Cv -m 0644 include/dragonfs.h $(INSTALLDIR)/mips64-elf/include/dragonfs.h
 	install -Cv -m 0644 include/audio.h $(INSTALLDIR)/mips64-elf/include/audio.h
+	install -Cv -m 0644 include/surface.h $(INSTALLDIR)/mips64-elf/include/surface.h
 	install -Cv -m 0644 include/display.h $(INSTALLDIR)/mips64-elf/include/display.h
 	install -Cv -m 0644 include/debug.h $(INSTALLDIR)/mips64-elf/include/debug.h
 	install -Cv -m 0644 include/usb.h $(INSTALLDIR)/mips64-elf/include/usb.h

--- a/examples/spritemap/spritemap.c
+++ b/examples/spritemap/spritemap.c
@@ -89,7 +89,7 @@ int main(void)
                 rdp_enable_texture_copy();
 
                 /* Attach RDP to display */
-                rdp_attach_display( disp );
+                rdp_attach( disp );
                     
                 /* Ensure the RDP is ready to receive sprites */
                 rdp_sync( SYNC_PIPE );
@@ -133,7 +133,7 @@ int main(void)
                 rdp_draw_sprite( 0, 50, 100, MIRROR_DISABLED );
 
                 /* Inform the RDP we are finished drawing and that any pending operations should be flushed */
-                rdp_detach_display();
+                rdp_detach();
 
                 break;
             }

--- a/include/display.h
+++ b/include/display.h
@@ -8,6 +8,32 @@
 
 #include <stdint.h>
 
+/**
+ * @defgroup display Display Subsystem
+ * @ingroup libdragon
+ * @brief Video interface system for configuring video output modes and displaying rendered
+ *        graphics.
+ *
+ * The display subsystem handles interfacing with the video interface (VI)
+ * and the hardware rasterizer (RDP) to allow software and hardware graphics
+ * operations.  It consists of the @ref display, the @ref graphics and the
+ * @ref rdp modules.  A separate module, the @ref console, provides a rudimentary
+ * console for developers.  Only the display subsystem or the console can be
+ * used at the same time.  However, commands to draw console text to the display
+ * subsystem are available.
+ *
+ * The display subsystem module is responsible for initializing the proper video
+ * mode for displaying 2D, 3D and software graphics.  To set up video on the N64,
+ * code should call #display_init with the appropriate options.  Once the display
+ * has been set, a surface can be requested from the display subsystem using
+ * #display_lock.  To draw to the acquired surface, code should use functions
+ * present in the @ref graphics and the @ref rdp modules.  Once drawing to a surface
+ * is complete, the rendered graphic can be displayed to the screen using 
+ * #display_show.  Once code has finished rendering all graphics, #display_close can 
+ * be used to shut down the display subsystem.
+ *
+ */
+
 ///@cond
 struct surface_s;
 typedef struct surface_s surface_t;
@@ -81,14 +107,85 @@ typedef surface_t* display_context_t;
 extern "C" {
 #endif
 
+/**
+ * @brief Initialize the display to a particular resolution and bit depth
+ *
+ * Initialize video system.  This sets up a double, triple, or multiple
+ * buffered drawing surface which can be blitted or rendered to using
+ * software or hardware.
+ *
+ * @param[in] res
+ *            The requested resolution
+ * @param[in] bit
+ *            The requested bit depth
+ * @param[in] num_buffers
+ *            Number of buffers, usually 2 or 3, but can be more.
+ * @param[in] gamma
+ *            The requested gamma setting
+ * @param[in] aa
+ *            The requested anti-aliasing setting
+ */
 void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, antialias_t aa );
-surface_t* display_lock(void);
-void display_show(surface_t* surf);
+
+/**
+ * @brief Close the display
+ *
+ * Close a display and free buffer memory associated with it.
+ */
 void display_close();
 
+/**
+ * @brief Lock a display buffer for rendering
+ *
+ * Grab a surface that is safe for drawing.  If none is available
+ * then this will return 0, without blocking. 
+ * 
+ * When you are done drawing on the buffer, use #display_show to unlock
+ * the surface and schedule the buffer to be displayed on the screen during
+ * next vblank.
+ * 
+ * It is possible to lock more than a display buffer at the same time, for
+ * instance to begin working on a new frame while the previous one is still
+ * being rendered in parallel through RDP. It is important to notice that
+ * surfaces will always be shown on the screen in locking order,
+ * irrespective of the order #display_show is called.
+ *
+ * @return A valid surface to render to or NULL if none is available.
+ */
+surface_t* display_lock(void);
+
+/**
+ * @brief Display a previously locked buffer
+ *
+ * Display a previously-locked surface to the screen on the next vblank. The
+ * surface should be locked via #display_lock.
+ * 
+ * This function does not accept any arbitrary surface, but only those returned
+ * by #display_lock.
+ * 
+ * @param[in] surf
+ *            A surface to show (previously retrieved using #display_lock)
+ */
+void display_show(surface_t* surf);
+
+/**
+ * @brief Get the currently configured width of the display in pixels
+ */
 uint32_t display_get_width(void);
+
+/**
+ * @brief Get the currently configured height of the display in pixels
+ */
 uint32_t display_get_height(void);
+
+/**
+ * @brief Get the currently configured bitdepth of the display (in bytes per pixels)
+ */
 uint32_t display_get_bitdepth(void);
+
+/**
+ * @brief Get the currently configured number of buffers
+ */
 uint32_t display_get_num_buffers(void);
 
 #ifdef __cplusplus

--- a/include/display.h
+++ b/include/display.h
@@ -8,6 +8,11 @@
 
 #include <stdint.h>
 
+///@cond
+struct surface_s;
+typedef struct surface_s surface_t;
+///@endcond
+
 /**
  * @addtogroup display
  * @{
@@ -65,17 +70,26 @@ typedef enum
     ANTIALIAS_RESAMPLE_FETCH_ALWAYS
 } antialias_t;
 
-/** @brief Display context */
-typedef int display_context_t;
+/** 
+ * @brief Display context (DEPRECATED: Use #surface_t instead)
+ * 
+ * @see #surface_t
+ */
+typedef surface_t* display_context_t;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, antialias_t aa );
-display_context_t display_lock();
-void display_show(display_context_t disp);
+surface_t* display_lock(void);
+void display_show(surface_t* surf);
 void display_close();
+
+uint32_t display_get_width(void);
+uint32_t display_get_height(void);
+uint32_t display_get_bitdepth(void);
+uint32_t display_get_num_buffers(void);
 
 #ifdef __cplusplus
 }

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -59,22 +59,22 @@ extern "C" {
 
 uint32_t graphics_make_color( int r, int g, int b, int a );
 uint32_t graphics_convert_color( color_t color );
-void graphics_draw_pixel( display_context_t disp, int x, int y, uint32_t c );
-void graphics_draw_pixel_trans( display_context_t disp, int x, int y, uint32_t c );
-void graphics_draw_line( display_context_t disp, int x0, int y0, int x1, int y1, uint32_t c );
-void graphics_draw_line_trans( display_context_t disp, int x0, int y0, int x1, int y1, uint32_t c );
-void graphics_draw_box( display_context_t disp, int x, int y, int width, int height, uint32_t color );
-void graphics_draw_box_trans( display_context_t disp, int x, int y, int width, int height, uint32_t color );
-void graphics_fill_screen( display_context_t disp, uint32_t c );
+void graphics_draw_pixel( surface_t* surf, int x, int y, uint32_t c );
+void graphics_draw_pixel_trans( surface_t* surf, int x, int y, uint32_t c );
+void graphics_draw_line( surface_t* surf, int x0, int y0, int x1, int y1, uint32_t c );
+void graphics_draw_line_trans( surface_t* surf, int x0, int y0, int x1, int y1, uint32_t c );
+void graphics_draw_box( surface_t* surf, int x, int y, int width, int height, uint32_t color );
+void graphics_draw_box_trans( surface_t* surf, int x, int y, int width, int height, uint32_t color );
+void graphics_fill_screen( surface_t* surf, uint32_t c );
 void graphics_set_color( uint32_t forecolor, uint32_t backcolor );
 void graphics_set_default_font( void );
 void graphics_set_font_sprite( sprite_t *font );
-void graphics_draw_character( display_context_t disp, int x, int y, char c );
-void graphics_draw_text( display_context_t disp, int x, int y, const char * const msg );
-void graphics_draw_sprite( display_context_t disp, int x, int y, sprite_t *sprite );
-void graphics_draw_sprite_stride( display_context_t disp, int x, int y, sprite_t *sprite, int offset );
-void graphics_draw_sprite_trans( display_context_t disp, int x, int y, sprite_t *sprite );
-void graphics_draw_sprite_trans_stride( display_context_t disp, int x, int y, sprite_t *sprite, int offset );
+void graphics_draw_character( surface_t* surf, int x, int y, char c );
+void graphics_draw_text( surface_t* surf, int x, int y, const char * const msg );
+void graphics_draw_sprite( surface_t* surf, int x, int y, sprite_t *sprite );
+void graphics_draw_sprite_stride( surface_t* surf, int x, int y, sprite_t *sprite, int offset );
+void graphics_draw_sprite_trans( surface_t* surf, int x, int y, sprite_t *sprite );
+void graphics_draw_sprite_trans_stride( surface_t* surf, int x, int y, sprite_t *sprite, int offset );
 
 #ifdef __cplusplus
 }

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -14,7 +14,7 @@
  */
 
 /** @brief Generic color structure */
-typedef struct
+typedef struct __attribute__((packed))
 {
     /** @brief Red component */
     uint8_t r;
@@ -25,6 +25,38 @@ typedef struct
     /** @brief Alpha component */
     uint8_t a;
 } color_t;
+
+_Static_assert(sizeof(color_t) == 4, "invalid sizeof for color_t");
+
+/** @brief Create a #color_t from the R,G,B,A components in the RGBA16 range (that is: RGB in 0-31, A in 0-1) */
+#define RGBA16(rx,gx,bx,ax) ({ \
+    int rx1 = rx, gx1 = gx, bx1 = bx; \
+    (color_t){.r=(rx1<<3)|(rx1>>3), .g=(gx1<<3)|(gx1>>3), .b=(bx1<<3)|(bx1>>3), .a=ax ? 0xFF : 0}; \
+})
+
+/** @brief Create a #color_t from the R,G,B,A components in the RGBA32 range (0-255). */
+#define RGBA32(rx,gx,bx,ax) ({ \
+    (color_t){.r=rx, .g=gx, .b=bx, .a=ax}; \
+})
+
+/** @brief Convert a #color_t to the 16-bit packed format used by a #FMT_RGBA16 surface (RGBA 5551) */
+inline uint16_t color_to_packed16(color_t c) {
+    return (((int)c.r >> 3) << 11) | (((int)c.g >> 3) << 6) | (((int)c.b >> 3) << 1) | (c.a >> 7);
+}
+
+/** @brief Convert a #color_t to the 32-bit packed format used by a #FMT_RGBA32 surface (RGBA 8888) */
+inline uint32_t color_to_packed32(color_t c) {
+    return *(uint32_t*)&c;
+}
+/** @brief Create a #color_t from the 16-bit packed format used by a #FMT_RGBA16 surface (RGBA 5551) */
+inline color_t color_from_packed16(uint16_t c) {
+    return (color_t){ .r=((c>>11)&0x1F)<<3, .g=((c>>6)&0x1F)<<3, .b=((c>>1)&0x1F)<<3, .a=(c&0x1) ? 0xFF : 0 };
+}
+
+/** @brief Create a #color_t from the 32-bit packed format used by a #FMT_RGBA32 surface (RGBA 8888) */
+inline color_t color_from_packed32(uint32_t c) {
+    return (color_t){ .r=(c>>24)&0xFF, .g=(c>>16)&0xFF, .b=(c>>8)&0xFF, .a=c&0xFF };
+}
 
 /** @brief Sprite structure */
 typedef struct

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -52,5 +52,6 @@
 #include "xm64.h"
 #include "ym64.h"
 #include "rspq.h"
+#include "surface.h"
 
 #endif

--- a/include/rdp.h
+++ b/include/rdp.h
@@ -62,8 +62,8 @@ extern "C" {
 #endif
 
 void rdp_init( void );
-void rdp_attach_display( display_context_t disp );
-void rdp_detach_display( void );
+void rdp_attach( surface_t* disp );
+void rdp_detach( void );
 void rdp_sync( sync_t sync );
 void rdp_set_clipping( uint32_t tx, uint32_t ty, uint32_t bx, uint32_t by );
 void rdp_set_default_clipping( void );
@@ -82,6 +82,18 @@ void rdp_draw_filled_rectangle( int tx, int ty, int bx, int by );
 void rdp_draw_filled_triangle( float x1, float y1, float x2, float y2, float x3, float y3 );
 void rdp_set_texture_flush( flush_t flush );
 void rdp_close( void );
+
+__attribute__((deprecated("use rdp_attach instead")))
+static inline void rdp_attach_display( display_context_t disp )
+{
+    rdp_attach(disp);
+}
+
+__attribute__((deprecated("use rdp_detach instead")))
+static inline void rdp_detach_display( void )
+{
+    rdp_detach();
+}
 
 #ifdef __cplusplus
 }

--- a/include/surface.h
+++ b/include/surface.h
@@ -1,0 +1,260 @@
+/**
+ * @file surface.h
+ * @brief Surface buffers used to draw images
+ * @ingroup graphics
+ * 
+ * This module implements a structure #surface_t which holds the basic
+ * information for a buffer of memory to be used for graphics rendering.
+ * 
+ * A surface is described by the following properties:
+ * 
+ *  * Size (width, height)
+ *  * Pixel format
+ *  * Stride (distance in bytes between rows)
+ * 
+ * #surface_t simply represents an aggregation of these properties.
+ * 
+ * To allocate a new surface, use #surface_alloc. Then later, you can release
+ * the memory using #surface_free.
+ * 
+ * @code{.c}
+ *      // Allocate a 64x64 buffer in RGBA 16-bit format
+ *      surface_t buf = surface_alloc(FMT_RGBA16, 64, 64);
+ *  
+ *      // Draw some text on it (with the CPU)
+ *      graphics_draw_text(&buf, 0, 0, "ABC");
+ * @endcode
+ *
+ * Sometimes, you might have an existing raw pointer to a buffer and need to pass it
+ * to an API that accepts a #surface_t. For those cases, you can use
+ * #surface_make to create a #surface_t instance, that you can throw away
+ * after you called the function; #surface_free does nothing on these surfaces.
+ * 
+ * In some cases, you might want to interact with a rectangular portion of
+ * an existing surface (for instance, you want to draw with RDP only in the
+ * top portion of the screen for some reason). To do so, you can use
+ * #surface_make_sub to create a #surface_t instance that is referring only to
+ * a portion of the original surface:
+ * 
+ * @code{.c}
+ *      surface_t *fb;
+ *      while (fb = display_lock()) ;  // wait for a framebuffer to be ready
+ *      
+ *      // Attach the RDP to the top 40 rows of the framebuffer
+ *      surface_t fbtop = surface_make_sub(fb, 0, 0, 320, 40);
+ *      rdp_attach(&fbtop);
+ * @endcode
+ * 
+ * Surfaces created by #surface_make_sub don't need to be freed as they
+ * are just references to the parent surface; #surface_free does nothing
+ * on them.
+ */
+
+#ifndef __LIBDRAGON_SURFACE_H
+#define __LIBDRAGON_SURFACE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @cond
+// Macro to create a texture format, combining the RDP native "fmt/size" tuple.
+// This macro is used to genearte the #tex_format_t enums creating identifiers
+// which are easy to convert back into RDP native fields.
+#define _RDP_FORMAT_CODE(rdp_fmt, rdp_size)        (((rdp_fmt)<<2)|(rdp_size))
+/// @endcond
+
+/** @brief Extract the depth (number of bits per pixel) from a #tex_format_t. (eg: `FMT_RGBA16` => 16) 
+ * 
+ * Note that there are texture format that are 4bpp, so don't divide this by 8 to get the number of bytes
+ * per pixels, but rather use #TEX_FORMAT_BYTES2PIX and #TEX_FORMAT_PIX2BYTES. */
+#define TEX_FORMAT_BITDEPTH(fmt)             (4 << ((fmt) & 0x3))
+/** @brief Convert the specified number of pixels to bytes. 
+ * 
+ * @note This macro rounds up the value. For 4bpp surfaces, this means that it returns
+ *       the safe number of bytes that can hold the specified number of pixels.
+ *       For instance, `TEX_FORMAT_PIX2BYTES(FMT_CI4, 3)` returns 2, as you need 2 bytes
+ *       to store 3 pixels in 4bpp format (even though the last byte is only half used).
+ */
+#define TEX_FORMAT_PIX2BYTES(fmt, pixels)    ((((pixels) << (((fmt) & 3) + 2)) + 7) >> 3)
+/** @brief Convert the specified number of bytes to pixels.
+  * 
+  * @note This macro rounds down the value. For instance, for a 32-bpp surface,
+  *       calling `TEX_FORMAT_BYTES2PIX(FMT_RGBA32, 5)` returns 1, because you can safely
+  *       store at maximum 1 32bpp pixel in 5 bytes.
+  */
+#define TEX_FORMAT_BYTES2PIX(fmt, bytes)     (((bytes) << 1) >> ((fmt) & 3))
+
+/**
+ * @brief Pixel format enum
+ * 
+ * This enum defines the pixel formats that can be used for #surface_t buffers.
+ * The list corresponds to the pixel formats that the RDP can use as textures.
+ * 
+ * Notice that only some of those can be used by RDP as framebuffer (specifically,
+ * #FMT_RGBA16, #FMT_RGBA32 and #FMT_CI8). Moreover, the CPU-based graphics library
+ * graphics.h only accepts surfaces in either #FMT_RGBA16 or #FMT_RGBA32 as target buffers.
+ */
+typedef enum {
+    FMT_NONE   = 0,                        ///< Placeholder for no format defined
+
+    FMT_RGBA16 = _RDP_FORMAT_CODE(0, 2),   ///< Format RGBA 5551 (16-bit)
+    FMT_RGBA32 = _RDP_FORMAT_CODE(0, 3),   ///< Format RGBA 8888 (32-bit)
+    FMT_YUV16  = _RDP_FORMAT_CODE(1, 2),   ///< Format YUV2 4:2:2 (data interleaved as YUYV)
+    FMT_CI4    = _RDP_FORMAT_CODE(2, 0),   ///< Format CI4: color index 4-bit (paletted, 2 indices per byte)
+    FMT_CI8    = _RDP_FORMAT_CODE(2, 1),   ///< Format CI8: color index 8-bit (paletted, 1 index per byte)
+    FMT_IA4    = _RDP_FORMAT_CODE(3, 0),   ///< Format IA4: 3-bit intensity + 1-bit alpha (4-bit per pixel)
+    FMT_IA8    = _RDP_FORMAT_CODE(3, 1),   ///< Format IA8: 4-bit intensity + 4-bit alpha (8-bit per pixel)
+    FMT_IA16   = _RDP_FORMAT_CODE(3, 2),   ///< Format IA16: 8-bit intensity + 8-bit alpha (16-bit per pixel)
+    FMT_I4     = _RDP_FORMAT_CODE(4, 0),   ///< Format I4: 4-bit intensity (4-bit per pixel)
+    FMT_I8     = _RDP_FORMAT_CODE(4, 1),   ///< Format I8: 8-bit intensity (8-bit per pixel)
+} tex_format_t;
+
+/** @brief Return the name of the texture format as a string (for debugging purposes) */
+const char* tex_format_name(tex_format_t fmt);
+
+#define SURFACE_FLAGS_TEXFORMAT    0x1F   ///< Pixel format of the surface
+#define SURFACE_FLAGS_OWNEDBUFFER  0x20   ///< Set if the buffer must be freed
+
+/**
+ * @brief A surface buffer for graphics
+ * 
+ * This structure holds the basic information about a buffer used to hold graphics.
+ * It is commonly used by graphics routines in libdragon as either a source (eg: texture)
+ * or a target (eg: framebuffer). It can be used for both CPU-based drawing
+ * (such as graphics.h) or RDP-basic drawing (such as rdp.h and rdpq.h).
+ * 
+ * Use #surface_alloc / #surface_free to allocate / free a surface. If you already have
+ * a memory pointer to a graphics buffer and you just need to wrap it in a #surface_t,
+ * use #surface_make.
+ */
+typedef struct surface_s
+{
+    uint16_t flags;       ///< Flags (including pixel format)
+    uint16_t width;       ///< Width in pixels
+    uint16_t height;      ///< Height in pixels
+    uint16_t stride;      ///< Stride in bytes (length of a row)
+    void *buffer;         ///< Buffer pointer
+} surface_t;
+
+/**
+ * @brief Initialize a surface_t structure with the provided buffer.
+ * 
+ * This functions initializes a surface_t structure with the provided buffer and information.
+ * It is just a helper to fill the structure fields.
+ * 
+ * It is not necessary to call #surface_free on surfaces created by #surface_make as there
+ * is nothing to free: the provided buffer will not be owned by the structure, so it is up
+ * to the caller to handle its lifetime.
+ * 
+ * If you plan to use this format as RDP framebuffer, make sure that the provided buffer
+ * respects the required alignment of 64 bytes, otherwise #rdp_attach will fail.
+ * 
+ * @param[in] buffer    Pointer to the memory buffer
+ * @param[in] format    Pixel format
+ * @param[in] width     Width in pixels
+ * @param[in] height    Height in pixels
+ * @param[in] stride    Stride in bytes (length of a row)
+ * @return              The initialized surface
+ * 
+ * @see #surface_make_linear
+ */
+inline surface_t surface_make(void *buffer, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride) {
+    return (surface_t){
+        .flags = format,
+        .width = width,
+        .height = height,
+        .stride = stride,
+        .buffer = buffer,
+    };
+}
+
+/**
+ * @brief Initialize a surface_t structure with the provided linear buffer.
+ *
+ * This function is similar to #surface_make, but it works for images that
+ * are linearly mapped with no per-line padding or extraneous data.
+ * 
+ * Compared to #surface_make, it does not accept a stride parameter, and
+ * calculate the stride from the width and the pixel format.
+ * 
+ * @param[in] buffer    Pointer to the memory buffer
+ * @param[in] format    Pixel format
+ * @param[in] width     Width in pixels
+ * @param[in] height    Height in pixels
+ * @return              The initialized surface
+ * 
+ * @see #surface_make
+ */
+inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint32_t width, uint32_t height) {
+    return surface_make(buffer, format, width, height, TEX_FORMAT_PIX2BYTES(format, width));
+}
+
+/**
+ * @brief Allocate a new surface in memory
+ * 
+ * This function allocates a new surface with the specified pixel format,
+ * width and height. The surface must be freed via #surface_free when it is
+ * not needed anymore.
+ * 
+ * A surface allocated via #surface_alloc can be used as a RDP frame buffer
+ * (passed to #rdp_attach) because it is guaranteed to have the required
+ * alignment of 64 bytes, provided it is using one of the formats supported by
+ * RDP as a framebuffer target (`FMT_RGBA32`, `FMT_RGBA16` or `FMT_I8`).
+ *
+ * @param[in]  format   Pixel format of the surface
+ * @param[in]  width    Width in pixels
+ * @param[in]  height   Height in pixels
+ * @return              The initialized surface
+ */
+surface_t surface_alloc(tex_format_t format, uint32_t width, uint32_t height);
+
+/**
+ * @brief Initialize a surface_t structure, pointing to a rectangular portion of another
+ *        surface.
+ * 
+ * The surface returned by this function will point to a portion of the buffer of
+ * the parent surface, and will have of course the same pixel format.
+ * 
+ * @param[in]  parent   Parent surface that will be pointed to
+ * @param[in]  x0       X coordinate of the top-left corner within the parent surface
+ * @param[in]  y0       Y coordinate of the top-left corner within the parent surface
+ * @param[in]  width    Width of the surface that will be returned
+ * @param[in]  height   Height of the surface that will be returned
+ * @return              The initialized surface
+ */
+surface_t surface_make_sub(surface_t *parent, 
+    uint32_t x0, uint32_t y0, uint32_t width, uint32_t height);
+
+/**
+ * @brief Free the buffer allocated in a surface.
+ * 
+ * This function should be called after a surface allocated via #surface_alloc is not
+ * needed anymore. 
+ * 
+ * Calling this function on surfaces allocated via #surface_make or #surface_make_sub
+ * (that is, surfaces initialized with an existing buffer pointer) has no effect but
+ * clearing the contents of the surface structure.
+ * 
+ * @param[in]  surface   The surface to free
+ */
+void surface_free(surface_t *surface);
+
+/**
+ * @brief Returns the pixel format of a surface
+ * 
+ * @param[in] surface   Surface
+ * @return              The pixel format of the provided surface
+ */
+inline tex_format_t surface_get_format(const surface_t *surface)
+{
+    return (tex_format_t)(surface->flags & SURFACE_FLAGS_TEXFORMAT);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/display.c
+++ b/src/display.c
@@ -14,33 +14,6 @@
 #include "debug.h"
 #include "surface.h"
 
-/**
- * @defgroup display Display Subsystem
- * @ingroup libdragon
- * @brief Video interface system for configuring video output modes and displaying rendered
- *        graphics.
- *
- * The display subsystem handles interfacing with the video interface (VI)
- * and the hardware rasterizer (RDP) to allow software and hardware graphics
- * operations.  It consists of the @ref display, the @ref graphics and the
- * @ref rdp modules.  A separate module, the @ref console, provides a rudimentary
- * console for developers.  Only the display subsystem or the console can be
- * used at the same time.  However, commands to draw console text to the display
- * subsystem are available.
- *
- * The display subsystem module is responsible for initializing the proper video
- * mode for displaying 2D, 3D and softward graphics.  To set up video on the N64,
- * code should call #display_init with the appropriate options.  Once the display
- * has been set, a surface can be requested from the display subsystem using
- * #display_lock.  To draw to the acquired surface, code should use functions
- * present in the @ref graphics and the @ref rdp modules.  Once drawing to a surface
- * is complete, the rendered graphic can be displayed to the screen using 
- * #display_show.  Once code has finished rendering all graphics, #display_close can 
- * be used to shut down the display subsystem.
- *
- * @{
- */
-
 /** @brief Maximum number of video backbuffers */
 #define NUM_BUFFERS         32
 
@@ -255,24 +228,6 @@ static void __display_callback()
     __write_dram_register(__safe_buffer[now_showing] + (!field ? __width * __bitdepth : 0));
 }
 
-/**
- * @brief Initialize the display to a particular resolution and bit depth
- *
- * Initialize video system.  This sets up a double, triple, or multiple
- * buffered drawing surface which can be blitted or rendered to using
- * software or hardware.
- *
- * @param[in] res
- *            The requested resolution
- * @param[in] bit
- *            The requested bit depth
- * @param[in] num_buffers
- *            Number of buffers, usually 2 or 3, but can be more.
- * @param[in] gamma
- *            The requested gamma setting
- * @param[in] aa
- *            The requested anti-aliasing setting
- */
 void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, antialias_t aa )
 {
     uint32_t registers[REGISTER_COUNT];
@@ -460,11 +415,6 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     set_VI_interrupt( 1, 0x2 );
 }
 
-/**
- * @brief Close the display
- *
- * Close a display and free buffer memory associated with it.
- */
 void display_close()
 {
     /* Can't have the video interrupt happening here */
@@ -495,24 +445,6 @@ void display_close()
     enable_interrupts();
 }
 
-/**
- * @brief Lock a display buffer for rendering
- *
- * Grab a surface that is safe for drawing.  If none is available
- * then this will return 0, without blocking. 
- * 
- * When you are done drawing on the buffer, use #display_show to unlock
- * the surface and schedule the buffer to be displayed on the screen during
- * next vblank.
- * 
- * It is possible to lock more than a display buffer at the same time, for
- * instance to begin working on a new frame while the previous one is still
- * being rendered in parallel through RDP. It is important to notice that
- * surfaces will always be shown on the screen in locking order,
- * irrespective of the order #display_show is called.
- *
- * @return A valid surface to render to or NULL if none is available.
- */
 surface_t* display_lock(void)
 {
     surface_t* retval = NULL;
@@ -538,18 +470,6 @@ surface_t* display_lock(void)
     return retval;
 }
 
-/**
- * @brief Display a previously locked buffer
- *
- * Display a previously-locked surface to the screen on the next vblank. The
- * surface should be locked via #display_lock.
- * 
- * This function does not accept any arbitrary surface, but only those returned
- * by #display_lock.
- * 
- * @param[in] surf
- *            A surface to show (previously retrieved using #display_lock)
- */
 void display_show( surface_t* surf )
 {
     /* They tried drawing on a bad context */
@@ -596,36 +516,22 @@ void display_show_force( display_context_t disp )
     enable_interrupts();
 }
 
-/**
- * @brief Get the currently configured width of the display in pixels
- */
 uint32_t display_get_width()
 {
     return __width;
 }
 
-/**
- * @brief Get the currently configured height of the display in pixels
- */
 uint32_t display_get_height()
 {
     return __height;
 }
 
-/**
- * @brief Get the currently configured bitdepth of the display (in bytes per pixels)
- */
 uint32_t display_get_bitdepth()
 {
     return __bitdepth;
 }
 
-/**
- * @brief Get the currently configured number of buffers
- */
 uint32_t display_get_num_buffers()
 {
     return __buffers;
 }
-
-/** @} */ /* display */

--- a/src/display.c
+++ b/src/display.c
@@ -42,7 +42,7 @@
  */
 
 /** @brief Maximum number of video backbuffers */
-#define NUM_BUFFERS         3
+#define NUM_BUFFERS         32
 
 /** @brief Register location in memory of VI */
 #define REGISTER_BASE       0xA4400000
@@ -177,15 +177,20 @@ static uint32_t __height;
 static uint32_t __buffers = NUM_BUFFERS;
 /** @brief Pointer to uncached 16-bit aligned version of buffers */
 static void *__safe_buffer[NUM_BUFFERS];
-
 /** @brief Currently displayed buffer */
 static int now_showing = -1;
+/** @brief Bitmask of surfaces that are currently being drawn */
+static uint32_t drawing_mask = 0;
+/** @brief Bitmask of surfaces that are ready to be shown */
+static volatile uint32_t ready_mask = 0;
 
-/** @brief Complete drawn buffer to display next */
-static int show_next = -1;
-
-/** @brief Buffer currently being drawn on */
-static int now_drawing = -1;
+/** @brief Get the next buffer index (with wraparound) */
+static inline int buffer_next(int idx) {
+    idx += 1;
+    if (idx == __buffers)
+        idx = 0;
+    return idx;
+}
 
 /**
  * @brief Write a set of video registers to the VI
@@ -239,12 +244,12 @@ static void __display_callback()
        if the currently displayed field is odd or even. */
     bool field = reg_base[4] & 1;
 
-    /* Only swap frames if we have a new frame to swap, otherwise just
+    /* Check if the next buffer is ready to be displayed, otherwise just
        leave up the current frame */
-    if(show_next >= 0 && show_next != now_drawing)
-    {
-        now_showing = show_next;
-        show_next = -1;
+    int next = buffer_next(now_showing);
+    if (ready_mask & (1 << next)) {
+        now_showing = next;
+        ready_mask &= ~(1 << next);
     }
 
     __write_dram_register(__safe_buffer[now_showing] + (!field ? __width * __bitdepth : 0));
@@ -253,15 +258,16 @@ static void __display_callback()
 /**
  * @brief Initialize the display to a particular resolution and bit depth
  *
- * Initialize video system.  This sets up a double or triple buffered drawing surface which can
- * be blitted or rendered to using software or hardware.
+ * Initialize video system.  This sets up a double, triple, or multiple
+ * buffered drawing surface which can be blitted or rendered to using
+ * software or hardware.
  *
  * @param[in] res
  *            The requested resolution
  * @param[in] bit
  *            The requested bit depth
  * @param[in] num_buffers
- *            Number of buffers (2 or 3)
+ *            Number of buffers, usually 2 or 3, but can be more.
  * @param[in] gamma
  *            The requested gamma setting
  * @param[in] aa
@@ -276,15 +282,8 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     /* Can't have the video interrupt happening here */
     disable_interrupts();
 
-    /* Ensure that buffering is either double or twiple */
-    if( num_buffers != 2 && num_buffers != 3 )
-    {
-        __buffers = NUM_BUFFERS;
-    }
-    else
-    {
-        __buffers = num_buffers;
-    }
+    /* Minimum is two buffers. */
+    __buffers = MAX(2, MIN(NUM_BUFFERS, num_buffers));
 
 	switch( res )
 	{
@@ -446,8 +445,8 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
 
     /* Set the first buffer as the displaying buffer */
     now_showing = 0;
-    now_drawing = -1;
-    show_next = -1;
+    drawing_mask = 0;
+    ready_mask = 0;
 
     /* Show our screen normally */
     registers[1] = (uintptr_t) __safe_buffer[0];
@@ -475,8 +474,8 @@ void display_close()
     unregister_VI_handler( __display_callback );
 
     now_showing = -1;
-    now_drawing = -1;
-    show_next = -1;
+    drawing_mask = 0;
+    ready_mask = 0;
 
     __width = 0;
     __height = 0;
@@ -492,6 +491,7 @@ void display_close()
 
     free(surfaces);
     surfaces = NULL;
+
     enable_interrupts();
 }
 
@@ -499,26 +499,35 @@ void display_close()
  * @brief Lock a display buffer for rendering
  *
  * Grab a surface that is safe for drawing.  If none is available
- * then this will return 0.  Do not check out more than one surface
- * at a time.
+ * then this will return 0, without blocking. 
+ * 
+ * When you are done drawing on the buffer, use #display_show to unlock
+ * the surface and schedule the buffer to be displayed on the screen during
+ * next vblank.
+ * 
+ * It is possible to lock more than a display buffer at the same time, for
+ * instance to begin working on a new frame while the previous one is still
+ * being rendered in parallel through RDP. It is important to notice that
+ * surfaces will always be shown on the screen in locking order,
+ * irrespective of the order #display_show is called.
  *
  * @return A valid surface to render to or NULL if none is available.
  */
 surface_t* display_lock(void)
 {
-    surface_t* retval = 0;
+    surface_t* retval = NULL;
+    int next;
 
     /* Can't have the video interrupt happening here */
     disable_interrupts();
 
-    for( int i = 0; i < __buffers; i++ )
-    {
-        if( i != now_showing && i != now_drawing && i != show_next )
-        {
-            /* This screen should be returned */
-            now_drawing = i;
-            retval = &surfaces[i];
-
+    /* Calculate index of next display context to draw on. We need
+       to find the first buffer which is not being drawn upon nor
+       being ready to be displayed. */
+    for (next = buffer_next(now_showing); next != now_showing; next = buffer_next(next)) {
+        if (((drawing_mask | ready_mask) & (1 << next)) == 0)  {
+            retval = &surfaces[next];
+            drawing_mask |= 1 << next;
             break;
         }
     }
@@ -552,12 +561,16 @@ void display_show( surface_t* surf )
     /* Correct to ensure we are handling the right screen */
     int i = surf - surfaces;
 
-    /* This should match, or something went awry */
-    assertf( i == now_drawing, "display_show invoked on non-locked display" );
+    assertf(i >= 0 && i < __buffers, "Display context is not valid!");
 
-    /* Ensure we display this next time */
-    now_drawing = -1;
-    show_next = i;
+    /* Check we have not unlocked this display already and is pending drawn. */
+    assertf(!(ready_mask & (1 << i)), "display_show called again on the same display %d (mask: %lx)", i, ready_mask);
+
+    /* This should match, or something went awry */
+    assertf(drawing_mask & (1 << i), "display_show called on non-locked display %d (mask: %lx)", i, drawing_mask);
+
+    drawing_mask &= ~(1 << i);
+    ready_mask |= 1 << i;
 
     enable_interrupts();
 }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -111,12 +111,10 @@ static uint32_t f_color = 0xFFFFFFFF;
 static uint32_t b_color = 0x00000000;
 
 /**
- * @brief Return a 32-bit representation of an RGBA color
+ * @brief Return a packed 32-bit representation of an RGBA color
  *
- * @note In 16 bpp mode, this function will return a packed 16-bit color
- * in BOTH the lower 16 bits and the upper 16 bits.  For software color assignment,
- * this doesn't matter.  However, for drawing solid shapes using the RDP, this is
- * required.
+ * This is exactly the same as calling `graphics_convert_color(RGBA32(r,g,b,a))`.
+ * Refer to #graphics_convert_color for more information.
  *
  * @param[in] r
  *            8-bit red value
@@ -128,6 +126,9 @@ static uint32_t b_color = 0x00000000;
  *            8-bit alpha value.  Note that 255 is opaque and 0 is transparent
  *
  * @return a 32-bit representation of the color suitable for blitting in software or hardware
+ * 
+ * @see #graphics_convert_color
+ * 
  */
 uint32_t graphics_make_color( int r, int g, int b, int a )
 {
@@ -143,7 +144,17 @@ uint32_t graphics_make_color( int r, int g, int b, int a )
 
 /**
  * @brief Convert a color structure to a 32-bit representation of an RGBA color
+ * 
+ * This function is similar to #color_to_packed16 and #color_to_packed32, but
+ * automatically picks the version matching with the current display configuration.
+ * Notice that this might be wrong if you are drawing to an arbitrary surface rather
+ * than a framebuffer.
  *
+ * @note In 16 bpp mode, this function will return a packed 16-bit color
+ * in BOTH the lower 16 bits and the upper 16 bits. In general, this is not necessary.
+ * However, for drawing with the old deprecated RDP API (in particular,
+ * rdp_set_primitive_color), this is still required.
+ * 
  * @param[in] color
  *            A color structure representing an RGBA color
  * 
@@ -153,19 +164,13 @@ uint32_t graphics_convert_color( color_t color )
 {
     if( display_get_bitdepth() == 2 )
     {
-        // 8 to 5 bit;
-        int r = color.r >> 3;
-        int g = color.g >> 3;
-        int b = color.b >> 3;
-
-        // Pack twice for compatibility with RDP packed colors
-        uint32_t conv = ((r & 0x1F) << 11) | ((g & 0x1F) << 6) | ((b & 0x1F) << 1) | (color.a >> 7);
-
+        // Pack twice for compatibility with RDP packed colors and the old deprecated RDP API.
+        uint32_t conv = color_to_packed16(color);
         return conv | (conv << 16);
     }
     else
     {
-        return (color.r << 24) | (color.g << 16) | (color.b << 8) | (color.a);
+        return color_to_packed32(color);
     }
 }
 
@@ -1175,5 +1180,10 @@ void graphics_draw_sprite_trans_stride( surface_t* disp, int x, int y, sprite_t 
         }
     }
 }
+
+extern inline uint16_t color_to_packed16(color_t c);
+extern inline uint32_t color_to_packed32(color_t c);
+extern inline color_t color_from_packed16(uint16_t c);
+extern inline color_t color_from_packed32(uint32_t c);
 
 /** @} */ /* graphics */

--- a/src/surface.c
+++ b/src/surface.c
@@ -1,0 +1,63 @@
+#include "surface.h"
+#include "n64sys.h"
+#include "debug.h"
+#include <assert.h>
+#include <string.h>
+
+const char* tex_format_name(tex_format_t fmt)
+{
+    switch (fmt) {
+    case FMT_NONE:   return "FMT_NONE";
+    case FMT_RGBA16: return "FMT_RGBA16";
+    case FMT_YUV16:  return "FMT_YUV16";
+    case FMT_CI4:    return "FMT_CI4";
+    case FMT_CI8:    return "FMT_CI8";
+    case FMT_IA4:    return "FMT_IA4";
+    case FMT_IA8:    return "FMT_IA8";
+    case FMT_IA16:   return "FMT_IA16";
+    case FMT_I4:     return "FMT_I4";
+    case FMT_I8:     return "FMT_I8";
+    default:         return "FMT_???";
+    }
+}
+
+surface_t surface_alloc(tex_format_t format, uint32_t width, uint32_t height)
+{
+    return (surface_t){ 
+        .flags = format | SURFACE_FLAGS_OWNEDBUFFER,
+        .width = width,
+        .height = height,
+        .stride = TEX_FORMAT_PIX2BYTES(format, width),
+        .buffer = malloc_uncached_aligned(64, height * TEX_FORMAT_PIX2BYTES(format, width)),
+    };
+}
+
+void surface_free(surface_t *surface)
+{
+    if (surface->buffer && surface->flags & SURFACE_FLAGS_OWNEDBUFFER) {
+        free_uncached(surface->buffer);
+        surface->buffer = NULL;
+    }
+    memset(surface, 0, sizeof(surface_t));
+}
+
+surface_t surface_make_sub(surface_t *parent, uint32_t x0, uint32_t y0, uint32_t width, uint32_t height)
+{
+    assert(x0 + width <= parent->width);
+    assert(y0 + height <= parent->height);
+
+    tex_format_t fmt = surface_get_format(parent);
+    assertf(TEX_FORMAT_BITDEPTH(fmt) != 4 || (x0 & 1) == 0,
+        "cannot create a subsurface with an odd X offset (%ld) in a 4bpp surface", x0);
+
+    surface_t sub;
+    sub.buffer = parent->buffer + y0 * parent->stride + TEX_FORMAT_PIX2BYTES(fmt, x0);
+    sub.width = width;
+    sub.height = height;
+    sub.stride = parent->stride;
+    sub.flags = parent->flags & ~SURFACE_FLAGS_OWNEDBUFFER;
+    return sub;
+}
+
+extern inline surface_t surface_make(void *buffer, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride);
+extern inline tex_format_t surface_get_format(const surface_t *surface);

--- a/src/surface.c
+++ b/src/surface.c
@@ -1,3 +1,9 @@
+/**
+ * @file surface.c
+ * @brief Surface buffers used to draw images
+ * @ingroup graphics
+ */
+
 #include "surface.h"
 #include "n64sys.h"
 #include "debug.h"


### PR DESCRIPTION
Another partial merge coming from the rdpq/opengl branch.

This introduces the new `surface_t` type and use it everywhere. Thanks to a trick, also display.c
will start using it in a backward compatible fashion.

See the descriptions of commit by commit for further information.