### PR TITLE
debug: add support for reading from SD to SDRAM in flashcarts

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -163,6 +163,8 @@ DSTATUS disk_status(BYTE pdrv)
 
 DRESULT disk_read(BYTE pdrv, BYTE* buff, LBA_t sector, UINT count)
 {
+	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
+	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 	if (fat_disks[pdrv].disk_read && PhysicalAddr(buff) < 0x00800000)
 		return fat_disks[pdrv].disk_read(buff, sector, count);
 	if (fat_disks[pdrv].disk_read_sdram && io_accessible(PhysicalAddr(buff)))
@@ -172,6 +174,8 @@ DRESULT disk_read(BYTE pdrv, BYTE* buff, LBA_t sector, UINT count)
 
 DRESULT disk_write(BYTE pdrv, const BYTE* buff, LBA_t sector, UINT count)
 {
+	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
+	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 	if (fat_disks[pdrv].disk_write)
 		return fat_disks[pdrv].disk_write(buff, sector, count);
 	return RES_PARERR;

--- a/src/debug_sdfs_64drive.c
+++ b/src/debug_sdfs_64drive.c
@@ -39,9 +39,6 @@ static void sd_abort_64drive(void)
 
 static DRESULT fat_disk_read_sdram_64drive(BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
-
 	usb_64drive_wait();
 	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LBA, sector);
 	usb_64drive_wait();
@@ -61,9 +58,6 @@ static DRESULT fat_disk_read_sdram_64drive(BYTE* buff, LBA_t sector, UINT count)
 
 static DRESULT fat_disk_read_64drive(BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
-
 	usb_64drive_wait();
 	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LENGTH, 1);
 	for (int i=0;i<count;i++)
@@ -88,9 +82,6 @@ static DRESULT fat_disk_read_64drive(BYTE* buff, LBA_t sector, UINT count)
 
 static DRESULT fat_disk_write_64drive(const BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
-
 	usb_64drive_wait();
 	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LENGTH, 1);
 	for (int i=0;i<count;i++)

--- a/src/debug_sdfs_64drive.c
+++ b/src/debug_sdfs_64drive.c
@@ -4,6 +4,7 @@
 
 #define D64_CIBASE_ADDRESS   0xB8000000
 #define D64_BUFFER           0x00000000
+#define D64_REGISTER_SDRAM   0x00000004
 #define D64_REGISTER_STATUS  0x00000200
 #define D64_REGISTER_COMMAND 0x00000208
 #define D64_REGISTER_LBA     0x00000210
@@ -23,11 +24,48 @@
 extern int8_t usb_64drive_wait(void);
 extern void usb_64drive_setwritable(int8_t enable);
 
+static void sd_abort_64drive(void)
+{
+	// Operation is taking too long. Probably SD was not inserted.
+	// Send a COMMAND_ABORT and SD_RESET, and return I/O error.
+	// Note that because of a 64drive firmware bug, this is not
+	// sufficient to unblock the 64drive. The USB channel will stay
+	// unresponsive. We don't currently have a workaround for this.
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_COMMAND, D64_COMMAND_ABORT);
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_COMMAND, D64_COMMAND_SD_RESET);
+	usb_64drive_wait();
+}
+
+static DRESULT fat_disk_read_sdram_64drive(BYTE* buff, LBA_t sector, UINT count)
+{
+	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
+	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
+
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LBA, sector);
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LENGTH, count);
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_SDRAM, PhysicalAddr(buff) >> 1);
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_COMMAND, D64_COMMAND_SD_READ);
+	if (usb_64drive_wait() != 0)
+	{
+		debugf("[debug] fat_disk_read_sdram_64drive: wait timeout\n");
+		sd_abort_64drive();
+		return FR_DISK_ERR;
+	}
+	return RES_OK;
+}
+
 static DRESULT fat_disk_read_64drive(BYTE* buff, LBA_t sector, UINT count)
 {
 	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
 	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LENGTH, 1);
 	for (int i=0;i<count;i++)
 	{
 		usb_64drive_wait();
@@ -37,15 +75,7 @@ static DRESULT fat_disk_read_64drive(BYTE* buff, LBA_t sector, UINT count)
 		if (usb_64drive_wait() != 0)
 		{
 			debugf("[debug] fat_disk_read_64drive: wait timeout\n");
-			// Operation is taking too long. Probably SD was not inserted.
-			// Send a COMMAND_ABORT and SD_RESET, and return I/O error.
-			// Note that because of a 64drive firmware bug, this is not
-			// sufficient to unblock the 64drive. The USB channel will stay
-			// unresponsive. We don't currently have a workaround for this.
-			io_write(D64_CIBASE_ADDRESS + D64_REGISTER_COMMAND, D64_COMMAND_ABORT);
-			usb_64drive_wait();
-			io_write(D64_CIBASE_ADDRESS + D64_REGISTER_COMMAND, D64_COMMAND_SD_RESET);
-			usb_64drive_wait();
+			sd_abort_64drive();
 			return FR_DISK_ERR;
 		}
 
@@ -61,6 +91,8 @@ static DRESULT fat_disk_write_64drive(const BYTE* buff, LBA_t sector, UINT count
 	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
 	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 
+	usb_64drive_wait();
+	io_write(D64_CIBASE_ADDRESS + D64_REGISTER_LENGTH, 1);
 	for (int i=0;i<count;i++)
 	{
 		if (((uint32_t)buff & 7) == 0)

--- a/src/debug_sdfs_ed64.c
+++ b/src/debug_sdfs_ed64.c
@@ -441,9 +441,6 @@ static DSTATUS fat_disk_initialize_everdrive(void) {
 
 static DRESULT fat_disk_read_everdrive(BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
-
 	uint8_t crc[8];
 	DRESULT ret_val = RES_OK;
 
@@ -505,9 +502,6 @@ cleanup:
 }
 
 static DRESULT fat_disk_write_everdrive(const BYTE* buff, LBA_t sector, UINT count) {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
-
 	uint8_t result;
 	DRESULT ret_val = RES_OK;
 

--- a/src/debug_sdfs_sc64.c
+++ b/src/debug_sdfs_sc64.c
@@ -67,6 +67,15 @@ static DRESULT fat_disk_read_sc64(BYTE* buff, LBA_t sector, UINT count)
 	return RES_OK;
 }
 
+static DRESULT fat_disk_read_sdram_sc64(BYTE* buff, LBA_t sector, UINT count)
+{
+	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
+	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
+	if (sc64_sd_read_sectors((uint32_t)buff, sector, count))
+		return FR_DISK_ERR;
+	return RES_OK;
+}
+
 static DRESULT fat_disk_write_sc64(const BYTE* buff, LBA_t sector, UINT count)
 {
 	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");

--- a/src/debug_sdfs_sc64.c
+++ b/src/debug_sdfs_sc64.c
@@ -51,8 +51,6 @@ static DSTATUS fat_disk_initialize_sc64(void)
 
 static DRESULT fat_disk_read_sc64(BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 	while (count > 0)
 	{
 		UINT sectors_to_process = MIN(count, SC64_BUFFER_SIZE/512);
@@ -69,8 +67,6 @@ static DRESULT fat_disk_read_sc64(BYTE* buff, LBA_t sector, UINT count)
 
 static DRESULT fat_disk_read_sdram_sc64(BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 	if (sc64_sd_read_sectors((uint32_t)buff, sector, count))
 		return FR_DISK_ERR;
 	return RES_OK;
@@ -78,8 +74,6 @@ static DRESULT fat_disk_read_sdram_sc64(BYTE* buff, LBA_t sector, UINT count)
 
 static DRESULT fat_disk_write_sc64(const BYTE* buff, LBA_t sector, UINT count)
 {
-	_Static_assert(FF_MIN_SS == 512, "this function assumes sector size == 512");
-	_Static_assert(FF_MAX_SS == 512, "this function assumes sector size == 512");
 	while (count > 0)
 	{
 		UINT sectors_to_process = MIN(count, SC64_BUFFER_SIZE/512);


### PR DESCRIPTION
Normally, reading from SD cards involve first issuing a flashcart-specific command to read SD contents into SDRAM (which is mapped in PI space as "ROM"), and then run a PI DMA transfer to copy contents into RDRAM, just like the data was in ROM.

There are use cases in which there is no need for the second half: the data can stay in SDRAM and be consumed from there. A common one is flashcart menus that want to load a ROM to boot, and don't need data to go into RDRAM (it wouldn't even fit).

This commit adds support to this use case by simply checking if the pointer provided to disk_read (and thus, to fread() by the user) is in RDRAM or in a PI-mapped space, and calling a new flashcart hook in the latter case.

This is implemented for now on 64drive and SC64.