### PR TITLE
n64tool: fix ROM overwrite on Windows

### DIFF
--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -468,6 +468,10 @@ int main(int argc, char *argv[])
 	fclose(write_file);
 
 	/* Rename to the final name */
+	#ifdef _WIN32
+	/* Windows doesn't support atomic renames, so we have to delete the old file first */
+	remove(output);
+	#endif
 	if(rename(tmp_output, output) != 0) {
 		fprintf(stderr, "Couldn't rename temporary output file '%s' to '%s': %s", tmp_output, output, strerror(errno));
 		return STATUS_ERROR;


### PR DESCRIPTION
n64tool was changed in 313e36fce to generate the output file atomically to avoid confusing make and/or creating truncated files in case of errors.

It looks like this broke it on Windows when the destination file already exists because rename(2) is broken there and follows the Windows semantics of not allowing to rename a file whose destination name already exists.

The breakage went unnoticed because n64.mk removes the z64 file before calling n64tool. Anyway, when invoking n64tool manually or through other build system, this is a nuisance that is better fixed.