### PR TITLE
Add interactive exception inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ examples:
 	$(MAKE) -C examples
 # We are unable to clean examples built with n64.mk unless we
 # install it first
-examples-clean: install-mk
+examples-clean: $(INSTALLDIR)/include/n64.mk
 	$(MAKE) -C examples clean
 
 doxygen: doxygen.conf
@@ -66,8 +66,12 @@ tools-install:
 tools-clean:
 	$(MAKE) -C tools clean
 
-install-mk: n64.mk
-	install -Cv -m 0644 n64.mk $(INSTALLDIR)/include/n64.mk
+install-mk: $(INSTALLDIR)/include/n64.mk
+
+$(INSTALLDIR)/include/n64.mk: n64.mk
+# Always update timestamp of n64.mk. This make sure that further targets
+# depending on install-mk won't always try to re-install it.
+	install -cv -m 0644 n64.mk $(INSTALLDIR)/include/n64.mk
 
 install: install-mk libdragon
 	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a
@@ -138,7 +142,7 @@ test-clean: install-mk
 
 clobber: clean doxygen-clean examples-clean tools-clean test-clean
 
-.PHONY : clobber clean doxygen-clean doxygen doxygen-api examples examples-clean tools tools-clean tools-install test test-clean
+.PHONY : clobber clean doxygen-clean doxygen doxygen-api examples examples-clean tools tools-clean tools-install test test-clean install-mk
 
 # Automatic dependency tracking
 -include $(wildcard $(BUILD_DIR)/*.d) $(wildcard $(BUILD_DIR)/*/*.d)

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ LIBDRAGON_CFLAGS = -I$(CURDIR)/src -I$(CURDIR)/include -ffile-prefix-map=$(CURDI
 
 # Activate N64 toolchain for libdragon build
 libdragon: CC=$(N64_CC)
+libdragon: CXX=$(N64_CXX)
 libdragon: AS=$(N64_AS)
 libdragon: LD=$(N64_LD)
 libdragon: CFLAGS+=$(N64_CFLAGS) $(LIBDRAGON_CFLAGS)
+libdragon: CXXFLAGS+=$(N64_CXXFLAGS) $(LIBDRAGON_CFLAGS)
 libdragon: ASFLAGS+=$(N64_ASFLAGS) $(LIBDRAGON_CFLAGS)
 libdragon: RSPASFLAGS+=$(N64_RSPASFLAGS) $(LIBDRAGON_CFLAGS)
 libdragon: LDFLAGS+=$(N64_LDFLAGS)
@@ -24,7 +26,7 @@ libdragonsys.a: $(BUILD_DIR)/system.o
 
 libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o $(BUILD_DIR)/backtrace.o \
 			 $(BUILD_DIR)/inthandler.o $(BUILD_DIR)/entrypoint.o \
-			 $(BUILD_DIR)/debug.o $(BUILD_DIR)/usb.o $(BUILD_DIR)/libcart/cart.o $(BUILD_DIR)/fatfs/ff.o \
+			 $(BUILD_DIR)/debug.o $(BUILD_DIR)/debugcpp.o $(BUILD_DIR)/usb.o $(BUILD_DIR)/libcart/cart.o $(BUILD_DIR)/fatfs/ff.o \
 			 $(BUILD_DIR)/fatfs/ffunicode.o $(BUILD_DIR)/rompak.o $(BUILD_DIR)/dragonfs.o \
 			 $(BUILD_DIR)/audio.o $(BUILD_DIR)/display.o $(BUILD_DIR)/surface.o \
 			 $(BUILD_DIR)/console.o $(BUILD_DIR)/joybus.o \
@@ -93,6 +95,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 include/surface.h $(INSTALLDIR)/mips64-elf/include/surface.h
 	install -Cv -m 0644 include/display.h $(INSTALLDIR)/mips64-elf/include/display.h
 	install -Cv -m 0644 include/debug.h $(INSTALLDIR)/mips64-elf/include/debug.h
+	install -Cv -m 0644 include/debugcpp.h $(INSTALLDIR)/mips64-elf/include/debugcpp.h
 	install -Cv -m 0644 include/usb.h $(INSTALLDIR)/mips64-elf/include/usb.h
 	install -Cv -m 0644 include/console.h $(INSTALLDIR)/mips64-elf/include/console.h
 	install -Cv -m 0644 include/joybus.h $(INSTALLDIR)/mips64-elf/include/joybus.h

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ libdragon.a: $(BUILD_DIR)/n64sys.o $(BUILD_DIR)/interrupt.o $(BUILD_DIR)/backtra
 			 $(BUILD_DIR)/eeprom.o $(BUILD_DIR)/eepromfs.o $(BUILD_DIR)/mempak.o \
 			 $(BUILD_DIR)/tpak.o $(BUILD_DIR)/graphics.o $(BUILD_DIR)/rdp.o \
 			 $(BUILD_DIR)/rsp.o $(BUILD_DIR)/rsp_crash.o \
+			 $(BUILD_DIR)/inspector.o \
 			 $(BUILD_DIR)/dma.o $(BUILD_DIR)/timer.o \
 			 $(BUILD_DIR)/exception.o $(BUILD_DIR)/do_ctors.o \
 			 $(BUILD_DIR)/audio/mixer.o $(BUILD_DIR)/audio/samplebuffer.o \

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <libdragon.h>
 #include <memory>
+#include <stdexcept>
 
 int state = 1;
 
@@ -36,6 +37,9 @@ class TestClass
             }
             return -1;
         }
+        void crash(void) {
+            throw std::runtime_error("Crash!");
+        }
 };
 
 // Test global constructor
@@ -45,11 +49,13 @@ int main(void)
 {
     debug_init_isviewer();
     debug_init_usblog();
+    controller_init();
 
     auto localClass = std::make_unique<TestClass>();
 
     console_init();
     console_set_render_mode(RENDER_MANUAL);
+
 
     while(1)
     {
@@ -57,6 +63,13 @@ int main(void)
         printf("Global class method: %d\n", globalClass.f1());
         printf("Local class method: %d\n", localClass->f1());
         printf("Exception data: %d\n", localClass->exc());
+        printf("\nPress A to crash (test uncaught C++ exceptions)\n");
         console_render();
+
+        controller_scan();
+        struct controller_data keys = get_keys_down();
+        if (keys.c[0].A)
+            localClass->crash();
+        
     }
 }

--- a/include/cop0.h
+++ b/include/cop0.h
@@ -12,6 +12,8 @@
 #ifndef __LIBDRAGON_COP0_H
 #define __LIBDRAGON_COP0_H
 
+#include <stdint.h>
+
 /** @brief Read the COP0 Count register (see also TICKS_READ). */
 #define C0_COUNT() ({ \
     uint32_t x; \
@@ -221,6 +223,18 @@
 #define C0_WIRED() ({ \
     uint32_t x; \
     asm volatile("mfc0 %0,$6":"=r"(x)); \
+    x; \
+})
+
+/**
+ * @brief Read the COP0 WATCHLO register
+ * 
+ * This register is used during watchpoint programming. It allows to trigger
+ * an exception when a memory access occurs on a specific memory location.
+ */
+#define C0_WATCHLO() ({ \
+    uint32_t x; \
+    asm volatile("mfc0 %0,$18":"=r"(x)); \
     x; \
 })
 

--- a/include/debugcpp.h
+++ b/include/debugcpp.h
@@ -1,0 +1,26 @@
+/**
+ * @file debug.h
+ * @brief Debugging Support (C++)
+ */
+
+#ifndef __LIBDRAGON_DEBUGCPP_H
+#define __LIBDRAGON_DEBUGCPP_H
+
+#if defined(__cplusplus) && !defined(NDEBUG)
+    // We need to run some initialization code only in case libdragon is compiled from
+    // a C++ program. So we hook a few common initialization functions and run our code.
+    // C programs are not affected and the C++-related code will be unused and stripped by the linker.
+    ///@cond
+    void __debug_init_cpp(void);
+
+    #define console_init() ({ __debug_init_cpp(); console_init(); })
+    #define dfs_init(a) ({ __debug_init_cpp(); dfs_init(a);})
+    #define controller_init() ({ __debug_init_cpp(); controller_init(); })
+    #define timer_init() ({ __debug_init_cpp(); timer_init(); })
+    #define display_init(a,b,c,d,e) ({ __debug_init_cpp(); display_init(a,b,c,d,e); })
+    #define debug_init_isviewer() ({ __debug_init_cpp(); debug_init_isviewer(); })
+    #define debug_init_usblog() ({ __debug_init_cpp(); debug_init_isviewer(); })
+    ///@endcond
+#endif
+
+#endif

