### PR TITLE
display.c: add hackish workaround to document predefined resolutions

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -48,8 +48,8 @@ typedef struct surface_s surface_t;
 /**
  * @brief Video resolution structure
  *
- * You can either use one of the pre-defined constants or define
- * a custom resolution.
+ * You can either use one of the pre-defined constants
+ * (such as #RESOLUTION_320x240) or define a custom resolution.
  */
 typedef struct {
     /** @brief Screen width (must be between 1 and 800) */
@@ -60,18 +60,22 @@ typedef struct {
     bool interlaced;
 } resolution_t;
 
+///@cond
+#define const static const /* fool doxygen to document these static members */
+///@endcond
 /** @brief 256x240 mode */
-static const resolution_t RESOLUTION_256x240 = {256, 240, false};
+const resolution_t RESOLUTION_256x240 = {256, 240, false};
 /** @brief 320x240 mode */
-static const resolution_t RESOLUTION_320x240 = {320, 240, false};
+const resolution_t RESOLUTION_320x240 = {320, 240, false};
 /** @brief 512x240 mode, high-res progressive */
-static const resolution_t RESOLUTION_512x240 = {512, 240, false};
+const resolution_t RESOLUTION_512x240 = {512, 240, false};
 /** @brief 640x240 mode, high-res progressive */
-static const resolution_t RESOLUTION_640x240 = {640, 240, false};
+const resolution_t RESOLUTION_640x240 = {640, 240, false};
 /** @brief 512x480 mode, interlaced */
-static const resolution_t RESOLUTION_512x480 = {512, 480, true};
+const resolution_t RESOLUTION_512x480 = {512, 480, true};
 /** @brief 640x480 mode, interlaced */
-static const resolution_t RESOLUTION_640x480 = {640, 480, true};
+const resolution_t RESOLUTION_640x480 = {640, 480, true};
+#undef const
 
 /** @brief Valid bit depths */
 typedef enum
@@ -125,11 +129,14 @@ extern "C" {
  * software or hardware.
  *
  * @param[in] res
- *            The requested resolution
+ *            The requested resolution. Use eiter one of the pre-defined
+ *            resolution (such as #RESOLUTION_320x240) or define a custom one.
  * @param[in] bit
- *            The requested bit depth
+ *            The requested bit depth (#DEPTH_16_BPP or #DEPTH_32_BPP)
  * @param[in] num_buffers
- *            Number of buffers, usually 2 or 3, but can be more.
+ *            Number of buffers, usually 2 or 3, but can be more. Triple buffering
+ *            is recommended in case the application cannot hold a steady full framerate,
+ *            so that slowdowns don't impact too much.
  * @param[in] gamma
  *            The requested gamma setting
  * @param[in] aa


### PR DESCRIPTION
Unfortunately we must declare these as "static const" (we could not find an alternative syntax that preserves backward compatible with resolution_t that used to be an enum), but we want to keep static member docs disabled.