### PR TITLE
rdpq_tileparms_t and rdpq_texparms_t comments fix, add a mask check to rdpq_set_tile

### DIFF
--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -44,9 +44,9 @@ typedef struct {
         float   translate;      // Translate the texture in pixels
         int     scale_log;      // Power of 2 scale modifier of the texture (default: 0)
 
-        float   repeats;        // Number of repetitions (default: unlimited)
+        float   repeats;        // Number of repetitions (default: 1)
         bool    mirror;         // Repetition mode (default: MIRROR_NONE)
-    } s, t;
+    } s, t; // S/T directions of texture parameters
 
 } rdpq_texparms_t;
 


### PR DESCRIPTION
Pretty much the title, the comments were wrong about the default behaviour, also the clamping is turned on explicidly when mask = 0, for debugging purposes.