--- a/include/exception.h
+++ b/include/exception.h
@@ -104,7 +104,7 @@ typedef struct
     /** @brief String information of exception */
     const char* info;
     /** @brief Registers at point of exception */
-    volatile reg_block_t* regs;
+    reg_block_t* regs;
 } exception_t;
 
 /** @} */

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -55,5 +55,6 @@
 #include "ym64.h"
 #include "rspq.h"
 #include "surface.h"
+#include "debugcpp.h"
 
 #endif

--- a/src/debugcpp.cpp
+++ b/src/debugcpp.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file debugcpp.cpp
+ * @brief Debugging Support (C++)
+ */
+
+#include "debug.h"
+#include "exception_internal.h"
+#include <exception>
+#include <cxxabi.h>
+#include <cstdlib>
+
+static void terminate_handler(void)
+{
+    std::exception_ptr eptr = std::current_exception();
+    if (eptr) {
+        try {
+            std::rethrow_exception(eptr);
+        }
+        catch (const std::exception& e) 
+        {
+            char buf[1024]; size_t sz = sizeof(buf);
+            char *demangled = abi::__cxa_demangle(typeid(e).name(), buf, &sz, NULL);
+            __inspector_cppexception(demangled, e.what());
+        }
+        catch (...) 
+        {
+            __inspector_cppexception(NULL, "Unknown exception");
+        }
+    }
+    else
+    {
+        __inspector_cppexception(NULL, "Direct std::terminate() call");
+    }    
+}
+
+/** @brief Initialize debug support for C++ programs */
+void __debug_init_cpp(void)
+{
+    static bool init = false;
+    if (init) return;
+    std::set_terminate(terminate_handler);
+    init = true;
+}

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -17,7 +17,7 @@ _start:
 	   so checking for a specific value while reading seems solid enough. */
 	lw t1, 0xA4300004
 	andi t1, 0xF0
-	bne t1, 0xB0, set_sp
+	bne t1, 0xB0, .Lset_sp
 	li fp, 0                    /* fp=0 -> vanilla N64 */
 
 	/* In iQue player, memory allocated to game can be configured and it appears
@@ -26,11 +26,11 @@ _start:
 	   See also get_memory_size. */
 	li fp, 1                    /* fp=1 -> iQue player */
 	li t1, 0x800000
-	blt t0, t1, set_sp
+	blt t0, t1, .Lset_sp
 	nop
 	li t0, 0x7C0000
 
-set_sp:
+.Lset_sp:
 	li t1, 0x7FFFFFF0
 	addu sp,t0,t1				/* init stack */
 	la gp, _gp					/* init data pointer */
@@ -72,18 +72,18 @@ set_sp:
 	or a0, 0x20000000           /* convert address to KSEG1 (uncached) */
 	la a1, __bss_end
 	or a1, 0x20000000
-bss_init:
+.Lbss_init:
 	sd $0,(a0)
 	addiu a0,8
-	bltu a0,a1, bss_init
+	bltu a0,a1, .Lbss_init
 	nop
 
 	/* Wait for DMA transfer to be finished */
 	lui t0, 0xA460
-wait_dma_end:
+.Lwait_dma_end:
 	lw t1, 0x10(t0)             /* PI_STATUS */
 	andi t1, 3                  /* PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY */
-	bnez t1, wait_dma_end
+	bnez t1, .Lwait_dma_end
 	nop
 
 	/* Store the bbplayer flag now that BSS has been cleared */
@@ -93,7 +93,7 @@ wait_dma_end:
 	la t0,intvector
 	la t1,0xa0000000
 	la t2,4
-loadintvectorloop:
+.Lloadintvectorloop:
 	lw t3,(t0)
 	sw t3,0(t1)
 	sw t3,0x80(t1)
@@ -107,7 +107,7 @@ loadintvectorloop:
 	addi t0,4
 	addi t1,4
 	addiu t2,-1
-	bnez t2,loadintvectorloop
+	bnez t2,.Lloadintvectorloop
 	nop
 
 	la t0, debug_assert_func    /* install assert function in system.c */
@@ -120,8 +120,8 @@ loadintvectorloop:
 	jal main					/* call main app */
 	li a1, 0
 
-deadloop:
-	j deadloop
+_abort:
+	j _abort
 	nop
 
 intvector:

--- a/src/entrypoint.S
+++ b/src/entrypoint.S
@@ -9,12 +9,17 @@
 	.section .boot
 	.global _start
 _start:
-	lw t0, 0x80000318			/* memory size */
+	/* Watchpoints have been proven to persist across resets and even
+	 * with the console being off. Zero it as early as possible, to
+	 * avoid it triggering during boot. This should really be done
+	 * at the start IPL3. */
+	mtc0 $0, C0_WATCHLO
 
 	/* Check whether we are running on iQue or N64. Use the MI version register
 	   which has LSB set to 0xB0 on iQue. We assume 0xBn was meant for BBPlayer.
 	   Notice that we want this test to be hard for emulators to pass by mistake,
 	   so checking for a specific value while reading seems solid enough. */
+	lw t0, 0x80000318			/* memory size */
 	lw t1, 0xA4300004
 	andi t1, 0xF0
 	bne t1, 0xB0, .Lset_sp

--- a/src/exception.c
+++ b/src/exception.c
@@ -4,6 +4,7 @@
  * @ingroup exceptions
  */
 #include "exception.h"
+#include "exception_internal.h"
 #include "console.h"
 #include "n64sys.h"
 #include "debug.h"
