### PR TITLE
Implement stack walking (backtrace)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,15 @@ BUILD_DIR = build
 include n64.mk
 INSTALLDIR = $(N64_INST)
 
+LIBDRAGON_CFLAGS = -I$(CURDIR)/src -I$(CURDIR)/include -ffile-prefix-map=$(CURDIR)=libdragon
+
 # Activate N64 toolchain for libdragon build
 libdragon: CC=$(N64_CC)
 libdragon: AS=$(N64_AS)
 libdragon: LD=$(N64_LD)
-libdragon: CFLAGS+=$(N64_CFLAGS) -I$(CURDIR)/src -I$(CURDIR)/include 
-libdragon: ASFLAGS+=$(N64_ASFLAGS) -I$(CURDIR)/src -I$(CURDIR)/include
-libdragon: RSPASFLAGS+=$(N64_RSPASFLAGS) -I$(CURDIR)/src -I$(CURDIR)/include
+libdragon: CFLAGS+=$(N64_CFLAGS) $(LIBDRAGON_CFLAGS)
+libdragon: ASFLAGS+=$(N64_ASFLAGS) $(LIBDRAGON_CFLAGS)
+libdragon: RSPASFLAGS+=$(N64_RSPASFLAGS) $(LIBDRAGON_CFLAGS)
 libdragon: LDFLAGS+=$(N64_LDFLAGS)
 libdragon: libdragon.a libdragonsys.a
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ libdragonsys.a: $(BUILD_DIR)/system.o
 	@echo "    [AR] $@"
 	$(N64_AR) -rcs -o $@ $^
 
-libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o \
+libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o $(BUILD_DIR)/backtrace.o \
 			 $(BUILD_DIR)/inthandler.o $(BUILD_DIR)/entrypoint.o \
 			 $(BUILD_DIR)/debug.o $(BUILD_DIR)/usb.o $(BUILD_DIR)/fatfs/ff.o \
 			 $(BUILD_DIR)/fatfs/ffunicode.o $(BUILD_DIR)/rompak.o $(BUILD_DIR)/dragonfs.o \
@@ -76,6 +76,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/n64types.h $(INSTALLDIR)/mips64-elf/include/n64types.h
 	install -Cv -m 0644 include/pputils.h $(INSTALLDIR)/mips64-elf/include/pputils.h
 	install -Cv -m 0644 include/n64sys.h $(INSTALLDIR)/mips64-elf/include/n64sys.h
+	install -Cv -m 0644 include/backtrace.h $(INSTALLDIR)/mips64-elf/include/backtrace.h
 	install -Cv -m 0644 include/cop0.h $(INSTALLDIR)/mips64-elf/include/cop0.h
 	install -Cv -m 0644 include/cop1.h $(INSTALLDIR)/mips64-elf/include/cop1.h
 	install -Cv -m 0644 include/interrupt.h $(INSTALLDIR)/mips64-elf/include/interrupt.h

