### PR TITLE
timer: allow timers with very short intervals

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -4,8 +4,11 @@
  * @ingroup timer
  */
 #include <malloc.h>
-#include "libdragon.h"
+#include "timer.h"
+#include "interrupt.h"
+#include "debug.h"
 #include "regsinternal.h"
+#include "utils.h"
 
 /**
  * @defgroup timer Timer Subsystem
@@ -55,8 +58,9 @@ extern volatile uint32_t interrupt_disabled_tick;
 #define TF_CALLED      0x80
 
 /** @brief Update the compare register to match the first expiring timer. */
-static void timer_update_compare(timer_link_t *head) {
-	uint32_t now = TICKS_READ();
+__attribute__((noinline))
+static void timer_update_compare(timer_link_t *head, uint32_t now)
+{
 	uint32_t smallest = 0xFFFFFFFF;
 
 	while (head)
@@ -119,6 +123,14 @@ static int __proc_timers(timer_link_t * thead)
 			else if (head->callback)
 				head->callback(head->ovfl);
 
+			if (head->flags & TF_DISABLED)
+			{
+				/* Timer was disabled during the callback. We need to
+				 * reprocess the list to see if there are other timers
+				 * that need to be called. */
+				return 1;
+			}
+
 			/* reset ticks if continuous */
 			if (head->flags & TF_CONTINUOUS)
 			{
@@ -177,11 +189,15 @@ static int __proc_timers(timer_link_t * thead)
  */
 static void timer_interrupt_callback(void)
 {
-	while (__proc_timers(TI_timers))
-		{}
+	uint32_t loop_count = 0;
+	while (__proc_timers(TI_timers)) {
+		++loop_count; (void)loop_count; // avoid warning (loop_count is used in assertf)
+		assertf(loop_count < 1000, "timer interrupt is stuck in an infinite loop.\n"
+			"Check continuous timers with a very short period.\n");
+	}
 
 	// Update counter for next interrupt.
-	timer_update_compare(TI_timers);
+	timer_update_compare(TI_timers, TICKS_READ());
 }
 
 /**
@@ -257,20 +273,22 @@ timer_link_t *new_timer(int ticks, int flags, timer_callback1_t callback)
 	timer_link_t *timer = malloc(sizeof(timer_link_t));
 	if (timer)
 	{
-		timer->left = TICKS_READ() + (int32_t)ticks;
+		disable_interrupts();
+
+		uint32_t now = TICKS_READ();
+		timer->left = now + (int32_t)ticks;
 		timer->set = ticks;
 		timer->flags = flags;
 		timer->callback = callback;
 		timer->ctx = NULL;
 
-		if (flags & TF_DISABLED)
-			return timer;
-
-		disable_interrupts();
-
-		timer->next = TI_timers;
-		TI_timers = timer;
-		timer_update_compare(TI_timers);
+		if (!(flags & TF_DISABLED))
+		{
+			timer->next = TI_timers;
+			TI_timers = timer;
+			timer_update_compare(TI_timers, now);
+			timer_interrupt_callback();
+		}
 
 		enable_interrupts();
 	}
@@ -299,20 +317,22 @@ timer_link_t *new_timer_context(int ticks, int flags, timer_callback2_t callback
 	timer_link_t *timer = malloc(sizeof(timer_link_t));
 	if (timer)
 	{
-		timer->left = TICKS_READ() + (int32_t)ticks;
+		disable_interrupts();
+
+		uint32_t now = TICKS_READ();
+		timer->left = now + (int32_t)ticks;
 		timer->set = ticks;
 		timer->flags = flags | TF_CONTEXT;
 		timer->callback_with_context = callback;
 		timer->ctx = ctx;
 
-		if (flags & TF_DISABLED)
-			return timer;
-
-		disable_interrupts();
-
-		timer->next = TI_timers;
-		TI_timers = timer;
-		timer_update_compare(TI_timers);
+		if (!(flags & TF_DISABLED))
+		{
+			timer->next = TI_timers;
+			TI_timers = timer;
+			timer_update_compare(TI_timers, now);
+			timer_interrupt_callback();
+		}
 
 		enable_interrupts();
 	}
@@ -339,20 +359,22 @@ void start_timer(timer_link_t *timer, int ticks, int flags, timer_callback1_t ca
 	assertf(TI_timers, "timer module not initialized");
 	if (timer)
 	{
-		timer->left = TICKS_READ() + (int32_t)ticks;
+		disable_interrupts();
+
+		uint32_t now = TICKS_READ();
+		timer->left = now + (int32_t)ticks;
 		timer->set = ticks;
 		timer->flags = flags;
 		timer->callback = callback;
 		timer->ctx = NULL;
 
-		if (flags & TF_DISABLED)
-			return;
-
-		disable_interrupts();
-
-		timer->next = TI_timers;
-		TI_timers = timer;
-		timer_update_compare(TI_timers);
+		if (!(flags & TF_DISABLED))
+		{
+			timer->next = TI_timers;
+			TI_timers = timer;
+			timer_update_compare(TI_timers, now);
+			timer_interrupt_callback();
+		}
 
 		enable_interrupts();
 	}
@@ -379,20 +401,22 @@ void start_timer_context(timer_link_t *timer, int ticks, int flags, timer_callba
 	assertf(TI_timers, "timer module not initialized");
 	if (timer)
 	{
-		timer->left = TICKS_READ() + (int32_t)ticks;
+		disable_interrupts();
+
+		uint32_t now = TICKS_READ();
+		timer->left = now + (int32_t)ticks;
 		timer->set = ticks;
 		timer->flags = flags | TF_CONTEXT;
 		timer->callback_with_context = callback;
 		timer->ctx = ctx;
 
 		if (flags & TF_DISABLED)
-			return;
-
-		disable_interrupts();
-
-		timer->next = TI_timers;
-		TI_timers = timer;
-		timer_update_compare(TI_timers);
+		{
+			timer->next = TI_timers;
+			TI_timers = timer;
+			timer_update_compare(TI_timers, now);
+			timer_interrupt_callback();
+		}
 
 		enable_interrupts();
 	}
@@ -408,14 +432,16 @@ void restart_timer(timer_link_t *timer)
 {
 	if (timer)
 	{
-		timer->left = TICKS_READ() + (int32_t)timer->set;
-		timer->flags &= ~TF_DISABLED;
-
 		disable_interrupts();
+
+		uint32_t now = TICKS_READ();
+		timer->left = now + (int32_t)timer->set;
+		timer->flags &= ~TF_DISABLED;
 
 		timer->next = TI_timers;
 		TI_timers = timer;
-		timer_update_compare(TI_timers);
+		timer_update_compare(TI_timers, now);
+		timer_interrupt_callback();
 
 		enable_interrupts();
 	}
@@ -426,6 +452,9 @@ void restart_timer(timer_link_t *timer)
  *
  * @note This function does not free a timer structure, use #delete_timer
  *       to do this.
+ * 
+ * @note It is safe to call this function from a timer callback, including
+ *       to stop a timer from its own callback.
  *
  * @param[in] timer
  *            Timer structure to stop and remove
@@ -456,7 +485,8 @@ void stop_timer(timer_link_t *timer)
 			last = head;
 			head = head->next;
 		}
-		timer_update_compare(TI_timers);
+		timer->flags |= TF_DISABLED;
+		timer_update_compare(TI_timers, TICKS_READ());
 		enable_interrupts();
 	}
 }
@@ -464,6 +494,8 @@ void stop_timer(timer_link_t *timer)
 /**
  * @brief Remove a timer from the list and delete it
  *
+ * @note It is not safe to call this function from a timer callback.
+
  * @param[in] timer
  *            Timer structure to stop, remove and free
  */

--- a/tests/test_timer.c
+++ b/tests/test_timer.c
@@ -335,3 +335,28 @@ void test_timer_disabled_start(TestContext *ctx) {
 		2+3+3+2+3+3,
 		"invalid timer_ticks");
 }
+
+void test_timer_continuous_short(TestContext *ctx) {
+	timer_init();
+	DEFER(timer_close());
+
+	timer_link_t t2;
+
+	volatile int cb_called = 0;
+	void cb2(int ovlf) {
+		cb_called++;
+		if (cb_called == 50) {
+			stop_timer(&t2);
+		}
+	}
+
+	// Create a timer that fires with very short intervals
+	int intervals[] = {0, 1, 2, 10, 50, 100 };
+
+	for (int tt=0; tt<sizeof(intervals) / sizeof(intervals[0]); tt++) {
+		cb_called = 0;
+		start_timer(&t2, intervals[tt], TF_CONTINUOUS, cb2);
+		wait_ms(2);
+		ASSERT_EQUAL_SIGNED(cb_called, 50, "invalid number of calls to timer callback");
+	}
+}

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -233,6 +233,7 @@ static const struct Testsuite
 	TEST_FUNC(test_timer_oneshot,            596, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_slow_callback,     1468, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_continuous,         688, TEST_FLAGS_RESET_COUNT),
+	TEST_FUNC(test_timer_continuous_short,   554, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_mixed,             1467, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_context,            186, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_timer_disabled_start,     733, TEST_FLAGS_RESET_COUNT),


### PR DESCRIPTION
The timer module currently happens to ignore timers scheduled with very small interval. This is not a deliberate choice but rather an implementation issue: if the expiration timer is shorter than the time it takes to the timer library to setup the new timer (including intervening other interrupts that might happen meanwhile), the timer basically is scheduled on the next timer wraparound (~90 secs). This behavior is obviously buggy.

This commit changes the timer code to account for a timer that expires too soon by basically polling the timer queue immediately after the timer is scheduled.

Continuous timers with very short interval would now effectively cause an infinite loop. To avoid a hard freeze without notifying the user, we add an assert in case a timer expires more than 1000 times in a row within the same interrupt. Moreover, we also adjust a bit the code to allow to call stop_timer from within a timer callback, in case a timer wants to stop itself; this also allows us to write a test for this whole issue.

Fixes #359