### PR TITLE
build: export fatfs/ffconf.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/rsp_queue.inc $(INSTALLDIR)/mips64-elf/include/rsp_queue.inc
 	install -CDv -m 0644 src/fatfs/diskio.h $(INSTALLDIR)/mips64-elf/include/fatfs/diskio.h
 	install -CDv -m 0644 src/fatfs/ff.h $(INSTALLDIR)/mips64-elf/include/fatfs/ff.h
+	install -CDv -m 0644 src/fatfs/ffconf.h $(INSTALLDIR)/mips64-elf/include/fatfs/ffconf.h
 
 
 clean:


### PR DESCRIPTION
I didn't catch this earlier, but `ff.h` includes `ffconf.h` and errors out in user code when it couldn't be found. This commit fixes that issue.