@@ -12,6 +13,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <math.h>
 
 /**
  * @defgroup exceptions Exception Handler
@@ -86,6 +88,144 @@ exception_handler_t register_exception_handler( exception_handler_t cb )
 	return old;
 }
 
+
+/** 
+ * @brief Dump a brief recap of the exception.
+ * 
+ * @param[in] out File to write to
+ * @param[in] ex Exception to dump
+ */
+void __exception_dump_header(FILE *out, exception_t* ex) {
+	uint32_t cr = ex->regs->cr;
+	uint32_t fcr31 = ex->regs->fc31;
+
+	fprintf(out, "%s exception at PC:%08lX\n", ex->info, (uint32_t)(ex->regs->epc + ((cr & C0_CAUSE_BD) ? 4 : 0)));
+	switch (ex->code) {
+		case EXCEPTION_CODE_STORE_ADDRESS_ERROR:
+		case EXCEPTION_CODE_LOAD_I_ADDRESS_ERROR:
+		case EXCEPTION_CODE_TLB_STORE_MISS:
+		case EXCEPTION_CODE_TLB_LOAD_I_MISS:
+		case EXCEPTION_CODE_I_BUS_ERROR:
+		case EXCEPTION_CODE_D_BUS_ERROR:
+		case EXCEPTION_CODE_TLB_MODIFICATION:
+			fprintf(out, "Exception address: %08lX\n", C0_BADVADDR());
+			break;
+
+		case EXCEPTION_CODE_FLOATING_POINT: {
+			const char *space = "";
+			fprintf(out, "FPU status: %08lX [", C1_FCR31());
+			if (fcr31 & C1_CAUSE_INEXACT_OP) fprintf(out, "%sINEXACT", space), space=" ";
+			if (fcr31 & C1_CAUSE_OVERFLOW) fprintf(out, "%sOVERFLOW", space), space=" ";
+			if (fcr31 & C1_CAUSE_DIV_BY_0) fprintf(out, "%sDIV0", space), space=" ";
+			if (fcr31 & C1_CAUSE_INVALID_OP) fprintf(out, "%sINVALID", space), space=" ";
+			if (fcr31 & C1_CAUSE_NOT_IMPLEMENTED) fprintf(out, "%sNOTIMPL", space), space=" ";
+			fprintf(out, "]\n");
+			break;
+		}
+
+		case EXCEPTION_CODE_COPROCESSOR_UNUSABLE:
+			fprintf(out, "COP: %ld\n", C0_GET_CAUSE_CE(cr));
+			break;
+
+		case EXCEPTION_CODE_WATCH:
+			fprintf(out, "Watched address: %08lX\n", C0_WATCHLO() & ~3);
+			break;
+
+		default:
+			break;
+	}
+}
+
+/**
+ * @brief Helper to dump the GPRs of an exception
+ * 
+ * @param ex 		Exception
+ * @param cb 		Callback that will be called for each register
+ * @param arg 		Argument to pass to the callback
+ */
+void __exception_dump_gpr(exception_t* ex, void (*cb)(void *arg, const char *regname, char* value), void *arg) {
+	char buf[24];
+	for (int i=0;i<34;i++) {
+		uint64_t v = (i<32) ? ex->regs->gpr[i] : (i == 33) ? ex->regs->lo : ex->regs->hi;
+		if ((int32_t)v == v) {
+			snprintf(buf, sizeof(buf), "---- ---- %04llx %04llx", (v >> 16) & 0xFFFF, v & 0xFFFF);
+		} else {
+			snprintf(buf, sizeof(buf), "%04llx %04llx %04llx %04llx", v >> 48, (v >> 32) & 0xFFFF, (v >> 16) & 0xFFFF, v & 0xFFFF);
+		}
+		cb(arg, __mips_gpr[i], buf);
+	}
+}
+
+/**
+ * @brief Helper to dump the FPRs of an exception
+ * 
+ * @param ex 		Exception
+ * @param cb 		Callback that will be called for each register
+ * @param arg 		Argument to pass to the callback
+ */
+// Make sure that -ffinite-math-only is disabled otherwise the compiler will assume that no NaN/Inf can exist
+// and thus __builtin_isnan/__builtin_isinf are folded to false at compile-time.
+__attribute__((optimize("no-finite-math-only"), noinline))
+void __exception_dump_fpr(exception_t* ex, void (*cb)(void *arg, const char *regname, char* hexvalue, char *singlevalue, char *doublevalue), void *arg) {
+	char hex[32], single[32], doubl[32]; char *singlep, *doublep;
+	for (int i = 0; i<32; i++) {
+		uint64_t fpr64 = ex->regs->fpr[i];
+		uint32_t fpr32 = fpr64;
+
+		snprintf(hex, sizeof(hex), "%016llx", fpr64);
+
+		float f;  memcpy(&f, &fpr32, sizeof(float));
+		double g; memcpy(&g, &fpr64, sizeof(double));
+
+		// Check for denormal on the integer representation. Unfortunately, even
+		// fpclassify() generates an unmaskable exception on denormals, so it can't be used.
+		// Open GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66462
+		if ((fpr32 & 0x7F800000) == 0 && (fpr32 & 0x007FFFFF) != 0)
+			singlep = "<Denormal>";
+		else if (__builtin_isnan(f))
+			singlep = "<NaN>";
+		else if (__builtin_isinf(f))
+			singlep = (f < 0) ? "<-Inf>" : "<+Inf>";
+		else
+			sprintf(single, "%.12g", f), singlep = single;
+
+		if ((fpr64 & 0x7FF0000000000000ull) == 0 && (fpr64 & 0x000FFFFFFFFFFFFFull) != 0)
+			doublep = "<Denormal>";
+		else if (__builtin_isnan(g))
+			doublep = "<NaN>";
+		else if (__builtin_isinf(g))
+			doublep = (g < 0) ? "<-Inf>" : "<+Inf>";
+		else
+			sprintf(doubl, "%.17g", g), doublep = doubl;
+
+		cb(arg, __mips_fpreg[i], hex, singlep, doublep);
+	}
+}
+
+static void debug_exception(exception_t* ex) {
+	debugf("\n\n******* CPU EXCEPTION *******\n");
+	__exception_dump_header(stderr, ex);
+
+	if (true) {
+		int idx = 0;
+		void cb(void *arg, const char *regname, char* value) {
+			debugf("%s: %s%s", regname, value, ++idx % 4 ? "   " : "\n");
+		}
+		debugf("GPR:\n"); 
+		__exception_dump_gpr(ex, cb, NULL);
+		debugf("\n\n");
+	}	
+	
+	if (ex->code == EXCEPTION_CODE_FLOATING_POINT) {
+		void cb(void *arg, const char *regname, char* hex, char *singlep, char *doublep) {
+			debugf("%4s: %s (%16s | %22s)\n", regname, hex, singlep, doublep);
+		}
+		debugf("FPR:\n"); 
+		__exception_dump_fpr(ex, cb, NULL);
+		debugf("\n");
+	}
+}
+
 /**
  * @brief Default exception handler.
  * 
@@ -94,128 +234,23 @@ exception_handler_t register_exception_handler( exception_handler_t cb )
  * of all GPR/FPR registers. It then calls abort() to abort execution.
  */
 void exception_default_handler(exception_t* ex) {
-	uint32_t cr = ex->regs->cr;
-	uint32_t sr = ex->regs->sr;
-	uint32_t fcr31 = ex->regs->fc31;
+	static bool backtrace_exception = false;
 
-	switch(ex->code) {
-		case EXCEPTION_CODE_STORE_ADDRESS_ERROR:
-		case EXCEPTION_CODE_LOAD_I_ADDRESS_ERROR:
-		case EXCEPTION_CODE_TLB_MODIFICATION:
-		case EXCEPTION_CODE_TLB_STORE_MISS:
-		case EXCEPTION_CODE_TLB_LOAD_I_MISS:
-		case EXCEPTION_CODE_COPROCESSOR_UNUSABLE:
-		case EXCEPTION_CODE_FLOATING_POINT:
-		case EXCEPTION_CODE_WATCH:
-		case EXCEPTION_CODE_ARITHMETIC_OVERFLOW:
-		case EXCEPTION_CODE_TRAP:
-		case EXCEPTION_CODE_I_BUS_ERROR:
-		case EXCEPTION_CODE_D_BUS_ERROR:
-		case EXCEPTION_CODE_SYS_CALL:
-		case EXCEPTION_CODE_BREAKPOINT:
-		case EXCEPTION_CODE_INTERRUPT:
-		default:
-		break;
-	}
+	// Write immediately as much data as we can to the debug spew. This is the
+	// "safe" path, because it doesn't involve touching the console drawing code.
+	debug_exception(ex);
 
-	console_init();
-	console_set_debug(true);
-	console_set_render_mode(RENDER_MANUAL);
+	// Show a backtrace (starting from just before the exception handler)
+	// Avoid recursive exceptions during backtrace printing
+	if (backtrace_exception) abort();
+	backtrace_exception = true;
+	extern void __debug_backtrace(FILE *out, bool skip_exception);
+	__debug_backtrace(stderr, true);
+	backtrace_exception = false;
 
-	fprintf(stdout, "%s exception at PC:%08lX\n", ex->info, (uint32_t)(ex->regs->epc + ((cr & C0_CAUSE_BD) ? 4 : 0)));
+	// Run the inspector
+	__inspector_exception(ex);
 
-	fprintf(stdout, "CR:%08lX (COP:%1lu BD:%u)\n", cr, C0_GET_CAUSE_CE(cr), (bool)(cr & C0_CAUSE_BD));
-	fprintf(stdout, "SR:%08lX FCR31:%08X BVAdr:%08lX \n", sr, (unsigned int)fcr31, C0_BADVADDR());
-	fprintf(stdout, "----------------------------------------------------------------");
-	fprintf(stdout, "FPU IOP UND OVE DV0 INV NI | INT sw0 sw1 ex0 ex1 ex2 ex3 ex4 tmr");
-	fprintf(stdout, "Cause%2u %3u %3u %3u %3u%3u | Cause%2u %3u %3u %3u %3u %3u %3u %3u",
-		(bool)(fcr31 & C1_CAUSE_INEXACT_OP),
-		(bool)(fcr31 & C1_CAUSE_UNDERFLOW),
-		(bool)(fcr31 & C1_CAUSE_OVERFLOW),
-		(bool)(fcr31 & C1_CAUSE_DIV_BY_0),
-		(bool)(fcr31 & C1_CAUSE_INVALID_OP),
-		(bool)(fcr31 & C1_CAUSE_NOT_IMPLEMENTED),
-
-		(bool)(cr & C0_INTERRUPT_0),
-		(bool)(cr & C0_INTERRUPT_1),
-		(bool)(cr & C0_INTERRUPT_RCP),
-		(bool)(cr & C0_INTERRUPT_3),
-		(bool)(cr & C0_INTERRUPT_4),
-		(bool)(cr & C0_INTERRUPT_5),
-		(bool)(cr & C0_INTERRUPT_6),
-		(bool)(cr & C0_INTERRUPT_TIMER)
-	);
-	fprintf(stdout, "En  %3u %3u %3u %3u %3u  - | MASK%3u %3u %3u %3u %3u %3u %3u %3u",
-		(bool)(fcr31 & C1_ENABLE_INEXACT_OP),
-		(bool)(fcr31 & C1_ENABLE_UNDERFLOW),
-		(bool)(fcr31 & C1_ENABLE_OVERFLOW),
-		(bool)(fcr31 & C1_ENABLE_DIV_BY_0),
-		(bool)(fcr31 & C1_ENABLE_INVALID_OP),
-
-		(bool)(sr & C0_INTERRUPT_0),
-		(bool)(sr & C0_INTERRUPT_1),
-		(bool)(sr & C0_INTERRUPT_RCP),
-		(bool)(sr & C0_INTERRUPT_3),
-		(bool)(sr & C0_INTERRUPT_4),
-		(bool)(sr & C0_INTERRUPT_5),
-		(bool)(sr & C0_INTERRUPT_6),
-		(bool)(sr & C0_INTERRUPT_TIMER)
-	);
-
-	fprintf(stdout, "Flags%2u %3u %3u %3u %3u  - |\n",
-		(bool)(fcr31 & C1_FLAG_INEXACT_OP),
-		(bool)(fcr31 & C1_FLAG_UNDERFLOW),
-		(bool)(fcr31 & C1_FLAG_OVERFLOW),
-		(bool)(fcr31 & C1_FLAG_DIV_BY_0),
-		(bool)(fcr31 & C1_FLAG_INVALID_OP)
-	);
-
-	fprintf(stdout, "-------------------------------------------------GP Registers---");
-
-	fprintf(stdout, "z0:%08lX ",		(uint32_t)ex->regs->gpr[0]);
-	fprintf(stdout, "at:%08lX ",		(uint32_t)ex->regs->gpr[1]);
-	fprintf(stdout, "v0:%08lX ",		(uint32_t)ex->regs->gpr[2]);
-	fprintf(stdout, "v1:%08lX ",		(uint32_t)ex->regs->gpr[3]);
-	fprintf(stdout, "a0:%08lX\n",		(uint32_t)ex->regs->gpr[4]);
-	fprintf(stdout, "a1:%08lX ",		(uint32_t)ex->regs->gpr[5]);
-	fprintf(stdout, "a2:%08lX ",		(uint32_t)ex->regs->gpr[6]);
-	fprintf(stdout, "a3:%08lX ",		(uint32_t)ex->regs->gpr[7]);
-	fprintf(stdout, "t0:%08lX ",		(uint32_t)ex->regs->gpr[8]);
-	fprintf(stdout, "t1:%08lX\n",		(uint32_t)ex->regs->gpr[9]);
-	fprintf(stdout, "t2:%08lX ",		(uint32_t)ex->regs->gpr[10]);
-	fprintf(stdout, "t3:%08lX ",		(uint32_t)ex->regs->gpr[11]);
-	fprintf(stdout, "t4:%08lX ",		(uint32_t)ex->regs->gpr[12]);
-	fprintf(stdout, "t5:%08lX ",		(uint32_t)ex->regs->gpr[13]);
-	fprintf(stdout, "t6:%08lX\n",		(uint32_t)ex->regs->gpr[14]);
-	fprintf(stdout, "t7:%08lX ",		(uint32_t)ex->regs->gpr[15]);
-	fprintf(stdout, "t8:%08lX ",		(uint32_t)ex->regs->gpr[24]);
-	fprintf(stdout, "t9:%08lX ",		(uint32_t)ex->regs->gpr[25]);
-
-	fprintf(stdout, "s0:%08lX ",		(uint32_t)ex->regs->gpr[16]);
-	fprintf(stdout, "s1:%08lX\n",		(uint32_t)ex->regs->gpr[17]);
-	fprintf(stdout, "s2:%08lX ",		(uint32_t)ex->regs->gpr[18]);
-	fprintf(stdout, "s3:%08lX ",		(uint32_t)ex->regs->gpr[19]);
-	fprintf(stdout, "s4:%08lX ",		(uint32_t)ex->regs->gpr[20]);
-	fprintf(stdout, "s5:%08lX ",		(uint32_t)ex->regs->gpr[21]);
-	fprintf(stdout, "s6:%08lX\n",		(uint32_t)ex->regs->gpr[22]);
-	fprintf(stdout, "s7:%08lX ",		(uint32_t)ex->regs->gpr[23]);
-
-	fprintf(stdout, "gp:%08lX ",		(uint32_t)ex->regs->gpr[28]);
-	fprintf(stdout, "sp:%08lX ",		(uint32_t)ex->regs->gpr[29]);
-	fprintf(stdout, "fp:%08lX ",		(uint32_t)ex->regs->gpr[30]);
-	fprintf(stdout, "ra:%08lX \n",		(uint32_t)ex->regs->gpr[31]);
-	fprintf(stdout, "lo:%016llX ",		ex->regs->lo);
-	fprintf(stdout, "hi:%016llX\n",		ex->regs->hi);
-
-	fprintf(stdout, "-------------------------------------------------FP Registers---");
-	for (int i = 0; i<32; i++) {
-		fprintf(stdout, "%02u:%016llX  ", i, ex->regs->fpr[i]);
-		if ((i % 3) == 2) {
-			fprintf(stdout, "\n");
-		}
-	}
-
-	console_render();
 	abort();
 }
 

