### PR TITLE
Activate FPU exceptions by default

### DIFF
--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -361,6 +361,23 @@ __attribute__((constructor)) void __init_cop1()
     /* Read initialized value from cop1 control register */
     uint32_t fcr31 = C1_FCR31();
     
+    /* Disable all pending exceptions to avoid triggering one immediately.
+       These can be survived from a soft reset. */
+    fcr31 &= ~(C1_CAUSE_OVERFLOW | 
+               C1_CAUSE_UNDERFLOW | 
+               C1_CAUSE_NOT_IMPLEMENTED | 
+               C1_CAUSE_DIV_BY_0 | 
+               C1_CAUSE_INEXACT_OP | 
+               C1_CAUSE_INVALID_OP);
+
+#ifndef NDEBUG
+    /* Enable FPU exceptions that can help programmers avoid bugs in their code. */
+    fcr31 |= C1_ENABLE_OVERFLOW | 
+             C1_ENABLE_UNDERFLOW | 
+             C1_ENABLE_DIV_BY_0 | 
+             C1_ENABLE_INVALID_OP;
+#endif
+
     /* Set FS bit to allow flashing of denormalized floats
        The FPU inside the N64 CPU does not implement denormalized floats
        and will generate an unmaskable exception if a denormalized float

--- a/src/surface.c
+++ b/src/surface.c
@@ -29,6 +29,12 @@ const char* tex_format_name(tex_format_t fmt)
 
 surface_t surface_alloc(tex_format_t format, uint32_t width, uint32_t height)
 {
+    // A common mistake is to call surface_format with the wrong argument order.
+    // Try to catch it by checking that the format is not valid.
+    // Do not limit ourselves to tex_format_t enum values, as people might want
+    // to test weird RDP formats (e.g. RGBA8) to find out what happens.
+    assertf((format & ~SURFACE_FLAGS_TEXFORMAT) == 0,
+        "invalid surface format: 0x%x (%d)", format, format);
     return (surface_t){ 
         .flags = format | SURFACE_FLAGS_OWNEDBUFFER,
         .width = width,
@@ -67,3 +73,4 @@ surface_t surface_make_sub(surface_t *parent, uint32_t x0, uint32_t y0, uint32_t
 
 extern inline surface_t surface_make(void *buffer, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride);
 extern inline tex_format_t surface_get_format(const surface_t *surface);
+extern inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint32_t width, uint32_t height);


### PR DESCRIPTION
FPU exceptions are a very useful tool to catch bugs in FPU code earlier.
Especially when not doing advanced numeric computations that need to
explicitly handle infinites or denormals, generating a NaN or an infinite
is often a signal of a bug.

This commit activates the exceptions by default at boot, when compiling
without NDEBUG. Having FPU exceptions on doesn't cause overhead at runtime,
but most people will want them disabled for production builds anyway
(hoping the game would somehow recover from FPU bugs, if one is hit).

(The PR also includes a minor commit that adds an assert to surface.c)