### PR TITLE
Create a TOC of files contained in a ROM, and use it for DragonFS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ libdragonsys.a: $(BUILD_DIR)/system.o
 libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o \
 			 $(BUILD_DIR)/inthandler.o $(BUILD_DIR)/entrypoint.o \
 			 $(BUILD_DIR)/debug.o $(BUILD_DIR)/usb.o $(BUILD_DIR)/fatfs/ff.o \
-			 $(BUILD_DIR)/fatfs/ffunicode.o $(BUILD_DIR)/dragonfs.o \
+			 $(BUILD_DIR)/fatfs/ffunicode.o $(BUILD_DIR)/rompak.o $(BUILD_DIR)/dragonfs.o \
 			 $(BUILD_DIR)/audio.o $(BUILD_DIR)/display.o $(BUILD_DIR)/surface.o \
 			 $(BUILD_DIR)/console.o $(BUILD_DIR)/joybus.o \
 			 $(BUILD_DIR)/controller.o $(BUILD_DIR)/rtc.o \

--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -14,9 +14,10 @@
 /**
  * @brief Default filesystem location 
  *
- * The default is 1 MiB into the ROM space, plus the header offset
+ * The default value 0 instruct #dfs_init to search for the DFS image
+ * within the rompak.
  */
-#define DFS_DEFAULT_LOCATION    0xB0101000
+#define DFS_DEFAULT_LOCATION    0
 
 /**
  * @brief Maximum open files in DragonFS

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -106,13 +106,19 @@ extern int __bbplayer;
     (((unsigned long)(_addrp))&~0xE0000000); \
 })
 
+/** @brief Symbol at the start of code (start of ROM contents after header) */
+extern char __libdragon_text_start[];
+
 /** @brief Symbol at the end of code, data, and sdata (set by the linker) */
 extern char __rom_end[];
+
+/** @brief Symbol at the end of code, data, sdata, and bss (set by the linker) */
+extern char __bss_end[];
 
 /**
  * @brief Void pointer to the start of heap memory
  */