--- a/src/exception_internal.h
+++ b/src/exception_internal.h
@@ -1,0 +1,27 @@
+#ifndef __LIBDRAGON_EXCEPTION_INTERNAL_H
+#define __LIBDRAGON_EXCEPTION_INTERNAL_H
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include "exception.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const char *__mips_gpr[34];
+extern const char *__mips_fpreg[32];
+
+void __exception_dump_header(FILE *out, exception_t* ex);
+void __exception_dump_gpr(exception_t* ex, void (*cb)(void *arg, const char *regname, char* value), void *arg);
+void __exception_dump_fpr(exception_t* ex, void (*cb)(void *arg, const char *regname, char* hexvalue, char *singlevalue, char *doublevalue), void *arg);
+
+__attribute__((noreturn))
+void __inspector_exception(exception_t* ex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/exception_internal.h
+++ b/src/exception_internal.h
@@ -20,6 +20,9 @@ void __exception_dump_fpr(exception_t* ex, void (*cb)(void *arg, const char *reg
 __attribute__((noreturn))
 void __inspector_exception(exception_t* ex);
 
+__attribute__((noreturn))
+void __inspector_assertion(const char *failedexpr, const char *msg, va_list args);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/exception_internal.h
+++ b/src/exception_internal.h
@@ -23,6 +23,9 @@ void __inspector_exception(exception_t* ex);
 __attribute__((noreturn))
 void __inspector_assertion(const char *failedexpr, const char *msg, va_list args);
 
+__attribute__((noreturn))
+void __inspector_cppexception(const char *exctype, const char *what);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -15,6 +15,7 @@
 enum Mode {
     MODE_EXCEPTION,
     MODE_ASSERTION,
+    MODE_CPP_EXCEPTION
 };
 
 enum {
@@ -256,6 +257,18 @@ static void inspector_page_exception(surface_t *disp, exception_t* ex, enum Mode
             printf("\b\aOASSERTION FAILED: %s\n\n", failedexpr);
         }
         bt_skip = 2;
+        break;
+    }
+    case MODE_CPP_EXCEPTION: {
+        title("Uncaught C++ Exception");
+        const char *exctype = (const char*)(uint32_t)ex->regs->gpr[4];
+        const char *what = (const char*)(uint32_t)ex->regs->gpr[5];
+        printf("\b\aOC++ Exception: %s\n\n", what);
+        if (exctype) {
+            printf("\aWException type:\n");
+            printf("    "); printf("\b%s", exctype); printf("\n\n");
+        }
+        bt_skip = 5;
         break;
     }
     }
@@ -516,11 +529,23 @@ void __inspector_assertion(const char *failedexpr, const char *msg, va_list args
     __builtin_unreachable();
 }
 
+__attribute__((noreturn))
+void __inspector_cppexception(const char *exctype, const char *what) {
+    asm volatile (
+        "move $a0, %0\n"
+        "move $a1, %1\n"
+        "syscall 0x2\n"
+        :: "p"(exctype), "p"(what)
+    );
+    __builtin_unreachable();    
+}
+
 __attribute__((constructor))
 void __inspector_init(void) {
     // Register SYSCALL 0x1 for assertion failures
     void handler(exception_t* ex, uint32_t code) {
         if (code == 1) inspector(ex, MODE_ASSERTION);
+        if (code == 2) inspector(ex, MODE_CPP_EXCEPTION);
     }
     register_syscall_handler(handler, 0x00001, 0x00002);
 }

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -1,0 +1,487 @@
+#include "graphics.h"
+#include "debug.h"
+#include "controller.h"
+#include "exception_internal.h"
+#include "system.h"
+#include "utils.h"
+#include "backtrace.h"
+#include "backtrace_internal.h"
+#include "cop0.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum Mode {
+    MODE_EXCEPTION,
+};
+
+enum {
+    XSTART = 48,
+    XEND = 640-48,
+    YSTART = 16,
+    YEND = 240-8-8,
+};
+
+#define pack32(x16)        ((x16) | ((x16) << 16))
+
+// Colors are coming from the Solarized color scheme
+#define COLOR_BACKGROUND   pack32(color_to_packed16(RGBA32(0x00, 0x2b, 0x36, 255)))
+#define COLOR_HIGHLIGHT    pack32(color_to_packed16(RGBA32(0x07, 0x36, 0x42, 128)))
+#define COLOR_TEXT         pack32(color_to_packed16(RGBA32(0x83, 0x94, 0x96, 255)))
+#define COLOR_EMPHASIS     pack32(color_to_packed16(RGBA32(0x93, 0xa1, 0xa1, 255)))
+#define COLOR_ORANGE       pack32(color_to_packed16(RGBA32(0xcb, 0x4b, 0x16, 255)))
+#define COLOR_RED          pack32(color_to_packed16(RGBA32(0xdc, 0x32, 0x2f, 255)))
+#define COLOR_GREEN        pack32(color_to_packed16(RGBA32(0x2a, 0xa1, 0x98, 255)))
+#define COLOR_YELLOW       pack32(color_to_packed16(RGBA32(0xb5, 0x89, 0x00, 255)))
+#define COLOR_BLUE         pack32(color_to_packed16(RGBA32(0x26, 0x8b, 0xd2, 255)))
+#define COLOR_MAGENTA      pack32(color_to_packed16(RGBA32(0xd3, 0x36, 0x82, 255)))
+#define COLOR_CYAN         pack32(color_to_packed16(RGBA32(0x2a, 0xa1, 0x98, 255)))
+#define COLOR_WHITE        pack32(color_to_packed16(RGBA32(0xee, 0xe8, 0xd5, 255)))
+
+static int cursor_x, cursor_y, cursor_columns, cursor_wordwrap;
+static surface_t *disp;
+static int fpr_show_mode = 1;
+static int disasm_bt_idx = 0;
+static int disasm_max_frames = 0;
+static int disasm_offset = 0;
+static bool first_backtrace = true;
+
+const char *__mips_gpr[34] = {
+	"zr", "at", "v0", "v1", "a0", "a1", "a2", "a3",
+	"t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7",
+	"s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
+	"t8", "t9", "k0", "k1", "gp", "sp", "s8", "ra",
+    "lo", "hi"
+};
+
+const char *__mips_fpreg[32] = {
+    "$f0", "$f1", "$f2", "$f3", "$f4", "$f5", "$f6", "$f7",
+    "$f8", "$f9", "$f10", "$f11", "$f12", "$f13", "$f14", "$f15",
+    "$f16", "$f17", "$f18", "$f19", "$f20", "$f21", "$f22", "$f23",
+    "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30", "$f31"
+};
+
+__attribute__((used))
+static void mips_disasm(uint32_t *ptr, char *out, int n) {
+	static const char *ops[64] = { 
+		"s", "r", "jj", "jjal", "bbeq", "bbne", "bblez", "bbgtz",
+		"iaddi", "iaddiu", "rslt", "isltiu", "iandi", "iori", "ixori", "klui",
+		"ccop0", "fcop1", "ccop2", "ccop3", "bbeql", "bbnel", "bblezl", "bbgtzl",
+		"ddaddi", "ddaddiu", "dldl", "dldr", "*", "*", "*", "*",
+		"mlb", "mlh", "mlwl", "mlw", "mlbu", "mlhu", "mlwr", "mlwu",
+		"msb", "msh", "mswl", "msw", "msdl", "msdr", "mswr", "*",
+		"mll", "nlwc1", "mlwc2", "*", "mlld", "nldc1", "mldc2", "mld",
+		"msc", "nswc1", "mswc2", "*", "mscd", "nsdc1", "msdc2", "msd",
+  	};
+	static const char *special[64]= {
+		"esll", "*", "esrl", "esra", "rsllv", "*", "rsrlv", "rsrav",
+		"wjr", "wjalr", "*", "*", "asyscall", "abreak", "*", "_sync",
+		"wmfhi", "wmflo", "wmthi", "wmtlo", "rdsslv", "*", "rdsrlv", "rdsrav",
+		"*", "*", "*", "*", "*", "*", "*", "*", 
+		"radd", "raddu", "rsub", "rsubu", "rand", "ror", "rxor", "rnor", 
+		"*", "*", "*", "*", "*", "*", "*", "*", 
+		"*", "*", "*", "*", "*", "*", "*", "*", 
+		"*", "*", "*", "*", "*", "*", "*", "*", 
+	};
+	static const char *fpu_ops[64]= {
+        "radd", "rsub", "rmul", "rdiv", "rsqrt", "sabs", "smov", "sneg",
+        "sround.l", "strunc.l", "sceil.l", "sfloor.l", "sround.w", "strunc.w", "sceil.w", "sfloor.w",
+        "*", "*", "*", "*", "*", "*", "*", "*",
+        "*", "*", "*", "*", "*", "*", "*", "*",
+        "scvt.s", "scvt.d", "*", "*", "scvt.w", "scvt.l", "*", "*",
+		"*", "*", "*", "*", "*", "*", "*", "*", 
+		"hc.f", "hc.un", "hc.eq", "hc.ueq", "hc.olt", "hc.ult", "hc.ole", "hc.ule", 
+		"hc.sf", "hc.ngle", "hc.seq", "hc.ngl", "hc.lt", "hc.nge", "hc.le", "hc.ngt", 
+    };
+
+	char symbuf[64];
+
+	// Disassemble MIPS instruction
+	uint32_t pc = (uint32_t)ptr;
+	uint32_t op = *ptr;
+	int16_t imm16 = op & 0xFFFF;
+	uint32_t tgt16 = (pc + 4) + (imm16 << 2);
+	uint32_t imm26 = op & 0x3FFFFFF;
+	uint32_t tgt26 = ((pc + 4) & 0xfffffffff0000000) | (imm26 << 2);
+	const char *rs = __mips_gpr[(op >> 21) & 0x1F];
+	const char *rt = __mips_gpr[(op >> 16) & 0x1F];
+	const char *rd = __mips_gpr[(op >> 11) & 0x1F];
+	const char *opn = ops[(op >> 26) & 0x3F];
+	if (op == 0) opn = "znop";
+	else if (((op >> 26) & 0x3F) == 9 && ((op >> 21) & 0x1F) == 0) opn = "kli";
+	else if ((op >> 16) == 0x1000) opn = "yb";
+	else if (*opn == 's') {
+		opn = special[(op >> 0) & 0x3F];
+		if (((op >> 0) & 0x3F) == 0x25 && ((op >> 16) & 0x1F) == 0) opn = "smove";
+	} else if (*opn == 'f') {
+        uint32_t sub = (op >> 21) & 0x1F;
+        switch (sub) {
+            case 0: opn = "gmfc1"; break;
+            case 1: opn = "gdmfc1"; break;
+            case 4: opn = "gmtc1"; break;
+            case 5: opn = "gdmtc1"; break;
+            case 8: switch ((op >> 16) & 0x1F) {
+                case 0: opn = "ybc1f"; break;
+                case 2: opn = "ybc1fl"; break;
+                case 1: opn = "ybc1t"; break;
+                case 3: opn = "ybc1tl"; break;
+            } break;
+            case 16: case 17:
+                opn = fpu_ops[(op >> 0) & 0x3F];
+                sprintf(symbuf, "%s.%s", opn, (sub == 16) ? "s" : "d");
+                opn = symbuf;
+                rt = __mips_fpreg[(op >> 11) & 0x1F];
+                rs = __mips_fpreg[(op >> 16) & 0x1F];
+                rd = __mips_fpreg[(op >> 6) & 0x1F];
+                break;
+        }
+    }
+	switch (*opn) {
+	/* op tgt26 */        case 'j': snprintf(out, n, "%08lx: \aG%-9s \aY%08lx <%s>", pc, opn+1, tgt26, __symbolize((void*)tgt26, symbuf, sizeof(symbuf))); break;
+	/* op rt, rs, imm */  case 'i': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s, %d", pc, opn+1, rt, rs, (int16_t)op); break;
+	/* op rt, imm */      case 'k': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %d", pc, opn+1, rt, (int16_t)op); break;
+	/* op rt, imm(rs) */  case 'm': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %d(%s)", pc, opn+1, rt, (int16_t)op, rs); break;
+	/* op fd, imm(rs) */  case 'n': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %d(%s)", pc, opn+1, __mips_fpreg[(op >> 16) & 0x1F], (int16_t)op, rs); break;
+	/* op rd, rs, rt  */  case 'r': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s, %s", pc, opn+1, rd, rs, rt); break;
+	/* op rd, rs */       case 's': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s", pc, opn+1, rd, rs); break;
+	/* op rd, rt, sa  */  case 'e': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s, %ld", pc, opn+1, rd, rt, (op >> 6) & 0x1F); break;
+	/* op rs, rt, tgt16 */case 'b': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s, %08lx <%s>", pc, opn+1, rs, rt, tgt16, __symbolize((void*)tgt16, symbuf, sizeof(symbuf))); break;
+	/* op tgt16 */        case 'y': snprintf(out, n, "%08lx: \aG%-9s \aY%08lx <%s>", pc, opn+1, tgt16, __symbolize((void*)tgt16, symbuf, sizeof(symbuf))); break;
+	/* op rt */           case 'w': snprintf(out, n, "%08lx: \aG%-9s \aY%s", pc, opn+1, rs); break;
+	/* op */			  case 'z': snprintf(out, n, "%08lx: \aG%-9s", pc, opn+1); break;
+    /* op fd, fs, ft */   case 'f': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s, %s", pc, opn+1, rd, rs, rt); break;
+    /* op rt, fs */       case 'g': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s", pc, opn+1, rt, __mips_fpreg[(op >> 11) & 0x1F]); break;
+	/* op rt, rs */       case 'h': snprintf(out, n, "%08lx: \aG%-9s \aY%s, %s", pc, opn+1, rt, rs); break;
+	/* op code20 */ 	  case 'a': snprintf(out, n, "%08lx: \aG%-9s \aY0x%lx", pc, opn+1, (op>>6) & 0xFFFFF); break;
+					      default:  snprintf(out, n, "%08lx: \aG%-9s", pc, opn+1); break;
+	}
+}
+
+bool disasm_valid_pc(uint32_t pc) {
+    // TODO: handle TLB ranges?
+    return pc >= 0x80000000 && pc < 0x80800000 && (pc & 3) == 0;
+}
+
+static int inspector_stdout(char *buf, unsigned int len) {
+    for (int i=0; i<len; i++) {
+        if (cursor_x >= 640) break;
+
+        switch (buf[i]) {
+        case '\a': {
+            uint32_t color = COLOR_TEXT;
+            switch (buf[++i]) {
+            case 'T': color = COLOR_TEXT; break;
+            case 'E': color = COLOR_EMPHASIS; break;
+            case 'O': color = COLOR_ORANGE; break;
+            case 'Y': color = COLOR_YELLOW; break;
+            case 'M': color = COLOR_MAGENTA; break;
+            case 'G': color = COLOR_GREEN; break;
+            case 'W': color = COLOR_WHITE; break;
+            }
+            graphics_set_color(color, COLOR_BACKGROUND);
+        }   break;
+        case '\b':
+            cursor_wordwrap = true;
+            break;
+        case '\t':
+            cursor_x = ROUND_UP(cursor_x+1, cursor_columns);
+            if (cursor_wordwrap && cursor_x >= XEND) {
+                cursor_x = XSTART;
+                cursor_y += 8;
+            }
+            break;
+        case '\n':
+            cursor_x = XSTART;
+            cursor_y += 8;
+            cursor_wordwrap = false;
+            graphics_set_color(COLOR_TEXT, COLOR_BACKGROUND);
+            break;
+        default:
+            if (cursor_x < XEND) {
+                graphics_draw_character(disp, cursor_x, cursor_y, buf[i]);
+                cursor_x += 8;
+                if (cursor_wordwrap && cursor_x >= XEND) {
+                    cursor_x = XSTART;
+                    cursor_y += 8;
+                }
+            }
+            break;
+        }
+	}
+    return len;
+}
+
+static void title(const char *title) {
+    graphics_draw_box(disp, 0, 0, 640, 12, COLOR_TEXT);
+    graphics_set_color(COLOR_BACKGROUND, COLOR_TEXT);
+    graphics_draw_text(disp, 64, 2, title);
+    graphics_set_color(COLOR_TEXT, COLOR_BACKGROUND);
+}
+
+static void inspector_page_exception(surface_t *disp, exception_t* ex, enum Mode mode, bool with_backtrace) {
+    int bt_skip = 0;
+
+    switch (mode) {
+    case MODE_EXCEPTION:
+        title("CPU Exception");
+        printf("\aO");
+        __exception_dump_header(stdout, ex);
+        printf("\n");
+
+        printf("\aWInstruction:\n");
+        uint32_t epc = (uint32_t)(ex->regs->epc + ((ex->regs->cr & C0_CAUSE_BD) ? 4 : 0));
+        if (disasm_valid_pc(epc)) {
+            char buf[128];
+            mips_disasm((void*)epc, buf, 128);
+            printf("    %s\n\n", buf);
+        } else {
+            printf("    <Invalid PC: %08lx>\n\n", epc);
+        }
+        break;
+
+    }
+
+    if (!with_backtrace)
+        return;
+
+    void *bt[32];
+    int n = backtrace(bt, 32);
+
+    printf("\aWBacktrace:\n");
+    if (first_backtrace) debugf("Backtrace:\n");
+    char func[128];
+    bool skip = true;
+    void cb(void *arg, backtrace_frame_t *frame) {
+        if (first_backtrace) { debugf("    "); backtrace_frame_print(frame, stderr); debugf("\n"); }
+        if (skip) {
+            if (strstr(frame->func, "<EXCEPTION HANDLER>"))
+                skip = false;
+            return;
+        }
+        if (bt_skip > 0) {
+            bt_skip--;
+            return;
+        }
+        printf("    ");
+        snprintf(func, sizeof(func), "\aG%s\aT", frame->func);
+        frame->func = func;
+        backtrace_frame_print_compact(frame, stdout, 60);
+    }
+    backtrace_symbols_cb(bt, n, 0, cb, NULL);
+    if (skip) {
+        // we didn't find the exception handler for some reason (eg: missing symbols)
+        // so just print the whole thing
+        skip = false;
+        backtrace_symbols_cb(bt, n, 0, cb, NULL);
+    }
+    first_backtrace = false;
+}
+
+static void inspector_page_gpr(surface_t *disp, exception_t* ex) {
+    title("CPU Registers");
+    cursor_columns = 92;
+
+    int c = 0;
+    void cb(void *arg, const char *name, char *value) {
+        printf("\t\aW%s: \aT%s", name, value);
+        if (++c % 2 == 0)
+            printf("\n");
+    }
+
+    __exception_dump_gpr(ex, cb, NULL);
+}
+
+static void inspector_page_fpr(surface_t *disp, exception_t* ex, struct controller_data *key_pressed) {
+    if (key_pressed->c[0].A)
+        fpr_show_mode = (fpr_show_mode + 1) % 3;
+
+    title(fpr_show_mode == 0 ? "CPU Floating Point Registers (Hex)" :
+          fpr_show_mode == 1 ? "CPU Floating Point Registers (Single)" :
+                               "CPU Floating Point Registers (Double)");
+
+    int c = 0;
+    void cb(void *arg, const char *name, char *hexvalue, char *singlevalue, char *doublevalue) {
+        char *value = fpr_show_mode == 0 ? hexvalue : fpr_show_mode == 1 ? singlevalue : doublevalue;
+        printf("\t\aW%4s: \aT%-19s%s", name, value, ++c % 2 == 0 ? "\n" : "\t");
+    }
+
+    __exception_dump_fpr(ex, cb, NULL);
+}
+
+static void inspector_page_disasm(surface_t *disp, exception_t* ex, struct controller_data *key_pressed) {
+    if (key_pressed->c[0].up && disasm_bt_idx > 0) {        
+        disasm_bt_idx--;
+        disasm_offset = 0;
+    }
+    if (key_pressed->c[0].down && disasm_bt_idx < disasm_max_frames-1) {
+        disasm_bt_idx++;
+        disasm_offset = 0;
+    }
+    if (key_pressed->c[0].C_up) {
+        disasm_offset -= 4*6;
+    }
+    if (key_pressed->c[0].C_down) {
+        disasm_offset += 4*6;
+    }
+
+    title("Disassembly");
+
+	void *bt[32];
+	int n = backtrace(bt, 32);
+
+    if (disasm_bt_idx < 2) printf("\n");
+    if (disasm_bt_idx < 1) printf("\n");
+
+    bool skip = true;
+    uint32_t frame_pc = 0;
+    int frame_idx = 0;
+    void cb(void *arg, backtrace_frame_t *frame) {
+        if (skip) {
+            if (strstr(frame->func, "<EXCEPTION HANDLER>"))
+                skip = false;
+            return;
+        }
+        if (frame_idx >= disasm_bt_idx-2 && frame_idx <= disasm_bt_idx+2) {
+            if (frame_idx == disasm_bt_idx) {
+                printf("\aW\t---> ");
+                frame_pc = frame->addr;
+            }
+            else
+                printf("\t     ");
+            
+            const char *basename = strrchr(frame->source_file, '/');
+            if (basename) basename++;
+            else basename = frame->source_file;
+            printf("%08lx %s (%s:%d)\n", frame->addr, frame->func, basename, frame->source_line);
+        }
+        frame_idx++;
+    }
+    backtrace_symbols_cb(bt, n, 0, cb, NULL);
+    disasm_max_frames = frame_idx;
+
+    if (disasm_bt_idx >= disasm_max_frames-2) printf("\n");
+    if (disasm_bt_idx >= disasm_max_frames-1) printf("\n");
+
+    printf("\n\n");
+
+    uint32_t pc = frame_pc + disasm_offset - 9*4;
+    char buf[128];
+    for (int i=0; i<18; i++) {
+        if (!disasm_valid_pc(pc)) {
+            printf("\t<invalid address>\n");
+        } else {
+            mips_disasm((void*)pc, buf, 128);
+            if (pc == frame_pc) {
+                printf("\aW---> ");
+            }
+            else
+                printf("     ");
+            printf("%s\n", buf);
+        }
+        pc += 4;
+    }
+}
+
+__attribute__((noreturn))
+static void inspector(exception_t* ex, enum Mode mode) {
+    static bool in_inspector = false;
+    if (in_inspector) abort();
+    in_inspector = true;
+
+	display_close();
+	display_init(RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+
+	enum Page {
+		PAGE_EXCEPTION,
+		PAGE_GPR,
+		PAGE_FPR,
+		PAGE_CODE,
+	};
+	enum { PAGE_COUNT = PAGE_CODE+1 };
+
+	hook_stdio_calls(&(stdio_t){ NULL, inspector_stdout, NULL });
+
+    static bool backtrace = false;
+    struct controller_data key_old = {0};
+    struct controller_data key_pressed = {0};
+	enum Page page = PAGE_EXCEPTION;
+	while (1) {
+        if (key_pressed.c[0].Z || key_pressed.c[0].R) {
+            //Do page wrapping logic from left
+            if(page == PAGE_COUNT-1) {
+                page = 0;
+            } else {
+                page++;
+            }
+        }
+        if (key_pressed.c[0].L) {
+            //Do page wrapping logic from right
+            if(page == 0) {
+                page = PAGE_COUNT-1;
+            } else {
+                page--;
+            }
+        }
+		while (!(disp = display_lock())) {}
+
+        cursor_x = XSTART;
+        cursor_y = YSTART;
+        cursor_columns = 8*8;
+        graphics_set_color(COLOR_TEXT, COLOR_BACKGROUND);
+        graphics_fill_screen(disp, COLOR_BACKGROUND);
+
+		switch (page) {
+		case PAGE_EXCEPTION:
+            inspector_page_exception(disp, ex, mode, backtrace);
+			break;
+        case PAGE_GPR:
+            inspector_page_gpr(disp, ex);
+            break;
+        case PAGE_FPR:
+            inspector_page_fpr(disp, ex, &key_pressed);
+            break;
+        case PAGE_CODE:
+            inspector_page_disasm(disp, ex, &key_pressed);
+            break;
+		}
+
+        fflush(stdout);
+
+        cursor_x = XSTART;
+        cursor_y = YEND + 2;
+        cursor_columns = 64;
+        graphics_draw_box(disp, 0, YEND, 640, 240-YEND, COLOR_TEXT);
+        graphics_set_color(COLOR_BACKGROUND, COLOR_TEXT);
+		printf("\t\t\tLibDragon Inspector | Page %d/%d", page+1, PAGE_COUNT);
+        fflush(stdout);
+
+        extern void display_show_force(display_context_t disp);
+		display_show_force(disp);
+
+        // Loop until a keypress
+        while (1) {
+            // Read controller using controller_read, that works also when the
+            // interrupts are disabled and when controller_init has not been called.
+            struct controller_data key_new;
+            controller_read(&key_new);
+            if (key_new.c->data != key_old.c->data) {
+                key_pressed.c->data = key_new.c->data & ~key_old.c->data;
+                key_old = key_new;
+	            break;
+            };
+            // If we draw the first frame, turn on backtrace and redraw immediately
+            if (!backtrace) {
+                backtrace = true;
+                break;
+            }
+        }
+    }
+
+	abort();
+}
+
+__attribute__((noreturn))
+void __inspector_exception(exception_t* ex) {
+    inspector(ex, MODE_EXCEPTION);
+}

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -151,10 +151,18 @@ exception_coprocessor:
 	nop
 
 exception_coprocessor_fpu:
-	# FPU exception. This happened because of the use of FPU in an interrupt handler,
-	# where it is disabled by default. We must save the full FPU context,
-	# reactivate the FPU, and then return from exception, so that the FPU instruction
-	# is executed again and this time it will work.
+	# COP1 unusable exception. This happened because a FPU operation was attempted
+	# while the COP1 was disabled.
+	# The interrupt handler below disables the COP1 during interrupt handler
+	# execution, so that we don't need to save interrupt registers on the stack.
+	# In this situation, we want to save the FPU registers, reenable the COP1
+	# and retrigger the same operation.
+	# There might be other code (user code) that disables the COP1, and in that
+	# case instead we want to just trigger a standard critical exception.
+	# To distinguish between the two cases, we use the interrupt_exception_frame
+	# pointer, which is set to non-NULL only when we are handling an interrupt.
+	lw a0, interrupt_exception_frame
+	beqz a0, exception_critical
 
 	# Make sure that FPU will also be enabled when we exit this exception
 	lw t0, STACK_SR(sp)
@@ -165,14 +173,12 @@ exception_coprocessor_fpu:
 	# in doing so, it will overwrite the FPU registers,
 	# but those are at this point still part of the context
 	# from when the interrupt was raised and have not been saved yet.
-	# Save the FPU registers now, into the *underlying* interrupt context.
+	# Save the FPU registers now, into the *underlying* interrupt context
+	# (read from interrupt_exception_frame into a0).
 	# That is, we want to make sure that they get restored when the
 	# underlying interrupt exits.
-	# Note: interrupt_exception_frame is always valid to use here,
-	#  as the FPU is only ever unusable in interrupt handlers:
-	#  entrypoint.S loads SR with SR_CU1
 	jal save_fpu_regs
-	lw a0, interrupt_exception_frame
+	nop
 
 	# OK we are done. We can now exit the exception
 	j end_interrupt
@@ -254,6 +260,7 @@ notcart:
 
 	# No more interrupts to process, we can exit
 	# (fallthrough)
+	sw zero, interrupt_exception_frame
 
 end_interrupt:
 	mfc0 t0, C0_SR

--- a/src/joybus.c
+++ b/src/joybus.c
@@ -64,6 +64,11 @@
  * @brief Structure used to interact with SI registers.
  */
 static volatile struct SI_regs_s * const SI_regs = (struct SI_regs_s *)0xa4800000;
+/** @brief Static structure to address MI registers */
+static volatile struct MI_regs_s * const MI_regs = (struct MI_regs_s *)0xa4300000;
+
+/** @brief SI interrupt bit */
+#define MI_INTR_SI 0x02
 
 /**
  * @brief Pointer to the memory-mapped location of the PIF RAM.
@@ -214,7 +219,6 @@ static void si_interrupt(void) {
     }
 }
 
-
 /**
  * @brief Execute an asynchronous joybus message.
  * 
@@ -295,7 +299,18 @@ void joybus_exec( const void * input, void * output )
     }
 
     joybus_exec_async(input, callback, NULL);
-    while (!done) {}
+    while (!done) {
+        // We want the blocking function to also work with interrupts disabled.
+        // So while we spin loop, poll SI interrupts manually in case they
+        // are disabled.
+        disable_interrupts();
+        unsigned long status = MI_regs->intr & MI_regs->mask;
+        if (status & MI_INTR_SI) {
+            SI_regs->status = 0;    // clear interrupt
+            si_interrupt();
+        }
+        enable_interrupts();
+    }
 }
 
 /** @} */ /* joybus */

--- a/src/regs.S
+++ b/src/regs.S
@@ -74,6 +74,7 @@
 #define C0_EPC		$14		/* Exception error address */
 #define C0_PRID		$15		/* Processor Revision ID */
 #define C0_CONFIG	$16		/* CPU configuration */
+#define C0_WATCHLO	$18		/* Watchpoint */
 
 /* Standard Processor Revision ID Register field offsets */
 #define PR_IMP	8

--- a/src/rsp.c
+++ b/src/rsp.c
@@ -391,6 +391,9 @@ void __rsp_crash(const char *file, int line, const char *func, const char *msg, 
         uc->crash_handler(&state);
     }
 
+    // Backtrace
+    debug_backtrace();
+
     // Full dump of DMEM into the debug log.
     debugf("DMEM:\n");
     debug_hexdump(state.dmem, 4096);

--- a/tests/test_cop1.c
+++ b/tests/test_cop1.c
@@ -1,5 +1,8 @@
 #include <float.h>
 
+// Avoid converting the division into a multiplication, as that would break
+// the test causing a "not implemented" exception instead of an underflow.
+__attribute__((optimize("no-reciprocal-math"), noinline))
 void test_cop1_denormalized_float(TestContext *ctx) {
     uint32_t fcr31 = C1_FCR31();
     DEFER(C1_WRITE_FCR31(fcr31));

--- a/tools/dumpdfs/dumpdfs.c
+++ b/tools/dumpdfs/dumpdfs.c
@@ -798,7 +798,7 @@ int main( int argc, char *argv[] )
             }
             
             int fl = dfs_open( argv[3] );
-            uint8_t *data = malloc( dfs_size( fl ) );
+            uint8_t *data = malloc( (size_t)dfs_size( fl ) );
 
             dfs_read( data, 1, dfs_size( fl ), fl );
             fwrite( data, 1, dfs_size( fl ), stdout );
@@ -834,7 +834,7 @@ int main( int argc, char *argv[] )
             dfs_read( &unused, 1, 4, nu );
             
             int fl = dfs_open( argv[3] );
-            uint8_t *data = malloc( dfs_size( fl ) );
+            uint8_t *data = malloc( (size_t)dfs_size( fl ) );
 
             dfs_read( data, 1, dfs_size( fl ), fl );
             fwrite( data, 1, dfs_size( fl ), stdout );


### PR DESCRIPTION
This PR contains the usual batch of small change (somewhat unrelated) and then adds an interactive exception inspector that shows many more details about an exception, compared to the current exception screen. The inspector has been used for months in the unstable branch and has proven to be quite useful and stable.

The inspector is made of four pages:

1) The main exception screen, showing the exception that triggered and the traceback leading to it
2) A dump of all GPR registers
3) A dump of all FPR registers (that can be switched between hex, single and double representation)
4) An interactive symbolized disassembler that also can walk the stack to show the code around the different traceback calls.