--- a/include/backtrace.h
+++ b/include/backtrace.h
@@ -1,0 +1,195 @@
+/**
+ * @file backtrace.h
+ * @brief Backtrace (call stack) support
+ * @ingroup backtrace
+ */
+
+/**
+ * @defgroup backtrace Backtrace (call stack) support
+ * @ingroup lowlevel
+ * @brief Implementation of functions to walk the stack and dump a backtrace
+ * 
+ * This module implements two POSIX/GNU standard functions to help walking
+ * the stack and providing the current execution context: backtrace() and
+ * backtrace_symbols().
+ * 
+ * The functions have an API fully compatible with the standard ones. The
+ * implementation is however optimized for the MIPS/N64 case, and with
+ * standard compilation settings. See the documentation in backtrace.c
+ * for implementation details.
+ * 
+ * You can call the functions to inspect the current call stack. For
+ * a higher level function that just prints the current call stack
+ * on the debug channels, see #debug_backtrace.
+ * 
+ * @{
+ */
+
+#ifndef __LIBDRAGON_BACKTRACE_H
+#define __LIBDRAGON_BACKTRACE_H
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** 
+ * @brief A stack frame, part of a backtrace
+ */
+typedef struct {
+    uint32_t addr;              ///< PC address of the frame (MIPS virtual address)
+
+    const char *func;           ///< Name of the function (this should always be present)
+    uint32_t func_offset;       ///< Byte offset of the address within the function
+
+    const char *source_file;    ///< Name of the source file (if known, or "???" otherwise)
+    int source_line;            ///< Line number in the source file (if known, or 0 otherwise)
+
+    bool is_inline;             ///< True if this frame refers to an inlined function
+} backtrace_frame_t;
+
+
+/**
+ * @brief Print a single frame of a backtrace
+ * 
+ * Print all the information about a single frame of a backtrace, with
+ * the following format:
+ * 
+ * ```
+ *    <func>+<offset> (<source_file>:<source_line>) [<address>]
+ * ```
+ * 
+ * for instance:
+ * 
+ * ```
+ *    debug_assert_func_f+0x9c (/home/user/src/libdragon/src/debug.c:537) [0x80010c5c]
+ * ```
+ * 
+ * @param out       File to print to
+ * @param frame     Frame to print
+ */
+void backtrace_frame_print(backtrace_frame_t *frame, FILE *out);
+
+/**
+ * @brief Print a single frame of a backtrace, in a compact format
+ * 
+ * Print a frame of a backtrace in a compact format, with a limited width in number
+ * of characters. This is the format:
+ * 
+ * ```
+ *    <func> (<source_file>:<source_line>)
+ * ```
+ * 
+ * but the source file will be truncated to fit the width, showing only its final
+ * part. For instance, if the width is 40 characters, the following frame:
+ * 
+ * ```
+ *   debug_assert_func_f+0x9c (/home/user/src/libdragon/src/debug.c:537) [0x80010c5c]
+ * ```
+ * 
+ * will be printed as:
+ * 
+ * ```
+ *    debug_assert_func_f (.../src/debug.c:537)
+ * ```
+ * 
+ * @param out       File to print to
+ * @param frame     Frame to print
+ * @param width     Width in characters to fit the frame information to
+ */
+void backtrace_frame_print_compact(backtrace_frame_t *frame, FILE *out, int width);
+
+/**
+ * @brief Walk the stack and return the current call stack
+ * 
+ * This function will analyze the current execution context,
+ * walking the stack and returning informations on the active
+ * call frames.
+ * 
+ * This function adheres to POSIX specification. It does not
+ * allocate memory so it is safe to be called even in the
+ * context of low memory conditions or possibly corrupted heap.
+ * 
+ * If called within an interrupt or exception handler, the function
+ * is able to correctly walk backward the interrupt handler and
+ * show the context even before the exception was triggered.
+ * 
+ * @param buffer    Empty array of pointers. This will be populated with pointers
+ *                  to the return addresses for each call frame.
+ * @param size      Size of the buffer, that is, maximum number of call frames
+ *                  that will be walked by the function.
+ * @return          Number of call frames walked (at most, size).
+ */
+int backtrace(void **buffer, int size);
+
+/**
+ * @brief Translate the buffer returned by #backtrace into a list of strings
+ * 
+ * This function symbolizes the buffer returned by #backtrace, translating
+ * return addresses into function names and source code locations.
+ * 
+ * The user-readable strings are allocated on the heap and must be freed by
+ * the caller (via a single free() call). There is no need to free each
+ * of the returned strings: a single free() call is enough, as they are
+ * allocated in a single contiguous block.
+ * 
+ * This function adheres to POSIX specification.
+ * 
+ * This function also handles inlined functions. In general, inlined function
+ * do not have a real stack frame because they are expanded in place; so for
+ * instance a single stack frame (as returned by #backtrace) can correspond
+ * to multiple symbolized stack frames, one per each inlined function. Since
+ * the POSIX API requires this function to return an array of the same size
+ * of the input array, all inlined functions are collapsed into a single
+ * string, separated by newlines.
+ * 
+ * @param buffer    Array of return addresses, populated by #backtrace
+ * @param size      Size of the provided buffer, in number of pointers.
+ * @return          Array of strings, one for each call frame. The array
+ *                  must be freed by the caller with a single free() call.
+ * 
+ * @see #backtrace_symbols_cb
+ */
+char** backtrace_symbols(void **buffer, int size);
+
+/**
+ * @brief Symbolize the buffer returned by #backtrace, calling a callback for each frame
+ * 
+ * This function is similar to #backtrace_symbols, but instead of formatting strings
+ * into a heap-allocated buffer, it invokes a callback for each symbolized stack
+ * frame. This allows to skip the memory allocation if not required, and also allows
+ * for custom processing / formatting of the backtrace by the caller.
+ * 
+ * The callback will receive an opaque argument (cb_arg) and a pointer to a
+ * stack frame descriptor (#backtrace_frame_t). The descriptor and all its
+ * contents (including strings) is valid only for the duration of the call,
+ * so the callback must (deep-)copy any data it needs to keep.
+ * 
+ * The callback implementation might find useful to call #backtrace_frame_print
+ * or #backtrace_frame_print_compact to print the frame information.
+ * 
+ * @param buffer    Array of return addresses, populated by #backtrace
+ * @param size      Size of the provided buffer, in number of pointers.
+ * @param flags     Flags to control the symbolization process. Use 0.
+ * @param cb        Callback function to invoke for each symbolized frame
+ * @param cb_arg    Opaque argument to pass to the callback function
+ * @return True if the symbolization was successful, false otherwise.
+ *         Notice that the function returns true even if some frames
+ *         were not symbolized; false is only used when the function
+ *         had to abort before even calling the callback once (eg:
+ *         no symbol table was found).
+ * 
+ * @see #backtrace_symbols
+ */
+bool backtrace_symbols_cb(void **buffer, int size, uint32_t flags,
+    void (*cb)(void *, backtrace_frame_t*), void *cb_arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif

--- a/include/debug.h
+++ b/include/debug.h
@@ -223,6 +223,22 @@ extern "C" {
  */
 void debug_hexdump(const void *buffer, int size);
 
+/**
+ * @brief Dump a backtrace (call stack) via #debugf
+ * 
+ * This function will dump the current call stack to the debugging channel. It is
+ * useful to understand where the program is currently executing, and to understand
+ * the context of an error.
+ * 
+ * The implementation of this function relies on the lower level #backtrace and
+ * #backtrace_symbols functions, which are implemented in libdragon itself via
+ * a symbol table embedded in the ROM. See #backtrace_symbols for more information.
+ * 
+ * @see #backtrace
+ * @see #backtrace_symbols
+ */
+void debug_backtrace(void);
+
 /** @brief Underlying implementation function for assert() and #assertf. */ 
 void debug_assert_func_f(const char *file, int line, const char *func, const char *failedexpr, const char *msg, ...)
    __attribute__((noreturn, format(printf, 5, 6)));

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -42,6 +42,7 @@
 #include "graphics.h"
 #include "interrupt.h"
 #include "n64sys.h"
+#include "backtrace.h"
 #include "rdp.h"
 #include "rsp.h"
 #include "timer.h"

--- a/n64.mk
+++ b/n64.mk
@@ -36,7 +36,8 @@ N64_SYM = $(N64_BINDIR)/n64sym
 N64_AUDIOCONV = $(N64_BINDIR)/audioconv64
 
 N64_CFLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
-N64_CFLAGS += -falign-functions=32 -ffunction-sections -fdata-sections -g
+N64_CFLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
+N64_CFLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map=$(CURDIR)=
 N64_CFLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -207,6 +207,7 @@ static symtable_header_t symt_open(void) {
  */
 static addrtable_entry_t symt_addrtab_entry(symtable_header_t *symt, int idx)
 {
+    assert(idx >= 0 && idx < symt->addrtab_size);
     return io_read(SYMT_ROM + symt->addrtab_off + idx * 4);
 }
 

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -330,7 +330,38 @@ char* __symbolize(void *vaddr, char *buf, int size)
  * uses a stack frame or not, whether it uses a frame pointer, and where the return address is stored.
  * 
  * Since we do not have DWARF informations or similar metadata, we can just do educated guesses. A
- * mistake in the heuristic will result probably in a wrong backtrace from this point on. 
+ * mistake in the heuristic will result probably in a wrong backtrace from this point on.
+ * 
+ * The heuristic works as follows:
+ * 
+ *  * Most functions do have a stack frame. In fact, 99.99% of the functions you can find in a call stack
+ *    must have a stack frame, because the only functions without a stack frame are leaf functions (functions
+ *    that do not call other functions), which in turns can never be part of a stack trace.
+ *  * The heuristic walks the function code backwards, looking for the stack frame. Specifically, it looks
+ *    for an instruction saving the RA register to the stack (eg: `sd $ra, nn($sp)`), and an instruction
+ *    creating the stack frame (eg: `addiu $sp, $sp, -nn`). Once both are found, the heuristic knows how to
+ *    fill in `.stack_size` and `.ra_offset` fields of the function description structure, and it can stop.
+ *  * Some functions also modify $fp (the frame pointer register): sometimes, they just use it as one additional
+ *    free register, and other times they really use it as frame pointer. If the heuristic finds the
+ *    instruction `move $fp, $sp`, it knows that the function uses $fp as frame pointer, and will mark
+ *    the function as BT_FUNCTION_FRAMEPOINTER. In any case, the field `.fp_offset` will be filled in
+ *    with the offset in the stack where $fp is stored, so that the backtrace engine can track the
+ *    current value of the register in any case.
+ *  * The 0.01% of the functions that do not have a stack frame but appear in the call stack are leaf
+ *    functions interrupted by exceptions. Leaf functions pose two important problems: first, $ra is
+ *    not saved into the stack so there is no way to know where to go back. Second, there is no clear
+ *    indication where the function begins (as we normally stops analysis when we see the stack frame
+ *    creation). So in this case the heuristic would fail. We rely thus on two hints coming from the caller:
+ *    * First, we expect the caller to set from_exception=true, so that we know that we might potentially
+ *      deal with a leaf function. 
+ *    * Second, the caller should provide the function start address, so that we stop the analysis when
+ *      we reach it, and mark the function as BT_LEAF.
+ *    * If the function start address is not provided (because e.g. the symbol table was not found and
+ *      thus we have no information about function starts), the last ditch heuristic is to look for
+ *      the nops that are normally used to align the function start to the FUNCTION_ALIGNMENT boundary.
+ *      Obviously this is a very fragile heuristic (it will fail if the function required no nops to be
+ *      properly aligned), but it is the best we can do. Worst case, in this specific case of a leaf
+ *      function interrupted by the exception, the stack trace will be wrong from this point on.
  * 
  * @param func                        Output function description structure
  * @param ptr                         Pointer to the function code at the point where the backtrace starts.
@@ -339,12 +370,13 @@ char* __symbolize(void *vaddr, char *buf, int size)
  * @param func_start                  Start of the function being analyzed. This is optional: the heuristic can work
  *                                    without this hint, but it is useful in certain situations (eg: to better
  *                                    walk up after an exception).
- * @param exception_ra                If != NULL, this function was interrupted by an exception. This variable
- *                                    stores the $ra register value as saved in the exception frame, that might be useful.
+ * @param from_exception              If true, this function was interrupted by an exception. This is a hint that
+ *                                    the function *might* even be a leaf function without a stack frame, and that
+ *                                    we must use special heuristics for it.
  * 
  * @return true if the backtrace can continue, false if must be aborted (eg: we are within invalid memory)
  */
-bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, void *exception_ra)
+bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, bool from_exception)
 {
     *func = (bt_func_t){
         .type = (ptr >= inthandler && ptr < inthandler_end) ? BT_EXCEPTION : BT_FUNCTION,
@@ -390,20 +422,27 @@ bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, void
         // We can stop looking and process the frame
         if (func->stack_size != 0 && func->ra_offset != 0)
             break;
-        if (exception_ra && addr == func_start) {
-            // The frame that was interrupted by an interrupt handler is a special case: the
-            // function could be a leaf function with no stack. If we were able to identify
-            // the function start (via the symbol table) and we reach it, it means that
-            // we are in a real leaf function.
-            func->type = BT_LEAF;
-            break;
-        } else if (exception_ra && !func_start && MIPS_OP_NOP(op) && (addr + 4) % FUNCTION_ALIGNMENT == 0) {
-            // If we are in the frame interrupted by an interrupt handler, and we does not know
-            // the start of the function (eg: no symbol table), then try to stop by looking for
-            // a NOP that pads between functions. Obviously the NOP we find can be either a false
-            // positive or a false negative, but we can't do any better without symbols.
-            func->type = BT_LEAF;
-            break;
+        if (from_exception) {
+            // The function we are analyzing was interrupted by an exception, so it might
+            // potentially be a leaf function (no stack frame). We need to make sure to stop
+            // at the beginning of the function and mark it as leaf function. Use
+            // func_start if specified, or try to guess using the nops used to align the function
+            // (crossing fingers that they're there).
+            if (addr == func_start) {
+                // The frame that was interrupted by an interrupt handler is a special case: the
+                // function could be a leaf function with no stack. If we were able to identify
+                // the function start (via the symbol table) and we reach it, it means that
+                // we are in a real leaf function.
+                func->type = BT_LEAF;
+                break;
+            } else if (!func_start && MIPS_OP_NOP(op) && (addr + 4) % FUNCTION_ALIGNMENT == 0) {
+                // If we are in the frame interrupted by an interrupt handler, and we does not know
+                // the start of the function (eg: no symbol table), then try to stop by looking for
+                // a NOP that pads between functions. Obviously the NOP we find can be either a false
+                // positive or a false negative, but we can't do any better without symbols.
+                func->type = BT_LEAF;
+                break;
+            }
         }
         addr -= 4;
     }

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -99,8 +99,8 @@
  *   split externally to allow for efficiency reasons. Each entry stores the function name, 
  *   the source file name and line number, and the binary offset of the symbol within the containing
  *   function.
- * * String table: This tables can be thought as a large buffer holding all the strings needed by all
- *   symbol entries (function names and file names). Each symbol entry stores a string as an index
+ * * String table: this table can be thought as a large buffer holding all the strings needed by all
+ *   symbol entries (function names and file names). Each symbol entry stores a string as an offset
  *   within the symbol table and a length. This allows to reuse the same string (or prefix thereof)
  *   multiple times. Notice that strings are not null terminated in the string table.
  * 

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -1,0 +1,682 @@
+/**
+ * @file backtrace.c
+ * @brief Backtrace (call stack) support
+ * @ingroup backtrace
+ * 
+ * This file contains the implementation of the backtrace support. See
+ * backtrace.h for an overview of the API. Here follows some implementation
+ * details.
+ * 
+ * Backtrace 
+ * =========
+ * MIPS ABIs do not generally provide a way to walk the stack, as the frame
+ * pointer is not guaranteed to be present. It is possible to force its presence
+ * via "-fno-omit-frame-pointer", but we tried to provide a solution that works
+ * with standard compilation settings.
+ * 
+ * To perform backtracing, we scan the code backward starting from the return address
+ * of each frame. While scanning, we note some special instructions that we look
+ * for. The two main instructions that we look for are `sd ra, offset(sp)` which is
+ * used to save the previous return address to the stack, and `addiu sp, sp, offset`
+ * which creates the stack frame for the current function. When we find both, we know
+ * how to get back to the previous frame. 
+ * 
+ * Notice that this also works through exceptions, as the exception handler does create
+ * a stack frame exactly like a standard function (see inthandler.S). 
+ * 
+ * Only a few functions do use a frame pointer: those that allocate a runtime-calculated
+ * amount of stack (eg: using alloca). Because of this, we actually look for usages
+ * of the frame pointer register fp, and track those as well to be able to correctly
+ * walk the stack in those cases.
+ * 
+ * Symbolization
+ * =============
+ * To symbolize the backtrace, we use a symbol table file (SYMT) that is generated
+ * by the n64sym tool during the build process. The symbol table is put into the
+ * rompak (see rompak_internal.h) and is structured in a way that can be queried
+ * directly from ROM, without even allocating memory. This is especially useful
+ * to provide backtrace in catastrophic situations where the heap is not available.
+ * 
+ * The symbol table file contains the source code references (function name, file name,
+ * line number) for a number of addresses in the ROM. Since it would be impractical to
+ * save information for all the addresses in the text segment, only special addresses
+ * are saved: in particular, those where a function call is made (ie: the address of
+ * JAL / JALR instructions), which are the ones that are commonly found in backtraces
+ * and thus need to be symbolized. In addition to these, the symbol table contains
+ * also information associated to the addresses that mark the start of each function,
+ * so that it's always possible to infer the function a certain address belongs to.
+ * 
+ * Given that not all addresses are saved, it is important to provide accurate
+ * source code references for stack frames that are interrupted by interrupts or 
+ * exceptions; in those cases, the symbolization will simply return the function name
+ * the addresses belongs to, without any source code reference.
+ * 
+ * To see more details on how the symbol table is structured in the ROM, see
+ * #symtable_header_t and the source code of the n64sym tool.
+ * 
+ */
+#include <stdint.h>
+#include <stdalign.h>
+#include <stdlib.h>
+#include <string.h>
+#include "backtrace.h"
+#include "backtrace_internal.h"
+#include "debug.h"
+#include "n64sys.h"
+#include "dma.h"
+#include "utils.h"
+#include "exception.h"
+#include "interrupt.h"
+#include "rompak_internal.h"
+
+/** @brief Enable to debug why a backtrace is wrong */
+#define BACKTRACE_DEBUG 0
+
+/** @brief Function alignment enfored by the compiler (-falign-functions). 
+ * 
+ * @note This must be kept in sync with n64.mk.
+ */
+#define FUNCTION_ALIGNMENT      32
+
+#define MAX_FILE_LEN 120        ///< Maximum length of a file name in a backtrace entry
+#define MAX_FUNC_LEN 120        ///< Maximum length of a function name in a backtrace entry
+
+/** 
+ * @brief Symbol table file header
+ * 
+ * The SYMT file is made of three main tables:
+ * 
+ * * Address table: this is a sequence of 32-bit integers, each representing an address in the ROM.
+ *   The table is sorted in ascending order to allow for binary search. Moreover, the lowest 2 bits
+ *   of each address can store additional information: If bit 0 is set to 1, the address is the start
+ *   of a function. If bit 1 is set to 1, the address is an inline duplicate. In fact, there might be
+ *   multiple symbols at the same address for inlined functions, so we need one entry in this table
+ *   for each entry; all of them will have the same address, and all but the last one will have bit
+ *   1 set to 1.
+ * * Symbol table: this is a sequence of symbol table entries, each representing a symbol. The size
+ *   of this table (in number of entries) is exactly the same as the address table. In fact, each
+ *   address of the address table can be thought of as an external member of this structure; it's
+ *   split externally to allow for efficiency reasons. Each entry stores the function name, 
+ *   the source file name and line number, and the binary offset of the symbol within the containing
+ *   function.
+ * * String table: This tables can be thought as a large buffer holding all the strings needed by all
+ *   symbol entries (function names and file names). Each symbol entry stores a string as an index
+ *   within the symbol table and a length. This allows to reuse the same string (or prefix thereof)
+ *   multiple times. Notice that strings are not null terminated in the string table.
+ * 
+ * The SYMT file is generated by the n64sym tool during the build process.
+ */
+typedef struct alignas(8) {
+    char head[4];           ///< Magic ID "SYMT"
+    uint32_t version;       ///< Version of the symbol table
+    uint32_t addrtab_off;   ///< Offset of the address table in the file
+    uint32_t addrtab_size;  ///< Size of the address table in the file (number of entries)
+    uint32_t symtab_off;    ///< Offset of the symbol table in the file
+    uint32_t symtab_size;   ///< Size of the symbol table in the file (number of entries); always equal to addrtab_size.
+    uint32_t strtab_off;    ///< Offset of the string table in the file
+    uint32_t strtab_size;   ///< Size of the string table in the file (number of entries)
+} symtable_header_t;
+
+/** @brief Symbol table entry **/
+typedef struct {
+    uint32_t func_sidx;     ///< Offset of the function name in the string table
+    uint32_t file_sidx;     ///< Offset of the file name in the string table
+    uint16_t func_len;      ///< Length of the function name
+    uint16_t file_len;      ///< Length of the file name
+    uint16_t line;          ///< Line number (or 0 if this symbol generically refers to a whole function)
+    uint16_t func_off;      ///< Offset of the symbol within its function
+} symtable_entry_t;
+
+/** 
+ * @brief Entry in the address table.
+ * 
+ * This is an address in RAM, with the lowest 2 bits used to store additional information.
+ * See the ADDRENTRY_* macros to access the various components.
+ */
+typedef uint32_t addrtable_entry_t;
+
+#define ADDRENTRY_ADDR(e)       ((e) & ~3)     ///< Address (without the flags9)
+#define ADDRENTRY_IS_FUNC(e)    ((e) &  1)     ///< True if the address is the start of a function
+#define ADDRENTRY_IS_INLINE(e)  ((e) &  2)     ///< True if the address is an inline duplicate
+
+#define MIPS_OP_ADDIU_SP(op)   (((op) & 0xFFFF0000) == 0x27BD0000)   ///< Matches: addiu $sp, $sp, imm
+#define MIPS_OP_DADDIU_SP(op)  (((op) & 0xFFFF0000) == 0x67BD0000)   ///< Matches: daddiu $sp, $sp, imm
+#define MIPS_OP_JR_RA(op)      (((op) & 0xFFFFFFFF) == 0x03E00008)   ///< Matches: jr $ra
+#define MIPS_OP_SD_RA_SP(op)   (((op) & 0xFFFF0000) == 0xFFBF0000)   ///< Matches: sd $ra, imm($sp)
+#define MIPS_OP_SD_FP_SP(op)   (((op) & 0xFFFF0000) == 0xFFBE0000)   ///< Matches: sd $fp, imm($sp)
+#define MIPS_OP_LUI_GP(op)     (((op) & 0xFFFF0000) == 0x3C1C0000)   ///< Matches: lui $gp, imm
+#define MIPS_OP_NOP(op)        ((op) == 0x00000000)                  ///< Matches: nop
+#define MIPS_OP_MOVE_FP_SP(op) ((op) == 0x03A0F025)                  ///< Matches: move $fp, $sp
+
+/** @brief Exception handler (see inthandler.S) */
+extern uint32_t inthandler[];
+/** @brief End of exception handler (see inthandler.S) */
+extern uint32_t inthandler_end[];
+
+/** @brief Address of the SYMT symbol table in the rompak. */
+static uint32_t SYMT_ROM = 0xFFFFFFFF;
+
+/** @brief Placeholder used in frames where symbols are not available */
+static const char *UNKNOWN_SYMBOL = "???";
+
+/** @brief Check if addr is a valid PC address */
+static bool is_valid_address(uint32_t addr)
+{
+    // TODO: for now we only handle RAM (cached access). This should be extended to handle
+    // TLB-mapped addresses for instance.
+    return addr >= 0x80000400 && addr < 0x80800000 && (addr & 3) == 0;
+}
+
+/** 
+ * @brief Open the SYMT symbol table in the rompak.
+ * 
+ * If not found, return a null header.
+ */
+static symtable_header_t symt_open(void) {
+    if (SYMT_ROM == 0xFFFFFFFF) {
+        SYMT_ROM = rompak_search_ext(".sym");
+        if (!SYMT_ROM)
+            debugf("backtrace: no symbol table found in the rompak\n");
+    }
+
+    if (!SYMT_ROM) {
+        return (symtable_header_t){0};
+    }
+
+    symtable_header_t symt_header;
+    data_cache_hit_writeback_invalidate(&symt_header, sizeof(symt_header));
+    dma_read_raw_async(&symt_header, SYMT_ROM, sizeof(symtable_header_t));
+    dma_wait();
+
+    if (symt_header.head[0] != 'S' || symt_header.head[1] != 'Y' || symt_header.head[2] != 'M' || symt_header.head[3] != 'T') {
+        debugf("backtrace: invalid symbol table found at 0x%08lx\n", SYMT_ROM);
+        SYMT_ROM = 0;
+        return (symtable_header_t){0};
+    }
+    if (symt_header.version != 2) {
+        debugf("backtrace: unsupported symbol table version %ld -- please update your n64sym tool\n", symt_header.version);
+        SYMT_ROM = 0;
+        return (symtable_header_t){0};
+    }
+
+    return symt_header;
+}
+
+/**
+ * @brief Return an entry in the address table by index
+ * 
+ * @param symt      SYMT file header
+ * @param idx       Index of the entry to return
+ * @return addrtable_entry_t  Entry of the address table
+ */
+static addrtable_entry_t symt_addrtab_entry(symtable_header_t *symt, int idx)
+{
+    return io_read(SYMT_ROM + symt->addrtab_off + idx * 4);
+}
+
+/**
+ * @brief Search the SYMT address table for the given address.
+ * 
+ * Run a binary search to find the entry in the table. If there is a single exact match,
+ * the entry is returned. If there are multiple entries with the same address, the first
+ * entry is returned (this is the case for inlined functions: so some entries following
+ * the current one will have the same address). If there is no exact match, the entry
+ * with the biggest address just before the given address is returned.
+ *
+ * @param symt      SYMT file header
+ * @param addr      Address to search for
+ * @param idx       If not null, will be set to the index of the entry found (or the index just before)
+ * @return          The found entry (or the entry just before)
+ */
+static addrtable_entry_t symt_addrtab_search(symtable_header_t *symt, uint32_t addr, int *idx)
+{
+    int min = 0;
+    int max = symt->addrtab_size - 1;
+    while (min < max) {
+        int mid = (min + max) / 2;
+        addrtable_entry_t entry = symt_addrtab_entry(symt, mid);
+        if (addr <= ADDRENTRY_ADDR(entry))
+            max = mid;
+        else
+            min = mid + 1;
+    }
+    addrtable_entry_t entry = symt_addrtab_entry(symt, min);
+    if (min > 0 && ADDRENTRY_ADDR(entry) > addr)
+        entry = symt_addrtab_entry(symt, --min);
+    if (idx) *idx = min;
+    return entry;
+}
+
+
+/**
+ * @brief Fetch a string from the string table
+ * 
+ * @param symt  SYMT file
+ * @param sidx  Index of the first character of the string in the string table
+ * @param slen  Length of the string
+ * @param buf   Destination buffer
+ * @param size  Size of the destination buffer
+ * @return char*  Fetched string within the destination buffer (might not be at offset 0 for alignment reasons)
+ */
+static char* symt_string(symtable_header_t *symt, int sidx, int slen, char *buf, int size)
+{
+    // Align 2-byte phase of the RAM buffer with the ROM address. This is required
+    // for dma_read.
+    int tweak = (sidx ^ (uint32_t)buf) & 1;
+    char *func = buf + tweak; size -= tweak;
+    int n = MIN(slen, size);
+
+    data_cache_hit_writeback_invalidate(buf, size);
+    dma_read(func, SYMT_ROM + symt->strtab_off + sidx, n);
+    func[n] = 0;
+    return func;
+}
+
+/**
+ * @brief Fetch a symbol table entry from the SYMT file.
+ * 
+ * @param symt    SYMT file
+ * @param entry   Output entry pointer
+ * @param idx     Index of the entry to fetch
+ */
+static void symt_entry_fetch(symtable_header_t *symt, symtable_entry_t *entry, int idx)
+{
+    data_cache_hit_writeback_invalidate(entry, sizeof(symtable_entry_t));
+    dma_read(entry, SYMT_ROM + symt->symtab_off + idx * sizeof(symtable_entry_t), sizeof(symtable_entry_t));
+}
+
+// Fetch the function name of an entry
+static char* symt_entry_func(symtable_header_t *symt, symtable_entry_t *entry, uint32_t addr, char *buf, int size)
+{
+    if (addr >= (uint32_t)inthandler && addr < (uint32_t)inthandler_end) {
+        // Special case exception handlers. This is just to show something slightly
+        // more readable instead of "notcart+0x0" or similar assembly symbols
+        snprintf(buf, size, "<EXCEPTION HANDLER>");
+        return buf;
+    } else {
+        return symt_string(symt, entry->func_sidx, entry->func_len, buf, size);
+    }
+}
+
+// Fetch the file name of an entry
+static char* symt_entry_file(symtable_header_t *symt, symtable_entry_t *entry, uint32_t addr, char *buf, int size)
+{
+    return symt_string(symt, entry->file_sidx, entry->file_len, buf, size);
+}
+
+char* __symbolize(void *vaddr, char *buf, int size)
+{
+    symtable_header_t symt = symt_open();
+    if (symt.head[0]) {
+        uint32_t addr = (uint32_t)vaddr;
+        int idx = 0;
+        addrtable_entry_t a = symt_addrtab_search(&symt, addr, &idx);
+        while (!ADDRENTRY_IS_FUNC(a))
+            a = symt_addrtab_entry(&symt, --idx);
+
+        // Read the symbol name
+        symtable_entry_t entry alignas(8);
+        symt_entry_fetch(&symt, &entry, idx);
+        char *func = symt_entry_func(&symt, &entry, addr, buf, size-12);
+        char lbuf[12];
+        snprintf(lbuf, sizeof(lbuf), "+0x%lx", addr - ADDRENTRY_ADDR(a));
+        return strcat(func, lbuf);
+    }
+    snprintf(buf, size, "%s", UNKNOWN_SYMBOL);
+    return buf;
+}
+
+/**
+ * @brief Analyze a function to find out its stack frame layout and properties (useful for backtracing).
+ * 
+ * This function implements the core heuristic used by the backtrace engine. It analyzes the actual
+ * code of a function in memory instruction by instruction, trying to find out whether the function
+ * uses a stack frame or not, whether it uses a frame pointer, and where the return address is stored.
+ * 
+ * Since we do not have DWARF informations or similar metadata, we can just do educated guesses. A
+ * mistake in the heuristic will result probably in a wrong backtrace from this point on. 
+ * 
+ * @param func                        Output function description structure
+ * @param ptr                         Pointer to the function code at the point where the backtrace starts.
+ *                                    This is normally the point where a JAL opcode is found, as we are walking
+ *                                    up the call stack.
+ * @param func_start                  Start of the function being analyzed. This is optional: the heuristic can work
+ *                                    without this hint, but it is useful in certain situations (eg: to better
+ *                                    walk up after an exception).
+ * @param exception_ra                If != NULL, this function was interrupted by an exception. This variable
+ *                                    stores the $ra register value as saved in the exception frame, that might be useful.
+ * 
+ * @return true if the backtrace can continue, false if must be aborted (eg: we are within invalid memory)
+ */
+bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, void *exception_ra)
+{
+    *func = (bt_func_t){
+        .type = (ptr >= inthandler && ptr < inthandler_end) ? BT_EXCEPTION : BT_FUNCTION,
+        .stack_size = 0, .ra_offset = 0, .fp_offset = 0
+    };
+
+    uint32_t addr = (uint32_t)ptr;
+    while (1) {
+        // Validate that we can dereference the virtual address without raising an exception
+        // TODO: enhance this check with more valid ranges.
+        if (!is_valid_address(addr)) {
+            // This address is invalid, probably something is corrupted. Avoid looking further.
+            debugf("backtrace: interrupted because of invalid return address 0x%08lx\n", addr);
+            return false;
+        }
+        uint32_t op = *(uint32_t*)addr;
+        if (MIPS_OP_ADDIU_SP(op) || MIPS_OP_DADDIU_SP(op)) {
+            // Extract the stack size only from the start of the function, where the
+            // stack is allocated (negative value). This is important because the RA
+            // could point to a leaf basis block at the end of the function (like in the
+            // assert case), and if we picked the positive ADDIU SP at the end of the
+            // proper function body, we might miss a fp_offset.
+            if (op & 0x8000)
+                func->stack_size = -(int16_t)(op & 0xFFFF);
+        } else if (MIPS_OP_SD_RA_SP(op)) {
+            func->ra_offset = (int16_t)(op & 0xFFFF) + 4; // +4 = load low 32 bit of RA
+            // If we found a stack size, it might be a red herring (an alloca); we need one
+            // happening "just before" sd ra,xx(sp)
+            func->stack_size = 0;
+        } else if (MIPS_OP_SD_FP_SP(op)) {
+            func->fp_offset = (int16_t)(op & 0xFFFF) + 4; // +4 = load low 32 bit of FP
+        } else if (MIPS_OP_LUI_GP(op)) {
+            // Loading gp is commonly done in _start, so it's useless to go back more
+            return false;
+        } else if (MIPS_OP_MOVE_FP_SP(op)) {
+            // This function uses the frame pointer. Uses that as base of the stack.
+            // Even with -fomit-frame-pointer (default on our toolchain), the compiler
+            // still emits a framepointer for functions using a variable stack size
+            // (eg: using alloca() or VLAs).
+            func->type = BT_FUNCTION_FRAMEPOINTER;
+        } 
+        // We found the stack frame size and the offset of the return address in the stack frame
+        // We can stop looking and process the frame
+        if (func->stack_size != 0 && func->ra_offset != 0)
+            break;
+        if (exception_ra && addr == func_start) {
+            // The frame that was interrupted by an interrupt handler is a special case: the
+            // function could be a leaf function with no stack. If we were able to identify
+            // the function start (via the symbol table) and we reach it, it means that
+            // we are in a real leaf function.
+            func->type = BT_LEAF;
+            break;
+        } else if (exception_ra && !func_start && MIPS_OP_NOP(op) && (addr + 4) % FUNCTION_ALIGNMENT == 0) {
+            // If we are in the frame interrupted by an interrupt handler, and we does not know
+            // the start of the function (eg: no symbol table), then try to stop by looking for
+            // a NOP that pads between functions. Obviously the NOP we find can be either a false
+            // positive or a false negative, but we can't do any better without symbols.
+            func->type = BT_LEAF;
+            break;
+        }
+        addr -= 4;
+    }
+    return true;
+}
+
+static void backtrace_foreach(void (*cb)(void *arg, void *ptr), void *arg)
+{
+    /*
+     * This function is called in very risky contexts, for instance as part of an exception
+     * handler or during an assertion. We try to always provide as much information as
+     * possible in these cases, with graceful degradation if something more elaborate cannot
+     * be extracted. Thus, this function:
+     * 
+     *  * Must not use malloc(). The heap might be corrupted or empty.
+     *  * Must not use assert(), because that might trigger recursive assertions.
+     *  * Must avoid raising exceptions. Specifically, it must avoid risky memory accesses
+     *    to wrong addresses.
+     */
+
+    // Current value of SP/RA/FP registers.
+    uint32_t *sp, *ra, *fp;
+    asm volatile (
+        "move %0, $ra\n"
+        "move %1, $sp\n"
+        "move %2, $fp\n"
+        : "=r"(ra), "=r"(sp), "=r"(fp)
+    );
+
+    #if BACKTRACE_DEBUG
+    debugf("backtrace: start\n"); 
+    #endif
+
+    uint32_t* exception_ra = NULL;      // If != NULL, 
+    uint32_t func_start = 0;            // Start of the current function (when known)
+
+    // Start from the backtrace function itself. Put the start pointer somewhere after the initial
+    // prolog (eg: 64 instructions after start), so that we parse the prolog itself to find sp/fp/ra offsets.
+    ra = (uint32_t*)backtrace_foreach + 64;
+
+    while (1) {
+        // Analyze the function pointed by ra, passing information about the previous exception frame if any.
+        // If the analysis fail (for invalid memory accesses), stop right away.
+        bt_func_t func; 
+        if (!__bt_analyze_func(&func, ra, func_start, exception_ra))
+            return;
+
+        #if BACKTRACE_DEBUG
+        debugf("backtrace: %s, ra=%p, sp=%p, fp=%p ra_offset=%d, fp_offset=%d, stack_size=%d\n", 
+            func.type == BT_FUNCTION ? "BT_FUNCTION" : (func.type == BT_EXCEPTION ? "BT_EXCEPTION" : (func.type == BT_FUNCTION_FRAMEPOINTER ? "BT_FRAMEPOINTER" : "BT_LEAF")),
+            ra, sp, fp, func.ra_offset, func.fp_offset, func.stack_size);
+        #endif
+
+        switch (func.type) {
+            case BT_FUNCTION_FRAMEPOINTER:
+                if (!func.fp_offset) {
+                    debugf("backtrace: framepointer used but not saved onto stack at %p\n", ra);
+                } else {
+                    // Use the frame pointer to refer to the current frame.
+                    sp = fp;
+                    if (!is_valid_address((uint32_t)sp)) {
+                        debugf("backtrace: interrupted because of invalid frame pointer 0x%08lx\n", (uint32_t)sp);
+                        return;
+                    }
+                }
+                // FALLTHROUGH!
+            case BT_FUNCTION:
+                if (func.fp_offset)
+                    fp = *(uint32_t**)((uint32_t)sp + func.fp_offset);
+                ra = *(uint32_t**)((uint32_t)sp + func.ra_offset) - 2;
+                sp = (uint32_t*)((uint32_t)sp + func.stack_size);
+                exception_ra = NULL;
+                func_start = 0;
+                break;
+            case BT_EXCEPTION: {
+                // Exception frame. We must return back to EPC, but let's keep the
+                // RA value. If the interrupted function is a leaf function, we
+                // will need it to further walk back.
+                // Notice that FP is a callee-saved register so we don't need to
+                // recover it from the exception frame (also, it isn't saved there
+                // during interrupts).
+                exception_ra = *(uint32_t**)((uint32_t)sp + func.ra_offset);
+
+                // Read EPC from exception frame and adjust it with CAUSE BD bit
+                ra = *(uint32_t**)((uint32_t)sp + offsetof(reg_block_t, epc) + 32);
+                uint32_t cause = *(uint32_t*)((uint32_t)sp + offsetof(reg_block_t, cr) + 32);
+                if (cause & C0_CAUSE_BD) ra++;
+
+                sp = (uint32_t*)((uint32_t)sp + func.stack_size);
+
+                // Special case: if the exception is due to an invalid EPC
+                // (eg: a null function pointer call), we can rely on RA to get
+                // back to the caller. This assumes that we got there via a function call
+                // rather than a raw jump, but that's a reasonable assumption. It's anyway
+                // the best we can do.
+                if (C0_GET_CAUSE_EXC_CODE(cause) == EXCEPTION_CODE_TLB_LOAD_I_MISS &&
+                    !is_valid_address((uint32_t)ra)) {
+                    
+                    // Store the invalid address in the backtrace, so that it will appear in dumps.
+                    // This makes it easier for the user to understand the reason for the exception.
+                    cb(arg, ra);
+                    #if BACKTRACE_DEBUG
+                    debugf("backtrace: %s, ra=%p, sp=%p, fp=%p ra_offset=%d, fp_offset=%d, stack_size=%d\n", 
+                        "BT_INVALID", ra, sp, fp, func.ra_offset, func.fp_offset, func.stack_size);
+                    #endif
+                    
+                    ra = exception_ra - 2;
+
+                    // The function that jumped into an invalid PC was not interrupted by the exception: it
+                    // is a regular function
+                    // call now.
+                    exception_ra = NULL;
+                    break;
+                }
+
+                // The next frame might be a leaf function, for which we will not be able
+                // to find a stack frame. It is useful to try finding the function start.
+                // Try to open the symbol table: if we find it, we can search for the start
+                // address of the function.
+                symtable_header_t symt = symt_open();
+                if (symt.head[0]) {
+                    int idx;
+                    addrtable_entry_t entry = symt_addrtab_search(&symt, (uint32_t)ra, &idx);
+                    while (!ADDRENTRY_IS_FUNC(entry))
+                        entry = symt_addrtab_entry(&symt, --idx);
+                    func_start = ADDRENTRY_ADDR(entry);
+                    #if BACKTRACE_DEBUG
+                    debugf("Found interrupted function start address: %08lx\n", func_start);
+                    #endif
+                }
+            }   break;
+            case BT_LEAF:
+                ra = exception_ra - 2;
+                // A leaf function has no stack. On the other hand, an exception happening at the
+                // beginning of a standard function (before RA is saved), does have a stack but
+                // will be marked as a leaf function. In this case, we mus update the stack pointer.
+                sp = (uint32_t*)((uint32_t)sp + func.stack_size);
+                exception_ra = NULL;
+                func_start = 0;
+                break;
+        }
+
+        // Call the callback with this stack frame
+        cb(arg, ra);
+    }
+}
+
+int backtrace(void **buffer, int size)
+{
+    int i = -1; // skip backtrace itself
+    void cb(void *arg, void *ptr) {
+        if (i >= 0 && i < size)
+            buffer[i] = ptr;
+        i++;
+    }
+    backtrace_foreach(cb, NULL);
+    return i;
+}
+
+static void format_entry(void (*cb)(void *, backtrace_frame_t *), void *cb_arg, 
+    symtable_header_t *symt, int idx, uint32_t addr, uint32_t offset, bool is_func, bool is_inline)
+{       
+    symtable_entry_t entry alignas(8);
+    symt_entry_fetch(symt, &entry, idx);
+
+    char file_buf[MAX_FILE_LEN+2] alignas(8);
+    char func_buf[MAX_FUNC_LEN+2] alignas(8);
+
+    cb(cb_arg, &(backtrace_frame_t){
+        .addr = addr,
+        .func_offset = offset ? offset : entry.func_off,
+        .func = symt_entry_func(symt, &entry, addr, func_buf, sizeof(func_buf)),
+        .source_file = symt_entry_file(symt, &entry, addr, file_buf, sizeof(file_buf)),
+        .source_line = is_func ? 0 : entry.line,
+        .is_inline = is_inline,
+    });
+}
+
+bool backtrace_symbols_cb(void **buffer, int size, uint32_t flags,
+    void (*cb)(void *, backtrace_frame_t *), void *cb_arg)
+{
+    // Open the symbol table. If not found, we will still invoke the
+    // callback but using unsymbolized addresses.
+    symtable_header_t symt_header = symt_open();
+    bool has_symt = symt_header.head[0];
+
+    for (int i=0; i<size; i++) {
+        uint32_t needle = (uint32_t)buffer[i];
+        if (!is_valid_address(needle)) {
+            // If the address is before the first symbol, we call it a NULL pointer, as that is the most likely case
+            cb(cb_arg, &(backtrace_frame_t){
+                .addr = needle,
+                .func_offset = needle,
+                .func = needle < 128 ? "<NULL POINTER>" : "<INVALID ADDRESS>",
+                .source_file = UNKNOWN_SYMBOL, .source_line = 0, .is_inline = false
+            });
+            continue;
+        }
+        if (!has_symt) {
+            // No symbol table. Call the callback with a dummy entry which just contains the address
+            bool exc = (needle >= (uint32_t)inthandler && needle < (uint32_t)inthandler_end);
+            cb(cb_arg, &(backtrace_frame_t){
+                .addr = needle,
+                .func = exc ? "<EXCEPTION HANDLER>" : UNKNOWN_SYMBOL, .func_offset = 0,
+                .source_file = UNKNOWN_SYMBOL, .source_line = 0, .is_inline = false
+            });
+            continue;
+        }
+        int idx; addrtable_entry_t a;
+        a = symt_addrtab_search(&symt_header, needle, &idx);
+
+        if (ADDRENTRY_ADDR(a) == needle) {
+            // Found an entry at this address. Go through all inlines for this address.
+            while (1) {
+                format_entry(cb, cb_arg, &symt_header, idx, needle, 0, false, ADDRENTRY_IS_INLINE(a));
+                if (!ADDRENTRY_IS_INLINE(a)) break;
+                a = symt_addrtab_entry(&symt_header, ++idx);
+            }
+        } else {
+            // Search the containing function
+            while (!ADDRENTRY_IS_FUNC(a))
+                a = symt_addrtab_entry(&symt_header, --idx);
+            format_entry(cb, cb_arg, &symt_header, idx, needle, needle - ADDRENTRY_ADDR(a), true, false);
+        }
+    }
+    return true;
+}
+
+char** backtrace_symbols(void **buffer, int size)
+{
+    const int MAX_SYM_LEN = MAX_FILE_LEN + MAX_FUNC_LEN + 24;
+    char **syms = malloc(2 * size * (sizeof(char*) + MAX_SYM_LEN));
+    char *out = (char*)syms + size*sizeof(char*);
+    int level = 0;
+
+    void cb(void *arg, backtrace_frame_t *frame) {
+        int n = snprintf(out, MAX_SYM_LEN,
+            "%s+0x%lx (%s:%d) [0x%08lx]", frame->func, frame->func_offset, frame->source_file, frame->source_line, frame->addr);
+        if (frame->is_inline)
+            out[-1] = '\n';
+        else
+            syms[level++] = out;
+        out += n + 1;
+    }
+
+    backtrace_symbols_cb(buffer, size, 0, cb, NULL);
+    return syms;
+}
+
+void backtrace_frame_print(backtrace_frame_t *frame, FILE *out)
+{
+    fprintf(out, "%s+0x%lx (%s:%d) [0x%08lx]%s", 
+        frame->func, frame->func_offset, 
+        frame->source_file, frame->source_line,
+        frame->addr, frame->is_inline ? " (inline)" : "");
+}
+
+void backtrace_frame_print_compact(backtrace_frame_t *frame, FILE *out, int width)
+{
+    const char *source_file = frame->source_file;
+    int len = strlen(frame->func) + strlen(source_file);
+    bool ellipsed = false;
+    if (len > width && source_file) {
+        source_file += len - (width - 8);
+        ellipsed = true;
+    }
+    if (frame->func != UNKNOWN_SYMBOL) fprintf(out, "%s ", frame->func);
+    if (source_file != UNKNOWN_SYMBOL) fprintf(out, "(%s%s:%d)", ellipsed ? "..." : "", source_file, frame->source_line);
+    if (frame->func == UNKNOWN_SYMBOL || source_file == UNKNOWN_SYMBOL)
+        fprintf(out, "[0x%08lx]", frame->addr);
+    fprintf(out, "\n");
+}

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -499,7 +499,8 @@ static void backtrace_foreach(void (*cb)(void *arg, void *ptr), void *arg)
                 // back to the caller. This assumes that we got there via a function call
                 // rather than a raw jump, but that's a reasonable assumption. It's anyway
                 // the best we can do.
-                if (C0_GET_CAUSE_EXC_CODE(cause) == EXCEPTION_CODE_TLB_LOAD_I_MISS &&
+                if ((C0_GET_CAUSE_EXC_CODE(cause) == EXCEPTION_CODE_TLB_LOAD_I_MISS ||
+                    C0_GET_CAUSE_EXC_CODE(cause) == EXCEPTION_CODE_LOAD_I_ADDRESS_ERROR) && 
                     !is_valid_address((uint32_t)ra)) {
                     
                     // Store the invalid address in the backtrace, so that it will appear in dumps.

--- a/src/backtrace_internal.h
+++ b/src/backtrace_internal.h
@@ -17,7 +17,7 @@ typedef struct {
     int fp_offset;           ///< Offset of the saved fp from the top of the stack frame; this is != 0 only if the function modifies fp (maybe as a frame pointer, but not necessarily)
 } bt_func_t;
 
-bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, void *exception_ra);
+bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, bool from_exception);
 
 
 /**

--- a/src/backtrace_internal.h
+++ b/src/backtrace_internal.h
@@ -13,8 +13,8 @@ typedef enum {
 typedef struct {
     bt_func_type type;       ///< Type of the function
     int stack_size;          ///< Size of the stack frame
-    int ra_offset;           ///< Offset of the return address in the stack frame
-    int fp_offset;           ///< Offset of the saved fp in the stack frame; this is != 0 only if the function modifies fp (maybe as a frame pointer, but not necessarily)
+    int ra_offset;           ///< Offset of the return address from the top of the stack frame
+    int fp_offset;           ///< Offset of the saved fp from the top of the stack frame; this is != 0 only if the function modifies fp (maybe as a frame pointer, but not necessarily)
 } bt_func_t;
 
 bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, void *exception_ra);

--- a/src/backtrace_internal.h
+++ b/src/backtrace_internal.h
@@ -1,0 +1,43 @@
+#ifndef __LIBDRAGON_BACKTRACE_INTERNAL_H
+#define __LIBDRAGON_BACKTRACE_INTERNAL_H
+
+/** @brief The "type" of funciton as categorized by the backtrace heuristic (__bt_analyze_func) */
+typedef enum {
+    BT_FUNCTION,                ///< Regular function with a stack frame
+    BT_FUNCTION_FRAMEPOINTER,   ///< The function uses the register fp as frame pointer (normally, this happens only when the function uses alloca)
+    BT_EXCEPTION,               ///< This is an exception handler (inthandler.S)
+    BT_LEAF                     ///< Leaf function (no calls), no stack frame allocated, sp/ra not modified
+} bt_func_type;
+
+/** @brief Description of a function for the purpose of backtracing (filled by __bt_analyze_func) */
+typedef struct {
+    bt_func_type type;       ///< Type of the function
+    int stack_size;          ///< Size of the stack frame
+    int ra_offset;           ///< Offset of the return address in the stack frame
+    int fp_offset;           ///< Offset of the saved fp in the stack frame; this is != 0 only if the function modifies fp (maybe as a frame pointer, but not necessarily)
+} bt_func_t;
+
+bool __bt_analyze_func(bt_func_t *func, uint32_t *ptr, uint32_t func_start, void *exception_ra);
+
+
+/**
+ * @brief Return the symbol associated to a given address.
+ * 
+ * This function inspect the symbol table (if any) to search for the
+ * specified address. It returns the function name the address belongs
+ * to, and the offset within the function as a string in the format
+ * "function_name+0x1234".
+ * 
+ * If the symbol table is not found in the rompack or the address is not found,
+ * the return string is "???".
+ * 
+ * @param vaddr         Address to symbolize 
+ * @param buf           Buffer where to store the result
+ * @param size          Size of the buffer
+ * @return char*        Pointer to the return string. This is within the provided
+ *                      buffer, but not necessarily at the beginning because of DMA
+ *                      alignment constraints.
+ */
+char* __symbolize(void *vaddr, char *buf, int size);
+
+#endif

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -9,9 +9,12 @@
 
 #include "regs.S"
 
-	.p2align 5
-inthandler:
 	.global inthandler
+	.global inthandler_end
+
+	.p2align 5
+	.func inthandler
+inthandler:
 
 	.set noat
 	.set noreorder
@@ -377,7 +380,8 @@ save_fpu_regs:
 	sdc1 $f19,(STACK_FPR+19*8)(a0)
 	jr ra
 	nop
-
+inthandler_end:
+	.endfunc
 
 	.section .bss
 	.p2align 2

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,11 +5,16 @@ all: testrom.z64 testrom_emu.z64
 
 $(BUILD_DIR)/testrom.dfs: $(wildcard filesystem/*)
 
-$(BUILD_DIR)/testrom.elf: $(BUILD_DIR)/testrom.o $(BUILD_DIR)/test_constructors_cpp.o $(BUILD_DIR)/rsp_test.o $(BUILD_DIR)/rsp_test2.o
+OBJS = $(BUILD_DIR)/test_constructors_cpp.o \
+	   $(BUILD_DIR)/rsp_test.o \
+	   $(BUILD_DIR)/rsp_test2.o \
+	   $(BUILD_DIR)/backtrace.o \
+
+$(BUILD_DIR)/testrom.elf: $(BUILD_DIR)/testrom.o $(OBJS)
 testrom.z64: N64_ROM_TITLE="Libdragon Test ROM"
 testrom.z64: $(BUILD_DIR)/testrom.dfs
 
-$(BUILD_DIR)/testrom_emu.elf: $(BUILD_DIR)/testrom_emu.o $(BUILD_DIR)/test_constructors_cpp.o $(BUILD_DIR)/rsp_test.o $(BUILD_DIR)/rsp_test2.o
+$(BUILD_DIR)/testrom_emu.elf: $(BUILD_DIR)/testrom_emu.o $(OBJS)
 testrom_emu.z64: N64_ROM_TITLE="Libdragon Test ROM"
 testrom_emu.z64: $(BUILD_DIR)/testrom.dfs
 

--- a/tests/backtrace.S
+++ b/tests/backtrace.S
@@ -1,0 +1,147 @@
+#include "../src/regs.S"
+
+	.set noreorder
+    
+    .text
+
+    # This file contains functions used by test_backtrace.c to test
+    # the backtrace analysis code. The code of this functions is not
+    # run, but just scanned to extract the stack frame information.
+
+    # BT1: a function with a stack frame that does not use FP as framepointer
+    # but dirties it.
+test_bt_1:
+    addiu   sp,sp,-112     # <- stack frame 112
+    sd      s3,56(sp)
+    lw      s3,148(sp)
+    lw      v0,4(a0)
+    lw      v1,0(a0)
+    sd      s5,72(sp)
+    sd      s4,64(sp)
+    addiu   s5,a0,8
+    addu    s4,a1,a2
+    subu    a2,s3,a2
+    sd      s7,88(sp)
+    sd      s6,80(sp)
+    sd      s2,48(sp)
+    sd      s1,40(sp)
+    sd      s0,32(sp)
+    sd      ra,104(sp)    # <- ra offset 104
+    sd      fp,96(sp)     # <- fp offset 96
+    .globl test_bt_1_start
+test_bt_1_start:
+    move    s1,a0
+    
+
+    # BT2: a function using FP as framepointer
+test_bt_2:
+    addiu   sp,sp,-128   # <- stack frame 128
+    sd      fp,112(sp)   # <- fp offset 112
+    move    fp,sp        # <- fp used as framepointer
+    sd      s0,48(sp)
+    move    s0,a0
+    lw      a0,188(fp)
+    sd      s7,104(sp)
+    sd      s5,88(sp)
+    sd      s2,64(sp)
+    sd      s1,56(sp)
+    sd      ra,120(sp)
+    sd      s6,96(sp)
+    sd      s4,80(sp)
+    sd      s3,72(sp)
+    addiu   a0,a0,108
+    sw      s0,128(fp)
+    lw      s2,172(fp)
+    sd      a2,144(fp)
+    sd      a3,152(fp)
+    # [...]
+    ld      ra,120(sp)
+    ld      fp,112(sp)
+    ld      s7,104(sp)
+    ld      s6,96(sp)
+    ld      s5,88(sp)
+    ld      s4,80(sp)
+    ld      s3,72(sp)
+    ld      s2,64(sp)
+    ld      s1,56(sp)
+    ld      s0,48(sp)
+    jr      ra            # <- return point in the middle of the function
+    addiu   sp,sp,128
+    # [...]
+    lw      v0,0(a0)
+    sll     v0,v0,0x2
+    addiu   sp,sp,-180   # <- potentially confusing alloca (not the real stack frame)
+    addu    v0,s2,v0
+    lw      v0,0(v0)
+    addu    v0,v0,s4
+    .globl test_bt_2_start
+test_bt_2_start:
+    lb      v0,0(v0)
+
+    # BT3: a function changing FP with a leaf basis block
+test_bt_3:
+    addiu   sp,sp,-80
+    sd      ra,20(sp)
+    sd      fp,16(sp)
+    # [...]
+    ld      fp,16(sp)
+    ld      ra,20(sp)
+    ld      s0,48(sp)
+    jr      ra            # <- return point in the middle of the function
+    addiu   sp,sp,80
+    .globl test_bt_3_start
+test_bt_3_start:
+    lb      v0,0(v0)      # <- leaf basis block
+
+
+    # BT4: a leaf function preceded by alignment nops
+    nop; nop; nop; nop
+    .align 5
+test_bt_4:
+    lw      a3,-29740(gp)
+    lui     t5,0x51eb
+    sll     v1,a3,0x3
+    ori     t5,t5,0x851f
+    mult    v1,t5
+    sll     t0,a3,0x5
+    sra     t1,t0,0x1f
+    sra     v1,v1,0x1f
+    dsra32  t2,a1,0x0
+    mfhi    v0
+    sra     v0,v0,0x5
+    subu    v0,v0,v1
+    mult    t0,t5
+    addu    v0,v0,t2
+    sd      a1,8(sp)
+    move    t3,t2
+    .globl test_bt_4_start
+test_bt_4_start:
+    mfhi    t0
+
+    # BT5: a leaf function without nop, identified via explicit start address
+    addiu   sp,sp,-80   # fake precedeing stack frame
+    sd      ra,20(sp)
+    ld      ra,20(sp)
+    jr      ra
+    addiu   sp,sp,80
+    .globl  test_bt_5
+test_bt_5:
+    lw      a3,-29740(gp)
+    lui     t5,0x51eb
+    sll     v1,a3,0x3
+    ori     t5,t5,0x851f
+    mult    v1,t5
+    sll     t0,a3,0x5
+    sra     t1,t0,0x1f
+    sra     v1,v1,0x1f
+    dsra32  t2,a1,0x0
+    mfhi    v0
+    sra     v0,v0,0x5
+    subu    v0,v0,v1
+    mult    t0,t5
+    addu    v0,v0,t2
+    sd      a1,8(sp)
+    move    t3,t2
+    .globl test_bt_5_start
+test_bt_5_start:
+    mfhi    t0

--- a/tests/test_backtrace.c
+++ b/tests/test_backtrace.c
@@ -1,0 +1,204 @@
+#include "backtrace.h"
+#include "../src/backtrace_internal.h"
+#include <alloca.h>
+
+#define NOINLINE static __attribute__((noinline,used))
+#define STACK_FRAME(n)   volatile char __stackframe[n] = {0}; (void)__stackframe;
+
+void* bt_buf[32];
+int bt_buf_len;
+int (*bt_null_func_ptr)(void);
+int (*bt_invalid_func_ptr)(void) = (int(*)(void))0xEBEBEBEB;
+
+// Test functions defined in backtrace_test.S
+int btt_end(void)
+{
+    memset(bt_buf, 0, sizeof(bt_buf));
+    bt_buf_len = backtrace(bt_buf, 32);
+    return 0;
+}
+
+NOINLINE int btt_fp(void) { STACK_FRAME(128); volatile char *buf = alloca(bt_buf_len+1); buf[0] = 2; return btt_end()+1+buf[0]; }
+NOINLINE int btt_dummy(void) { return 1; }
+
+void btt_crash_handler(exception_t *exc)
+{
+    btt_end();
+    exc->regs->epc = (uint32_t)btt_dummy;
+}
+
+#define BT_SYSCALL()       asm volatile ("syscall 0x0F001")   // Syscall for the backtrace test
+#define BT_SYSCALL_FP()    asm volatile ("syscall 0x0F002")   // Syscall for the backtrace test, clobbering the frame pointer
+
+void btt_syscall_handler(exception_t *exc, uint32_t code)
+{
+    volatile int ret; 
+    switch (code & 0xFF) {
+    case 0x02:  ret = btt_fp(); break;
+    default:    ret = btt_end(); break;
+    }
+    (void)ret;
+}
+
+void btt_register_syscall(void)
+{
+    static bool registered = false;
+    if (!registered) {
+        register_syscall_handler(btt_syscall_handler, 0x0F001, 0x0F002);
+        registered = true;
+    }
+}
+
+NOINLINE int btt_b3(void) { STACK_FRAME(128);  return btt_end()+1; }
+NOINLINE int btt_b2(void) { STACK_FRAME(12);   return btt_b3()+1;  }
+NOINLINE int btt_b1(void) { STACK_FRAME(1024); return btt_b2()+1;  }
+
+NOINLINE int btt_c3(void) { STACK_FRAME(128); volatile char *buf = alloca(bt_buf_len+1); return btt_end()+1+buf[0]; }
+NOINLINE int btt_c2(void) { STACK_FRAME(12);   return btt_c3()+1;  }
+NOINLINE int btt_c1(void) { STACK_FRAME(1024); volatile char *buf = alloca(bt_buf_len+1); return btt_c2()+1+buf[0];  }
+
+NOINLINE int btt_d2(void) { STACK_FRAME(12); return 0; }
+NOINLINE int btt_d1(void) { STACK_FRAME(16); BT_SYSCALL(); return btt_d2()+1; }
+
+NOINLINE int btt_e2(void) { BT_SYSCALL(); return 1;  } // this is a leaf function (no stack frame)
+NOINLINE int btt_e1(void) { STACK_FRAME(1024); return btt_e2()+1;  }
+
+NOINLINE int btt_f3(void) { BT_SYSCALL_FP(); return 1;  }
+NOINLINE int btt_f2(void) { STACK_FRAME(128); volatile char *buf = alloca(bt_buf_len+1); return btt_f3()+1+buf[0]; }
+NOINLINE int btt_f1(void) { STACK_FRAME(1024); return btt_f2()+1;  }
+
+NOINLINE int btt_g2(void) { STACK_FRAME(1024); return bt_null_func_ptr() + 1; }
+NOINLINE int btt_g1(void) { STACK_FRAME(1024); return btt_g2()+1;  }
+
+NOINLINE int btt_h2(void) { STACK_FRAME(1024); return bt_invalid_func_ptr() + 1; }
+NOINLINE int btt_h1(void) { STACK_FRAME(1024); return btt_h2()+1;  }
+
+void btt_start(TestContext *ctx, int (*func)(void), const char *expected[])
+{
+    bt_buf_len = 0;
+    func();
+    ASSERT(bt_buf_len > 0, "backtrace not called");
+
+    int i = 0;
+    void cb(void *user, backtrace_frame_t *frame)
+    {
+        //backtrace_frame_print(frame, stderr); debugf("\n");
+        if (ctx->result == TEST_FAILED) return;
+        if (expected[i] == NULL) return;
+        ASSERT_EQUAL_STR(expected[i], frame->func, "invalid backtrace entry");
+        i++;
+    }
+    backtrace_symbols_cb(bt_buf, bt_buf_len, 0, cb, NULL);
+    if (expected[i] != NULL) ASSERT(0, "backtrace too short");
+}
+
+void test_backtrace_basic(TestContext *ctx)
+{
+    // A standard call stack
+    btt_start(ctx, btt_b1, (const char*[]) {
+        "btt_end", "btt_b3", "btt_b2", "btt_b1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_fp(TestContext *ctx)
+{
+    // A standard call stack where one of the function uses the frame pointer (eg: alloca)
+    btt_start(ctx, btt_c1, (const char*[]) {
+        "btt_end", "btt_c3", "btt_c2", "btt_c1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_exception(TestContext *ctx)
+{
+    // A call stack including an exception
+    btt_register_syscall();
+    btt_start(ctx, btt_d1, (const char*[]) {
+        "btt_end", "btt_syscall_handler", "__onSyscallException", "<EXCEPTION HANDLER>", "btt_d1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_exception_leaf(TestContext *ctx)
+{
+    // A call stack including an exception, interrupting a leaf function
+    btt_register_syscall();
+    btt_start(ctx, btt_e1, (const char*[]) {
+        "btt_end", "btt_syscall_handler", "__onSyscallException", "<EXCEPTION HANDLER>", "btt_e2", "btt_e1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_exception_fp(TestContext *ctx)
+{
+    // A call stack including an exception, with frame pointer being used before and after the exception
+    btt_register_syscall();
+    btt_start(ctx, btt_f1, (const char*[]) {
+        "btt_end", "btt_fp", "btt_syscall_handler", "__onSyscallException", "<EXCEPTION HANDLER>", "btt_f3", "btt_f2", "btt_f1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_zerofunc(TestContext *ctx)
+{
+    // A call stack including an exception due to a call to a null pointer
+    exception_handler_t prev = register_exception_handler(btt_crash_handler);
+    DEFER(register_exception_handler(prev));
+    
+    btt_start(ctx, btt_g1, (const char*[]) {
+        "btt_end", "btt_crash_handler", "__onCriticalException", "<EXCEPTION HANDLER>", "<NULL POINTER>", "btt_g2", "btt_g1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_invalidptr(TestContext *ctx)
+{
+    // A call stack including an exception due to a call to a null pointer
+    exception_handler_t prev = register_exception_handler(btt_crash_handler);
+    DEFER(register_exception_handler(prev));
+
+    btt_start(ctx, btt_h1, (const char*[]) {
+        "btt_end", "btt_crash_handler", "__onCriticalException", "<EXCEPTION HANDLER>", "<INVALID ADDRESS>", "btt_h2", "btt_h1", "btt_start", NULL
+    });
+}
+
+void test_backtrace_analyze(TestContext *ctx)
+{
+    bt_func_t func; bool ret;
+    uint32_t* exception_ra = (uint32_t*)(0x8000CCCC);
+
+    extern uint32_t test_bt_1_start[];
+    ret = __bt_analyze_func(&func, test_bt_1_start, 0, NULL);
+    ASSERT(ret, "bt_analyze failed");
+    ASSERT_EQUAL_UNSIGNED(func.type, BT_FUNCTION, "invalid function type");
+    ASSERT_EQUAL_UNSIGNED(func.stack_size, 112, "invalid stack size");
+    ASSERT_EQUAL_UNSIGNED(func.ra_offset, 104+4, "invalid RA offset");
+    ASSERT_EQUAL_UNSIGNED(func.fp_offset, 96+4, "invalid FP offset");
+
+    extern uint32_t test_bt_2_start[];
+    ret = __bt_analyze_func(&func, test_bt_2_start, 0, NULL);
+    ASSERT(ret, "bt_analyze failed");
+    ASSERT_EQUAL_UNSIGNED(func.type, BT_FUNCTION_FRAMEPOINTER, "invalid function type");
+    ASSERT_EQUAL_UNSIGNED(func.stack_size, 128, "invalid stack size");
+    ASSERT_EQUAL_UNSIGNED(func.ra_offset, 120+4, "invalid RA offset");
+    ASSERT_EQUAL_UNSIGNED(func.fp_offset, 112+4, "invalid FP offset");
+
+    extern uint32_t test_bt_3_start[];
+    ret = __bt_analyze_func(&func, test_bt_3_start, 0, NULL);
+    ASSERT(ret, "bt_analyze failed");
+    ASSERT_EQUAL_UNSIGNED(func.type, BT_FUNCTION, "invalid function type");
+    ASSERT_EQUAL_UNSIGNED(func.stack_size, 80, "invalid stack size");
+    ASSERT_EQUAL_UNSIGNED(func.ra_offset, 20+4, "invalid RA offset");
+    ASSERT_EQUAL_UNSIGNED(func.fp_offset, 16+4, "invalid FP offset");
+
+    extern uint32_t test_bt_4_start[];
+    ret = __bt_analyze_func(&func, test_bt_4_start, 0, exception_ra);
+    ASSERT(ret, "bt_analyze failed");
+    ASSERT_EQUAL_UNSIGNED(func.type, BT_LEAF, "invalid function type");
+    ASSERT_EQUAL_UNSIGNED(func.stack_size, 0, "invalid stack size");
+    ASSERT_EQUAL_UNSIGNED(func.ra_offset, 0, "invalid RA offset");
+    ASSERT_EQUAL_UNSIGNED(func.fp_offset, 0, "invalid FP offset");
+
+    extern uint32_t test_bt_5_start[], test_bt_5[];
+    ret = __bt_analyze_func(&func, test_bt_5_start, (uint32_t)test_bt_5, exception_ra);
+    ASSERT(ret, "bt_analyze failed");
+    ASSERT_EQUAL_UNSIGNED(func.type, BT_LEAF, "invalid function type");
+    ASSERT_EQUAL_UNSIGNED(func.stack_size, 0, "invalid stack size");
+    ASSERT_EQUAL_UNSIGNED(func.ra_offset, 0, "invalid RA offset");
+    ASSERT_EQUAL_UNSIGNED(func.fp_offset, 0, "invalid FP offset");
+}

--- a/tests/test_backtrace.c
+++ b/tests/test_backtrace.c
@@ -164,10 +164,9 @@ void test_backtrace_invalidptr(TestContext *ctx)
 void test_backtrace_analyze(TestContext *ctx)
 {
     bt_func_t func; bool ret;
-    uint32_t* exception_ra = (uint32_t*)(0x8000CCCC);
 
     extern uint32_t test_bt_1_start[];
-    ret = __bt_analyze_func(&func, test_bt_1_start, 0, NULL);
+    ret = __bt_analyze_func(&func, test_bt_1_start, 0, false);
     ASSERT(ret, "bt_analyze failed");
     ASSERT_EQUAL_UNSIGNED(func.type, BT_FUNCTION, "invalid function type");
     ASSERT_EQUAL_UNSIGNED(func.stack_size, 112, "invalid stack size");
@@ -175,7 +174,7 @@ void test_backtrace_analyze(TestContext *ctx)
     ASSERT_EQUAL_UNSIGNED(func.fp_offset, 96+4, "invalid FP offset");
 
     extern uint32_t test_bt_2_start[];
-    ret = __bt_analyze_func(&func, test_bt_2_start, 0, NULL);
+    ret = __bt_analyze_func(&func, test_bt_2_start, 0, false);
     ASSERT(ret, "bt_analyze failed");
     ASSERT_EQUAL_UNSIGNED(func.type, BT_FUNCTION_FRAMEPOINTER, "invalid function type");
     ASSERT_EQUAL_UNSIGNED(func.stack_size, 128, "invalid stack size");
@@ -183,7 +182,7 @@ void test_backtrace_analyze(TestContext *ctx)
     ASSERT_EQUAL_UNSIGNED(func.fp_offset, 112+4, "invalid FP offset");
 
     extern uint32_t test_bt_3_start[];
-    ret = __bt_analyze_func(&func, test_bt_3_start, 0, NULL);
+    ret = __bt_analyze_func(&func, test_bt_3_start, 0, false);
     ASSERT(ret, "bt_analyze failed");
     ASSERT_EQUAL_UNSIGNED(func.type, BT_FUNCTION, "invalid function type");
     ASSERT_EQUAL_UNSIGNED(func.stack_size, 80, "invalid stack size");
@@ -191,7 +190,7 @@ void test_backtrace_analyze(TestContext *ctx)
     ASSERT_EQUAL_UNSIGNED(func.fp_offset, 16+4, "invalid FP offset");
 
     extern uint32_t test_bt_4_start[];
-    ret = __bt_analyze_func(&func, test_bt_4_start, 0, exception_ra);
+    ret = __bt_analyze_func(&func, test_bt_4_start, 0, true);
     ASSERT(ret, "bt_analyze failed");
     ASSERT_EQUAL_UNSIGNED(func.type, BT_LEAF, "invalid function type");
     ASSERT_EQUAL_UNSIGNED(func.stack_size, 0, "invalid stack size");
@@ -199,7 +198,7 @@ void test_backtrace_analyze(TestContext *ctx)
     ASSERT_EQUAL_UNSIGNED(func.fp_offset, 0, "invalid FP offset");
 
     extern uint32_t test_bt_5_start[], test_bt_5[];
-    ret = __bt_analyze_func(&func, test_bt_5_start, (uint32_t)test_bt_5, exception_ra);
+    ret = __bt_analyze_func(&func, test_bt_5_start, (uint32_t)test_bt_5, true);
     ASSERT(ret, "bt_analyze failed");
     ASSERT_EQUAL_UNSIGNED(func.type, BT_LEAF, "invalid function type");
     ASSERT_EQUAL_UNSIGNED(func.stack_size, 0, "invalid stack size");

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -203,6 +203,7 @@ int assert_equal_mem(TestContext *ctx, const char *file, int line, const uint8_t
 #include "test_dma.c"
 #include "test_cop1.c"
 #include "test_constructors.c"
+#include "test_backtrace.c"
 #include "test_rspq.c"
 
 /**********************************************************************
@@ -244,6 +245,14 @@ static const struct Testsuite
 	TEST_FUNC(test_debug_sdfs,                 0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dma_read_misalign,       7003, TEST_FLAGS_NONE),
 	TEST_FUNC(test_cop1_denormalized_float,    0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_analyze,          0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_basic,            0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_fp,               0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_exception,        0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_exception_leaf,   0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_exception_fp,     0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_zerofunc,         0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_backtrace_invalidptr,       0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_queue_single,          0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_queue_multiple,        0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_queue_rapid,           0, TEST_FLAGS_NO_BENCHMARK),

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -251,7 +251,6 @@ static const struct Testsuite
 	TEST_FUNC(test_backtrace_exception,        0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_backtrace_exception_leaf,   0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_backtrace_exception_fp,     0, TEST_FLAGS_NO_BENCHMARK),
-	TEST_FUNC(test_backtrace_zerofunc,         0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_backtrace_invalidptr,       0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_queue_single,          0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_queue_multiple,        0, TEST_FLAGS_NO_BENCHMARK),

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,10 +1,10 @@
 INSTALLDIR ?= $(N64_INST)
 
-all: chksum64 dumpdfs ed64romconfig mkdfs mksprite n64tool audioconv64
+all: chksum64 dumpdfs ed64romconfig mkdfs mksprite n64tool n64sym audioconv64
 
 .PHONY: install
-install: chksum64 ed64romconfig n64tool audioconv64
-	install -m 0755 chksum64 ed64romconfig n64tool $(INSTALLDIR)/bin
+install: all
+	install -m 0755 chksum64 ed64romconfig n64tool n64sym $(INSTALLDIR)/bin
 	$(MAKE) -C dumpdfs install
 	$(MAKE) -C mkdfs install
 	$(MAKE) -C mksprite install
@@ -12,7 +12,7 @@ install: chksum64 ed64romconfig n64tool audioconv64
 
 .PHONY: clean
 clean:
-	rm -rf chksum64 ed64romconfig n64tool
+	rm -rf chksum64 ed64romconfig n64tool n64sym
 	$(MAKE) -C dumpdfs clean
 	$(MAKE) -C mkdfs clean
 	$(MAKE) -C mksprite clean
@@ -23,6 +23,9 @@ chksum64: chksum64.c
 
 n64tool: n64tool.c
 	gcc -o n64tool n64tool.c
+
+n64sym: n64sym.c
+	gcc -O2 -o n64sym n64sym.c
 
 ed64romconfig: ed64romconfig.c
 	gcc -o ed64romconfig ed64romconfig.c

--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -5,66 +5,73 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <stdint.h>
 #include <string.h>
 
-size_t getline(char **lineptr, size_t *n, FILE *stream) {
-    char *bufptr = NULL;
-    char *p = bufptr;
-    size_t size;
+// if typedef doesn't exist (msvc, blah)
+typedef intptr_t ssize_t;
+
+/* Fetched from: https://stackoverflow.com/a/47229318 */
+/* The original code is public domain -- Will Hartung 4/9/09 */
+/* Modifications, public domain as well, by Antti Haapala, 11/10/17
+   - Switched to getc on 5/23/19 */
+
+ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+    size_t pos;
     int c;
 
-    if (lineptr == NULL) {
+    if (lineptr == NULL || stream == NULL || n == NULL) {
+        errno = EINVAL;
         return -1;
     }
-    if (stream == NULL) {
-        return -1;
-    }
-    if (n == NULL) {
-        return -1;
-    }
-    bufptr = *lineptr;
-    size = *n;
 
-    c = fgetc(stream);
+    c = getc(stream);
     if (c == EOF) {
         return -1;
     }
-    if (bufptr == NULL) {
-        bufptr = malloc(128);
-        if (bufptr == NULL) {
+
+    if (*lineptr == NULL) {
+        *lineptr = malloc(128);
+        if (*lineptr == NULL) {
             return -1;
         }
-        size = 128;
+        *n = 128;
     }
-    p = bufptr;
+
+    pos = 0;
     while(c != EOF) {
-        if ((p - bufptr) > (size - 1)) {
-            size = size + 128;
-            bufptr = realloc(bufptr, size);
-            if (bufptr == NULL) {
+        if (pos + 1 >= *n) {
+            size_t new_size = *n + (*n >> 2);
+            if (new_size < 128) {
+                new_size = 128;
+            }
+            char *new_ptr = realloc(*lineptr, new_size);
+            if (new_ptr == NULL) {
                 return -1;
             }
+            *n = new_size;
+            *lineptr = new_ptr;
         }
-        *p++ = c;
+
+        ((unsigned char *)(*lineptr))[pos ++] = c;
         if (c == '\n') {
             break;
         }
-        c = fgetc(stream);
+        c = getc(stream);
     }
 
-    *p++ = '\0';
-    *lineptr = bufptr;
-    *n = size;
-
-    return p - bufptr - 1;
+    (*lineptr)[pos] = '\0';
+    return pos;
 }
 
+/* This function is original code in libdragon */
 char *strndup(const char *s, size_t n)
 {
   size_t len = strnlen(s, n);
   char *ret = malloc(len + 1);
   if (!ret) return NULL;
-  memcpy (ret, s, len);
+  memcpy(ret, s, len);
   ret[len] = '\0';
   return ret;
 }

--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -1,0 +1,74 @@
+#ifndef LIBDRAGON_TOOLS_POLYFILL_H
+#define LIBDRAGON_TOOLS_POLYFILL_H
+
+#ifdef __MINGW32__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+size_t getline(char **lineptr, size_t *n, FILE *stream) {
+    char *bufptr = NULL;
+    char *p = bufptr;
+    size_t size;
+    int c;
+
+    if (lineptr == NULL) {
+        return -1;
+    }
+    if (stream == NULL) {
+        return -1;
+    }
+    if (n == NULL) {
+        return -1;
+    }
+    bufptr = *lineptr;
+    size = *n;
+
+    c = fgetc(stream);
+    if (c == EOF) {
+        return -1;
+    }
+    if (bufptr == NULL) {
+        bufptr = malloc(128);
+        if (bufptr == NULL) {
+            return -1;
+        }
+        size = 128;
+    }
+    p = bufptr;
+    while(c != EOF) {
+        if ((p - bufptr) > (size - 1)) {
+            size = size + 128;
+            bufptr = realloc(bufptr, size);
+            if (bufptr == NULL) {
+                return -1;
+            }
+        }
+        *p++ = c;
+        if (c == '\n') {
+            break;
+        }
+        c = fgetc(stream);
+    }
+
+    *p++ = '\0';
+    *lineptr = bufptr;
+    *n = size;
+
+    return p - bufptr - 1;
+}
+
+char *strndup(const char *s, size_t n)
+{
+  size_t len = strnlen(s, n);
+  char *ret = malloc(len + 1);
+  if (!ret) return NULL;
+  memcpy (ret, s, len);
+  ret[len] = '\0';
+  return ret;
+}
+
+#endif
+
+#endif

--- a/tools/common/stb_ds.h
+++ b/tools/common/stb_ds.h
@@ -1,0 +1,1895 @@
+/* stb_ds.h - v0.67 - public domain data structures - Sean Barrett 2019
+
+   This is a single-header-file library that provides easy-to-use
+   dynamic arrays and hash tables for C (also works in C++).
+
+   For a gentle introduction:
+      http://nothings.org/stb_ds
+
+   To use this library, do this in *one* C or C++ file:
+      #define STB_DS_IMPLEMENTATION
+      #include "stb_ds.h"
+
+TABLE OF CONTENTS
+
+  Table of Contents
+  Compile-time options
+  License
+  Documentation
+  Notes
+  Notes - Dynamic arrays
+  Notes - Hash maps
+  Credits
+
+COMPILE-TIME OPTIONS
+
+  #define STBDS_NO_SHORT_NAMES
+
+     This flag needs to be set globally.
+
+     By default stb_ds exposes shorter function names that are not qualified
+     with the "stbds_" prefix. If these names conflict with the names in your
+     code, define this flag.
+
+  #define STBDS_SIPHASH_2_4
+
+     This flag only needs to be set in the file containing #define STB_DS_IMPLEMENTATION.
+
+     By default stb_ds.h hashes using a weaker variant of SipHash and a custom hash for
+     4- and 8-byte keys. On 64-bit platforms, you can define the above flag to force
+     stb_ds.h to use specification-compliant SipHash-2-4 for all keys. Doing so makes
+     hash table insertion about 20% slower on 4- and 8-byte keys, 5% slower on
+     64-byte keys, and 10% slower on 256-byte keys on my test computer.
+
+  #define STBDS_REALLOC(context,ptr,size) better_realloc
+  #define STBDS_FREE(context,ptr)         better_free
+
+     These defines only need to be set in the file containing #define STB_DS_IMPLEMENTATION.
+
+     By default stb_ds uses stdlib realloc() and free() for memory management. You can
+     substitute your own functions instead by defining these symbols. You must either
+     define both, or neither. Note that at the moment, 'context' will always be NULL.
+     @TODO add an array/hash initialization function that takes a memory context pointer.
+
+  #define STBDS_UNIT_TESTS
+
+     Defines a function stbds_unit_tests() that checks the functioning of the data structures.
+
+  Note that on older versions of gcc (e.g. 5.x.x) you may need to build with '-std=c++0x'
+     (or equivalentally '-std=c++11') when using anonymous structures as seen on the web
+     page or in STBDS_UNIT_TESTS.
+
+LICENSE
+
+  Placed in the public domain and also MIT licensed.
+  See end of file for detailed license information.
+
+DOCUMENTATION
+
+  Dynamic Arrays
+
+    Non-function interface:
+
+      Declare an empty dynamic array of type T
+        T* foo = NULL;
+
+      Access the i'th item of a dynamic array 'foo' of type T, T* foo:
+        foo[i]
+
+    Functions (actually macros)
+
+      arrfree:
+        void arrfree(T*);
+          Frees the array.
+
+      arrlen:
+        ptrdiff_t arrlen(T*);
+          Returns the number of elements in the array.
+
+      arrlenu:
+        size_t arrlenu(T*);
+          Returns the number of elements in the array as an unsigned type.
+
+      arrpop:
+        T arrpop(T* a)
+          Removes the final element of the array and returns it.
+
+      arrput:
+        T arrput(T* a, T b);
+          Appends the item b to the end of array a. Returns b.
+
+      arrins:
+        T arrins(T* a, int p, T b);
+          Inserts the item b into the middle of array a, into a[p],
+          moving the rest of the array over. Returns b.
+
+      arrinsn:
+        void arrinsn(T* a, int p, int n);
+          Inserts n uninitialized items into array a starting at a[p],
+          moving the rest of the array over.
+
+      arraddnptr:
+        T* arraddnptr(T* a, int n)
+          Appends n uninitialized items onto array at the end.
+          Returns a pointer to the first uninitialized item added.
+
+      arraddnindex:
+        size_t arraddnindex(T* a, int n)
+          Appends n uninitialized items onto array at the end.
+          Returns the index of the first uninitialized item added.
+
+      arrdel:
+        void arrdel(T* a, int p);
+          Deletes the element at a[p], moving the rest of the array over.
+
+      arrdeln:
+        void arrdeln(T* a, int p, int n);
+          Deletes n elements starting at a[p], moving the rest of the array over.
+
+      arrdelswap:
+        void arrdelswap(T* a, int p);
+          Deletes the element at a[p], replacing it with the element from
+          the end of the array. O(1) performance.
+
+      arrsetlen:
+        void arrsetlen(T* a, int n);
+          Changes the length of the array to n. Allocates uninitialized
+          slots at the end if necessary.
+
+      arrsetcap:
+        size_t arrsetcap(T* a, int n);
+          Sets the length of allocated storage to at least n. It will not
+          change the length of the array.
+
+      arrcap:
+        size_t arrcap(T* a);
+          Returns the number of total elements the array can contain without
+          needing to be reallocated.
+
+  Hash maps & String hash maps
+
+    Given T is a structure type: struct { TK key; TV value; }. Note that some
+    functions do not require TV value and can have other fields. For string
+    hash maps, TK must be 'char *'.
+
+    Special interface:
+
+      stbds_rand_seed:
+        void stbds_rand_seed(size_t seed);
+          For security against adversarially chosen data, you should seed the
+          library with a strong random number. Or at least seed it with time().
+
+      stbds_hash_string:
+        size_t stbds_hash_string(char *str, size_t seed);
+          Returns a hash value for a string.
+
+      stbds_hash_bytes:
+        size_t stbds_hash_bytes(void *p, size_t len, size_t seed);
+          These functions hash an arbitrary number of bytes. The function
+          uses a custom hash for 4- and 8-byte data, and a weakened version
+          of SipHash for everything else. On 64-bit platforms you can get
+          specification-compliant SipHash-2-4 on all data by defining
+          STBDS_SIPHASH_2_4, at a significant cost in speed.
+
+    Non-function interface:
+
+      Declare an empty hash map of type T
+        T* foo = NULL;
+
+      Access the i'th entry in a hash table T* foo:
+        foo[i]
+
+    Function interface (actually macros):
+
+      hmfree
+      shfree
+        void hmfree(T*);
+        void shfree(T*);
+          Frees the hashmap and sets the pointer to NULL.
+
+      hmlen
+      shlen
+        ptrdiff_t hmlen(T*)
+        ptrdiff_t shlen(T*)
+          Returns the number of elements in the hashmap.
+
+      hmlenu
+      shlenu
+        size_t hmlenu(T*)
+        size_t shlenu(T*)
+          Returns the number of elements in the hashmap.
+
+      hmgeti
+      shgeti
+      hmgeti_ts
+        ptrdiff_t hmgeti(T*, TK key)
+        ptrdiff_t shgeti(T*, char* key)
+        ptrdiff_t hmgeti_ts(T*, TK key, ptrdiff_t tempvar)
+          Returns the index in the hashmap which has the key 'key', or -1
+          if the key is not present.
+
+      hmget
+      hmget_ts
+      shget
+        TV hmget(T*, TK key)
+        TV shget(T*, char* key)
+        TV hmget_ts(T*, TK key, ptrdiff_t tempvar)
+          Returns the value corresponding to 'key' in the hashmap.
+          The structure must have a 'value' field
+
+      hmgets
+      shgets
+        T hmgets(T*, TK key)
+        T shgets(T*, char* key)
+          Returns the structure corresponding to 'key' in the hashmap.
+
+      hmgetp
+      shgetp
+      hmgetp_ts
+      hmgetp_null
+      shgetp_null
+        T* hmgetp(T*, TK key)
+        T* shgetp(T*, char* key)
+        T* hmgetp_ts(T*, TK key, ptrdiff_t tempvar)
+        T* hmgetp_null(T*, TK key)
+        T* shgetp_null(T*, char *key)
+          Returns a pointer to the structure corresponding to 'key' in
+          the hashmap. Functions ending in "_null" return NULL if the key
+          is not present in the hashmap; the others return a pointer to a
+          structure holding the default value (but not the searched-for key).
+
+      hmdefault
+      shdefault
+        TV hmdefault(T*, TV value)
+        TV shdefault(T*, TV value)
+          Sets the default value for the hashmap, the value which will be
+          returned by hmget/shget if the key is not present.
+
+      hmdefaults
+      shdefaults
+        TV hmdefaults(T*, T item)
+        TV shdefaults(T*, T item)
+          Sets the default struct for the hashmap, the contents which will be
+          returned by hmgets/shgets if the key is not present.
+
+      hmput
+      shput
+        TV hmput(T*, TK key, TV value)
+        TV shput(T*, char* key, TV value)
+          Inserts a <key,value> pair into the hashmap. If the key is already
+          present in the hashmap, updates its value.
+
+      hmputs
+      shputs
+        T hmputs(T*, T item)
+        T shputs(T*, T item)
+          Inserts a struct with T.key into the hashmap. If the struct is already
+          present in the hashmap, updates it.
+
+      hmdel
+      shdel
+        int hmdel(T*, TK key)
+        int shdel(T*, char* key)
+          If 'key' is in the hashmap, deletes its entry and returns 1.
+          Otherwise returns 0.
+
+    Function interface (actually macros) for strings only:
+
+      sh_new_strdup
+        void sh_new_strdup(T*);
+          Overwrites the existing pointer with a newly allocated
+          string hashmap which will automatically allocate and free
+          each string key using realloc/free
+
+      sh_new_arena
+        void sh_new_arena(T*);
+          Overwrites the existing pointer with a newly allocated
+          string hashmap which will automatically allocate each string
+          key to a string arena. Every string key ever used by this
+          hash table remains in the arena until the arena is freed.
+          Additionally, any key which is deleted and reinserted will
+          be allocated multiple times in the string arena.
+
+NOTES
+
+  * These data structures are realloc'd when they grow, and the macro
+    "functions" write to the provided pointer. This means: (a) the pointer
+    must be an lvalue, and (b) the pointer to the data structure is not
+    stable, and you must maintain it the same as you would a realloc'd
+    pointer. For example, if you pass a pointer to a dynamic array to a
+    function which updates it, the function must return back the new
+    pointer to the caller. This is the price of trying to do this in C.
+
+  * The following are the only functions that are thread-safe on a single data
+    structure, i.e. can be run in multiple threads simultaneously on the same
+    data structure
+        hmlen        shlen
+        hmlenu       shlenu
+        hmget_ts     shget_ts
+        hmgeti_ts    shgeti_ts
+        hmgets_ts    shgets_ts
+
+  * You iterate over the contents of a dynamic array and a hashmap in exactly
+    the same way, using arrlen/hmlen/shlen:
+
+      for (i=0; i < arrlen(foo); ++i)
+         ... foo[i] ...
+
+  * All operations except arrins/arrdel are O(1) amortized, but individual
+    operations can be slow, so these data structures may not be suitable
+    for real time use. Dynamic arrays double in capacity as needed, so
+    elements are copied an average of once. Hash tables double/halve
+    their size as needed, with appropriate hysteresis to maintain O(1)
+    performance.
+
+NOTES - DYNAMIC ARRAY
+
+  * If you know how long a dynamic array is going to be in advance, you can avoid
+    extra memory allocations by using arrsetlen to allocate it to that length in
+    advance and use foo[n] while filling it out, or arrsetcap to allocate the memory
+    for that length and use arrput/arrpush as normal.
+
+  * Unlike some other versions of the dynamic array, this version should
+    be safe to use with strict-aliasing optimizations.
+
+NOTES - HASH MAP
+
+  * For compilers other than GCC and clang (e.g. Visual Studio), for hmput/hmget/hmdel
+    and variants, the key must be an lvalue (so the macro can take the address of it).
+    Extensions are used that eliminate this requirement if you're using C99 and later
+    in GCC or clang, or if you're using C++ in GCC. But note that this can make your
+    code less portable.
+
+  * To test for presence of a key in a hashmap, just do 'hmgeti(foo,key) >= 0'.
+
+  * The iteration order of your data in the hashmap is determined solely by the
+    order of insertions and deletions. In particular, if you never delete, new
+    keys are always added at the end of the array. This will be consistent
+    across all platforms and versions of the library. However, you should not
+    attempt to serialize the internal hash table, as the hash is not consistent
+    between different platforms, and may change with future versions of the library.
+
+  * Use sh_new_arena() for string hashmaps that you never delete from. Initialize
+    with NULL if you're managing the memory for your strings, or your strings are
+    never freed (at least until the hashmap is freed). Otherwise, use sh_new_strdup().
+    @TODO: make an arena variant that garbage collects the strings with a trivial
+    copy collector into a new arena whenever the table shrinks / rebuilds. Since
+    current arena recommendation is to only use arena if it never deletes, then
+    this can just replace current arena implementation.
+
+  * If adversarial input is a serious concern and you're on a 64-bit platform,
+    enable STBDS_SIPHASH_2_4 (see the 'Compile-time options' section), and pass
+    a strong random number to stbds_rand_seed.
+
+  * The default value for the hash table is stored in foo[-1], so if you
+    use code like 'hmget(T,k)->value = 5' you can accidentally overwrite
+    the value stored by hmdefault if 'k' is not present.
+
+CREDITS
+
+  Sean Barrett -- library, idea for dynamic array API/implementation
+  Per Vognsen  -- idea for hash table API/implementation
+  Rafael Sachetto -- arrpop()
+  github:HeroicKatora -- arraddn() reworking
+
+  Bugfixes:
+    Andy Durdin
+    Shane Liesegang
+    Vinh Truong
+    Andreas Molzer
+    github:hashitaku
+    github:srdjanstipic
+    Macoy Madson
+    Andreas Vennstrom
+    Tobias Mansfield-Williams
+*/
+
+#ifdef STBDS_UNIT_TESTS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#ifndef INCLUDE_STB_DS_H
+#define INCLUDE_STB_DS_H
+
+#include <stddef.h>
+#include <string.h>
+
+#ifndef STBDS_NO_SHORT_NAMES
+#define arrlen      stbds_arrlen
+#define arrlenu     stbds_arrlenu
+#define arrput      stbds_arrput
+#define arrpush     stbds_arrput
+#define arrpop      stbds_arrpop
+#define arrfree     stbds_arrfree
+#define arraddn     stbds_arraddn // deprecated, use one of the following instead:
+#define arraddnptr  stbds_arraddnptr
+#define arraddnindex stbds_arraddnindex
+#define arrsetlen   stbds_arrsetlen
+#define arrlast     stbds_arrlast
+#define arrins      stbds_arrins
+#define arrinsn     stbds_arrinsn
+#define arrdel      stbds_arrdel
+#define arrdeln     stbds_arrdeln
+#define arrdelswap  stbds_arrdelswap
+#define arrcap      stbds_arrcap
+#define arrsetcap   stbds_arrsetcap
+
+#define hmput       stbds_hmput
+#define hmputs      stbds_hmputs
+#define hmget       stbds_hmget
+#define hmget_ts    stbds_hmget_ts
+#define hmgets      stbds_hmgets
+#define hmgetp      stbds_hmgetp
+#define hmgetp_ts   stbds_hmgetp_ts
+#define hmgetp_null stbds_hmgetp_null
+#define hmgeti      stbds_hmgeti
+#define hmgeti_ts   stbds_hmgeti_ts
+#define hmdel       stbds_hmdel
+#define hmlen       stbds_hmlen
+#define hmlenu      stbds_hmlenu
+#define hmfree      stbds_hmfree
+#define hmdefault   stbds_hmdefault
+#define hmdefaults  stbds_hmdefaults
+
+#define shput       stbds_shput
+#define shputi      stbds_shputi
+#define shputs      stbds_shputs
+#define shget       stbds_shget
+#define shgeti      stbds_shgeti
+#define shgets      stbds_shgets
+#define shgetp      stbds_shgetp
+#define shgetp_null stbds_shgetp_null
+#define shdel       stbds_shdel
+#define shlen       stbds_shlen
+#define shlenu      stbds_shlenu
+#define shfree      stbds_shfree
+#define shdefault   stbds_shdefault
+#define shdefaults  stbds_shdefaults
+#define sh_new_arena  stbds_sh_new_arena
+#define sh_new_strdup stbds_sh_new_strdup
+
+#define stralloc    stbds_stralloc
+#define strreset    stbds_strreset
+#endif
+
+#if defined(STBDS_REALLOC) && !defined(STBDS_FREE) || !defined(STBDS_REALLOC) && defined(STBDS_FREE)
+#error "You must define both STBDS_REALLOC and STBDS_FREE, or neither."
+#endif
+#if !defined(STBDS_REALLOC) && !defined(STBDS_FREE)
+#include <stdlib.h>
+#define STBDS_REALLOC(c,p,s) realloc(p,s)
+#define STBDS_FREE(c,p)      free(p)
+#endif
+
+#ifdef _MSC_VER
+#define STBDS_NOTUSED(v)  (void)(v)
+#else
+#define STBDS_NOTUSED(v)  (void)sizeof(v)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// for security against attackers, seed the library with a random number, at least time() but stronger is better
+extern void stbds_rand_seed(size_t seed);
+
+// these are the hash functions used internally if you want to test them or use them for other purposes
+extern size_t stbds_hash_bytes(void *p, size_t len, size_t seed);
+extern size_t stbds_hash_string(char *str, size_t seed);
+
+// this is a simple string arena allocator, initialize with e.g. 'stbds_string_arena my_arena={0}'.
+typedef struct stbds_string_arena stbds_string_arena;
+extern char * stbds_stralloc(stbds_string_arena *a, char *str);
+extern void   stbds_strreset(stbds_string_arena *a);
+
+// have to #define STBDS_UNIT_TESTS to call this
+extern void stbds_unit_tests(void);
+
+///////////////
+//
+// Everything below here is implementation details
+//
+
+extern void * stbds_arrgrowf(void *a, size_t elemsize, size_t addlen, size_t min_cap);
+extern void   stbds_arrfreef(void *a);
+extern void   stbds_hmfree_func(void *p, size_t elemsize);
+extern void * stbds_hmget_key(void *a, size_t elemsize, void *key, size_t keysize, int mode);
+extern void * stbds_hmget_key_ts(void *a, size_t elemsize, void *key, size_t keysize, ptrdiff_t *temp, int mode);
+extern void * stbds_hmput_default(void *a, size_t elemsize);
+extern void * stbds_hmput_key(void *a, size_t elemsize, void *key, size_t keysize, int mode);
+extern void * stbds_hmdel_key(void *a, size_t elemsize, void *key, size_t keysize, size_t keyoffset, int mode);
+extern void * stbds_shmode_func(size_t elemsize, int mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define STBDS_HAS_TYPEOF
+#ifdef __cplusplus
+//#define STBDS_HAS_LITERAL_ARRAY  // this is currently broken for clang
+#endif
+#endif
+
+#if !defined(__cplusplus)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define STBDS_HAS_LITERAL_ARRAY
+#endif
+#endif
+
+// this macro takes the address of the argument, but on gcc/clang can accept rvalues
+#if defined(STBDS_HAS_LITERAL_ARRAY) && defined(STBDS_HAS_TYPEOF)
+  #if __clang__
+  #define STBDS_ADDRESSOF(typevar, value)     ((__typeof__(typevar)[1]){value}) // literal array decays to pointer to value
+  #else
+  #define STBDS_ADDRESSOF(typevar, value)     ((typeof(typevar)[1]){value}) // literal array decays to pointer to value
+  #endif
+#else
+#define STBDS_ADDRESSOF(typevar, value)     &(value)
+#endif
+
+#define STBDS_OFFSETOF(var,field)           ((char *) &(var)->field - (char *) (var))
+
+#define stbds_header(t)  ((stbds_array_header *) (t) - 1)
+#define stbds_temp(t)    stbds_header(t)->temp
+#define stbds_temp_key(t) (*(char **) stbds_header(t)->hash_table)
+
+#define stbds_arrsetcap(a,n)   (stbds_arrgrow(a,0,n))
+#define stbds_arrsetlen(a,n)   ((stbds_arrcap(a) < (size_t) (n) ? stbds_arrsetcap((a),(size_t)(n)),0 : 0), (a) ? stbds_header(a)->length = (size_t) (n) : 0)
+#define stbds_arrcap(a)        ((a) ? stbds_header(a)->capacity : 0)
+#define stbds_arrlen(a)        ((a) ? (ptrdiff_t) stbds_header(a)->length : 0)
+#define stbds_arrlenu(a)       ((a) ?             stbds_header(a)->length : 0)
+#define stbds_arrput(a,v)      (stbds_arrmaybegrow(a,1), (a)[stbds_header(a)->length++] = (v))
+#define stbds_arrpush          stbds_arrput  // synonym
+#define stbds_arrpop(a)        (stbds_header(a)->length--, (a)[stbds_header(a)->length])
+#define stbds_arraddn(a,n)     ((void)(stbds_arraddnindex(a, n)))    // deprecated, use one of the following instead:
+#define stbds_arraddnptr(a,n)  (stbds_arrmaybegrow(a,n), (n) ? (stbds_header(a)->length += (n), &(a)[stbds_header(a)->length-(n)]) : (a))
+#define stbds_arraddnindex(a,n)(stbds_arrmaybegrow(a,n), (n) ? (stbds_header(a)->length += (n), stbds_header(a)->length-(n)) : stbds_arrlen(a))
+#define stbds_arraddnoff       stbds_arraddnindex
+#define stbds_arrlast(a)       ((a)[stbds_header(a)->length-1])
+#define stbds_arrfree(a)       ((void) ((a) ? STBDS_FREE(NULL,stbds_header(a)) : (void)0), (a)=NULL)
+#define stbds_arrdel(a,i)      stbds_arrdeln(a,i,1)
+#define stbds_arrdeln(a,i,n)   (memmove(&(a)[i], &(a)[(i)+(n)], sizeof *(a) * (stbds_header(a)->length-(n)-(i))), stbds_header(a)->length -= (n))
+#define stbds_arrdelswap(a,i)  ((a)[i] = stbds_arrlast(a), stbds_header(a)->length -= 1)
+#define stbds_arrinsn(a,i,n)   (stbds_arraddn((a),(n)), memmove(&(a)[(i)+(n)], &(a)[i], sizeof *(a) * (stbds_header(a)->length-(n)-(i))))
+#define stbds_arrins(a,i,v)    (stbds_arrinsn((a),(i),1), (a)[i]=(v))
+
+#define stbds_arrmaybegrow(a,n)  ((!(a) || stbds_header(a)->length + (n) > stbds_header(a)->capacity) \
+                                  ? (stbds_arrgrow(a,n,0),0) : 0)
+
+#define stbds_arrgrow(a,b,c)   ((a) = stbds_arrgrowf_wrapper((a), sizeof *(a), (b), (c)))
+
+#define stbds_hmput(t, k, v) \
+    ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), (void*) STBDS_ADDRESSOF((t)->key, (k)), sizeof (t)->key, 0),   \
+     (t)[stbds_temp((t)-1)].key = (k),    \
+     (t)[stbds_temp((t)-1)].value = (v))
+
+#define stbds_hmputs(t, s) \
+    ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), &(s).key, sizeof (s).key, STBDS_HM_BINARY), \
+     (t)[stbds_temp((t)-1)] = (s))
+
+#define stbds_hmgeti(t,k) \
+    ((t) = stbds_hmget_key_wrapper((t), sizeof *(t), (void*) STBDS_ADDRESSOF((t)->key, (k)), sizeof (t)->key, STBDS_HM_BINARY), \
+      stbds_temp((t)-1))
+
+#define stbds_hmgeti_ts(t,k,temp) \
+    ((t) = stbds_hmget_key_ts_wrapper((t), sizeof *(t), (void*) STBDS_ADDRESSOF((t)->key, (k)), sizeof (t)->key, &(temp), STBDS_HM_BINARY), \
+      (temp))
+
+#define stbds_hmgetp(t, k) \
+    ((void) stbds_hmgeti(t,k), &(t)[stbds_temp((t)-1)])
+
+#define stbds_hmgetp_ts(t, k, temp) \
+    ((void) stbds_hmgeti_ts(t,k,temp), &(t)[temp])
+
+#define stbds_hmdel(t,k) \
+    (((t) = stbds_hmdel_key_wrapper((t),sizeof *(t), (void*) STBDS_ADDRESSOF((t)->key, (k)), sizeof (t)->key, STBDS_OFFSETOF((t),key), STBDS_HM_BINARY)),(t)?stbds_temp((t)-1):0)
+
+#define stbds_hmdefault(t, v) \
+    ((t) = stbds_hmput_default_wrapper((t), sizeof *(t)), (t)[-1].value = (v))
+
+#define stbds_hmdefaults(t, s) \
+    ((t) = stbds_hmput_default_wrapper((t), sizeof *(t)), (t)[-1] = (s))
+
+#define stbds_hmfree(p)        \
+    ((void) ((p) != NULL ? stbds_hmfree_func((p)-1,sizeof*(p)),0 : 0),(p)=NULL)
+
+#define stbds_hmgets(t, k)    (*stbds_hmgetp(t,k))
+#define stbds_hmget(t, k)     (stbds_hmgetp(t,k)->value)
+#define stbds_hmget_ts(t, k, temp)  (stbds_hmgetp_ts(t,k,temp)->value)
+#define stbds_hmlen(t)        ((t) ? (ptrdiff_t) stbds_header((t)-1)->length-1 : 0)
+#define stbds_hmlenu(t)       ((t) ?             stbds_header((t)-1)->length-1 : 0)
+#define stbds_hmgetp_null(t,k)  (stbds_hmgeti(t,k) == -1 ? NULL : &(t)[stbds_temp((t)-1)])
+
+#define stbds_shput(t, k, v) \
+    ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), (void*) (k), sizeof (t)->key, STBDS_HM_STRING),   \
+     (t)[stbds_temp((t)-1)].value = (v))
+
+#define stbds_shputi(t, k, v) \
+    ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), (void*) (k), sizeof (t)->key, STBDS_HM_STRING),   \
+     (t)[stbds_temp((t)-1)].value = (v), stbds_temp((t)-1))
+
+#define stbds_shputs(t, s) \
+    ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), (void*) (s).key, sizeof (s).key, STBDS_HM_STRING), \
+     (t)[stbds_temp((t)-1)] = (s), \
+     (t)[stbds_temp((t)-1)].key = stbds_temp_key((t)-1)) // above line overwrites whole structure, so must rewrite key here if it was allocated internally
+
+#define stbds_pshput(t, p) \
+    ((t) = stbds_hmput_key_wrapper((t), sizeof *(t), (void*) (p)->key, sizeof (p)->key, STBDS_HM_PTR_TO_STRING), \
+     (t)[stbds_temp((t)-1)] = (p))
+
+#define stbds_shgeti(t,k) \
+     ((t) = stbds_hmget_key_wrapper((t), sizeof *(t), (void*) (k), sizeof (t)->key, STBDS_HM_STRING), \
+      stbds_temp((t)-1))
+
+#define stbds_pshgeti(t,k) \
+     ((t) = stbds_hmget_key_wrapper((t), sizeof *(t), (void*) (k), sizeof (*(t))->key, STBDS_HM_PTR_TO_STRING), \
+      stbds_temp((t)-1))
+
+#define stbds_shgetp(t, k) \
+    ((void) stbds_shgeti(t,k), &(t)[stbds_temp((t)-1)])
+
+#define stbds_pshget(t, k) \
+    ((void) stbds_pshgeti(t,k), (t)[stbds_temp((t)-1)])
+
+#define stbds_shdel(t,k) \
+    (((t) = stbds_hmdel_key_wrapper((t),sizeof *(t), (void*) (k), sizeof (t)->key, STBDS_OFFSETOF((t),key), STBDS_HM_STRING)),(t)?stbds_temp((t)-1):0)
+#define stbds_pshdel(t,k) \
+    (((t) = stbds_hmdel_key_wrapper((t),sizeof *(t), (void*) (k), sizeof (*(t))->key, STBDS_OFFSETOF(*(t),key), STBDS_HM_PTR_TO_STRING)),(t)?stbds_temp((t)-1):0)
+
+#define stbds_sh_new_arena(t)  \
+    ((t) = stbds_shmode_func_wrapper(t, sizeof *(t), STBDS_SH_ARENA))
+#define stbds_sh_new_strdup(t) \
+    ((t) = stbds_shmode_func_wrapper(t, sizeof *(t), STBDS_SH_STRDUP))
+
+#define stbds_shdefault(t, v)  stbds_hmdefault(t,v)
+#define stbds_shdefaults(t, s) stbds_hmdefaults(t,s)
+
+#define stbds_shfree       stbds_hmfree
+#define stbds_shlenu       stbds_hmlenu
+
+#define stbds_shgets(t, k) (*stbds_shgetp(t,k))
+#define stbds_shget(t, k)  (stbds_shgetp(t,k)->value)
+#define stbds_shgetp_null(t,k)  (stbds_shgeti(t,k) == -1 ? NULL : &(t)[stbds_temp((t)-1)])
+#define stbds_shlen        stbds_hmlen
+
+typedef struct
+{
+  size_t      length;
+  size_t      capacity;
+  void      * hash_table;
+  ptrdiff_t   temp;
+} stbds_array_header;
+
+typedef struct stbds_string_block
+{
+  struct stbds_string_block *next;
+  char storage[8];
+} stbds_string_block;
+
+struct stbds_string_arena
+{
+  stbds_string_block *storage;
+  size_t remaining;
+  unsigned char block;
+  unsigned char mode;  // this isn't used by the string arena itself
+};
+
+#define STBDS_HM_BINARY         0
+#define STBDS_HM_STRING         1
+
+enum
+{
+   STBDS_SH_NONE,
+   STBDS_SH_DEFAULT,
+   STBDS_SH_STRDUP,
+   STBDS_SH_ARENA
+};
+
+#ifdef __cplusplus
+// in C we use implicit assignment from these void*-returning functions to T*.
+// in C++ these templates make the same code work
+template<class T> static T * stbds_arrgrowf_wrapper(T *a, size_t elemsize, size_t addlen, size_t min_cap) {
+  return (T*)stbds_arrgrowf((void *)a, elemsize, addlen, min_cap);
+}
+template<class T> static T * stbds_hmget_key_wrapper(T *a, size_t elemsize, void *key, size_t keysize, int mode) {
+  return (T*)stbds_hmget_key((void*)a, elemsize, key, keysize, mode);
+}
+template<class T> static T * stbds_hmget_key_ts_wrapper(T *a, size_t elemsize, void *key, size_t keysize, ptrdiff_t *temp, int mode) {
+  return (T*)stbds_hmget_key_ts((void*)a, elemsize, key, keysize, temp, mode);
+}
+template<class T> static T * stbds_hmput_default_wrapper(T *a, size_t elemsize) {
+  return (T*)stbds_hmput_default((void *)a, elemsize);
+}
+template<class T> static T * stbds_hmput_key_wrapper(T *a, size_t elemsize, void *key, size_t keysize, int mode) {
+  return (T*)stbds_hmput_key((void*)a, elemsize, key, keysize, mode);
+}
+template<class T> static T * stbds_hmdel_key_wrapper(T *a, size_t elemsize, void *key, size_t keysize, size_t keyoffset, int mode){
+  return (T*)stbds_hmdel_key((void*)a, elemsize, key, keysize, keyoffset, mode);
+}
+template<class T> static T * stbds_shmode_func_wrapper(T *, size_t elemsize, int mode) {
+  return (T*)stbds_shmode_func(elemsize, mode);
+}
+#else
+#define stbds_arrgrowf_wrapper            stbds_arrgrowf
+#define stbds_hmget_key_wrapper           stbds_hmget_key
+#define stbds_hmget_key_ts_wrapper        stbds_hmget_key_ts
+#define stbds_hmput_default_wrapper       stbds_hmput_default
+#define stbds_hmput_key_wrapper           stbds_hmput_key
+#define stbds_hmdel_key_wrapper           stbds_hmdel_key
+#define stbds_shmode_func_wrapper(t,e,m)  stbds_shmode_func(e,m)
+#endif
+
+#endif // INCLUDE_STB_DS_H
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//   IMPLEMENTATION
+//
+
+#ifdef STB_DS_IMPLEMENTATION
+#include <assert.h>
+#include <string.h>
+
+#ifndef STBDS_ASSERT
+#define STBDS_ASSERT_WAS_UNDEFINED
+#define STBDS_ASSERT(x)   ((void) 0)
+#endif
+
+#ifdef STBDS_STATISTICS
+#define STBDS_STATS(x)   x
+size_t stbds_array_grow;
+size_t stbds_hash_grow;
+size_t stbds_hash_shrink;
+size_t stbds_hash_rebuild;
+size_t stbds_hash_probes;
+size_t stbds_hash_alloc;
+size_t stbds_rehash_probes;
+size_t stbds_rehash_items;
+#else
+#define STBDS_STATS(x)
+#endif
+
+//
+// stbds_arr implementation
+//
+
+//int *prev_allocs[65536];
+//int num_prev;
+
+void *stbds_arrgrowf(void *a, size_t elemsize, size_t addlen, size_t min_cap)
+{
+  stbds_array_header temp={0}; // force debugging
+  void *b;
+  size_t min_len = stbds_arrlen(a) + addlen;
+  (void) sizeof(temp);
+
+  // compute the minimum capacity needed
+  if (min_len > min_cap)
+    min_cap = min_len;
+
+  if (min_cap <= stbds_arrcap(a))
+    return a;
+
+  // increase needed capacity to guarantee O(1) amortized
+  if (min_cap < 2 * stbds_arrcap(a))
+    min_cap = 2 * stbds_arrcap(a);
+  else if (min_cap < 4)
+    min_cap = 4;
+
+  //if (num_prev < 65536) if (a) prev_allocs[num_prev++] = (int *) ((char *) a+1);
+  //if (num_prev == 2201)
+  //  num_prev = num_prev;
+  b = STBDS_REALLOC(NULL, (a) ? stbds_header(a) : 0, elemsize * min_cap + sizeof(stbds_array_header));
+  //if (num_prev < 65536) prev_allocs[num_prev++] = (int *) (char *) b;
+  b = (char *) b + sizeof(stbds_array_header);
+  if (a == NULL) {
+    stbds_header(b)->length = 0;
+    stbds_header(b)->hash_table = 0;
+    stbds_header(b)->temp = 0;
+  } else {
+    STBDS_STATS(++stbds_array_grow);
+  }
+  stbds_header(b)->capacity = min_cap;
+
+  return b;
+}
+
+void stbds_arrfreef(void *a)
+{
+  STBDS_FREE(NULL, stbds_header(a));
+}
+
+//
+// stbds_hm hash table implementation
+//
+
+#ifdef STBDS_INTERNAL_SMALL_BUCKET
+#define STBDS_BUCKET_LENGTH      4
+#else
+#define STBDS_BUCKET_LENGTH      8
+#endif
+
+#define STBDS_BUCKET_SHIFT      (STBDS_BUCKET_LENGTH == 8 ? 3 : 2)
+#define STBDS_BUCKET_MASK       (STBDS_BUCKET_LENGTH-1)
+#define STBDS_CACHE_LINE_SIZE   64
+
+#define STBDS_ALIGN_FWD(n,a)   (((n) + (a) - 1) & ~((a)-1))
+
+typedef struct
+{
+   size_t    hash [STBDS_BUCKET_LENGTH];
+   ptrdiff_t index[STBDS_BUCKET_LENGTH];
+} stbds_hash_bucket; // in 32-bit, this is one 64-byte cache line; in 64-bit, each array is one 64-byte cache line
+
+typedef struct
+{
+  char * temp_key; // this MUST be the first field of the hash table
+  size_t slot_count;
+  size_t used_count;
+  size_t used_count_threshold;
+  size_t used_count_shrink_threshold;
+  size_t tombstone_count;
+  size_t tombstone_count_threshold;
+  size_t seed;
+  size_t slot_count_log2;
+  stbds_string_arena string;
+  stbds_hash_bucket *storage; // not a separate allocation, just 64-byte aligned storage after this struct
+} stbds_hash_index;
+
+#define STBDS_INDEX_EMPTY    -1
+#define STBDS_INDEX_DELETED  -2
+#define STBDS_INDEX_IN_USE(x)  ((x) >= 0)
+
+#define STBDS_HASH_EMPTY      0
+#define STBDS_HASH_DELETED    1
+
+static size_t stbds_hash_seed=0x31415926;
+
+void stbds_rand_seed(size_t seed)
+{
+  stbds_hash_seed = seed;
+}
+
+#define stbds_load_32_or_64(var, temp, v32, v64_hi, v64_lo)                                          \
+  temp = v64_lo ^ v32, temp <<= 16, temp <<= 16, temp >>= 16, temp >>= 16, /* discard if 32-bit */   \
+  var = v64_hi, var <<= 16, var <<= 16,                                    /* discard if 32-bit */   \
+  var ^= temp ^ v32
+
+#define STBDS_SIZE_T_BITS           ((sizeof (size_t)) * 8)
+
+static size_t stbds_probe_position(size_t hash, size_t slot_count, size_t slot_log2)
+{
+  size_t pos;
+  STBDS_NOTUSED(slot_log2);
+  pos = hash & (slot_count-1);
+  #ifdef STBDS_INTERNAL_BUCKET_START
+  pos &= ~STBDS_BUCKET_MASK;
+  #endif
+  return pos;
+}
+
+static size_t stbds_log2(size_t slot_count)
+{
+  size_t n=0;
+  while (slot_count > 1) {
+    slot_count >>= 1;
+    ++n;
+  }
+  return n;
+}
+
+static stbds_hash_index *stbds_make_hash_index(size_t slot_count, stbds_hash_index *ot)
+{
+  stbds_hash_index *t;
+  t = (stbds_hash_index *) STBDS_REALLOC(NULL,0,(slot_count >> STBDS_BUCKET_SHIFT) * sizeof(stbds_hash_bucket) + sizeof(stbds_hash_index) + STBDS_CACHE_LINE_SIZE-1);
+  t->storage = (stbds_hash_bucket *) STBDS_ALIGN_FWD((size_t) (t+1), STBDS_CACHE_LINE_SIZE);
+  t->slot_count = slot_count;
+  t->slot_count_log2 = stbds_log2(slot_count);
+  t->tombstone_count = 0;
+  t->used_count = 0;
+
+  #if 0 // A1
+  t->used_count_threshold        = slot_count*12/16; // if 12/16th of table is occupied, grow
+  t->tombstone_count_threshold   = slot_count* 2/16; // if tombstones are 2/16th of table, rebuild
+  t->used_count_shrink_threshold = slot_count* 4/16; // if table is only 4/16th full, shrink
+  #elif 1 // A2
+  //t->used_count_threshold        = slot_count*12/16; // if 12/16th of table is occupied, grow
+  //t->tombstone_count_threshold   = slot_count* 3/16; // if tombstones are 3/16th of table, rebuild
+  //t->used_count_shrink_threshold = slot_count* 4/16; // if table is only 4/16th full, shrink
+
+  // compute without overflowing
+  t->used_count_threshold        = slot_count - (slot_count>>2);
+  t->tombstone_count_threshold   = (slot_count>>3) + (slot_count>>4);
+  t->used_count_shrink_threshold = slot_count >> 2;
+
+  #elif 0 // B1
+  t->used_count_threshold        = slot_count*13/16; // if 13/16th of table is occupied, grow
+  t->tombstone_count_threshold   = slot_count* 2/16; // if tombstones are 2/16th of table, rebuild
+  t->used_count_shrink_threshold = slot_count* 5/16; // if table is only 5/16th full, shrink
+  #else // C1
+  t->used_count_threshold        = slot_count*14/16; // if 14/16th of table is occupied, grow
+  t->tombstone_count_threshold   = slot_count* 2/16; // if tombstones are 2/16th of table, rebuild
+  t->used_count_shrink_threshold = slot_count* 6/16; // if table is only 6/16th full, shrink
+  #endif
+  // Following statistics were measured on a Core i7-6700 @ 4.00Ghz, compiled with clang 7.0.1 -O2
+    // Note that the larger tables have high variance as they were run fewer times
+  //     A1            A2          B1           C1
+  //    0.10ms :     0.10ms :     0.10ms :     0.11ms :      2,000 inserts creating 2K table
+  //    0.96ms :     0.95ms :     0.97ms :     1.04ms :     20,000 inserts creating 20K table
+  //   14.48ms :    14.46ms :    10.63ms :    11.00ms :    200,000 inserts creating 200K table
+  //  195.74ms :   196.35ms :   203.69ms :   214.92ms :  2,000,000 inserts creating 2M table
+  // 2193.88ms :  2209.22ms :  2285.54ms :  2437.17ms : 20,000,000 inserts creating 20M table
+  //   65.27ms :    53.77ms :    65.33ms :    65.47ms : 500,000 inserts & deletes in 2K table
+  //   72.78ms :    62.45ms :    71.95ms :    72.85ms : 500,000 inserts & deletes in 20K table
+  //   89.47ms :    77.72ms :    96.49ms :    96.75ms : 500,000 inserts & deletes in 200K table
+  //   97.58ms :    98.14ms :    97.18ms :    97.53ms : 500,000 inserts & deletes in 2M table
+  //  118.61ms :   119.62ms :   120.16ms :   118.86ms : 500,000 inserts & deletes in 20M table
+  //  192.11ms :   194.39ms :   196.38ms :   195.73ms : 500,000 inserts & deletes in 200M table
+
+  if (slot_count <= STBDS_BUCKET_LENGTH)
+    t->used_count_shrink_threshold = 0;
+  // to avoid infinite loop, we need to guarantee that at least one slot is empty and will terminate probes
+  STBDS_ASSERT(t->used_count_threshold + t->tombstone_count_threshold < t->slot_count);
+  STBDS_STATS(++stbds_hash_alloc);
+  if (ot) {
+    t->string = ot->string;
+    // reuse old seed so we can reuse old hashes so below "copy out old data" doesn't do any hashing
+    t->seed = ot->seed;
+  } else {
+    size_t a,b,temp;
+    memset(&t->string, 0, sizeof(t->string));
+    t->seed = stbds_hash_seed;
+    // LCG
+    // in 32-bit, a =          2147001325   b =  715136305
+    // in 64-bit, a = 2862933555777941757   b = 3037000493
+    stbds_load_32_or_64(a,temp, 2147001325, 0x27bb2ee6, 0x87b0b0fd);
+    stbds_load_32_or_64(b,temp,  715136305,          0, 0xb504f32d);
+    stbds_hash_seed = stbds_hash_seed  * a + b;
+  }
+
+  {
+    size_t i,j;
+    for (i=0; i < slot_count >> STBDS_BUCKET_SHIFT; ++i) {
+      stbds_hash_bucket *b = &t->storage[i];
+      for (j=0; j < STBDS_BUCKET_LENGTH; ++j)
+        b->hash[j] = STBDS_HASH_EMPTY;
+      for (j=0; j < STBDS_BUCKET_LENGTH; ++j)
+        b->index[j] = STBDS_INDEX_EMPTY;
+    }
+  }
+
+  // copy out the old data, if any
+  if (ot) {
+    size_t i,j;
+    t->used_count = ot->used_count;
+    for (i=0; i < ot->slot_count >> STBDS_BUCKET_SHIFT; ++i) {
+      stbds_hash_bucket *ob = &ot->storage[i];
+      for (j=0; j < STBDS_BUCKET_LENGTH; ++j) {
+        if (STBDS_INDEX_IN_USE(ob->index[j])) {
+          size_t hash = ob->hash[j];
+          size_t pos = stbds_probe_position(hash, t->slot_count, t->slot_count_log2);
+          size_t step = STBDS_BUCKET_LENGTH;
+          STBDS_STATS(++stbds_rehash_items);
+          for (;;) {
+            size_t limit,z;
+            stbds_hash_bucket *bucket;
+            bucket = &t->storage[pos >> STBDS_BUCKET_SHIFT];
+            STBDS_STATS(++stbds_rehash_probes);
+
+            for (z=pos & STBDS_BUCKET_MASK; z < STBDS_BUCKET_LENGTH; ++z) {
+              if (bucket->hash[z] == 0) {
+                bucket->hash[z] = hash;
+                bucket->index[z] = ob->index[j];
+                goto done;
+              }
+            }
+
+            limit = pos & STBDS_BUCKET_MASK;
+            for (z = 0; z < limit; ++z) {
+              if (bucket->hash[z] == 0) {
+                bucket->hash[z] = hash;
+                bucket->index[z] = ob->index[j];
+                goto done;
+              }
+            }
+
+            pos += step;                  // quadratic probing
+            step += STBDS_BUCKET_LENGTH;
+            pos &= (t->slot_count-1);
+          }
+        }
+       done:
+        ;
+      }
+    }
+  }
+
+  return t;
+}
+
+#define STBDS_ROTATE_LEFT(val, n)   (((val) << (n)) | ((val) >> (STBDS_SIZE_T_BITS - (n))))
+#define STBDS_ROTATE_RIGHT(val, n)  (((val) >> (n)) | ((val) << (STBDS_SIZE_T_BITS - (n))))
+
+size_t stbds_hash_string(char *str, size_t seed)
+{
+  size_t hash = seed;
+  while (*str)
+     hash = STBDS_ROTATE_LEFT(hash, 9) + (unsigned char) *str++;
+
+  // Thomas Wang 64-to-32 bit mix function, hopefully also works in 32 bits
+  hash ^= seed;
+  hash = (~hash) + (hash << 18);
+  hash ^= hash ^ STBDS_ROTATE_RIGHT(hash,31);
+  hash = hash * 21;
+  hash ^= hash ^ STBDS_ROTATE_RIGHT(hash,11);
+  hash += (hash << 6);
+  hash ^= STBDS_ROTATE_RIGHT(hash,22);
+  return hash+seed;
+}
+
+#ifdef STBDS_SIPHASH_2_4
+#define STBDS_SIPHASH_C_ROUNDS 2
+#define STBDS_SIPHASH_D_ROUNDS 4
+typedef int STBDS_SIPHASH_2_4_can_only_be_used_in_64_bit_builds[sizeof(size_t) == 8 ? 1 : -1];
+#endif
+
+#ifndef STBDS_SIPHASH_C_ROUNDS
+#define STBDS_SIPHASH_C_ROUNDS 1
+#endif
+#ifndef STBDS_SIPHASH_D_ROUNDS
+#define STBDS_SIPHASH_D_ROUNDS 1
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant, for do..while(0) and sizeof()==
+#endif
+
+static size_t stbds_siphash_bytes(void *p, size_t len, size_t seed)
+{
+  unsigned char *d = (unsigned char *) p;
+  size_t i,j;
+  size_t v0,v1,v2,v3, data;
+
+  // hash that works on 32- or 64-bit registers without knowing which we have
+  // (computes different results on 32-bit and 64-bit platform)
+  // derived from siphash, but on 32-bit platforms very different as it uses 4 32-bit state not 4 64-bit
+  v0 = ((((size_t) 0x736f6d65 << 16) << 16) + 0x70736575) ^  seed;
+  v1 = ((((size_t) 0x646f7261 << 16) << 16) + 0x6e646f6d) ^ ~seed;
+  v2 = ((((size_t) 0x6c796765 << 16) << 16) + 0x6e657261) ^  seed;
+  v3 = ((((size_t) 0x74656462 << 16) << 16) + 0x79746573) ^ ~seed;
+
+  #ifdef STBDS_TEST_SIPHASH_2_4
+  // hardcoded with key material in the siphash test vectors
+  v0 ^= 0x0706050403020100ull ^  seed;
+  v1 ^= 0x0f0e0d0c0b0a0908ull ^ ~seed;
+  v2 ^= 0x0706050403020100ull ^  seed;
+  v3 ^= 0x0f0e0d0c0b0a0908ull ^ ~seed;
+  #endif
+
+  #define STBDS_SIPROUND() \
+    do {                   \
+      v0 += v1; v1 = STBDS_ROTATE_LEFT(v1, 13);  v1 ^= v0; v0 = STBDS_ROTATE_LEFT(v0,STBDS_SIZE_T_BITS/2); \
+      v2 += v3; v3 = STBDS_ROTATE_LEFT(v3, 16);  v3 ^= v2;                                                 \
+      v2 += v1; v1 = STBDS_ROTATE_LEFT(v1, 17);  v1 ^= v2; v2 = STBDS_ROTATE_LEFT(v2,STBDS_SIZE_T_BITS/2); \
+      v0 += v3; v3 = STBDS_ROTATE_LEFT(v3, 21);  v3 ^= v0;                                                 \
+    } while (0)
+
+  for (i=0; i+sizeof(size_t) <= len; i += sizeof(size_t), d += sizeof(size_t)) {
+    data = d[0] | (d[1] << 8) | (d[2] << 16) | (d[3] << 24);
+    data |= (size_t) (d[4] | (d[5] << 8) | (d[6] << 16) | (d[7] << 24)) << 16 << 16; // discarded if size_t == 4
+
+    v3 ^= data;
+    for (j=0; j < STBDS_SIPHASH_C_ROUNDS; ++j)
+      STBDS_SIPROUND();
+    v0 ^= data;
+  }
+  data = len << (STBDS_SIZE_T_BITS-8);
+  switch (len - i) {
+    case 7: data |= ((size_t) d[6] << 24) << 24; // fall through
+    case 6: data |= ((size_t) d[5] << 20) << 20; // fall through
+    case 5: data |= ((size_t) d[4] << 16) << 16; // fall through
+    case 4: data |= (d[3] << 24); // fall through
+    case 3: data |= (d[2] << 16); // fall through
+    case 2: data |= (d[1] << 8); // fall through
+    case 1: data |= d[0]; // fall through
+    case 0: break;
+  }
+  v3 ^= data;
+  for (j=0; j < STBDS_SIPHASH_C_ROUNDS; ++j)
+    STBDS_SIPROUND();
+  v0 ^= data;
+  v2 ^= 0xff;
+  for (j=0; j < STBDS_SIPHASH_D_ROUNDS; ++j)
+    STBDS_SIPROUND();
+
+#ifdef STBDS_SIPHASH_2_4
+  return v0^v1^v2^v3;
+#else
+  return v1^v2^v3; // slightly stronger since v0^v3 in above cancels out final round operation? I tweeted at the authors of SipHash about this but they didn't reply
+#endif
+}
+
+size_t stbds_hash_bytes(void *p, size_t len, size_t seed)
+{
+#ifdef STBDS_SIPHASH_2_4
+  return stbds_siphash_bytes(p,len,seed);
+#else
+  unsigned char *d = (unsigned char *) p;
+
+  if (len == 4) {
+    unsigned int hash = d[0] | (d[1] << 8) | (d[2] << 16) | (d[3] << 24);
+    #if 0
+    // HASH32-A  Bob Jenkin's hash function w/o large constants
+    hash ^= seed;
+    hash -= (hash<<6);
+    hash ^= (hash>>17);
+    hash -= (hash<<9);
+    hash ^= seed;
+    hash ^= (hash<<4);
+    hash -= (hash<<3);
+    hash ^= (hash<<10);
+    hash ^= (hash>>15);
+    #elif 1
+    // HASH32-BB  Bob Jenkin's presumably-accidental version of Thomas Wang hash with rotates turned into shifts.
+    // Note that converting these back to rotates makes it run a lot slower, presumably due to collisions, so I'm
+    // not really sure what's going on.
+    hash ^= seed;
+    hash = (hash ^ 61) ^ (hash >> 16);
+    hash = hash + (hash << 3);
+    hash = hash ^ (hash >> 4);
+    hash = hash * 0x27d4eb2d;
+    hash ^= seed;
+    hash = hash ^ (hash >> 15);
+    #else  // HASH32-C   -  Murmur3
+    hash ^= seed;
+    hash *= 0xcc9e2d51;
+    hash = (hash << 17) | (hash >> 15);
+    hash *= 0x1b873593;
+    hash ^= seed;
+    hash = (hash << 19) | (hash >> 13);
+    hash = hash*5 + 0xe6546b64;
+    hash ^= hash >> 16;
+    hash *= 0x85ebca6b;
+    hash ^= seed;
+    hash ^= hash >> 13;
+    hash *= 0xc2b2ae35;
+    hash ^= hash >> 16;
+    #endif
+    // Following statistics were measured on a Core i7-6700 @ 4.00Ghz, compiled with clang 7.0.1 -O2
+    // Note that the larger tables have high variance as they were run fewer times
+    //  HASH32-A   //  HASH32-BB  //  HASH32-C
+    //    0.10ms   //    0.10ms   //    0.10ms :      2,000 inserts creating 2K table
+    //    0.96ms   //    0.95ms   //    0.99ms :     20,000 inserts creating 20K table
+    //   14.69ms   //   14.43ms   //   14.97ms :    200,000 inserts creating 200K table
+    //  199.99ms   //  195.36ms   //  202.05ms :  2,000,000 inserts creating 2M table
+    // 2234.84ms   // 2187.74ms   // 2240.38ms : 20,000,000 inserts creating 20M table
+    //   55.68ms   //   53.72ms   //   57.31ms : 500,000 inserts & deletes in 2K table
+    //   63.43ms   //   61.99ms   //   65.73ms : 500,000 inserts & deletes in 20K table
+    //   80.04ms   //   77.96ms   //   81.83ms : 500,000 inserts & deletes in 200K table
+    //  100.42ms   //   97.40ms   //  102.39ms : 500,000 inserts & deletes in 2M table
+    //  119.71ms   //  120.59ms   //  121.63ms : 500,000 inserts & deletes in 20M table
+    //  185.28ms   //  195.15ms   //  187.74ms : 500,000 inserts & deletes in 200M table
+    //   15.58ms   //   14.79ms   //   15.52ms : 200,000 inserts creating 200K table with varying key spacing
+
+    return (((size_t) hash << 16 << 16) | hash) ^ seed;
+  } else if (len == 8 && sizeof(size_t) == 8) {
+    size_t hash = d[0] | (d[1] << 8) | (d[2] << 16) | (d[3] << 24);
+    hash |= (size_t) (d[4] | (d[5] << 8) | (d[6] << 16) | (d[7] << 24)) << 16 << 16; // avoid warning if size_t == 4
+    hash ^= seed;
+    hash = (~hash) + (hash << 21);
+    hash ^= STBDS_ROTATE_RIGHT(hash,24);
+    hash *= 265;
+    hash ^= STBDS_ROTATE_RIGHT(hash,14);
+    hash ^= seed;
+    hash *= 21;
+    hash ^= STBDS_ROTATE_RIGHT(hash,28);
+    hash += (hash << 31);
+    hash = (~hash) + (hash << 18);
+    return hash;
+  } else {
+    return stbds_siphash_bytes(p,len,seed);
+  }
+#endif
+}
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+
+static int stbds_is_key_equal(void *a, size_t elemsize, void *key, size_t keysize, size_t keyoffset, int mode, size_t i)
+{
+  if (mode >= STBDS_HM_STRING)
+    return 0==strcmp((char *) key, * (char **) ((char *) a + elemsize*i + keyoffset));
+  else
+    return 0==memcmp(key, (char *) a + elemsize*i + keyoffset, keysize);
+}
+
+#define STBDS_HASH_TO_ARR(x,elemsize) ((char*) (x) - (elemsize))
+#define STBDS_ARR_TO_HASH(x,elemsize) ((char*) (x) + (elemsize))
+
+#define stbds_hash_table(a)  ((stbds_hash_index *) stbds_header(a)->hash_table)
+
+void stbds_hmfree_func(void *a, size_t elemsize)
+{
+  if (a == NULL) return;
+  if (stbds_hash_table(a) != NULL) {
+    if (stbds_hash_table(a)->string.mode == STBDS_SH_STRDUP) {
+      size_t i;
+      // skip 0th element, which is default
+      for (i=1; i < stbds_header(a)->length; ++i)
+        STBDS_FREE(NULL, *(char**) ((char *) a + elemsize*i));
+    }
+    stbds_strreset(&stbds_hash_table(a)->string);
+  }
+  STBDS_FREE(NULL, stbds_header(a)->hash_table);
+  STBDS_FREE(NULL, stbds_header(a));
+}
+
+static ptrdiff_t stbds_hm_find_slot(void *a, size_t elemsize, void *key, size_t keysize, size_t keyoffset, int mode)
+{
+  void *raw_a = STBDS_HASH_TO_ARR(a,elemsize);
+  stbds_hash_index *table = stbds_hash_table(raw_a);
+  size_t hash = mode >= STBDS_HM_STRING ? stbds_hash_string((char*)key,table->seed) : stbds_hash_bytes(key, keysize,table->seed);
+  size_t step = STBDS_BUCKET_LENGTH;
+  size_t limit,i;
+  size_t pos;
+  stbds_hash_bucket *bucket;
+
+  if (hash < 2) hash += 2; // stored hash values are forbidden from being 0, so we can detect empty slots
+
+  pos = stbds_probe_position(hash, table->slot_count, table->slot_count_log2);
+
+  for (;;) {
+    STBDS_STATS(++stbds_hash_probes);
+    bucket = &table->storage[pos >> STBDS_BUCKET_SHIFT];
+
+    // start searching from pos to end of bucket, this should help performance on small hash tables that fit in cache
+    for (i=pos & STBDS_BUCKET_MASK; i < STBDS_BUCKET_LENGTH; ++i) {
+      if (bucket->hash[i] == hash) {
+        if (stbds_is_key_equal(a, elemsize, key, keysize, keyoffset, mode, bucket->index[i])) {
+          return (pos & ~STBDS_BUCKET_MASK)+i;
+        }
+      } else if (bucket->hash[i] == STBDS_HASH_EMPTY) {
+        return -1;
+      }
+    }
+
+    // search from beginning of bucket to pos
+    limit = pos & STBDS_BUCKET_MASK;
+    for (i = 0; i < limit; ++i) {
+      if (bucket->hash[i] == hash) {
+        if (stbds_is_key_equal(a, elemsize, key, keysize, keyoffset, mode, bucket->index[i])) {
+          return (pos & ~STBDS_BUCKET_MASK)+i;
+        }
+      } else if (bucket->hash[i] == STBDS_HASH_EMPTY) {
+        return -1;
+      }
+    }
+
+    // quadratic probing
+    pos += step;
+    step += STBDS_BUCKET_LENGTH;
+    pos &= (table->slot_count-1);
+  }
+  /* NOTREACHED */
+}
+
+void * stbds_hmget_key_ts(void *a, size_t elemsize, void *key, size_t keysize, ptrdiff_t *temp, int mode)
+{
+  size_t keyoffset = 0;
+  if (a == NULL) {
+    // make it non-empty so we can return a temp
+    a = stbds_arrgrowf(0, elemsize, 0, 1);
+    stbds_header(a)->length += 1;
+    memset(a, 0, elemsize);
+    *temp = STBDS_INDEX_EMPTY;
+    // adjust a to point after the default element
+    return STBDS_ARR_TO_HASH(a,elemsize);
+  } else {
+    stbds_hash_index *table;
+    void *raw_a = STBDS_HASH_TO_ARR(a,elemsize);
+    // adjust a to point to the default element
+    table = (stbds_hash_index *) stbds_header(raw_a)->hash_table;
+    if (table == 0) {
+      *temp = -1;
+    } else {
+      ptrdiff_t slot = stbds_hm_find_slot(a, elemsize, key, keysize, keyoffset, mode);
+      if (slot < 0) {
+        *temp = STBDS_INDEX_EMPTY;
+      } else {
+        stbds_hash_bucket *b = &table->storage[slot >> STBDS_BUCKET_SHIFT];
+        *temp = b->index[slot & STBDS_BUCKET_MASK];
+      }
+    }
+    return a;
+  }
+}
+
+void * stbds_hmget_key(void *a, size_t elemsize, void *key, size_t keysize, int mode)
+{
+  ptrdiff_t temp;
+  void *p = stbds_hmget_key_ts(a, elemsize, key, keysize, &temp, mode);
+  stbds_temp(STBDS_HASH_TO_ARR(p,elemsize)) = temp;
+  return p;
+}
+
+void * stbds_hmput_default(void *a, size_t elemsize)
+{
+  // three cases:
+  //   a is NULL <- allocate
+  //   a has a hash table but no entries, because of shmode <- grow
+  //   a has entries <- do nothing
+  if (a == NULL || stbds_header(STBDS_HASH_TO_ARR(a,elemsize))->length == 0) {
+    a = stbds_arrgrowf(a ? STBDS_HASH_TO_ARR(a,elemsize) : NULL, elemsize, 0, 1);
+    stbds_header(a)->length += 1;
+    memset(a, 0, elemsize);
+    a=STBDS_ARR_TO_HASH(a,elemsize);
+  }
+  return a;
+}
+
+static char *stbds_strdup(char *str);
+
+void *stbds_hmput_key(void *a, size_t elemsize, void *key, size_t keysize, int mode)
+{
+  size_t keyoffset=0;
+  void *raw_a;
+  stbds_hash_index *table;
+
+  if (a == NULL) {
+    a = stbds_arrgrowf(0, elemsize, 0, 1);
+    memset(a, 0, elemsize);
+    stbds_header(a)->length += 1;
+    // adjust a to point AFTER the default element
+    a = STBDS_ARR_TO_HASH(a,elemsize);
+  }
+
+  // adjust a to point to the default element
+  raw_a = a;
+  a = STBDS_HASH_TO_ARR(a,elemsize);
+
+  table = (stbds_hash_index *) stbds_header(a)->hash_table;
+
+  if (table == NULL || table->used_count >= table->used_count_threshold) {
+    stbds_hash_index *nt;
+    size_t slot_count;
+
+    slot_count = (table == NULL) ? STBDS_BUCKET_LENGTH : table->slot_count*2;
+    nt = stbds_make_hash_index(slot_count, table);
+    if (table)
+      STBDS_FREE(NULL, table);
+    else
+      nt->string.mode = mode >= STBDS_HM_STRING ? STBDS_SH_DEFAULT : 0;
+    stbds_header(a)->hash_table = table = nt;
+    STBDS_STATS(++stbds_hash_grow);
+  }
+
+  // we iterate hash table explicitly because we want to track if we saw a tombstone
+  {
+    size_t hash = mode >= STBDS_HM_STRING ? stbds_hash_string((char*)key,table->seed) : stbds_hash_bytes(key, keysize,table->seed);
+    size_t step = STBDS_BUCKET_LENGTH;
+    size_t pos;
+    ptrdiff_t tombstone = -1;
+    stbds_hash_bucket *bucket;
+
+    // stored hash values are forbidden from being 0, so we can detect empty slots to early out quickly
+    if (hash < 2) hash += 2;
+
+    pos = stbds_probe_position(hash, table->slot_count, table->slot_count_log2);
+
+    for (;;) {
+      size_t limit, i;
+      STBDS_STATS(++stbds_hash_probes);
+      bucket = &table->storage[pos >> STBDS_BUCKET_SHIFT];
+
+      // start searching from pos to end of bucket
+      for (i=pos & STBDS_BUCKET_MASK; i < STBDS_BUCKET_LENGTH; ++i) {
+        if (bucket->hash[i] == hash) {
+          if (stbds_is_key_equal(raw_a, elemsize, key, keysize, keyoffset, mode, bucket->index[i])) {
+            stbds_temp(a) = bucket->index[i];
+            if (mode >= STBDS_HM_STRING)
+              stbds_temp_key(a) = * (char **) ((char *) raw_a + elemsize*bucket->index[i] + keyoffset);
+            return STBDS_ARR_TO_HASH(a,elemsize);
+          }
+        } else if (bucket->hash[i] == 0) {
+          pos = (pos & ~STBDS_BUCKET_MASK) + i;
+          goto found_empty_slot;
+        } else if (tombstone < 0) {
+          if (bucket->index[i] == STBDS_INDEX_DELETED)
+            tombstone = (ptrdiff_t) ((pos & ~STBDS_BUCKET_MASK) + i);
+        }
+      }
+
+      // search from beginning of bucket to pos
+      limit = pos & STBDS_BUCKET_MASK;
+      for (i = 0; i < limit; ++i) {
+        if (bucket->hash[i] == hash) {
+          if (stbds_is_key_equal(raw_a, elemsize, key, keysize, keyoffset, mode, bucket->index[i])) {
+            stbds_temp(a) = bucket->index[i];
+            return STBDS_ARR_TO_HASH(a,elemsize);
+          }
+        } else if (bucket->hash[i] == 0) {
+          pos = (pos & ~STBDS_BUCKET_MASK) + i;
+          goto found_empty_slot;
+        } else if (tombstone < 0) {
+          if (bucket->index[i] == STBDS_INDEX_DELETED)
+            tombstone = (ptrdiff_t) ((pos & ~STBDS_BUCKET_MASK) + i);
+        }
+      }
+
+      // quadratic probing
+      pos += step;
+      step += STBDS_BUCKET_LENGTH;
+      pos &= (table->slot_count-1);
+    }
+   found_empty_slot:
+    if (tombstone >= 0) {
+      pos = tombstone;
+      --table->tombstone_count;
+    }
+    ++table->used_count;
+
+    {
+      ptrdiff_t i = (ptrdiff_t) stbds_arrlen(a);
+      // we want to do stbds_arraddn(1), but we can't use the macros since we don't have something of the right type
+      if ((size_t) i+1 > stbds_arrcap(a))
+        *(void **) &a = stbds_arrgrowf(a, elemsize, 1, 0);
+      raw_a = STBDS_ARR_TO_HASH(a,elemsize);
+
+      STBDS_ASSERT((size_t) i+1 <= stbds_arrcap(a));
+      stbds_header(a)->length = i+1;
+      bucket = &table->storage[pos >> STBDS_BUCKET_SHIFT];
+      bucket->hash[pos & STBDS_BUCKET_MASK] = hash;
+      bucket->index[pos & STBDS_BUCKET_MASK] = i-1;
+      stbds_temp(a) = i-1;
+
+      switch (table->string.mode) {
+         case STBDS_SH_STRDUP:  stbds_temp_key(a) = *(char **) ((char *) a + elemsize*i) = stbds_strdup((char*) key); break;
+         case STBDS_SH_ARENA:   stbds_temp_key(a) = *(char **) ((char *) a + elemsize*i) = stbds_stralloc(&table->string, (char*)key); break;
+         case STBDS_SH_DEFAULT: stbds_temp_key(a) = *(char **) ((char *) a + elemsize*i) = (char *) key; break;
+         default:                memcpy((char *) a + elemsize*i, key, keysize); break;
+      }
+    }
+    return STBDS_ARR_TO_HASH(a,elemsize);
+  }
+}
+
+void * stbds_shmode_func(size_t elemsize, int mode)
+{
+  void *a = stbds_arrgrowf(0, elemsize, 0, 1);
+  stbds_hash_index *h;
+  memset(a, 0, elemsize);
+  stbds_header(a)->length = 1;
+  stbds_header(a)->hash_table = h = (stbds_hash_index *) stbds_make_hash_index(STBDS_BUCKET_LENGTH, NULL);
+  h->string.mode = (unsigned char) mode;
+  return STBDS_ARR_TO_HASH(a,elemsize);
+}
+
+void * stbds_hmdel_key(void *a, size_t elemsize, void *key, size_t keysize, size_t keyoffset, int mode)
+{
+  if (a == NULL) {
+    return 0;
+  } else {
+    stbds_hash_index *table;
+    void *raw_a = STBDS_HASH_TO_ARR(a,elemsize);
+    table = (stbds_hash_index *) stbds_header(raw_a)->hash_table;
+    stbds_temp(raw_a) = 0;
+    if (table == 0) {
+      return a;
+    } else {
+      ptrdiff_t slot;
+      slot = stbds_hm_find_slot(a, elemsize, key, keysize, keyoffset, mode);
+      if (slot < 0)
+        return a;
+      else {
+        stbds_hash_bucket *b = &table->storage[slot >> STBDS_BUCKET_SHIFT];
+        int i = slot & STBDS_BUCKET_MASK;
+        ptrdiff_t old_index = b->index[i];
+        ptrdiff_t final_index = (ptrdiff_t) stbds_arrlen(raw_a)-1-1; // minus one for the raw_a vs a, and minus one for 'last'
+        STBDS_ASSERT(slot < (ptrdiff_t) table->slot_count);
+        --table->used_count;
+        ++table->tombstone_count;
+        stbds_temp(raw_a) = 1;
+        STBDS_ASSERT(table->used_count >= 0);
+        //STBDS_ASSERT(table->tombstone_count < table->slot_count/4);
+        b->hash[i] = STBDS_HASH_DELETED;
+        b->index[i] = STBDS_INDEX_DELETED;
+
+        if (mode == STBDS_HM_STRING && table->string.mode == STBDS_SH_STRDUP)
+          STBDS_FREE(NULL, *(char**) ((char *) a+elemsize*old_index));
+
+        // if indices are the same, memcpy is a no-op, but back-pointer-fixup will fail, so skip
+        if (old_index != final_index) {
+          // swap delete
+          memmove((char*) a + elemsize*old_index, (char*) a + elemsize*final_index, elemsize);
+
+          // now find the slot for the last element
+          if (mode == STBDS_HM_STRING)
+            slot = stbds_hm_find_slot(a, elemsize, *(char**) ((char *) a+elemsize*old_index + keyoffset), keysize, keyoffset, mode);
+          else
+            slot = stbds_hm_find_slot(a, elemsize,  (char* ) a+elemsize*old_index + keyoffset, keysize, keyoffset, mode);
+          STBDS_ASSERT(slot >= 0);
+          b = &table->storage[slot >> STBDS_BUCKET_SHIFT];
+          i = slot & STBDS_BUCKET_MASK;
+          STBDS_ASSERT(b->index[i] == final_index);
+          b->index[i] = old_index;
+        }
+        stbds_header(raw_a)->length -= 1;
+
+        if (table->used_count < table->used_count_shrink_threshold && table->slot_count > STBDS_BUCKET_LENGTH) {
+          stbds_header(raw_a)->hash_table = stbds_make_hash_index(table->slot_count>>1, table);
+          STBDS_FREE(NULL, table);
+          STBDS_STATS(++stbds_hash_shrink);
+        } else if (table->tombstone_count > table->tombstone_count_threshold) {
+          stbds_header(raw_a)->hash_table = stbds_make_hash_index(table->slot_count   , table);
+          STBDS_FREE(NULL, table);
+          STBDS_STATS(++stbds_hash_rebuild);
+        }
+
+        return a;
+      }
+    }
+  }
+  /* NOTREACHED */
+}
+
+static char *stbds_strdup(char *str)
+{
+  // to keep replaceable allocator simple, we don't want to use strdup.
+  // rolling our own also avoids problem of strdup vs _strdup
+  size_t len = strlen(str)+1;
+  char *p = (char*) STBDS_REALLOC(NULL, 0, len);
+  memmove(p, str, len);
+  return p;
+}
+
+#ifndef STBDS_STRING_ARENA_BLOCKSIZE_MIN
+#define STBDS_STRING_ARENA_BLOCKSIZE_MIN  512u
+#endif
+#ifndef STBDS_STRING_ARENA_BLOCKSIZE_MAX
+#define STBDS_STRING_ARENA_BLOCKSIZE_MAX  (1u<<20)
+#endif
+
+char *stbds_stralloc(stbds_string_arena *a, char *str)
+{
+  char *p;
+  size_t len = strlen(str)+1;
+  if (len > a->remaining) {
+    // compute the next blocksize
+    size_t blocksize = a->block;
+
+    // size is 512, 512, 1024, 1024, 2048, 2048, 4096, 4096, etc., so that
+    // there are log(SIZE) allocations to free when we destroy the table
+    blocksize = (size_t) (STBDS_STRING_ARENA_BLOCKSIZE_MIN) << (blocksize>>1);
+
+    // if size is under 1M, advance to next blocktype
+    if (blocksize < (size_t)(STBDS_STRING_ARENA_BLOCKSIZE_MAX))
+      ++a->block;
+
+    if (len > blocksize) {
+      // if string is larger than blocksize, then just allocate the full size.
+      // note that we still advance string_block so block size will continue
+      // increasing, so e.g. if somebody only calls this with 1000-long strings,
+      // eventually the arena will start doubling and handling those as well
+      stbds_string_block *sb = (stbds_string_block *) STBDS_REALLOC(NULL, 0, sizeof(*sb)-8 + len);
+      memmove(sb->storage, str, len);
+      if (a->storage) {
+        // insert it after the first element, so that we don't waste the space there
+        sb->next = a->storage->next;
+        a->storage->next = sb;
+      } else {
+        sb->next = 0;
+        a->storage = sb;
+        a->remaining = 0; // this is redundant, but good for clarity
+      }
+      return sb->storage;
+    } else {
+      stbds_string_block *sb = (stbds_string_block *) STBDS_REALLOC(NULL, 0, sizeof(*sb)-8 + blocksize);
+      sb->next = a->storage;
+      a->storage = sb;
+      a->remaining = blocksize;
+    }
+  }
+
+  STBDS_ASSERT(len <= a->remaining);
+  p = a->storage->storage + a->remaining - len;
+  a->remaining -= len;
+  memmove(p, str, len);
+  return p;
+}
+
+void stbds_strreset(stbds_string_arena *a)
+{
+  stbds_string_block *x,*y;
+  x = a->storage;
+  while (x) {
+    y = x->next;
+    STBDS_FREE(NULL, x);
+    x = y;
+  }
+  memset(a, 0, sizeof(*a));
+}
+
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//   UNIT TESTS
+//
+
+#ifdef STBDS_UNIT_TESTS
+#include <stdio.h>
+#ifdef STBDS_ASSERT_WAS_UNDEFINED
+#undef STBDS_ASSERT
+#endif
+#ifndef STBDS_ASSERT
+#define STBDS_ASSERT assert
+#include <assert.h>
+#endif
+
+typedef struct { int key,b,c,d; } stbds_struct;
+typedef struct { int key[2],b,c,d; } stbds_struct2;
+
+static char buffer[256];
+char *strkey(int n)
+{
+#if defined(_WIN32) && defined(__STDC_WANT_SECURE_LIB__)
+   sprintf_s(buffer, sizeof(buffer), "test_%d", n);
+#else
+   sprintf(buffer, "test_%d", n);
+#endif
+   return buffer;
+}
+
+void stbds_unit_tests(void)
+{
+#if defined(_MSC_VER) && _MSC_VER <= 1200 && defined(__cplusplus)
+  // VC6 C++ doesn't like the template<> trick on unnamed structures, so do nothing!
+  STBDS_ASSERT(0);
+#else
+  const int testsize = 100000;
+  const int testsize2 = testsize/20;
+  int *arr=NULL;
+  struct { int   key;        int value; }  *intmap  = NULL;
+  struct { char *key;        int value; }  *strmap  = NULL, s;
+  struct { stbds_struct key; int value; }  *map     = NULL;
+  stbds_struct                             *map2    = NULL;
+  stbds_struct2                            *map3    = NULL;
+  stbds_string_arena                        sa      = { 0 };
+  int key3[2] = { 1,2 };
+  ptrdiff_t temp;
+
+  int i,j;
+
+  STBDS_ASSERT(arrlen(arr)==0);
+  for (i=0; i < 20000; i += 50) {
+    for (j=0; j < i; ++j)
+      arrpush(arr,j);
+    arrfree(arr);
+  }
+
+  for (i=0; i < 4; ++i) {
+    arrpush(arr,1); arrpush(arr,2); arrpush(arr,3); arrpush(arr,4);
+    arrdel(arr,i);
+    arrfree(arr);
+    arrpush(arr,1); arrpush(arr,2); arrpush(arr,3); arrpush(arr,4);
+    arrdelswap(arr,i);
+    arrfree(arr);
+  }
+
+  for (i=0; i < 5; ++i) {
+    arrpush(arr,1); arrpush(arr,2); arrpush(arr,3); arrpush(arr,4);
+    stbds_arrins(arr,i,5);
+    STBDS_ASSERT(arr[i] == 5);
+    if (i < 4)
+      STBDS_ASSERT(arr[4] == 4);
+    arrfree(arr);
+  }
+
+  i = 1;
+  STBDS_ASSERT(hmgeti(intmap,i) == -1);
+  hmdefault(intmap, -2);
+  STBDS_ASSERT(hmgeti(intmap, i) == -1);
+  STBDS_ASSERT(hmget (intmap, i) == -2);
+  for (i=0; i < testsize; i+=2)
+    hmput(intmap, i, i*5);
+  for (i=0; i < testsize; i+=1) {
+    if (i & 1) STBDS_ASSERT(hmget(intmap, i) == -2 );
+    else       STBDS_ASSERT(hmget(intmap, i) == i*5);
+    if (i & 1) STBDS_ASSERT(hmget_ts(intmap, i, temp) == -2 );
+    else       STBDS_ASSERT(hmget_ts(intmap, i, temp) == i*5);
+  }
+  for (i=0; i < testsize; i+=2)
+    hmput(intmap, i, i*3);
+  for (i=0; i < testsize; i+=1)
+    if (i & 1) STBDS_ASSERT(hmget(intmap, i) == -2 );
+    else       STBDS_ASSERT(hmget(intmap, i) == i*3);
+  for (i=2; i < testsize; i+=4)
+    hmdel(intmap, i); // delete half the entries
+  for (i=0; i < testsize; i+=1)
+    if (i & 3) STBDS_ASSERT(hmget(intmap, i) == -2 );
+    else       STBDS_ASSERT(hmget(intmap, i) == i*3);
+  for (i=0; i < testsize; i+=1)
+    hmdel(intmap, i); // delete the rest of the entries
+  for (i=0; i < testsize; i+=1)
+    STBDS_ASSERT(hmget(intmap, i) == -2 );
+  hmfree(intmap);
+  for (i=0; i < testsize; i+=2)
+    hmput(intmap, i, i*3);
+  hmfree(intmap);
+
+  #if defined(__clang__) || defined(__GNUC__)
+  #ifndef __cplusplus
+  intmap = NULL;
+  hmput(intmap, 15, 7);
+  hmput(intmap, 11, 3);
+  hmput(intmap,  9, 5);
+  STBDS_ASSERT(hmget(intmap, 9) == 5);
+  STBDS_ASSERT(hmget(intmap, 11) == 3);
+  STBDS_ASSERT(hmget(intmap, 15) == 7);
+  #endif
+  #endif
+
+  for (i=0; i < testsize; ++i)
+    stralloc(&sa, strkey(i));
+  strreset(&sa);
+
+  {
+    s.key = "a", s.value = 1;
+    shputs(strmap, s);
+    STBDS_ASSERT(*strmap[0].key == 'a');
+    STBDS_ASSERT(strmap[0].key == s.key);
+    STBDS_ASSERT(strmap[0].value == s.value);
+    shfree(strmap);
+  }
+
+  {
+    s.key = "a", s.value = 1;
+    sh_new_strdup(strmap);
+    shputs(strmap, s);
+    STBDS_ASSERT(*strmap[0].key == 'a');
+    STBDS_ASSERT(strmap[0].key != s.key);
+    STBDS_ASSERT(strmap[0].value == s.value);
+    shfree(strmap);
+  }
+
+  {
+    s.key = "a", s.value = 1;
+    sh_new_arena(strmap);
+    shputs(strmap, s);
+    STBDS_ASSERT(*strmap[0].key == 'a');
+    STBDS_ASSERT(strmap[0].key != s.key);
+    STBDS_ASSERT(strmap[0].value == s.value);
+    shfree(strmap);
+  }
+
+  for (j=0; j < 2; ++j) {
+    STBDS_ASSERT(shgeti(strmap,"foo") == -1);
+    if (j == 0)
+      sh_new_strdup(strmap);
+    else
+      sh_new_arena(strmap);
+    STBDS_ASSERT(shgeti(strmap,"foo") == -1);
+    shdefault(strmap, -2);
+    STBDS_ASSERT(shgeti(strmap,"foo") == -1);
+    for (i=0; i < testsize; i+=2)
+      shput(strmap, strkey(i), i*3);
+    for (i=0; i < testsize; i+=1)
+      if (i & 1) STBDS_ASSERT(shget(strmap, strkey(i)) == -2 );
+      else       STBDS_ASSERT(shget(strmap, strkey(i)) == i*3);
+    for (i=2; i < testsize; i+=4)
+      shdel(strmap, strkey(i)); // delete half the entries
+    for (i=0; i < testsize; i+=1)
+      if (i & 3) STBDS_ASSERT(shget(strmap, strkey(i)) == -2 );
+      else       STBDS_ASSERT(shget(strmap, strkey(i)) == i*3);
+    for (i=0; i < testsize; i+=1)
+      shdel(strmap, strkey(i)); // delete the rest of the entries
+    for (i=0; i < testsize; i+=1)
+      STBDS_ASSERT(shget(strmap, strkey(i)) == -2 );
+    shfree(strmap);
+  }
+
+  {
+    struct { char *key; char value; } *hash = NULL;
+    char name[4] = "jen";
+    shput(hash, "bob"   , 'h');
+    shput(hash, "sally" , 'e');
+    shput(hash, "fred"  , 'l');
+    shput(hash, "jen"   , 'x');
+    shput(hash, "doug"  , 'o');
+
+    shput(hash, name    , 'l');
+    shfree(hash);
+  }
+
+  for (i=0; i < testsize; i += 2) {
+    stbds_struct s = { i,i*2,i*3,i*4 };
+    hmput(map, s, i*5);
+  }
+
+  for (i=0; i < testsize; i += 1) {
+    stbds_struct s = { i,i*2,i*3  ,i*4 };
+    stbds_struct t = { i,i*2,i*3+1,i*4 };
+    if (i & 1) STBDS_ASSERT(hmget(map, s) == 0);
+    else       STBDS_ASSERT(hmget(map, s) == i*5);
+    if (i & 1) STBDS_ASSERT(hmget_ts(map, s, temp) == 0);
+    else       STBDS_ASSERT(hmget_ts(map, s, temp) == i*5);
+    //STBDS_ASSERT(hmget(map, t.key) == 0);
+  }
+
+  for (i=0; i < testsize; i += 2) {
+    stbds_struct s = { i,i*2,i*3,i*4 };
+    hmputs(map2, s);
+  }
+  hmfree(map);
+
+  for (i=0; i < testsize; i += 1) {
+    stbds_struct s = { i,i*2,i*3,i*4 };
+    stbds_struct t = { i,i*2,i*3+1,i*4 };
+    if (i & 1) STBDS_ASSERT(hmgets(map2, s.key).d == 0);
+    else       STBDS_ASSERT(hmgets(map2, s.key).d == i*4);
+    //STBDS_ASSERT(hmgetp(map2, t.key) == 0);
+  }
+  hmfree(map2);
+
+  for (i=0; i < testsize; i += 2) {
+    stbds_struct2 s = { { i,i*2 }, i*3,i*4, i*5 };
+    hmputs(map3, s);
+  }
+  for (i=0; i < testsize; i += 1) {
+    stbds_struct2 s = { { i,i*2}, i*3, i*4, i*5 };
+    stbds_struct2 t = { { i,i*2}, i*3+1, i*4, i*5 };
+    if (i & 1) STBDS_ASSERT(hmgets(map3, s.key).d == 0);
+    else       STBDS_ASSERT(hmgets(map3, s.key).d == i*5);
+    //STBDS_ASSERT(hmgetp(map3, t.key) == 0);
+  }
+#endif
+}
+#endif
+
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2019 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/tools/common/subprocess.h
+++ b/tools/common/subprocess.h
@@ -1,0 +1,1162 @@
+/*
+   The latest version of this library is available on GitHub;
+   https://github.com/sheredom/subprocess.h
+*/
+
+/*
+   This is free and unencumbered software released into the public domain.
+
+   Anyone is free to copy, modify, publish, use, compile, sell, or
+   distribute this software, either in source code form or as a compiled
+   binary, for any purpose, commercial or non-commercial, and by any
+   means.
+
+   In jurisdictions that recognize copyright laws, the author or authors
+   of this software dedicate any and all copyright interest in the
+   software to the public domain. We make this dedication for the benefit
+   of the public at large and to the detriment of our heirs and
+   successors. We intend this dedication to be an overt act of
+   relinquishment in perpetuity of all present and future rights to this
+   software under copyright law.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+   OTHER DEALINGS IN THE SOFTWARE.
+
+   For more information, please refer to <http://unlicense.org/>
+*/
+
+#ifndef SHEREDOM_SUBPROCESS_H_INCLUDED
+#define SHEREDOM_SUBPROCESS_H_INCLUDED
+
+#if defined(_MSC_VER)
+#pragma warning(push, 1)
+
+/* disable warning: '__cplusplus' is not defined as a preprocessor macro,
+ * replacing with '0' for '#if/#elif' */
+#pragma warning(disable : 4668)
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#if defined(_MSC_VER)
+#define subprocess_pure
+#define subprocess_weak __inline
+#define subprocess_tls __declspec(thread)
+#elif defined(__clang__) || defined(__GNUC__)
+#define subprocess_pure __attribute__((pure))
+#define subprocess_weak __attribute__((weak))
+#define subprocess_tls __thread
+#else
+#error Non clang, non gcc, non MSVC compiler found!
+#endif
+
+struct subprocess_s;
+
+enum subprocess_option_e {
+  // stdout and stderr are the same FILE.
+  subprocess_option_combined_stdout_stderr = 0x1,
+
+  // The child process should inherit the environment variables of the parent.
+  subprocess_option_inherit_environment = 0x2,
+
+  // Enable asynchronous reading of stdout/stderr before it has completed.
+  subprocess_option_enable_async = 0x4,
+
+  // Enable the child process to be spawned with no window visible if supported
+  // by the platform.
+  subprocess_option_no_window = 0x8,
+
+  // Search for program names in the PATH variable. Always enabled on Windows.
+  // Note: this will **not** search for paths in any provided custom environment
+  // and instead uses the PATH of the spawning process.
+  subprocess_option_search_user_path = 0x10
+};
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/// @brief Create a process.
+/// @param command_line An array of strings for the command line to execute for
+/// this process. The last element must be NULL to signify the end of the array.
+/// The memory backing this parameter only needs to persist until this function
+/// returns.
+/// @param options A bit field of subprocess_option_e's to pass.
+/// @param out_process The newly created process.
+/// @return On success zero is returned.
+subprocess_weak int subprocess_create(const char *const command_line[],
+                                      int options,
+                                      struct subprocess_s *const out_process);
+
+/// @brief Create a process (extended create).
+/// @param command_line An array of strings for the command line to execute for
+/// this process. The last element must be NULL to signify the end of the array.
+/// The memory backing this parameter only needs to persist until this function
+/// returns.
+/// @param options A bit field of subprocess_option_e's to pass.
+/// @param environment An optional array of strings for the environment to use
+/// for a child process (each element of the form FOO=BAR). The last element
+/// must be NULL to signify the end of the array.
+/// @param out_process The newly created process.
+/// @return On success zero is returned.
+///
+/// If `options` contains `subprocess_option_inherit_environment`, then
+/// `environment` must be NULL.
+subprocess_weak int
+subprocess_create_ex(const char *const command_line[], int options,
+                     const char *const environment[],
+                     struct subprocess_s *const out_process);
+
+/// @brief Get the standard input file for a process.
+/// @param process The process to query.
+/// @return The file for standard input of the process.
+///
+/// The file returned can be written to by the parent process to feed data to
+/// the standard input of the process.
+subprocess_pure subprocess_weak FILE *
+subprocess_stdin(const struct subprocess_s *const process);
+
+/// @brief Get the standard output file for a process.
+/// @param process The process to query.
+/// @return The file for standard output of the process.
+///
+/// The file returned can be read from by the parent process to read data from
+/// the standard output of the child process.
+subprocess_pure subprocess_weak FILE *
+subprocess_stdout(const struct subprocess_s *const process);
+
+/// @brief Get the standard error file for a process.
+/// @param process The process to query.
+/// @return The file for standard error of the process.
+///
+/// The file returned can be read from by the parent process to read data from
+/// the standard error of the child process.
+///
+/// If the process was created with the subprocess_option_combined_stdout_stderr
+/// option bit set, this function will return NULL, and the subprocess_stdout
+/// function should be used for both the standard output and error combined.
+subprocess_pure subprocess_weak FILE *
+subprocess_stderr(const struct subprocess_s *const process);
+
+/// @brief Wait for a process to finish execution.
+/// @param process The process to wait for.
+/// @param out_return_code The return code of the returned process (can be
+/// NULL).
+/// @return On success zero is returned.
+///
+/// Joining a process will close the stdin pipe to the process.
+subprocess_weak int subprocess_join(struct subprocess_s *const process,
+                                    int *const out_return_code);
+
+/// @brief Destroy a previously created process.
+/// @param process The process to destroy.
+/// @return On success zero is returned.
+///
+/// If the process to be destroyed had not finished execution, it may out live
+/// the parent process.
+subprocess_weak int subprocess_destroy(struct subprocess_s *const process);
+
+/// @brief Terminate a previously created process.
+/// @param process The process to terminate.
+/// @return On success zero is returned.
+///
+/// If the process to be destroyed had not finished execution, it will be
+/// terminated (i.e killed).
+subprocess_weak int subprocess_terminate(struct subprocess_s *const process);
+
+/// @brief Read the standard output from the child process.
+/// @param process The process to read from.
+/// @param buffer The buffer to read into.
+/// @param size The maximum number of bytes to read.
+/// @return The number of bytes actually read into buffer. Can only be 0 if the
+/// process has complete.
+///
+/// The only safe way to read from the standard output of a process during it's
+/// execution is to use the `subprocess_option_enable_async` option in
+/// conjuction with this method.
+subprocess_weak unsigned
+subprocess_read_stdout(struct subprocess_s *const process, char *const buffer,
+                       unsigned size);
+
+/// @brief Read the standard error from the child process.
+/// @param process The process to read from.
+/// @param buffer The buffer to read into.
+/// @param size The maximum number of bytes to read.
+/// @return The number of bytes actually read into buffer. Can only be 0 if the
+/// process has complete.
+///
+/// The only safe way to read from the standard error of a process during it's
+/// execution is to use the `subprocess_option_enable_async` option in
+/// conjuction with this method.
+subprocess_weak unsigned
+subprocess_read_stderr(struct subprocess_s *const process, char *const buffer,
+                       unsigned size);
+
+/// @brief Returns if the subprocess is currently still alive and executing.
+/// @param process The process to check.
+/// @return If the process is still alive non-zero is returned.
+subprocess_weak int subprocess_alive(struct subprocess_s *const process);
+
+#if defined(__cplusplus)
+#define SUBPROCESS_CAST(type, x) static_cast<type>(x)
+#define SUBPROCESS_PTR_CAST(type, x) reinterpret_cast<type>(x)
+#define SUBPROCESS_CONST_CAST(type, x) const_cast<type>(x)
+#define SUBPROCESS_NULL NULL
+#else
+#define SUBPROCESS_CAST(type, x) ((type)(x))
+#define SUBPROCESS_PTR_CAST(type, x) ((type)(x))
+#define SUBPROCESS_CONST_CAST(type, x) ((type)(x))
+#define SUBPROCESS_NULL 0
+#endif
+
+#if !defined(_WIN32)
+#include <signal.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#if defined(_WIN32)
+
+#if (_MSC_VER < 1920)
+#ifdef _WIN64
+typedef __int64 subprocess_intptr_t;
+typedef unsigned __int64 subprocess_size_t;
+#else
+typedef int subprocess_intptr_t;
+typedef unsigned int subprocess_size_t;
+#endif
+#else
+#include <inttypes.h>
+
+typedef intptr_t subprocess_intptr_t;
+typedef size_t subprocess_size_t;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
+typedef struct _PROCESS_INFORMATION *LPPROCESS_INFORMATION;
+typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
+typedef struct _STARTUPINFOA *LPSTARTUPINFOA;
+typedef struct _OVERLAPPED *LPOVERLAPPED;
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#pragma warning(push, 1)
+struct subprocess_subprocess_information_s {
+  void *hProcess;
+  void *hThread;
+  unsigned long dwProcessId;
+  unsigned long dwThreadId;
+};
+
+struct subprocess_security_attributes_s {
+  unsigned long nLength;
+  void *lpSecurityDescriptor;
+  int bInheritHandle;
+};
+
+struct subprocess_startup_info_s {
+  unsigned long cb;
+  char *lpReserved;
+  char *lpDesktop;
+  char *lpTitle;
+  unsigned long dwX;
+  unsigned long dwY;
+  unsigned long dwXSize;
+  unsigned long dwYSize;
+  unsigned long dwXCountChars;
+  unsigned long dwYCountChars;
+  unsigned long dwFillAttribute;
+  unsigned long dwFlags;
+  unsigned short wShowWindow;
+  unsigned short cbReserved2;
+  unsigned char *lpReserved2;
+  void *hStdInput;
+  void *hStdOutput;
+  void *hStdError;
+};
+
+struct subprocess_overlapped_s {
+  uintptr_t Internal;
+  uintptr_t InternalHigh;
+  union {
+    struct {
+      unsigned long Offset;
+      unsigned long OffsetHigh;
+    } DUMMYSTRUCTNAME;
+    void *Pointer;
+  } DUMMYUNIONNAME;
+
+  void *hEvent;
+};
+
+#pragma warning(pop)
+
+__declspec(dllimport) unsigned long __stdcall GetLastError(void);
+__declspec(dllimport) int __stdcall SetHandleInformation(void *, unsigned long,
+                                                         unsigned long);
+__declspec(dllimport) int __stdcall CreatePipe(void **, void **,
+                                               LPSECURITY_ATTRIBUTES,
+                                               unsigned long);
+__declspec(dllimport) void *__stdcall CreateNamedPipeA(
+    const char *, unsigned long, unsigned long, unsigned long, unsigned long,
+    unsigned long, unsigned long, LPSECURITY_ATTRIBUTES);
+__declspec(dllimport) int __stdcall ReadFile(void *, void *, unsigned long,
+                                             unsigned long *, LPOVERLAPPED);
+__declspec(dllimport) unsigned long __stdcall GetCurrentProcessId(void);
+__declspec(dllimport) unsigned long __stdcall GetCurrentThreadId(void);
+__declspec(dllimport) void *__stdcall CreateFileA(const char *, unsigned long,
+                                                  unsigned long,
+                                                  LPSECURITY_ATTRIBUTES,
+                                                  unsigned long, unsigned long,
+                                                  void *);
+__declspec(dllimport) void *__stdcall CreateEventA(LPSECURITY_ATTRIBUTES, int,
+                                                   int, const char *);
+__declspec(dllimport) int __stdcall CreateProcessA(
+    const char *, char *, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES, int,
+    unsigned long, void *, const char *, LPSTARTUPINFOA, LPPROCESS_INFORMATION);
+__declspec(dllimport) int __stdcall CloseHandle(void *);
+__declspec(dllimport) unsigned long __stdcall WaitForSingleObject(
+    void *, unsigned long);
+__declspec(dllimport) int __stdcall GetExitCodeProcess(
+    void *, unsigned long *lpExitCode);
+__declspec(dllimport) int __stdcall TerminateProcess(void *, unsigned int);
+__declspec(dllimport) unsigned long __stdcall WaitForMultipleObjects(
+    unsigned long, void *const *, int, unsigned long);
+__declspec(dllimport) int __stdcall GetOverlappedResult(void *, LPOVERLAPPED,
+                                                        unsigned long *, int);
+
+#if defined(_DLL)
+#define SUBPROCESS_DLLIMPORT __declspec(dllimport)
+#else
+#define SUBPROCESS_DLLIMPORT
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
+SUBPROCESS_DLLIMPORT int __cdecl _fileno(FILE *);
+SUBPROCESS_DLLIMPORT int __cdecl _open_osfhandle(subprocess_intptr_t, int);
+SUBPROCESS_DLLIMPORT subprocess_intptr_t __cdecl _get_osfhandle(int);
+
+#ifndef __MINGW32__
+void *__cdecl _alloca(subprocess_size_t);
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#else
+typedef size_t subprocess_size_t;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+struct subprocess_s {
+  FILE *stdin_file;
+  FILE *stdout_file;
+  FILE *stderr_file;
+
+#if defined(_WIN32)
+  void *hProcess;
+  void *hStdInput;
+  void *hEventOutput;
+  void *hEventError;
+#else
+  pid_t child;
+  int return_status;
+#endif
+
+  subprocess_size_t alive;
+};
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#if defined(_WIN32)
+subprocess_weak int subprocess_create_named_pipe_helper(void **rd, void **wr);
+int subprocess_create_named_pipe_helper(void **rd, void **wr) {
+  const unsigned long pipeAccessInbound = 0x00000001;
+  const unsigned long fileFlagOverlapped = 0x40000000;
+  const unsigned long pipeTypeByte = 0x00000000;
+  const unsigned long pipeWait = 0x00000000;
+  const unsigned long genericWrite = 0x40000000;
+  const unsigned long openExisting = 3;
+  const unsigned long fileAttributeNormal = 0x00000080;
+  const void *const invalidHandleValue =
+      SUBPROCESS_PTR_CAST(void *, ~(SUBPROCESS_CAST(subprocess_intptr_t, 0)));
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
+                                                    SUBPROCESS_NULL, 1};
+  char name[256] = {0};
+  static subprocess_tls long index = 0;
+  const long unique = index++;
+
+#if _MSC_VER < 1900
+#pragma warning(push, 1)
+#pragma warning(disable : 4996)
+  _snprintf(name, sizeof(name) - 1,
+            "\\\\.\\pipe\\sheredom_subprocess_h.%08lx.%08lx.%ld",
+            GetCurrentProcessId(), GetCurrentThreadId(), unique);
+#pragma warning(pop)
+#else
+  snprintf(name, sizeof(name) - 1,
+           "\\\\.\\pipe\\sheredom_subprocess_h.%08lx.%08lx.%ld",
+           GetCurrentProcessId(), GetCurrentThreadId(), unique);
+#endif
+
+  *rd =
+      CreateNamedPipeA(name, pipeAccessInbound | fileFlagOverlapped,
+                       pipeTypeByte | pipeWait, 1, 4096, 4096, SUBPROCESS_NULL,
+                       SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr));
+
+  if (invalidHandleValue == *rd) {
+    return -1;
+  }
+
+  *wr = CreateFileA(name, genericWrite, SUBPROCESS_NULL,
+                    SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
+                    openExisting, fileAttributeNormal, SUBPROCESS_NULL);
+
+  if (invalidHandleValue == *wr) {
+    return -1;
+  }
+
+  return 0;
+}
+#endif
+
+int subprocess_create(const char *const commandLine[], int options,
+                      struct subprocess_s *const out_process) {
+  return subprocess_create_ex(commandLine, options, SUBPROCESS_NULL,
+                              out_process);
+}
+
+int subprocess_create_ex(const char *const commandLine[], int options,
+                         const char *const environment[],
+                         struct subprocess_s *const out_process) {
+#if defined(_WIN32)
+  int fd;
+  void *rd, *wr;
+  char *commandLineCombined;
+  subprocess_size_t len;
+  int i, j;
+  int need_quoting;
+  unsigned long flags = 0;
+  const unsigned long startFUseStdHandles = 0x00000100;
+  const unsigned long handleFlagInherit = 0x00000001;
+  const unsigned long createNoWindow = 0x08000000;
+  struct subprocess_subprocess_information_s processInfo;
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
+                                                    SUBPROCESS_NULL, 1};
+  char *used_environment = SUBPROCESS_NULL;
+  struct subprocess_startup_info_s startInfo = {0,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL};
+
+  startInfo.cb = sizeof(startInfo);
+  startInfo.dwFlags = startFUseStdHandles;
+
+  if (subprocess_option_no_window == (options & subprocess_option_no_window)) {
+    flags |= createNoWindow;
+  }
+
+  if (subprocess_option_inherit_environment !=
+      (options & subprocess_option_inherit_environment)) {
+    if (SUBPROCESS_NULL == environment) {
+      used_environment = SUBPROCESS_CONST_CAST(char *, "\0\0");
+    } else {
+      // We always end with two null terminators.
+      len = 2;
+
+      for (i = 0; environment[i]; i++) {
+        for (j = 0; '\0' != environment[i][j]; j++) {
+          len++;
+        }
+
+        // For the null terminator too.
+        len++;
+      }
+
+      used_environment = SUBPROCESS_CAST(char *, _alloca(len));
+
+      // Re-use len for the insertion position
+      len = 0;
+
+      for (i = 0; environment[i]; i++) {
+        for (j = 0; '\0' != environment[i][j]; j++) {
+          used_environment[len++] = environment[i][j];
+        }
+
+        used_environment[len++] = '\0';
+      }
+
+      // End with the two null terminators.
+      used_environment[len++] = '\0';
+      used_environment[len++] = '\0';
+    }
+  } else {
+    if (SUBPROCESS_NULL != environment) {
+      return -1;
+    }
+  }
+
+  if (!CreatePipe(&rd, &wr, SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
+                  0)) {
+    return -1;
+  }
+
+  if (!SetHandleInformation(wr, handleFlagInherit, 0)) {
+    return -1;
+  }
+
+  fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, wr), 0);
+
+  if (-1 != fd) {
+    out_process->stdin_file = _fdopen(fd, "wb");
+
+    if (SUBPROCESS_NULL == out_process->stdin_file) {
+      return -1;
+    }
+  }
+
+  startInfo.hStdInput = rd;
+
+  if (options & subprocess_option_enable_async) {
+    if (subprocess_create_named_pipe_helper(&rd, &wr)) {
+      return -1;
+    }
+  } else {
+    if (!CreatePipe(&rd, &wr,
+                    SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
+      return -1;
+    }
+  }
+
+  if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
+    return -1;
+  }
+
+  fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+
+  if (-1 != fd) {
+    out_process->stdout_file = _fdopen(fd, "rb");
+
+    if (SUBPROCESS_NULL == out_process->stdout_file) {
+      return -1;
+    }
+  }
+
+  startInfo.hStdOutput = wr;
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    out_process->stderr_file = out_process->stdout_file;
+    startInfo.hStdError = startInfo.hStdOutput;
+  } else {
+    if (options & subprocess_option_enable_async) {
+      if (subprocess_create_named_pipe_helper(&rd, &wr)) {
+        return -1;
+      }
+    } else {
+      if (!CreatePipe(&rd, &wr,
+                      SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
+        return -1;
+      }
+    }
+
+    if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
+      return -1;
+    }
+
+    fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+
+    if (-1 != fd) {
+      out_process->stderr_file = _fdopen(fd, "rb");
+
+      if (SUBPROCESS_NULL == out_process->stderr_file) {
+        return -1;
+      }
+    }
+
+    startInfo.hStdError = wr;
+  }
+
+  if (options & subprocess_option_enable_async) {
+    out_process->hEventOutput =
+        CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
+                     SUBPROCESS_NULL);
+    out_process->hEventError =
+        CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
+                     SUBPROCESS_NULL);
+  } else {
+    out_process->hEventOutput = SUBPROCESS_NULL;
+    out_process->hEventError = SUBPROCESS_NULL;
+  }
+
+  // Combine commandLine together into a single string
+  len = 0;
+  for (i = 0; commandLine[i]; i++) {
+    // for the trailing \0
+    len++;
+
+    // Quote the argument if it has a space in it
+    if (strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL)
+      len += 2;
+
+    for (j = 0; '\0' != commandLine[i][j]; j++) {
+      switch (commandLine[i][j]) {
+      default:
+        break;
+      case '\\':
+        if (commandLine[i][j + 1] == '"') {
+          len++;
+        }
+
+        break;
+      case '"':
+        len++;
+        break;
+      }
+      len++;
+    }
+  }
+
+  commandLineCombined = SUBPROCESS_CAST(char *, _alloca(len));
+
+  if (!commandLineCombined) {
+    return -1;
+  }
+
+  // Gonna re-use len to store the write index into commandLineCombined
+  len = 0;
+
+  for (i = 0; commandLine[i]; i++) {
+    if (0 != i) {
+      commandLineCombined[len++] = ' ';
+    }
+
+    need_quoting = strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL;
+    if (need_quoting) {
+      commandLineCombined[len++] = '"';
+    }
+
+    for (j = 0; '\0' != commandLine[i][j]; j++) {
+      switch (commandLine[i][j]) {
+      default:
+        break;
+      case '\\':
+        if (commandLine[i][j + 1] == '"') {
+          commandLineCombined[len++] = '\\';
+        }
+
+        break;
+      case '"':
+        commandLineCombined[len++] = '\\';
+        break;
+      }
+
+      commandLineCombined[len++] = commandLine[i][j];
+    }
+    if (need_quoting) {
+      commandLineCombined[len++] = '"';
+    }
+  }
+
+  commandLineCombined[len] = '\0';
+
+  if (!CreateProcessA(
+          SUBPROCESS_NULL,
+          commandLineCombined, // command line
+          SUBPROCESS_NULL,     // process security attributes
+          SUBPROCESS_NULL,     // primary thread security attributes
+          1,                   // handles are inherited
+          flags,               // creation flags
+          used_environment,    // used environment
+          SUBPROCESS_NULL,     // use parent's current directory
+          SUBPROCESS_PTR_CAST(LPSTARTUPINFOA,
+                              &startInfo), // STARTUPINFO pointer
+          SUBPROCESS_PTR_CAST(LPPROCESS_INFORMATION, &processInfo))) {
+    return -1;
+  }
+
+  out_process->hProcess = processInfo.hProcess;
+
+  out_process->hStdInput = startInfo.hStdInput;
+
+  // We don't need the handle of the primary thread in the called process.
+  CloseHandle(processInfo.hThread);
+
+  if (SUBPROCESS_NULL != startInfo.hStdOutput) {
+    CloseHandle(startInfo.hStdOutput);
+
+    if (startInfo.hStdError != startInfo.hStdOutput) {
+      CloseHandle(startInfo.hStdError);
+    }
+  }
+
+  out_process->alive = 1;
+
+  return 0;
+#else
+  int stdinfd[2];
+  int stdoutfd[2];
+  int stderrfd[2];
+  pid_t child;
+  extern char **environ;
+  char *const empty_environment[1] = {SUBPROCESS_NULL};
+  posix_spawn_file_actions_t actions;
+  char *const *used_environment;
+
+  if (subprocess_option_inherit_environment ==
+      (options & subprocess_option_inherit_environment)) {
+    if (SUBPROCESS_NULL != environment) {
+      return -1;
+    }
+  }
+
+  if (0 != pipe(stdinfd)) {
+    return -1;
+  }
+
+  if (0 != pipe(stdoutfd)) {
+    return -1;
+  }
+
+  if (subprocess_option_combined_stdout_stderr !=
+      (options & subprocess_option_combined_stdout_stderr)) {
+    if (0 != pipe(stderrfd)) {
+      return -1;
+    }
+  }
+
+  if (environment) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
+    used_environment = (char *const *)environment;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  } else if (subprocess_option_inherit_environment ==
+             (options & subprocess_option_inherit_environment)) {
+    used_environment = environ;
+  } else {
+    used_environment = empty_environment;
+  }
+
+  if (0 != posix_spawn_file_actions_init(&actions)) {
+    return -1;
+  }
+
+  // Close the stdin write end
+  if (0 != posix_spawn_file_actions_addclose(&actions, stdinfd[1])) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Map the read end to stdin
+  if (0 !=
+      posix_spawn_file_actions_adddup2(&actions, stdinfd[0], STDIN_FILENO)) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Close the stdout read end
+  if (0 != posix_spawn_file_actions_addclose(&actions, stdoutfd[0])) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Map the write end to stdout
+  if (0 !=
+      posix_spawn_file_actions_adddup2(&actions, stdoutfd[1], STDOUT_FILENO)) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    if (0 != posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
+                                              STDERR_FILENO)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  } else {
+    // Close the stderr read end
+    if (0 != posix_spawn_file_actions_addclose(&actions, stderrfd[0])) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+    // Map the write end to stdout
+    if (0 != posix_spawn_file_actions_adddup2(&actions, stderrfd[1],
+                                              STDERR_FILENO)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  }
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
+  if (subprocess_option_search_user_path ==
+      (options & subprocess_option_search_user_path)) {
+    if (0 != posix_spawnp(&child, commandLine[0], &actions, SUBPROCESS_NULL,
+                          (char *const *)commandLine, used_environment)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  } else {
+    if (0 != posix_spawn(&child, commandLine[0], &actions, SUBPROCESS_NULL,
+                         (char *const *)commandLine, used_environment)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+  // Close the stdin read end
+  close(stdinfd[0]);
+  // Store the stdin write end
+  out_process->stdin_file = fdopen(stdinfd[1], "wb");
+
+  // Close the stdout write end
+  close(stdoutfd[1]);
+  // Store the stdout read end
+  out_process->stdout_file = fdopen(stdoutfd[0], "rb");
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    out_process->stderr_file = out_process->stdout_file;
+  } else {
+    // Close the stderr write end
+    close(stderrfd[1]);
+    // Store the stderr read end
+    out_process->stderr_file = fdopen(stderrfd[0], "rb");
+  }
+
+  // Store the child's pid
+  out_process->child = child;
+
+  out_process->alive = 1;
+
+  posix_spawn_file_actions_destroy(&actions);
+  return 0;
+#endif
+}
+
+FILE *subprocess_stdin(const struct subprocess_s *const process) {
+  return process->stdin_file;
+}
+
+FILE *subprocess_stdout(const struct subprocess_s *const process) {
+  return process->stdout_file;
+}
+
+FILE *subprocess_stderr(const struct subprocess_s *const process) {
+  if (process->stdout_file != process->stderr_file) {
+    return process->stderr_file;
+  } else {
+    return SUBPROCESS_NULL;
+  }
+}
+
+int subprocess_join(struct subprocess_s *const process,
+                    int *const out_return_code) {
+#if defined(_WIN32)
+  const unsigned long infinite = 0xFFFFFFFF;
+
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->hStdInput) {
+    CloseHandle(process->hStdInput);
+    process->hStdInput = SUBPROCESS_NULL;
+  }
+
+  WaitForSingleObject(process->hProcess, infinite);
+
+  if (out_return_code) {
+    if (!GetExitCodeProcess(
+            process->hProcess,
+            SUBPROCESS_PTR_CAST(unsigned long *, out_return_code))) {
+      return -1;
+    }
+  }
+
+  process->alive = 0;
+
+  return 0;
+#else
+  int status;
+
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->child) {
+    if (process->child != waitpid(process->child, &status, 0)) {
+      return -1;
+    }
+
+    process->child = 0;
+
+    if (WIFEXITED(status)) {
+      process->return_status = WEXITSTATUS(status);
+    } else {
+      process->return_status = EXIT_FAILURE;
+    }
+
+    process->alive = 0;
+  }
+
+  if (out_return_code) {
+    *out_return_code = process->return_status;
+  }
+
+  return 0;
+#endif
+}
+
+int subprocess_destroy(struct subprocess_s *const process) {
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->stdout_file) {
+    fclose(process->stdout_file);
+
+    if (process->stdout_file != process->stderr_file) {
+      fclose(process->stderr_file);
+    }
+
+    process->stdout_file = SUBPROCESS_NULL;
+    process->stderr_file = SUBPROCESS_NULL;
+  }
+
+#if defined(_WIN32)
+  if (process->hProcess) {
+    CloseHandle(process->hProcess);
+    process->hProcess = SUBPROCESS_NULL;
+
+    if (process->hStdInput) {
+      CloseHandle(process->hStdInput);
+    }
+
+    if (process->hEventOutput) {
+      CloseHandle(process->hEventOutput);
+    }
+
+    if (process->hEventError) {
+      CloseHandle(process->hEventError);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+int subprocess_terminate(struct subprocess_s *const process) {
+#if defined(_WIN32)
+  unsigned int killed_process_exit_code;
+  int success_terminate;
+  int windows_call_result;
+
+  killed_process_exit_code = 99;
+  windows_call_result =
+      TerminateProcess(process->hProcess, killed_process_exit_code);
+  success_terminate = (windows_call_result == 0) ? 1 : 0;
+  return success_terminate;
+#else
+  int result;
+  result = kill(process->child, 9);
+  return result;
+#endif
+}
+
+unsigned subprocess_read_stdout(struct subprocess_s *const process,
+                                char *const buffer, unsigned size) {
+#if defined(_WIN32)
+  void *handle;
+  unsigned long bytes_read = 0;
+  struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
+  overlapped.hEvent = process->hEventOutput;
+
+  handle = SUBPROCESS_PTR_CAST(void *,
+                               _get_osfhandle(_fileno(process->stdout_file)));
+
+  if (!ReadFile(handle, buffer, size, &bytes_read,
+                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
+    const unsigned long errorIoPending = 997;
+    unsigned long error = GetLastError();
+
+    // Means we've got an async read!
+    if (error == errorIoPending) {
+      if (!GetOverlappedResult(handle,
+                               SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
+                               &bytes_read, 1)) {
+        const unsigned long errorIoIncomplete = 996;
+        const unsigned long errorHandleEOF = 38;
+        error = GetLastError();
+
+        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#else
+  const int fd = fileno(process->stdout_file);
+  const ssize_t bytes_read = read(fd, buffer, size);
+
+  if (bytes_read < 0) {
+    return 0;
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#endif
+}
+
+unsigned subprocess_read_stderr(struct subprocess_s *const process,
+                                char *const buffer, unsigned size) {
+#if defined(_WIN32)
+  void *handle;
+  unsigned long bytes_read = 0;
+  struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
+  overlapped.hEvent = process->hEventError;
+
+  handle = SUBPROCESS_PTR_CAST(void *,
+                               _get_osfhandle(_fileno(process->stderr_file)));
+
+  if (!ReadFile(handle, buffer, size, &bytes_read,
+                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
+    const unsigned long errorIoPending = 997;
+    unsigned long error = GetLastError();
+
+    // Means we've got an async read!
+    if (error == errorIoPending) {
+      if (!GetOverlappedResult(handle,
+                               SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
+                               &bytes_read, 1)) {
+        const unsigned long errorIoIncomplete = 996;
+        const unsigned long errorHandleEOF = 38;
+        error = GetLastError();
+
+        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#else
+  const int fd = fileno(process->stderr_file);
+  const ssize_t bytes_read = read(fd, buffer, size);
+
+  if (bytes_read < 0) {
+    return 0;
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#endif
+}
+
+int subprocess_alive(struct subprocess_s *const process) {
+  int is_alive = SUBPROCESS_CAST(int, process->alive);
+
+  if (!is_alive) {
+    return 0;
+  }
+#if defined(_WIN32)
+  {
+    const unsigned long zero = 0x0;
+    const unsigned long wait_object_0 = 0x00000000L;
+
+    is_alive = wait_object_0 != WaitForSingleObject(process->hProcess, zero);
+  }
+#else
+  {
+    int status;
+    is_alive = 0 == waitpid(process->child, &status, WNOHANG);
+
+    // If the process was successfully waited on we need to cleanup now.
+    if (!is_alive) {
+      if (WIFEXITED(status)) {
+        process->return_status = WEXITSTATUS(status);
+      } else {
+        process->return_status = EXIT_FAILURE;
+      }
+
+      // Since we've already successfully waited on the process, we need to wipe
+      // the child now.
+      process->child = 0;
+
+      if (subprocess_join(process, SUBPROCESS_NULL)) {
+        return -1;
+      }
+    }
+  }
+#endif
+
+  if (!is_alive) {
+    process->alive = 0;
+  }
+
+  return is_alive;
+}
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif /* SHEREDOM_SUBPROCESS_H_INCLUDED */

--- a/tools/common/utils.h
+++ b/tools/common/utils.h
@@ -1,0 +1,6 @@
+#ifndef LIBDRAGON_TOOLS_UTILS_H
+#define LIBDRAGON_TOOLS_UTILS_H
+
+#include "../../src/utils.h"
+
+#endif

--- a/tools/common/utils.h
+++ b/tools/common/utils.h
@@ -3,4 +3,35 @@
 
 #include "../../src/utils.h"
 
+#include <stdlib.h>
+#include <string.h>
+
+static const char *n64_toolchain_dir(void)
+{
+    static char *n64_inst = NULL;
+    if (n64_inst)
+        return n64_inst;
+
+    // Find the toolchain installation directory.
+    // n64.mk supports having a separate installation for the toolchain and
+    // libdragon. So first check if N64_GCCPREFIX is set; if so the toolchain
+    // is there. Otherwise, fallback to N64_INST which is where we expect
+    // the toolchain to reside.
+    n64_inst = getenv("N64_GCCPREFIX");
+    if (!n64_inst)
+        n64_inst = getenv("N64_INST");
+    if (!n64_inst)
+        return NULL;
+
+    // Remove the trailing backslash if any. On some system, running
+    // popen with a path containing double backslashes will fail, so
+    // we normalize it here.
+    n64_inst = strdup(n64_inst);
+    int n = strlen(n64_inst);
+    if (n64_inst[n-1] == '/' || n64_inst[n-1] == '\\')
+        n64_inst[n-1] = 0;
+
+    return n64_inst;
+}
+
 #endif

--- a/tools/n64sym.c
+++ b/tools/n64sym.c
@@ -15,7 +15,7 @@
 bool flag_verbose = false;
 int flag_max_sym_len = 64;
 bool flag_inlines = true;
-char *n64_inst = NULL;
+const char *n64_inst = NULL;
 
 // Printf if verbose
 void verbose(const char *fmt, ...) {
@@ -448,27 +448,14 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    // Find the toolchain installation directory.
-    // n64.mk supports having a separate installation for the toolchain and
-    // libdragon. So first check if N64_GCCPREFIX is set; if so the toolchain
-    // is there. Otherwise, fallback to N64_INST which is where we expect
-    // the toolchain to reside.
-    n64_inst = getenv("N64_GCCPREFIX");
-    if (!n64_inst)
-        n64_inst = getenv("N64_INST");
+    // Find n64 installation directory
+    n64_inst = n64_toolchain_dir();
     if (!n64_inst) {
         // Do not mention N64_GCCPREFIX in the error message, since it is
         // a seldom used configuration.
-        fprintf(stderr, "Error: N64_INST environment variable not set.\n");
+        fprintf(stderr, "Error: N64_INST environment variable not set\n");
         return 1;
     }
-    // Remove the trailing backslash if any. On some system, running
-    // popen with a path containing double backslashes will fail, so
-    // we normalize it here.
-    n64_inst = strdup(n64_inst);
-    int n = strlen(n64_inst);
-    if (n64_inst[n-1] == '/' || n64_inst[n-1] == '\\')
-        n64_inst[n-1] = 0;
 
     const char *infn = argv[i];
     if (i < argc-1)

--- a/tools/n64sym.c
+++ b/tools/n64sym.c
@@ -1,0 +1,487 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+#define STBDS_NO_SHORT_NAMES
+#define STB_DS_IMPLEMENTATION
+#include "common/stb_ds.h"
+
+#include "common/subprocess.h"
+#include "common/polyfill.h"
+#include "common/utils.h"
+
+bool flag_verbose = false;
+int flag_max_sym_len = 64;
+bool flag_inlines = true;
+char *n64_inst = NULL;
+
+// Printf if verbose
+void verbose(const char *fmt, ...) {
+    if (flag_verbose) {
+        va_list args;
+        va_start(args, fmt);
+        vprintf(fmt, args);
+        va_end(args);
+    }
+}
+
+void usage(const char *progname)
+{
+    fprintf(stderr, "%s - Prepare symbol table for N64 ROMs\n", progname);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: %s [flags] <program.elf> [<program.sym>]\n", progname);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Command-line flags:\n");
+    fprintf(stderr, "   -v/--verbose          Verbose output\n");
+    fprintf(stderr, "   -m/--max-len <N>      Maximum symbol length (default: 64)\n");
+    fprintf(stderr, "   --no-inlines          Do not export inlined symbols\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "This program requires a libdragon toolchain installed in $N64_INST.\n");
+}
+
+char *stringtable = NULL;
+struct { char *key; int value; } *string_hash = NULL;
+
+int stringtable_add(char *word)
+{
+    if (!string_hash) {
+        stbds_sh_new_arena(string_hash);
+        stbds_shdefault(string_hash, -1);
+    }
+
+    int word_len = strlen(word);
+    if (stringtable) {
+        int pos = stbds_shget(string_hash, word);
+        if (pos >= 0)
+            return pos;
+    }
+
+    // Append the word (without the trailing \0)
+    int idx = stbds_arraddnindex(stringtable, word_len);
+    memcpy(stringtable + idx, word, word_len);
+
+    // Add all prefixes to the hash
+    for (int i = word_len; i >= 2; --i) {
+        char ch = word[i];
+        word[i] = 0;
+        stbds_shput(string_hash, word, idx);
+        word[i] = ch;
+    }
+    return idx;
+}
+
+#define conv(type, v) ({ \
+    typeof(v) _v = (v); assert((type)_v == _v); (type)_v; \
+})
+
+void _w8(FILE *f, uint8_t v)  { fputc(v, f); }
+void _w16(FILE *f, uint16_t v) { _w8(f, v >> 8); _w8(f, v & 0xff); }
+void _w32(FILE *f, uint32_t v) { _w16(f, v >> 16); _w16(f, v & 0xffff); }
+#define w8(f, v) _w8(f, conv(uint8_t, v))
+#define w16(f, v) _w16(f, conv(uint16_t, v))
+#define w32(f, v) _w32(f, conv(uint32_t, v))
+
+int w32_placeholder(FILE *f) { int pos = ftell(f); w32(f, 0); return pos; }
+void w32_at(FILE *f, int pos, uint32_t v)
+{
+    int cur = ftell(f);
+    fseek(f, pos, SEEK_SET);
+    w32(f, v);
+    fseek(f, cur, SEEK_SET);
+}
+void walign(FILE *f, int align) { 
+    int pos = ftell(f);
+    while (pos++ % align) w8(f, 0);
+}
+
+struct symtable_s {
+    uint32_t uuid;
+    uint32_t addr;
+    char *func;
+    char *file;
+    int line;
+
+    int func_sidx;
+    int file_sidx;
+
+    int func_offset;
+
+    bool is_func, is_inline;
+} *symtable = NULL;
+
+void symbol_add(const char *elf, uint32_t addr, bool is_func)
+{
+    // We keep one addr2line process open for the last ELF file we processed.
+    // This allows to convert multiple symbols very fast, avoiding spawning a
+    // new process for each symbol.
+    // NOTE: we cannot use popen() here because on some platforms (eg. glibc)
+    // it only allows a single direction pipe, and we need both directions.
+    // So we rely on the subprocess library for this.
+    static char *addrbin = NULL;
+    static struct subprocess_s subp;
+    static FILE *addr2line_w = NULL, *addr2line_r = NULL;
+    static const char *cur_elf = NULL;
+    static char *line_buf = NULL;
+    static size_t line_buf_size = 0;
+
+    // Check if this is a new ELF file (or it's the first time we run this function)
+    if (!cur_elf || strcmp(cur_elf, elf)) {
+        if (cur_elf) {
+            subprocess_terminate(&subp);
+            cur_elf = NULL; addr2line_r = addr2line_w = NULL;
+        }
+        if (!addrbin)
+            asprintf(&addrbin, "%s/bin/mips64-elf-addr2line", n64_inst);
+
+        const char *cmd_addr[16] = {0}; int i = 0;
+        cmd_addr[i++] = addrbin;
+        cmd_addr[i++] = "--addresses";
+        cmd_addr[i++] = "--functions";
+        cmd_addr[i++] = "--demangle";
+        if (flag_inlines) cmd_addr[i++] = "--inlines";
+        cmd_addr[i++] = "--exe";
+        cmd_addr[i++] = elf;
+
+        if (subprocess_create(cmd_addr, subprocess_option_no_window, &subp) != 0) {
+            fprintf(stderr, "Error: cannot run: %s\n", addrbin);
+            exit(1);
+        }
+        addr2line_w = subprocess_stdin(&subp);
+        addr2line_r = subprocess_stdout(&subp);
+        cur_elf = elf;
+    }
+
+    // Send the address to addr2line and fetch back the symbol and the function name
+    // Since we activated the "--inlines" option, addr2line produces an unknown number
+    // of output lines. This is a problem with pipes, as we don't know when to stop.
+    // Thus, we always add a dummy second address (0x0) so that we stop when we see the
+    // reply for it
+    fprintf(addr2line_w, "%08x\n0\n", addr);
+    fflush(addr2line_w);
+
+    // First line is the address. It's just an echo, so ignore it.
+    int n = getline(&line_buf, &line_buf_size, addr2line_r);
+    assert(n >= 2 && strncmp(line_buf, "0x", 2) == 0);
+
+    // Add one symbol for each inlined function
+    bool at_least_one = false;
+    while (1) {
+        // First line is the function name. If instead it's the dummy 0x0 address,
+        // it means that we're done.
+        int n = getline(&line_buf, &line_buf_size, addr2line_r);
+        if (strncmp(line_buf, "0x00000000", 10) == 0) break;
+
+        // If the function of name is longer than 64 bytes, truncate it. This also
+        // avoid paradoxically long function names like in C++ that can even be
+        // several thousands of characters long.
+        char *func = strndup(line_buf, MIN(n-1, flag_max_sym_len));
+        if (n-1 > flag_max_sym_len) strcpy(&func[flag_max_sym_len-3], "...");
+
+        // Second line is the file name and line number
+        getline(&line_buf, &line_buf_size, addr2line_r);
+        char *colon = strrchr(line_buf, ':');
+        char *file = strndup(line_buf, colon - line_buf);
+        int line = atoi(colon + 1);
+
+        // Add the callsite to the list
+        stbds_arrput(symtable, ((struct symtable_s) {
+            .uuid = stbds_arrlen(symtable),
+            .addr = addr,
+            .func = func,
+            .file = file,
+            .line = line,
+            .is_func = is_func,
+            .is_inline = true,
+        }));
+        at_least_one = true;
+    }
+    assert(at_least_one);
+    symtable[stbds_arrlen(symtable)-1].is_inline = false;
+
+    // Read and skip the two remaining lines (function and file position)
+    // that refers to the dummy 0x0 address
+    getline(&line_buf, &line_buf_size, addr2line_r);
+    getline(&line_buf, &line_buf_size, addr2line_r);
+}
+
+void elf_find_callsites(const char *elf)
+{
+    // Start objdump to parse the disassembly of the ELF file
+    char *cmd = NULL;
+    asprintf(&cmd, "%s/bin/mips64-elf-objdump -d %s", n64_inst, elf);
+    verbose("Running: %s\n", cmd);
+    FILE *disasm = popen(cmd, "r");
+    if (!disasm) {
+        fprintf(stderr, "Error: cannot run: %s\n", cmd);
+        exit(1);
+    }
+
+    // Parse the disassembly
+    char *line = NULL; size_t line_size = 0;
+    while (getline(&line, &line_size, disasm) != -1) {
+        // Find the functions
+        if (strstr(line, ">:")) {
+            uint32_t addr = strtoul(line, NULL, 16);
+            symbol_add(elf, addr, true);
+        }
+        // Find the callsites
+        if (strstr(line, "\tjal\t") || strstr(line, "\tjalr\t")) {
+            uint32_t addr = strtoul(line, NULL, 16);
+            symbol_add(elf, addr, false);
+        }
+    }
+    free(line);
+    pclose(disasm);
+}
+
+void compact_filenames(void)
+{
+    while (1) {
+        char *prefix = NULL; int prefix_len = 0;
+
+        for (int i=0; i<stbds_arrlen(symtable); i++) {
+            struct symtable_s *s = &symtable[i];
+            if (!s->file) continue;
+            if (s->file[0] != '/' && s->file[1] != ':') continue;
+
+            if (!prefix) {
+                prefix = s->file;
+                prefix_len = 0;
+                if (prefix[prefix_len] == '/' || prefix[prefix_len] == '\\')
+                    prefix_len++;
+                while (prefix[prefix_len] && prefix[prefix_len] != '/' && prefix[prefix_len] != '\\')
+                    prefix_len++;
+                verbose("Initial prefix: %.*s\n", prefix_len, prefix);
+                if (prefix[prefix_len] == 0)
+                    return;
+            } else {
+                if (strncmp(prefix, s->file, prefix_len) != 0) {
+                    verbose("Prefix mismatch: %.*s vs %s\n", prefix_len, prefix, s->file);
+                    return;
+                }
+            }
+        }
+
+        verbose("Removing common prefix: %.*s\n", prefix_len, prefix);
+
+        // The prefix is common to all files, remove it
+        for (int i=0; i<stbds_arrlen(symtable); i++) {
+            struct symtable_s *s = &symtable[i];
+            if (!s->file) continue;
+            if (s->file[0] != '/' && s->file[1] != ':') continue;
+            s->file += prefix_len;
+        }
+        break;
+    }
+}
+
+void compute_function_offsets(void)
+{
+    uint32_t func_addr = 0;
+    for (int i=0; i<stbds_arrlen(symtable); i++) {
+        struct symtable_s *s = &symtable[i];
+        if (s->is_func) {
+            func_addr = s->addr;
+            s->func_offset = 0;
+        } else {
+            s->func_offset = s->addr - func_addr;
+        }
+    }
+}
+
+int symtable_sort_by_addr(const void *a, const void *b)
+{
+    const struct symtable_s *sa = a;
+    const struct symtable_s *sb = b;
+    // In case the address match, it means that there are multiple
+    // inlines at this address. Sort by insertion order (aka stable sort)
+    // so that we preserve the inline order.
+    if (sa->addr != sb->addr)
+        return sa->addr - sb->addr;
+    return sa->uuid - sb->uuid;
+}
+
+int symtable_sort_by_func(const void *a, const void *b)
+{
+    const struct symtable_s *sa = a;
+    const struct symtable_s *sb = b;
+    int sa_len = sa->func ? strlen(sa->func) : 0;
+    int sb_len = sb->func ? strlen(sb->func) : 0;
+    return sb_len - sa_len;
+}
+
+void process(const char *infn, const char *outfn)
+{
+    verbose("Processing: %s -> %s\n", infn, outfn);
+
+    // First, find all functions and call sites. We do this by disassembling
+    // the ELF file and grepping it.
+    elf_find_callsites(infn);
+    verbose("Found %d callsites\n", stbds_arrlen(symtable));
+
+    // Compact the file names to avoid common prefixes
+    // FIXME: we need to improve this to handle multiple common prefixes
+    // eg: /home/foo vs /opt/n64/include
+    //compact_filenames();
+
+    // Sort the symbole table by symbol length. We want longer symbols
+    // to go in first, so that shorter symbols can be found as substrings.
+    // We sort by function name rather than file name, because we expect
+    // substrings to match more in functions.
+    verbose("Sorting symbol table...\n");
+    qsort(symtable, stbds_arrlen(symtable), sizeof(struct symtable_s), symtable_sort_by_func);
+
+    // Go through the symbol table and build the string table
+    verbose("Creating string table...\n");
+    for (int i=0; i < stbds_arrlen(symtable); i++) {
+        if (i % 5000 == 0)
+            verbose("  %d/%d\n", i, stbds_arrlen(symtable));
+        struct symtable_s *sym = &symtable[i];
+        if (sym->func)
+            sym->func_sidx = stringtable_add(sym->func);
+        else
+            sym->func_sidx = -1;
+        if (sym->file)
+            sym->file_sidx = stringtable_add(sym->file);
+        else
+            sym->file_sidx = -1;
+    }
+
+    // Sort the symbol table by address
+    qsort(symtable, stbds_arrlen(symtable), sizeof(struct symtable_s), symtable_sort_by_addr);
+
+    // Fill in the function offset field in the entries in the symbol table.
+    verbose("Computing function offsets...\n");
+    compute_function_offsets();
+
+    // Write the symbol table to file
+    verbose("Writing %s\n", outfn);
+    FILE *out = fopen(outfn, "wb");
+    if (!out) {
+        fprintf(stderr, "Cannot create file: symtable.bin\n");
+        exit(1);
+    }
+
+    fwrite("SYMT", 4, 1, out);
+    w32(out, 2); // Version
+    int addrtable_off = w32_placeholder(out);
+    w32(out, stbds_arrlen(symtable));
+    int symtable_off = w32_placeholder(out);
+    w32(out, stbds_arrlen(symtable));
+    int stringtable_off = w32_placeholder(out);
+    w32(out, stbds_arrlen(stringtable));
+
+    walign(out, 16);
+    w32_at(out, addrtable_off, ftell(out));
+    for (int i=0; i < stbds_arrlen(symtable); i++) {
+        struct symtable_s *sym = &symtable[i];
+        w32(out, sym->addr | (sym->is_func ? 0x1 : 0) | (sym->is_inline ? 0x2 : 0));
+    }
+
+    walign(out, 16);
+    w32_at(out, symtable_off, ftell(out));
+    for (int i=0; i < stbds_arrlen(symtable); i++) {
+        struct symtable_s *sym = &symtable[i];
+        w32(out, sym->func_sidx);
+        w32(out, sym->file_sidx);
+        w16(out, strlen(sym->func));
+        w16(out, strlen(sym->file));
+        w16(out, sym->line);
+        w16(out, sym->func_offset < 0x10000 ? sym->func_offset : 0);
+    }
+
+    walign(out, 16);
+    w32_at(out, stringtable_off, ftell(out));
+    fwrite(stringtable, stbds_arrlen(stringtable), 1, out);
+    fclose(out);
+}
+
+// Change filename extension
+char *change_ext(const char *fn, const char *ext)
+{
+    char *out = strdup(fn);
+    char *dot = strrchr(out, '.');
+    if (dot) *dot = 0;
+    strcat(out, ext);
+    return out;
+}
+
+int main(int argc, char *argv[])
+{
+    const char *outfn = NULL;
+
+    int i;
+    for (i = 1; i < argc && argv[i][0] == '-'; i++) {
+        if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {
+            usage(argv[0]);
+            return 0;
+        } else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) {
+            flag_verbose = true;
+        } else if (!strcmp(argv[i], "--no-inlines")) {
+            flag_inlines = false;
+        } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
+            if (++i == argc) {
+                fprintf(stderr, "missing argument for %s\n", argv[i-1]);
+                return 1;
+            }
+            outfn = argv[i];
+        } else if (!strcmp(argv[i], "-m") || !strcmp(argv[i], "--max-len")) {
+            if (++i == argc) {
+                fprintf(stderr, "missing argument for %s\n", argv[i-1]);
+                return 1;
+            }
+            flag_max_sym_len = atoi(argv[i]);
+        } else {
+            fprintf(stderr, "invalid flag: %s\n", argv[i]);
+            return 1;
+        }
+    }
+
+    if (i == argc) {
+        fprintf(stderr, "missing input filename\n");
+        return 1;
+    }
+
+    if (!n64_inst) {
+        // n64.mk supports having a separate installation for the toolchain and
+        // libdragon. So first check if N64_GCCPREFIX is set; if so the toolchain
+        // is there. Otherwise, fallback to N64_INST which is where we expect
+        // the toolchain to reside.
+        n64_inst = getenv("N64_GCCPREFIX");
+        if (!n64_inst)
+            n64_inst = getenv("N64_INST");
+        if (!n64_inst) {
+            // Do not mention N64_GCCPREFIX in the error message, since it is
+            // a seldom used configuration.
+            fprintf(stderr, "Error: N64_INST environment variable not set.\n");
+            return 1;
+        }
+        // Remove the trailing backslash if any. On some system, running
+        // popen with a path containing double backslashes will fail, so
+        // we normalize it here.
+        n64_inst = strdup(n64_inst);
+        int n = strlen(n64_inst);
+        if (n64_inst[n-1] == '/' || n64_inst[n-1] == '\\')
+            n64_inst[n-1] = 0;
+    }
+
+    const char *infn = argv[i];
+    if (i < argc-1)
+        outfn = argv[i+1];
+    else
+        outfn = change_ext(infn, ".sym");
+
+    // Check that infn exists and is readable
+    FILE *in = fopen(infn, "rb");
+    if (!in) {
+        fprintf(stderr, "Error: cannot open file: %s\n", infn);
+        return 1;
+    }
+    fclose(in);
+
+    process(infn, outfn);
+    return 0;
+}
+


### PR DESCRIPTION
Quoting the docs:

```
This module implements two POSIX/GNU standard functions to help walking
the stack and providing the current execution context: backtrace() and
backtrace_symbols().
 
The functions have an API fully compatible with the standard ones. The
implementation is however optimized for the MIPS/N64 case, and with
standard compilation settings. See the documentation in backtrace.c
for implementation details.
 
You can call the functions to inspect the current call stack. For
a higher level function that just prints the current call stack
on the debug channels, see #debug_backtrace.
```

An optimized symbol table is generated by a new tool (n64sym), which is then hooked up to the build system (n64.mk). The symbol table is then embedded in the ROM as rompak.

n64sym analyzes standard DWARF debugging symbol in the ELF file using tools from the toolchain, so that it doesn't have to embed a DWARF parser and is thus hopefully very solid to feature evolutions of these (ever changing) standards. It is quite fast (~100ms for a standard C ROM, ~1 sec for huge C++ ROMs that take forever to link). The symbol table is reasonably compact (100-200K up to 1M for huge ROMs) and is never loaded into ROM, but fully queried directly from ROM. Obviously it can be removed from production builds (backtracing still works without symbol table, but of course only hexadecimal addresses will be printed).

This feature has been extensively tested in the unstable channel and is quite stable and incredibly useful during development. This PR brings in the core functionality, it doesn't hook it up yet to assertions or exceptions.