### PR TITLE
build: export FatFs header files / sdfs: added RTC support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,8 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/rspq.h $(INSTALLDIR)/mips64-elf/include/rspq.h
 	install -Cv -m 0644 include/rspq_constants.h $(INSTALLDIR)/mips64-elf/include/rspq_constants.h
 	install -Cv -m 0644 include/rsp_queue.inc $(INSTALLDIR)/mips64-elf/include/rsp_queue.inc
+	install -CDv -m 0644 src/fatfs/diskio.h $(INSTALLDIR)/mips64-elf/include/fatfs/diskio.h
+	install -CDv -m 0644 src/fatfs/ff.h $(INSTALLDIR)/mips64-elf/include/fatfs/ff.h
 
 
 clean:

--- a/src/debug.c
+++ b/src/debug.c
@@ -511,6 +511,7 @@ bool debug_init_sdfs(const char *prefix, int npart)
 	strlcpy(sdfs_prefix, prefix, sizeof(sdfs_prefix));
 	attach_filesystem(sdfs_prefix, &fat_fs);
 	enabled_features |= DEBUG_FEATURE_FILE_SD;
+	timer_init();
 	rtc_init();
 	return true;
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -181,6 +181,23 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void* buff)
 	return RES_PARERR;
 }
 
+DWORD get_fattime(void)
+{
+	rtc_time_t time;
+	return rtc_get(&time) ? (DWORD)(
+		(time.year - 1980) << 25 |
+		(time.month + 1) << 21 |
+		time.day << 16 |
+		time.hour << 11 |
+		time.min << 5 |
+		(time.sec / 2)
+	) : (
+		(DWORD)(FF_NORTC_YEAR - 1980) << 25 |
+		(DWORD)FF_NORTC_MON << 21 |
+		(DWORD)FF_NORTC_MDAY << 16
+	);
+}
+
 /** @endcond */
 
 /*********************************************************************
@@ -494,6 +511,7 @@ bool debug_init_sdfs(const char *prefix, int npart)
 	strlcpy(sdfs_prefix, prefix, sizeof(sdfs_prefix));
 	attach_filesystem(sdfs_prefix, &fat_fs);
 	enabled_features |= DEBUG_FEATURE_FILE_SD;
+	rtc_init();
 	return true;
 }
 

--- a/src/fatfs/ffconf.h
+++ b/src/fatfs/ffconf.h
@@ -221,7 +221,7 @@
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY		0
+#define FF_FS_TINY		1
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector

--- a/src/fatfs/ffconf.h
+++ b/src/fatfs/ffconf.h
@@ -221,7 +221,7 @@
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY		1
+#define FF_FS_TINY		0
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
@@ -234,7 +234,7 @@
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
 
-#define FF_FS_NORTC		1
+#define FF_FS_NORTC		0
 #define FF_NORTC_MON	1
 #define FF_NORTC_MDAY	1
 #define FF_NORTC_YEAR	2020


### PR DESCRIPTION
This change will redefine all publicly exported function symbols from FatFs library. It allows for linking apps with user provided FatFs code without namespace clash. This is beneficial for flashcart menu loaders as low level interaction with filesystem is required.

Mechanism can also be used for other external libraries integrated into libdragon.