The inspector is hooked to:
 * unhandled exceptions
 * assertions
 * uncaught C++ exceptions

Interaction is made using the controller in port 1.

Some screenshots:

<img width="800" alt="Schermata 2023-05-14 alle 14 38 06" src="https://github.com/DragonMinded/libdragon/assets/1014109/0a87899e-6195-47ad-a161-236e1680bcc2">
<img width="800" alt="Schermata 2023-05-14 alle 14 38 09" src="https://github.com/DragonMinded/libdragon/assets/1014109/7a0e38b8-d544-46e1-888b-3a678672e9ad">
<img width="800" alt="Schermata 2023-05-14 alle 14 38 12" src="https://github.com/DragonMinded/libdragon/assets/1014109/21071dc6-d323-4e6f-a556-082b39cf35a1">
<img width="800" alt="Schermata 2023-05-14 alle 14 38 16" src="https://github.com/DragonMinded/libdragon/assets/1014109/014c4dcf-93a1-4585-b17f-2e1744d46f89">
<img width="800" alt="Schermata 2023-05-14 alle 14 27 41" src="https://github.com/DragonMinded/libdragon/assets/1014109/4a357465-e15b-4060-b6ba-98b44a7ddbd0">
<img width="800" alt="Schermata 2023-05-14 alle 14 32 34" src="https://github.com/DragonMinded/libdragon/assets/1014109/0d0ec2f7-5831-469c-922d-0c53cda824ab">



