### PR TITLE
Change documentation to use binary prefixes more consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ WSL1 users must [upgrade to WSL2 first](https://docs.microsoft.com/en-us/windows
    toolchain to be installed. For instance: `export N64_INST=/opt/n64` or
    `export N64_INST=/usr/local`.
 2. If you are on macOS, make sure [homebrew](https://brew.sh) is installed.
-3. Make sure you have at least 7 Gb of disk space available (notice that after
-   build, only about 300 Mb will be used, but during build a lot of space is
+3. Make sure you have at least 7 GB of disk space available (notice that after
+   build, only about 300 MB will be used, but during build a lot of space is
    required).
 4. Enter the `tools` directory and Run `./build-toolchain.sh`, let it build and
    install the toolchain. The process will take a while depending on your computer
@@ -89,7 +89,7 @@ WSL1 users must [upgrade to WSL2 first](https://docs.microsoft.com/en-us/windows
 You are now ready to run the examples on your N64 or emulator.
 
 Once you are sure everything is fine, you can delete the `tools/toolchain/`
-directory, where the toolchain was built. This will free around 6Gb of space.
+directory, where the toolchain was built. This will free around 6 GB of space.
 You will only need the installed binaries in the `N64_INST` from now on.
 
 ## Getting started: how to run a ROM

--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -235,7 +235,7 @@ enum Page page_song(void) {
 		sprintf(sbuf, "Channels: %d", song_channels);
 		graphics_draw_text(disp, 20, 60, sbuf);
 
-		sprintf(sbuf, "ROM: %d Kb | RDRAM: %d Kb", (song_romsz+512)/1024, (song_ramsz+512)/1024);
+		sprintf(sbuf, "ROM: %d KiB | RDRAM: %d KiB", (song_romsz+512)/1024, (song_ramsz+512)/1024);
 		graphics_draw_text(disp, 20, 70, sbuf);
 
 		if (song_type == SONG_XM) {

--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -314,7 +314,7 @@ static int validate_eeprom_4k(void)
         { "/player.sav",      sizeof(game_save_state_t) }
     };
 
-    printf( "EEPROM Detected: 4Kb (64 blocks)\n" );
+    printf( "EEPROM Detected: 4 Kibit (64 blocks)\n" );
     printf( "Initializing EEPROM Filesystem...\n" );
     result = eepfs_init(eeprom_4k_files, 3);
     switch ( result )
@@ -375,7 +375,7 @@ static int validate_eeprom_16k(void)
         { "saves/slot4.sav", sizeof(game_save_state_t) }
     };
 
-    printf( "EEPROM Detected: 16Kb (256 blocks)\n" );
+    printf( "EEPROM Detected: 16 Kibit (256 blocks)\n" );
     printf( "Initializing EEPROM Filesystem...\n" );
     result = eepfs_init(eeprom_16k_files, 6);
     switch ( result )

--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -14,7 +14,7 @@
 /**
  * @brief Default filesystem location 
  *
- * The default is 1MB into the ROM space, plus the header offset
+ * The default is 1 MiB into the ROM space, plus the header offset
  */
 #define DFS_DEFAULT_LOCATION    0xB0101000
 

--- a/include/tpak.h
+++ b/include/tpak.h
@@ -78,21 +78,21 @@ extern "C" {
  */
 typedef enum __attribute__ ((packed))
 {
-    /** @brief ROM only (32KB ROM) */
+    /** @brief ROM only (32 KiB ROM) */
     GB_ROM_ONLY = 0x00,
-    /** @brief MBC1 (max 2MB ROM) */
+    /** @brief MBC1 (max 2 MiB ROM) */
     GB_MBC1 = 0x01,
-    /** @brief MBC1 (max 2MB ROM) + RAM (32KB) */
+    /** @brief MBC1 (max 2 MiB ROM) + RAM (32 KiB) */
     GB_MBC1_RAM = 0x02,
-    /** @brief MBC1 (max 2MB ROM) + RAM (32KB) + Battery */
+    /** @brief MBC1 (max 2 MiB ROM) + RAM (32 KiB) + Battery */
     GB_MBC1_RAM_BATTERY = 0x03,
-    /** @brief MBC2 (max 256KB ROM; 512x4 bits RAM built-in) */
+    /** @brief MBC2 (max 256 KiB ROM; 512x4 bits RAM built-in) */
     GB_MBC2 = 0x05,
-    /** @brief MBC2 (max 256KB ROM; 512x4 bits RAM built-in) + Battery */
+    /** @brief MBC2 (max 256 KiB ROM; 512x4 bits RAM built-in) + Battery */
     GB_MBC2_BATTERY = 0x06,
-    /** @brief ROM (32KB) + RAM (max 8KB) */
+    /** @brief ROM (32 KiB) + RAM (max 8 KiB) */
     GB_ROM_RAM = 0x08,
-    /** @brief ROM (32KB) + RAM (max 8KB) + Battery */
+    /** @brief ROM (32 KiB) + RAM (max 8 KiB) + Battery */
     GB_ROM_RAM_BATTERY = 0x09,
     /** @brief MMM01 ("Meta-mapper") */
     GB_MMM01 = 0x0B,
@@ -100,27 +100,27 @@ typedef enum __attribute__ ((packed))
     GB_MMM01_RAM = 0x0C,
     /** @brief MMM01 ("Meta-mapper") + RAM + Battery */
     GB_MMM01_RAM_BATTERY = 0x0D,
-    /** @brief MBC3 (max 2MB ROM) */
+    /** @brief MBC3 (max 2 MiB ROM) */
     GB_MBC3 = 0x11,
-    /** @brief MBC3 (max 2MB ROM) + RAM (64KB) */
+    /** @brief MBC3 (max 2 MiB ROM) + RAM (64 KiB) */
     GB_MBC3_RAM = 0x12,
-    /** @brief MBC3 (max 2MB ROM) + RAM (64KB) + Battery */
+    /** @brief MBC3 (max 2 MiB ROM) + RAM (64 KiB) + Battery */
     GB_MBC3_RAM_BATTERY = 0x13,
-    /** @brief MBC3 (max 2MB ROM) + Real-Time Clock + Battery */
+    /** @brief MBC3 (max 2 MiB ROM) + Real-Time Clock + Battery */
     GB_MBC3_TIMER_BATTERY = 0x0F,
-    /** @brief MBC3 (max 2MB ROM) + Real-Time Clock + RAM (64KB) + Battery */
+    /** @brief MBC3 (max 2 MiB ROM) + Real-Time Clock + RAM (64 KiB) + Battery */
     GB_MBC3_TIMER_RAM_BATTERY = 0x10,
-    /** @brief MBC5 (max 8MB ROM) */
+    /** @brief MBC5 (max 8 MiB ROM) */
     GB_MBC5 = 0x19,
-    /** @brief MBC5 (max 8MB ROM) + RAM (128KB) */
+    /** @brief MBC5 (max 8 MiB ROM) + RAM (128 KiB) */
     GB_MBC5_RAM = 0x1A,
-    /** @brief MBC5 (max 8MB ROM) + RAM (128KB) + Battery */
+    /** @brief MBC5 (max 8 MiB ROM) + RAM (128 KiB) + Battery */
     GB_MBC5_RAM_BATTERY = 0x1B,
-    /** @brief MBC5 (max 8MB ROM) + Rumble */
+    /** @brief MBC5 (max 8 MiB ROM) + Rumble */
     GB_MBC5_RUMBLE = 0x1C,
-    /** @brief MBC5 (max 8MB ROM) + Rumble + RAM (128KB) */
+    /** @brief MBC5 (max 8 MiB ROM) + Rumble + RAM (128 KiB) */
     GB_MBC5_RUMBLE_RAM = 0x1D,
-    /** @brief MBC5 (max 8MB ROM) + Rumble + RAM (128KB) + Battery */
+    /** @brief MBC5 (max 8 MiB ROM) + Rumble + RAM (128 KiB) + Battery */
     GB_MBC5_RUMBLE_RAM_BATTERY = 0x1E,
     /** @brief MBC6 */
     GB_MBC6 = 0x20,
@@ -143,29 +143,29 @@ typedef enum __attribute__ ((packed))
  */
 typedef enum __attribute__ ((packed))
 {
-    /** @brief ROM size: 32KB (no banks) */
+    /** @brief ROM size: 32 KiB (no banks) */
     GB_ROM_32KB = 0x00,
-    /** @brief ROM size: 64KB (4 banks) */
+    /** @brief ROM size: 64 KiB (4 banks) */
     GB_ROM_64KB = 0x01,
-    /** @brief ROM size: 128KB (8 banks) */
+    /** @brief ROM size: 128 KiB (8 banks) */
     GB_ROM_128KB = 0x02,
-    /** @brief ROM size: 256KB (16 banks) */
+    /** @brief ROM size: 256 KiB (16 banks) */
     GB_ROM_256KB = 0x03,
-    /** @brief ROM size: 512KB (32 banks) */
+    /** @brief ROM size: 512 KiB (32 banks) */
     GB_ROM_512KB = 0x04,
-    /** @brief ROM size: 1MB (64 banks) */
+    /** @brief ROM size: 1 MiB (64 banks) */
     GB_ROM_1MB = 0x05,
-    /** @brief ROM size: 2MB (128 banks) */
+    /** @brief ROM size: 2 MiB (128 banks) */
     GB_ROM_2MB = 0x06,
-    /** @brief ROM size: 4MB (256 banks) */
+    /** @brief ROM size: 4 MiB (256 banks) */
     GB_ROM_4MB = 0x07,
-    /** @brief ROM size: 8MB (512 banks) */
+    /** @brief ROM size: 8 MiB (512 banks) */
     GB_ROM_8MB = 0x08,
-    /** @brief ROM size: 1.1MB (72 banks) */
+    /** @brief ROM size: 1.125 MiB (72 banks) */
     GB_ROM_1152KB = 0x52,
-    /** @brief ROM size: 1.2MB (80 banks) */
+    /** @brief ROM size: 1.25 MiB (80 banks) */
     GB_ROM_1280KB = 0x53,
-    /** @brief ROM size: 1.5MB (96 banks) */
+    /** @brief ROM size: 1.5 MiB (96 banks) */
     GB_ROM_1536KB = 0x54,
 } gb_cart_rom_size_t;
 
@@ -178,15 +178,15 @@ typedef enum __attribute__ ((packed))
 {
     /** @brief RAM not available */
     GB_RAM_NONE = 0x00,
-    /** @brief RAM size: 2KB (no banks) */
+    /** @brief RAM size: 2 KiB (no banks) */
     GB_RAM_2KB = 0x01,
-    /** @brief RAM size: 8KB (no banks) */
+    /** @brief RAM size: 8 KiB (no banks) */
     GB_RAM_8KB = 0x02,
-    /** @brief RAM size: 32KB (4 banks) */
+    /** @brief RAM size: 32 KiB (4 banks) */
     GB_RAM_32KB = 0x03,
-    /** @brief RAM size: 64KB (8 banks) */
+    /** @brief RAM size: 64 KiB (8 banks) */
     GB_RAM_64KB = 0x05,
-    /** @brief RAM size: 128KB (16 banks) */
+    /** @brief RAM size: 128 KiB (16 banks) */
     GB_RAM_128KB = 0x04,
 } gb_cart_ram_size_t;
 

--- a/include/ym64.h
+++ b/include/ym64.h
@@ -42,7 +42,7 @@ typedef struct _LHANewDecoder LHANewDecoder;
  * already fully compatible).
  * 
  * The main conversion option to pay attention too is whether the output file
- * must be compressed or not. Compressed files are smaller but takes 18Kb
+ * must be compressed or not. Compressed files are smaller but takes 18 KiB
  * more of RDRAM to be played back and cannot be seeked.
  * 
  * This player is dedicated to the late Sir Clive Sinclair whose computer,

--- a/src/debug_sdfs_sc64.c
+++ b/src/debug_sdfs_sc64.c
@@ -2,7 +2,7 @@
  * FAT backend: SC64
  *********************************************************************/
 
-// SC64 internal 8 kB general use buffer
+// SC64 internal 8 KiB general use buffer
 #define SC64_BUFFER_ADDRESS		0xBFFE0000
 #define SC64_BUFFER_SIZE		8192
 

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -21,7 +21,7 @@ _start:
 	li fp, 0                    /* fp=0 -> vanilla N64 */
 
 	/* In iQue player, memory allocated to game can be configured and it appears
-	   in 0x80000318. On the other hand, the top 8Mb of RDRAM is reserved to
+	   in 0x80000318. On the other hand, the top 8 MiB of RDRAM is reserved to
 	   savegames. So avoid putting the stack there, capping the size to 0x7C0000.
 	   See also get_memory_size. */
 	li fp, 1                    /* fp=1 -> iQue player */

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -19,7 +19,7 @@
  * the memory setup on the system.  This includes cache operations to
  * invalidate or flush regions and the ability to set the boot CIC.
  * The @ref system use the knowledge of the boot CIC to properly determine
- * if the expansion pak is present, giving 4MB of additional memory.  Aside
+ * if the expansion pak is present, giving 4 MiB of additional memory.  Aside
  * from this, the MIPS r4300 uses a manual cache management strategy, where
  * SW that requires passing buffers to and from hardware components using
  * DMA controllers needs to ensure that cache and RDRAM are in sync.  A
@@ -284,7 +284,7 @@ int get_memory_size()
 {
     if (sys_bbplayer()) {
         /* On iQue, memory allocated to the game can be decided by the OS.
-           Even if the memory is allocated as 8Mb, the top part handles
+           Even if the memory is allocated as 8 MiB, the top part handles
            save states (emulation of EEPROM/Flash/SRAM), so we should avoid
            writing there anyway. See also entrypoint.S which sets up the
            stack with the same logic. */
@@ -299,12 +299,12 @@ int get_memory_size()
 /**
  * @brief Is expansion pak in use.
  *
- * Checks whether the maximum available memory has been expanded to 8MB
+ * Checks whether the maximum available memory has been expanded to 8 MiB
  *
  * @return true if expansion pak detected, false otherwise.
  * 
  * @note On iQue, this function returns true only if the game has been assigned
- *       exactly 8MB of RAM.
+ *       exactly 8 MiB of RAM.
  */
 bool is_memory_expanded()
 {

--- a/src/tpak.c
+++ b/src/tpak.c
@@ -66,7 +66,7 @@
 
 /** @brief Transfer Pak command block size (32 bytes) */
 #define TPAK_BLOCK_SIZE  0x20
-/** @brief Transfer Pak cartridge bank size (16KB) */
+/** @brief Transfer Pak cartridge bank size (16 KiB) */
 #define TPAK_BANK_SIZE   0x4000
 
 /**

--- a/src/usb.c
+++ b/src/usb.c
@@ -23,7 +23,7 @@ https://github.com/buu342/N64-UNFLoader
 #define BUFFER_SIZE 512
 
 // USB Memory location
-#define DEBUG_ADDRESS  0x04000000-DEBUG_ADDRESS_SIZE // Put the debug area at the 63MB area in ROM space
+#define DEBUG_ADDRESS  0x04000000-DEBUG_ADDRESS_SIZE // Put the debug area at the 63 MiB area in ROM space
 
 // Data header related
 #define USBHEADER_CREATE(type, left) (((type<<24) | (left & 0x00FFFFFF)))

--- a/tools/audioconv64/conv_xm64.c
+++ b/tools/audioconv64/conv_xm64.c
@@ -207,9 +207,9 @@ int xm_convert(const char *infn, const char *outfn) {
 
 	// Dump some statistics for the conversion
 	if (flag_verbose) {	
-		fprintf(stderr, "  * ROM size: %u Kb (samples:%zu)\n",
+		fprintf(stderr, "  * ROM size: %u KiB (samples:%zu)\n",
 			romsize / 1024, mem_sam / 1024);
-		fprintf(stderr, "  * RAM size: %zu Kb (ctx:%zu, patterns:%u, samples:%u)\n",
+		fprintf(stderr, "  * RAM size: %zu KiB (ctx:%zu, patterns:%u, samples:%u)\n",
 			(mem_ctx+sam_size+ctx->ctx_size_stream_pattern_buf)/1024,
 			mem_ctx / 1024,
 			ctx->ctx_size_stream_pattern_buf / 1024,

--- a/tools/audioconv64/lzh5_compress.c
+++ b/tools/audioconv64/lzh5_compress.c
@@ -121,18 +121,18 @@ static void __attribute__((noreturn, format(printf, 1, 2))) fatal_error(const ch
 /* Added N.Watazaki ..^ */
 
 #define LZHUFF0_DICBIT           0      /* no compress */
-#define LZHUFF1_DICBIT          12      /* 2^12 =  4KB sliding dictionary */
-#define LZHUFF2_DICBIT          13      /* 2^13 =  8KB sliding dictionary */
-#define LZHUFF3_DICBIT          13      /* 2^13 =  8KB sliding dictionary */
-#define LZHUFF4_DICBIT          12      /* 2^12 =  4KB sliding dictionary */
-#define LZHUFF5_DICBIT          13      /* 2^13 =  8KB sliding dictionary */
-#define LZHUFF6_DICBIT          15      /* 2^15 = 32KB sliding dictionary */
-#define LZHUFF7_DICBIT          16      /* 2^16 = 64KB sliding dictionary */
-#define LARC_DICBIT             11      /* 2^11 =  2KB sliding dictionary */
-#define LARC5_DICBIT            12      /* 2^12 =  4KB sliding dictionary */
+#define LZHUFF1_DICBIT          12      /* 2^12 =  4 KiB sliding dictionary */
+#define LZHUFF2_DICBIT          13      /* 2^13 =  8 KiB sliding dictionary */
+#define LZHUFF3_DICBIT          13      /* 2^13 =  8 KiB sliding dictionary */
+#define LZHUFF4_DICBIT          12      /* 2^12 =  4 KiB sliding dictionary */
+#define LZHUFF5_DICBIT          13      /* 2^13 =  8 KiB sliding dictionary */
+#define LZHUFF6_DICBIT          15      /* 2^15 = 32 KiB sliding dictionary */
+#define LZHUFF7_DICBIT          16      /* 2^16 = 64 KiB sliding dictionary */
+#define LARC_DICBIT             11      /* 2^11 =  2 KiB sliding dictionary */
+#define LARC5_DICBIT            12      /* 2^12 =  4 KiB sliding dictionary */
 #define LARC4_DICBIT             0      /* no compress */
 #define PMARC0_DICBIT            0      /* no compress */
-#define PMARC2_DICBIT           13      /* 2^13 =  8KB sliding dictionary */
+#define PMARC2_DICBIT           13      /* 2^13 =  8 KiB sliding dictionary */
 
 #ifdef SUPPORT_LH7
 #define MAX_DICBIT          LZHUFF7_DICBIT      /* lh7 use 16bits */

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -38,9 +38,9 @@
 //    tools like UNFloader and g64drive work around this bug by padding ROMs,
 //    but others (like the official one) don't. So it's better in general to
 //    pad to 512 bytes.
-//  * iQue player only allows loading ROMs which are multiple of 16 Kbyte in size.
+//  * iQue player only allows loading ROMs which are multiple of 16 KiB in size.
 //  
-// To allow the maximum compatibility, we pad to 16Kb by default. Users can still
+// To allow the maximum compatibility, we pad to 16 KiB by default. Users can still
 // force a specific length with --size, if they need to.
 #define PAD_ALIGN    16384
 


### PR DESCRIPTION
This PR updates documentation, other comments and some debug prints to consistently use IEC binary prefixes and capital B for bytes (and "bit" for bits) in order to minimize possible ambiguity. Existing API constant names (mostly applicable to Transfer Pak Support) are left as is for compatibility.