### PR TITLE
Add n64types.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 rsp.ld $(INSTALLDIR)/mips64-elf/lib/rsp.ld
 	install -Cv -m 0644 header $(INSTALLDIR)/mips64-elf/lib/header
 	install -Cv -m 0644 libdragonsys.a $(INSTALLDIR)/mips64-elf/lib/libdragonsys.a
+	install -Cv -m 0644 include/n64types.h $(INSTALLDIR)/mips64-elf/include/n64types.h
 	install -Cv -m 0644 include/pputils.h $(INSTALLDIR)/mips64-elf/include/pputils.h
 	install -Cv -m 0644 include/n64sys.h $(INSTALLDIR)/mips64-elf/include/n64sys.h
 	install -Cv -m 0644 include/cop0.h $(INSTALLDIR)/mips64-elf/include/cop0.h

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -25,6 +25,7 @@
  */
 
 /* Easy include wrapper */
+#include "n64types.h"
 #include "audio.h"
 #include "console.h"
 #include "debug.h"

--- a/include/n64types.h
+++ b/include/n64types.h
@@ -1,0 +1,48 @@
+/**
+ * @file n64types.h
+ * @brief Custom types used by libdragon
+ * @ingroup libdragon
+ */
+
+#ifndef __LIBDRAGON_N64TYPES_H
+#define __LIBDRAGON_N64TYPES_H
+
+#include <stdint.h>
+#include <stdalign.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Unaligned 64-bit integer type.
+ * 
+ * This type is used to represent 64-bit integers that are not aligned to 8-byte.
+ * Accessing memory through a pointer of this type will make the compiler
+ * issue the appropriate unaligned load/store instructions (LDL/LDR/SDL/SDR).
+ */
+typedef uint64_t u_uint64_t __attribute__((aligned(1)));
+
+/**
+ * @brief Unaligned 32-bit integer type.
+ * 
+ * This type is used to represent 32-bit integers that are not aligned to 4-byte.
+ * Accessing memory through a pointer of this type will make the compiler
+ * issue the appropriate unaligned load/store instructions (LWL/LWR/SWL/SWR).
+ */
+typedef uint32_t u_uint32_t __attribute__((aligned(1)));
+
+/**
+ * @brief Unaligned 16-bit integer type.
+ * 
+ * This type is used to represent 16-bit integers that are not aligned to 2-byte.
+ * Accessing memory through a pointer of this type will make the compiler
+ * issue the appropriate sequence (eg: loading two bytes and combining them)
+ */
+typedef uint16_t u_uint16_t __attribute__((aligned(1)));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -7,6 +7,7 @@
 #include "mixer.h"
 #include "samplebuffer.h"
 #include "n64sys.h"
+#include "n64types.h"
 #include "utils.h"
 #include "debug.h"
 #include <string.h>
@@ -200,7 +201,6 @@ void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
 		// to a multiple of 8 the amount of bytes, as it doesn't matter if we
 		// copy more, as long as we're fast.
 		// This has been benchmarked to be faster than memmove() + cache flush.
-		typedef uint64_t u_uint64_t __attribute__((aligned(1)));
 		kept_bytes = ROUND_UP(kept_bytes, 8);
 		u_uint64_t *src64 = (u_uint64_t*)src;
 		uint64_t *dst64 = (uint64_t*)dst;

--- a/src/debug.c
+++ b/src/debug.c
@@ -3,7 +3,6 @@
  * @brief Debugging Support
  */
 
-#include <libdragon.h>
 #include <string.h>
 #include <fcntl.h>
 #include <assert.h>
@@ -11,8 +10,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include "console.h"
+#include "debug.h"
 #include "regsinternal.h"
 #include "system.h"
+#include "n64types.h"
+#include "n64sys.h"
+#include "dma.h"
 #include "usb.h"
 #include "utils.h"
 #include "fatfs/ff.h"

