### PR TITLE
Retrieve ROM address from file descriptor.

### DIFF
--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -94,6 +94,7 @@ int dfs_tell(uint32_t handle);
 int dfs_close(uint32_t handle);
 int dfs_eof(uint32_t handle);
 int dfs_size(uint32_t handle);
+uint32_t dfs_rom_addr_of_file(uint32_t handle);
 uint32_t dfs_rom_addr(const char *path);
 
 #ifdef __cplusplus

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -1328,6 +1328,23 @@ static void __dfs_check_emulation(void)
 }
 
 /**
+ * @brief Get Address in ROM of file open with given handle.
+ *
+ * Given a handle of a file open by dfs_open, this function will return the
+ * address of that file in the ROM.
+ *
+ * @param[in] handle
+ *            File handle of an open file by dragonfs dfs_open.
+ *
+ * @return Address of file in ROM or 0 otherwise.
+ */
+uint32_t dfs_rom_addr_of_file(uint32_t handle)
+{
+    open_file_t *fptr = find_open_file(handle);
+    return fptr ? fptr->cart_start_loc : 0;
+}
+
+/**
  * @brief Initialize the filesystem.
  *
  * Given a base offset where the filesystem should be found, this function will

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -80,6 +80,9 @@ void test_dfs_rom_addr(TestContext *ctx) {
 	uint32_t rom = dfs_rom_addr("counter.dat");
 	ASSERT(rom != 0, "counter.dat not found by dfs_rom_addr");
 
+	uint32_t rom2 = dfs_rom_addr_of_file(fh);
+	ASSERT_EQUAL_HEX(rom, rom2, "rom address retrieved from handle is different from retrieved from path");
+
 	ASSERT_EQUAL_HEX(io_read(rom), *(uint32_t*)buf1, "direct ROM address is different");
 	ASSERT_EQUAL_HEX(io_read(rom+8), *(uint32_t*)(buf1+8), "direct ROM address is different");
 


### PR DESCRIPTION
This commit adds a new function which allows the user to retrieve the ROM address of a file given its file descriptor.  This is useful if the user is using some virtual filesystem and wants to extract some extra performance by bypassing newlib read functions at all, or even dfs_read at all if it is known that things are well behaved.

Note: One can use
```
dfs_rom_addr_of_file(fp->_handle - 2);
```
to retrieve the rom address of a FILE* object.