-#define HEAP_START_ADDR ((void*)__rom_end)
+#define HEAP_START_ADDR ((void*)__bss_end)
 
 /**
  * @brief Memory barrier to ensure in-order execution

--- a/n64.ld
+++ b/n64.ld
@@ -133,7 +133,12 @@ SECTIONS {
         . = ALIGN(8);
     } > mem
 
+    . = ALIGN(8);
     __data_end = .;
+
+    /* Here the ROM is finished. The rest is just in RAM */
+    . = ALIGN(8);
+    __rom_end = .;
 
     .sbss (NOLOAD) : {
          __bss_start = .;
@@ -157,7 +162,8 @@ SECTIONS {
     } > mem
 
     . = ALIGN(8);
-    __rom_end = .;
+    
+
 
     /* Deprecated */
     end = .;

--- a/n64.mk
+++ b/n64.mk
@@ -76,9 +76,9 @@ N64_CFLAGS += -std=gnu99
 	@rm -f $@
 	DFS_FILE="$(filter %.dfs, $^)"; \
 	if [ -z "$$DFS_FILE" ]; then \
-		$(N64_TOOL) $(N64_TOOLFLAGS) --output $@ $<.bin; \
+		$(N64_TOOL) $(N64_TOOLFLAGS) --toc --output $@ $<.bin; \
 	else \
-		$(N64_TOOL) $(N64_TOOLFLAGS) --output $@ $<.bin --offset $(N64_DFS_OFFSET) "$$DFS_FILE"; \
+		$(N64_TOOL) $(N64_TOOLFLAGS) --toc --output $@ $<.bin --align 16 "$$DFS_FILE"; \
 	fi
 	if [ ! -z "$(strip $(N64_ED64ROMCONFIGFLAGS))" ]; then \
 		$(N64_ED64ROMCONFIG) $(N64_ED64ROMCONFIGFLAGS) $@; \

--- a/src/rompak.c
+++ b/src/rompak.c
@@ -1,0 +1,74 @@
+/**
+ * @file rompak.c
+ * @brief ROM bundle support
+ * @ingroup rompak
+ */
+#include "rompak_internal.h"
+#include "n64sys.h"
+#include "dma.h"
+#include "debug.h"
+#include <stdalign.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define TOC_MAGIC    0x544F4330         ///< Magic ID "TOC0"
+
+/** @brief Physical address of the ROMPAK TOC */
+#define TOC_ADDR     (0x10001000 + (__rom_end - __libdragon_text_start))
+
+/** @brief ROMPAK TOC header */
+typedef struct {
+    uint32_t magic;       ///< Magic (#TOC_MAGIC)
+    uint32_t toc_size;    ///< Size of the TOC in bytes
+    uint32_t entry_size;  ///< Size of an entry of the TOC (in bytes)
+    uint32_t num_entries; ///< Number of entries in the TOC
+} header_t;
+
+/** @brief ROMPAK TOC entry */
+typedef struct {
+    uint32_t offset;        ///< Offset of the file in the ROM
+    char name[];            ///< Name of the file
+} entry_t;
+
+static bool extension_match(const char *ext, const char *name)
+{
+    int ext_len = strlen(ext);
+    int name_len = strlen(name);
+    if (ext_len > name_len) {
+        return false;
+    }
+    return strcmp(ext, name + name_len - ext_len) == 0;
+}
+
+uint32_t rompak_search_ext(const char *ext)
+{
+    static bool rompak_corrupted = false;
+
+    if (rompak_corrupted || io_read(TOC_ADDR) != TOC_MAGIC) {
+        return 0;
+    }
+
+    header_t header;
+    data_cache_hit_writeback_invalidate(&header, sizeof(header_t));
+    dma_read(&header, TOC_ADDR, sizeof(header_t));
+
+    // These asserts prevent a miscompiled TOC from causing a hard-to-diagnose
+    // stack overflow because of alloca. The number 1024 is arbitrary, we just
+    // want to protect against important corruptions (eg: little-endian / big-endian mistakes).
+    if (header.entry_size >= 1024 || header.num_entries >= 1024) {
+        rompak_corrupted = true;
+        assertf(header.entry_size < 1024, "Corrupted rompak TOC: entry size too big (0x%lx)", header.entry_size);
+        assertf(header.num_entries < 1024, "Corrupted rompak TOC: too many entries (0x%lx)", header.num_entries);
+    }
+
+    entry_t *entry = alloca(header.entry_size);
+    for (int i=0; i < header.num_entries; i++) {
+        data_cache_hit_writeback_invalidate(entry, header.entry_size);
+        dma_read(entry, TOC_ADDR + sizeof(header_t) + i*header.entry_size, header.entry_size);
+
+        if (extension_match(ext, entry->name))
+            return 0x10000000 + entry->offset;
+    }
+
+    return 0;
+}

--- a/src/rompak_internal.h
+++ b/src/rompak_internal.h
@@ -1,0 +1,48 @@
+/**
+ * @file rompak_internal.h
+ * @brief ROM bundle support
+ * @ingroup rompak
+ */
+
+#ifndef __LIBDRAGON_ROM_INTERNAL_H
+#define __LIBDRAGON_ROM_INTERNAL_H
+
+#include <stdint.h>
+
+/**
+ * @defgroup rompak ROM bundle support
+ * @ingroup lowlevel
+ * @brief Rompak functions (private API)
+ * 
+ * Libdragon ROMs created by n64tool allows to have several data files
+ * attached to them. We call this super minimal filesystem "rompak".
+ * 
+ * The rompak can optionally contain a TOC (table of contents) which is
+ * a directory that allows to list the files and know their offset. The
+ * libdragon build system (n64.mk) creates this by default.
+ * 
+ * Rompak is used by libdragon itself to provide a few features. Users
+ * should not typically use rompak directly, but rather use the
+ * DragonFS (which is itself a single file in the rompak).
+ * 
+ * @{
+ */
+
+/**
+ * @brief Search a file in the rompak by extension
+ * 
+ * Files in the rompak are usually named as the ROM itself, with
+ * different extensions. To avoid forcing to embed the ROM name in the
+ * code itself, the most typical pattern is to look for a file by
+ * its extension.
+ * 
+ * @param ext     Extension to search for (will be matched case sensitively).
+ *                This extension must contain the dot, e.g. ".bin".
+ * @return        Physical address of the file in the ROM, or 0 if the file
+ *                doesn't exist or the TOC is not present.
+ */
+uint32_t rompak_search_ext(const char *ext);
+
+/** @} */
+
+#endif

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -33,6 +33,17 @@
 	(((_n) + (_d) - 1) / (_d) * (_d)); \
 })
 
+// strlcpy() is not available on all platforms, so we provide a simple implementation
+#ifndef strlcpy
+size_t __strlcpy(char * restrict dst, const char * restrict src, size_t dstsize)
+{
+	strncpy(dst, src, dstsize - 1);
+	dst[dstsize - 1] = '\0';
+	return strlen(dst);
+}
+#define strlcpy __strlcpy
+#endif
+
 // Minimum ROM size alignment, used by default. We currently know of two constraints:
 //  * 64drive firmware has a bug and can only transfer chunks of 512 bytes. Some
 //    tools like UNFloader and g64drive work around this bug by padding ROMs,