--- a/src/debug_sdfs_64drive.c
+++ b/src/debug_sdfs_64drive.c
@@ -93,8 +93,6 @@ static DRESULT fat_disk_write_64drive(const BYTE* buff, LBA_t sector, UINT count
 		}
 		else
 		{
-			typedef uint32_t u_uint32_t __attribute__((aligned(1)));
-
 			uint32_t* dst = (uint32_t*)(D64_CIBASE_ADDRESS + D64_BUFFER);
 			u_uint32_t* src = (u_uint32_t*)buff;
 			for (int i = 0; i < 512/16; i++)

--- a/src/debug_sdfs_ed64.c
+++ b/src/debug_sdfs_ed64.c
@@ -530,8 +530,6 @@ static DRESULT fat_disk_write_everdrive(const BYTE* buff, LBA_t sector, UINT cou
 		}
 		else
 		{
-			typedef uint32_t u_uint32_t __attribute__((aligned(1)));
-
 			uint32_t* dst = (uint32_t*)(ED64_BASE_ADDRESS + ED64_SD_IO_BUFFER);
 			u_uint32_t* src = (u_uint32_t*)buff;
 			for (int i = 0; i < 512/16; i++)

--- a/src/debug_sdfs_sc64.c
+++ b/src/debug_sdfs_sc64.c
@@ -84,8 +84,6 @@ static DRESULT fat_disk_write_sc64(const BYTE* buff, LBA_t sector, UINT count)
 		}
 		else
 		{
-			typedef uint32_t u_uint32_t __attribute__((aligned(1)));
-
 			uint32_t* dst = (uint32_t*)(SC64_BUFFER_ADDRESS);
 			u_uint32_t* src = (u_uint32_t*)buff;
 			for (int i = 0; i < (sectors_to_process*512)/16; i++)

--- a/src/dma.c
+++ b/src/dma.c
@@ -3,7 +3,11 @@
  * @brief DMA Controller
  * @ingroup dma
  */
-#include "libdragon.h"
+#include <stdbool.h>
+#include "n64types.h"
+#include "n64sys.h"
+#include "interrupt.h"
+#include "debug.h"
 #include "regsinternal.h"
 
 /**
@@ -345,7 +349,6 @@ void dma_read_async(void *ram_pointer, unsigned long pi_address, unsigned long l
     // we need to write the last odd byte ourselves, and we do that with a 32-bit
     // unaligned transfer (LWL/LWR + SWL/SWR).
     if ((len & 1) != 0 && len >= 0x7F) {
-        typedef uint32_t u_uint32_t __attribute__((aligned(1)));
         *(u_uint32_t*)(ram+len-4) = __io_read32u(rom+len-4);
         len -= 3;
     }

--- a/src/dma.c
+++ b/src/dma.c
@@ -16,13 +16,13 @@
  * @brief DMA functionality for transfers between cartridge space and RDRAM
  *
  * The DMA controller is responsible for handling block and word accesses from
- * the catridge domain.  Because of the nature of the catridge interface, code
- * cannot use memcpy or standard pointer accesses on memory mapped to the catridge.
+ * the cartridge domain.  Because of the nature of the cartridge interface, code
+ * cannot use memcpy or standard pointer accesses on memory mapped to the cartridge.
  * Consequently, the peripheral interface (PI) provides a DMA controller for
  * accessing data.
  *
  * The DMA controller requires no initialization.  Using #dma_read and #dma_write
- * will allow reading from the cartridge and writing to the catridge respectively
+ * will allow reading from the cartridge and writing to the cartridge respectively
  * in block mode.  #io_read and #io_write will allow a single 32-bit integer to
  * be read from or written to the cartridge.  These are especially useful for
  * manipulating registers on a cartridge such as a gameshark.  Code should never


### PR DESCRIPTION
Small new header file that includes common definitions for unaligned data types. These are used across several different files already (and even more often in the unstable branch) so it makes sense to define them just once.

Took the chance to migrate the affected files (debug.c and dma.c) to granular includes rather than including libdragon.h.