### PR TITLE
Fix C++ Exceptions

### DIFF
--- a/n64.ld
+++ b/n64.ld
@@ -53,7 +53,10 @@ SECTIONS {
     } > mem
 
    .eh_frame_hdr : { *(.eh_frame_hdr) } > mem
-   .eh_frame : { KEEP (*(.eh_frame)) } > mem
+   .eh_frame : { 
+		__EH_FRAME_BEGIN__ = .; /* Define symbol for accessing eh_frame section */
+		KEEP (*(.eh_frame)) 
+	} > mem
    .gcc_except_table : { *(.gcc_except_table*) } > mem
    .jcr : { KEEP (*(.jcr)) } > mem
 

--- a/src/do_ctors.c
+++ b/src/do_ctors.c
@@ -20,6 +20,24 @@ extern func_ptr __CTOR_LIST__[] __attribute__((section (".data")));
 /** @brief Pointer to the end of the constructor list */
 extern func_ptr __CTOR_END__[] __attribute__((section (".data")));
 
+/** @brief Pointer to the beginning of exception frames */
+extern char __EH_FRAME_BEGIN__[];
+
+/**
+ * @brief Data used for registering exception frame info
+ * Must be 24 bytes big and 4-byte aligned.
+ */
+static uint32_t eh_frame_object[6];
+
+/**
+ * @brief Register exception frames
+ * This is used as a placeholder if the user does not link in libgcc
+ */
+void __attribute__((weak)) __register_frame_info(void *begin, uint32_t *ob)
+{
+	
+}
+
 /**
  * @brief Execute global constructors
  * "Constructors are called in reverse order of the list"
@@ -35,6 +53,8 @@ void __do_global_ctors()
 {
 	func_ptr * ctor_addr = __CTOR_END__ - 1;
 	func_ptr * ctor_sentinel = __CTOR_LIST__;
+	// Register exception handler frames
+	__register_frame_info(__EH_FRAME_BEGIN__, eh_frame_object);
 	assertf((uint32_t) ctor_sentinel[0] != 0xFFFFFFFF,
 		"Invalid constructor sentinel.\nWhen linking with g++, please specify:\n   --wrap __do_global_ctors");
 	while (ctor_addr >= ctor_sentinel) {
@@ -58,6 +78,8 @@ void __wrap___do_global_ctors()
 	// thus the "-2".
 	func_ptr * ctor_addr = __CTOR_END__ - 2;
 	func_ptr * ctor_sentinel = __CTOR_LIST__;
+	// Register exception handler frames
+	__register_frame_info(__EH_FRAME_BEGIN__, eh_frame_object);
 	// This will break if you link using LD. You'll need to change the linker
 	// script and add the sentinel manually. g++ already does that but ld does
 	// not. In that case, this will skip the last function. If this was an

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -6,6 +6,11 @@
 
 	.set noreorder
 
+.section .bss
+.align 4
+ehframe_object:
+.skip 24
+
 	.section .boot
 	.global _start
 _start:
@@ -106,7 +111,12 @@ loadintvectorloop:
 	la t0, debug_assert_func    /* install assert function in system.c */
 	la t1, __assert_func_ptr
 	sw t0, 0(t1)	
-
+	
+	la a0, __EH_FRAME_BEGIN__
+	la a1, ehframe_object
+	jal __register_frame_info /* Register eh_frame section */
+	nop
+	
 	jal __do_global_ctors		/* call global constructors */
 	nop
 	li a0, 0

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -132,4 +132,11 @@ intvector:
 	jr k1
 	nop
 
+/* Dummy weak definition of __register_frame_info to fix examples not linking in libgcc */ 
+.section .text.__register_frame_info
+.weak __register_frame_info
+__register_frame_info:
+jr ra
+nop
+
 	.section .code

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -6,11 +6,6 @@
 
 	.set noreorder
 
-.section .bss
-.align 4
-ehframe_object:
-.skip 24
-
 	.section .boot
 	.global _start
 _start:
@@ -111,12 +106,7 @@ loadintvectorloop:
 	la t0, debug_assert_func    /* install assert function in system.c */
 	la t1, __assert_func_ptr
 	sw t0, 0(t1)	
-	
-	la a0, __EH_FRAME_BEGIN__
-	la a1, ehframe_object
-	jal __register_frame_info /* Register eh_frame section */
-	nop
-	
+
 	jal __do_global_ctors		/* call global constructors */
 	nop
 	li a0, 0
@@ -131,12 +121,5 @@ intvector:
 	la k1,inthandler
 	jr k1
 	nop
-
-/* Dummy weak definition of __register_frame_info to fix examples not linking in libgcc */ 
-.section .text.__register_frame_info
-.weak __register_frame_info
-__register_frame_info:
-jr ra
-nop
 
 	.section .code


### PR DESCRIPTION
Breaks linking dfsdemo, mptest, mputest, vrutest, and vtest. All of these demos that fail to link do not use n64.mk