### PR TITLE
n64sys: reinstate removed read_count function 

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -190,7 +190,7 @@ void sys_set_boot_cic(int bc);
  *
  * @return The number of ticks since system startup
  */
-static inline volatile unsigned long get_ticks(void)
+inline volatile unsigned long get_ticks(void)
 {
     return TICKS_READ();
 }
@@ -204,7 +204,7 @@ static inline volatile unsigned long get_ticks(void)
  *
  * @return The number of millisecounds since system startup
  */
-static inline volatile unsigned long get_ticks_ms(void)
+inline volatile unsigned long get_ticks_ms(void)
 {
     return TICKS_READ() / (TICKS_PER_SECOND / 1000);
 }

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -268,6 +268,15 @@ typedef enum {
 
 tv_type_t get_tv_type();
 
+
+/** @cond */
+/* Deprecated version of get_ticks */
+__attribute__((deprecated("use get_ticks instead")))
+static inline volatile unsigned long read_count(void) {
+    return get_ticks();
+}
+/** @endcond */
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -392,3 +392,7 @@ __attribute__((constructor)) void __init_cop1()
 }
 
 /** @} */
+
+/* Inline instantiations */
+extern inline volatile unsigned long get_ticks(void);
+extern inline volatile unsigned long get_ticks_ms(void);


### PR DESCRIPTION
read_count was removed in 2010 (https://github.com/DragonMinded/libdragon/commit/02a385d0db69b1fdcabe11032ed9072468215a3a). Unfortunately, it is
still in use in UNFLoader's debug.c as of today:
https://github.com/buu342/N64-UNFLoader/blob/46c6bef215fe2ea70bf5bf38b74a9e6a566f19f2/USB%2BDebug%20Library/debug.c#L602

Reinstating it is the simplest way to help the ecosystem and avoid
gratuitous breakages.