@@ -55,22 +66,54 @@
 #define STATUS_ERROR    1
 #define STATUS_BADUSAGE 2
 
+#define TOC_SIZE         1024
+#define TOC_ALIGN        8            // This must match the ALIGN directive in the linker script before __rom_end
+#define TOC_ENTRY_SIZE   64
+#define TOC_MAX_ENTRIES  ((TOC_SIZE - 16) / 64)
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define SWAPLONG(i) (i)
+#else
+#define SWAPLONG(i) (((uint32_t)((i) & 0xFF000000) >> 24) | ((uint32_t)((i) & 0x00FF0000) >>  8) | ((uint32_t)((i) & 0x0000FF00) <<  8) | ((uint32_t)((i) & 0x000000FF) << 24))
+#endif
+
 static const unsigned char zero[1024] = {0};
 static char * tmp_output = NULL;
 
+struct toc_s {
+	char magic[4];
+	uint32_t toc_size;
+	uint32_t entry_size;
+	uint32_t num_entries;
+	struct {
+		uint32_t offset;
+		char name[TOC_ENTRY_SIZE - 4];
+	} files[TOC_MAX_ENTRIES];
+} toc = {
+	.magic = "TOC0",
+	.toc_size = TOC_SIZE,
+	.entry_size = TOC_ENTRY_SIZE,
+	.num_entries = 0,
+};
+
+_Static_assert(sizeof(toc) <= TOC_SIZE, "invalid table size");
 
 int print_usage(const char * prog_name)
 {
-	fprintf(stderr, "Usage: %s [-t <title>] [-l <size>B/K/M] -h <file> -o <file> <file> [[-s <offset>B/K/M] <file>]*\n\n", prog_name);
+	fprintf(stderr, "Usage: %s [flags] <file> [[file-flags] <file> ...]\n\n", prog_name);
 	fprintf(stderr, "This program creates an N64 ROM from a header and a list of files,\n");
-	fprintf(stderr, "the first being an Nintendo64 binary and the rest arbitrary data.\n");
+	fprintf(stderr, "the first being an Nintendo 64 binary and the rest arbitrary data.\n");
 	fprintf(stderr, "\n");
-	fprintf(stderr, "Command-line flags:\n");
+	fprintf(stderr, "General flags (to be used before any file):\n");
 	fprintf(stderr, "\t-t, --title <title>    Title of ROM (max %d characters).\n", TITLE_SIZE);
 	fprintf(stderr, "\t-l, --size <size>      Force ROM output file size to <size> (min 1 mebibyte).\n");
 	fprintf(stderr, "\t-h, --header <file>    Use <file> as IPL3 header.\n");
 	fprintf(stderr, "\t-o, --output <file>    Save output ROM to <file>.\n");
-	fprintf(stderr, "\t-s, --offset <offset>  Next file starts at <offset> from top of memory. Offset must be 32-bit aligned.\n");
+	fprintf(stderr, "\t-T, --toc              Create a table of contents file after the first binary.\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "File flags (to be used between files):\n");
+	fprintf(stderr, "\t-a, --align <align>    Next file is aligned at <align> bytes from top of memory (minimum: 4).\n");
+	fprintf(stderr, "\t-s, --offset <offset>  Next file starts at <offset> from top of memory. Offset must be 4-byte aligned.\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Binary byte size/offset suffix notation:\n");
 	fprintf(stderr, "\tB for bytes.\n");
@@ -202,6 +245,9 @@ int main(int argc, char *argv[])
 	size_t declared_size = 0;
 	size_t total_bytes_written = 0;
 	char title[TITLE_SIZE + 1] = { 0, };
+	bool create_toc = false;
+	size_t toc_offset = 0;
+
 
 	if(argc <= 1)
 	{
@@ -300,6 +346,16 @@ int main(int argc, char *argv[])
 			declared_size = size;
 			continue;
 		}
+		if(check_flag(arg, "-T", "--toc"))
+		{
+			if(total_bytes_written)
+			{
+				fprintf(stderr, "ERROR: -T / --toc must be specified before any input file\n\n");
+				return print_usage(argv[0]);
+			}
+			create_toc = true;
+			continue;
+		}
 		if(check_flag(arg, "-s", "--offset"))
 		{
 			if(!header || !output)
@@ -346,6 +402,48 @@ int main(int argc, char *argv[])
 
 			/* Same as total_bytes_written = offset */
 			total_bytes_written += num_zeros;
+			continue;
+		}
+		if(check_flag(arg, "-a", "--align"))
+		{
+			if(!header || !output)
+			{
+				fprintf(stderr, "ERROR: Need header and output flags before alignment\n\n");
+				return print_usage(argv[0]);
+			}
+
+			if(!total_bytes_written)
+			{
+				fprintf(stderr, "ERROR: The first file cannot have an alignment\n\n");
+				return print_usage(argv[0]);
+			}
+
+			if(i >= argc)
+			{
+				/* Expected another argument */
+				fprintf(stderr, "ERROR: Expected an argument to align flag\n\n");
+				return print_usage(argv[0]);
+			}
+
+			int align = atoi(argv[i++]);
+			if (align < 4)
+			{
+				fprintf(stderr, "ERROR: Minimum alignment is 4 bytes\n\n");
+				return print_usage(argv[0]);
+			}
+
+			if (total_bytes_written % align)
+			{
+				ssize_t num_zeros = align - (total_bytes_written % align);
+
+				if(output_zeros(write_file, num_zeros))
+				{
+					fprintf(stderr, "ERROR: Invalid alignment %d to seek to in %s!\n", align, output);
+					return STATUS_ERROR;
+				}
+
+				total_bytes_written += num_zeros;
+			}
 			continue;
 		}
 		if(check_flag(arg, "-t", "--title"))
@@ -404,6 +502,8 @@ int main(int argc, char *argv[])
 			}
 		}
 
