### PR TITLE
mixer: fix audio statics at the end of non-looping waveforms.

### DIFF
--- a/src/audio/libxm/context.c
+++ b/src/audio/libxm/context.c
@@ -127,7 +127,7 @@ void xm_context_save(xm_context_t* ctx, FILE* out) {
 	#define WALIGN()  ({ while (ftell(out) % 8) _W8(0); })
 
 
-	const uint8_t version = 5;
+	const uint8_t version = 6;
 	WA("XM64", 4);
 	W8(version);
 	W32(ctx->ctx_size);
@@ -440,8 +440,13 @@ int xm_context_load(xm_context_t** ctxp, FILE* in, uint32_t rate) {
 		DEBUG("invalid header\n");
 		return 1;
 	}
+
+	// Version log:
+	//  5: first public version
+	//  6: added overread for non-looping samples. The size of optimal
+	//     stream sample buffer size must change, hance the version bump.
 	R8(version);
-	if (version != 5) {
+	if (version != 5 && version != 6) {
 		DEBUG("invalid XM64 version %d\n", version);
 		return 1;		
 	}
@@ -453,6 +458,14 @@ int xm_context_load(xm_context_t** ctxp, FILE* in, uint32_t rate) {
 	R32(ctx_size_all_samples);
 	R32(ctx_size_stream_pattern_buf);
 	for (int i=0;i<32;i++) R32(ctx_size_stream_sample_buf[i]);
+	if (version == 5) {
+		for (int i=0;i<32;i++) {
+			// Add the overread size to all (non-empty) channels. This is a small pessimization,
+			// but it's trivial and we allow loading v5 files (albeit consuming a little bit more RAM).
+			if (ctx_size_stream_sample_buf[i])
+				ctx_size_stream_sample_buf[i] += 64;
+		}
+	}
 
 	uint32_t alloc_bytes = ctx_size;
 	#if XM_STREAM_PATTERNS

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -505,6 +505,9 @@ static void mixer_exec(int32_t *out, int num_samples) {
 				// actually present in the waveform.
 				if (wpos+wlen > len)
 					wlen = len-wpos;
+				// FIXME: due to a limit in the RSP ucode, we need to overread
+				// more data, possibly even past the end of the sample
+				wlen += MIXER_LOOP_OVERREAD >> bps;
 				assert(wlen >= 0);
 			} else if (loop_len < sbuf->size) {
 				// If the whole loop fits the sample buffer, we just need to

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -503,22 +503,6 @@ WaveDmaFetch:
 	jal DMAIn
 	li t0, DMA_SIZE(SAMPLE_CACHE_SIZE, 1)
 
-#if 0 
-	# TEST WITHOUT OVERREAD
-
-	sub wv_addr_end, SAMPLE_CACHE_SIZE # do it once
-
-	sub t0, wv_addr_end, s0
-	bltz t0, start_dma
-	addi t0, SAMPLE_CACHE_SIZE
-	li t0, SAMPLE_CACHE_SIZE
-start_dma:
-	addi dma_cache_end, t0, %lo(DMEM_SAMPLE_CACHE)
-	sll dma_cache_end, WAVEFORM_POS_FRAC_BITS
-#endif
-
-
-
 	# Calculate an offset that converts wv_pos from a (fixed point) RDRAM
 	# pointer into a (fixed point) DMEM pointer. This will be used because
 	# the inner loop will use wv_pos adjusted to be a DMEM pointer

--- a/tools/audioconv64/conv_xm64.c
+++ b/tools/audioconv64/conv_xm64.c
@@ -75,8 +75,6 @@ int xm_convert(const char *infn, const char *outfn) {
 			default:
 				fatal("invalid loop type: %d\n", s->loop_type);
 			case XM_NO_LOOP:
-				// FIXME: we probably don't need overread anymore in case of
-				// non-looping samples.
 				sout = malloc(length + MIXER_LOOP_OVERREAD);
 				memcpy(sout, s->data8, length);
 				memset(sout+length, 0, MIXER_LOOP_OVERREAD);
@@ -175,9 +173,8 @@ int xm_convert(const char *infn, const char *outfn) {
 				if (ch->sample->bits == 16)
 					n *= 2;
 
-				// Looping samples require the overread buffer
-				if (ch->sample->loop_type != XM_NO_LOOP)
-					n += MIXER_LOOP_OVERREAD;
+				// Take overread buffer into account
+				n += MIXER_LOOP_OVERREAD;
 
 				// Keep the maximum
 				if (ch_buf[i] < n)


### PR DESCRIPTION
rsp_mixer ucode has an "optimization" to avoid an expensive per-sample check: it doesn't check if it's reading out of bounds (within the samples that were DMA'd into DMEM). This means that in general it can read up to 64 bytes after the end of a waveform. In the mixer code, this is referred as "waveform over-read".

To workaround for this, audioconv64 pads non-looping waveforms with 64 bytes of silence, and pads looping waveforms by repeating the first 64 bytes of the loop beginning. This in general works very well and the overhead is basically none.

The only problem is that, at some point during mixer/xm64 development, I got confused and thought that overread was only needed for looping waveforms, so I axed a few places were the code was accounting for over-reads in non-looping waveforms, and even added FIXME to other places to remember myself to remove them in the future.

This is so wrong. The overread is badly needed for non looping waveforms as well. So this commit reinstates the missing calculations, and removes the wrong FIXMEs.

An unfortunate follow-up to this is that the optimal buffer calculation for XM64 was one of the rouine were overread computation was removed, so RAM buffers allocated for XM64 files created until today are not sufficient anymore after this commit. This requires an internal version bump of the XM64 format to avoid random asserts to users. I have also added the code to load the current version and simply increase the buffers manually (it is a conservative increase, but better than just crashing). Reconverting the files via audioconv will of course calculate the new optimal values.

Fixes #302