### PR TITLE
Clean recipes for the build system should also depend on install-mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ clean:
 test:
 	$(MAKE) -C tests
 
-test-clean:
+test-clean: install-mk
 	$(MAKE) -C tests clean
 
 clobber: clean doxygen-clean examples-clean tools-clean test-clean


### PR DESCRIPTION
Added it to the dependency list for test-clean. It was breaking some installations when the conditions are right. Running in a multi threaded environment where test-clean executes faster than examples-clean should trigger the bug per my theory.