+		size_t offset = ftell(write_file);
+
 		/* Copy the input file into the output file */
 		ssize_t bytes_copied = copy_file(write_file, arg);
 
@@ -413,8 +513,45 @@ int main(int argc, char *argv[])
 			return STATUS_ERROR;
 		}
 
+		if (toc.num_entries < TOC_MAX_ENTRIES)
+		{
+			/* Add the file to the toc */
+			toc.files[toc.num_entries].offset = offset;
+
+			const char *basename = strrchr(arg, '/');
+			if (!basename) basename = strrchr(arg, '\\');
+			if (!basename) basename = arg;
+			if (basename[0] == '/' || basename[0] == '\\') basename++;
+			strlcpy(toc.files[toc.num_entries].name, basename, sizeof(toc.files[toc.num_entries].name));
+			toc.num_entries++;
+		}
+		else
+		{
+			if (create_toc)
+			{
+				fprintf(stderr, "ERROR: Too many files to add to table.\n");
+				return STATUS_ERROR;
+			}
+		}
+
+
 		/* Keep track to be sure we align properly when they request a memory alignment */
 		total_bytes_written += bytes_copied;
+
+		/* Leave space for the table, if asked to do so. */
+		if(create_toc && !toc_offset)
+		{	
+			if (total_bytes_written % TOC_ALIGN)
+			{
+				ssize_t num_zeros = TOC_ALIGN - (total_bytes_written % TOC_ALIGN);
+				output_zeros(write_file, num_zeros);
+				total_bytes_written += num_zeros;
+			}
+
+			toc_offset = ftell(write_file);
+			output_zeros(write_file, TOC_SIZE);
+			total_bytes_written += TOC_SIZE;
+		}
 	}
 
 	if(!total_bytes_written)
@@ -463,6 +600,19 @@ int main(int argc, char *argv[])
 	/* Set title in header */
 	fseek(write_file, TITLE_OFFSET, SEEK_SET);
 	fwrite(title, 1, TITLE_SIZE, write_file);
+
+	/* Write table of contents */
+	if(create_toc)
+	{
+		for (int i=0; i<toc.num_entries; i++)
+			toc.files[i].offset = SWAPLONG(toc.files[i].offset);
+		toc.num_entries = SWAPLONG(toc.num_entries);
+		toc.toc_size = SWAPLONG(toc.toc_size);
+		toc.entry_size = SWAPLONG(toc.entry_size);
+
+		fseek(write_file, toc_offset, SEEK_SET);
+		fwrite(&toc, 1, TOC_SIZE, write_file);
+	}
 
 	/* Sync and close the output file */
 	fclose(write_file);


### PR DESCRIPTION
These commits do the following:

 * Add to n64tool a feature to create a TOC of the files appended in the ROM
 * Add to libdragon an internal API (rompak_internal.h) to search this TOC. Users should stick to DragonFS of course, but libdragon might find useful to store its own data files in the ROM, without recurring to weird hacks, nor polluting the user-level DragonFS (which might not even exist).
 * Change DragonFS to use the TOC to open the image. This also allows to part with the hardcoded offset, which means that it now works by default even for ROMs bigger than 1Mb. Also the padding to 1Mb is now all at the end of the ROM, ready to be removed as soon as we have an open-source IPL3.

This PR should be 100% backward compatible. TOC generation is optional (though activated by default in n64.mk), and DragonFS will respect hardcoded offsets passed to `dfs_init`: the TOC is inspected only when `DFS_DEFAULT_LOCATION` is specified.