### PR TITLE
Clean up rdpq_tex_blit fields

### DIFF
--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -67,11 +67,10 @@ static void draw_actors()
         if(actors[i] && actors[i]->visible) {
             //Blit sprite surface to screen
             surface_t surf = sprite_get_pixels(actors[i]->sprite);
+			rdpq_blit_transform_t transform = { actors[i]->x_scale, actors[i]->y_scale, actors[i]->angle };
             rdpq_tex_blit(&surf, actors[i]->x, actors[i]->y, &(rdpq_blitparms_t){
                 .cx = surf.width/2, .cy = surf.height/2,
-                .scale_x = actors[i]->x_scale, .scale_y = actors[i]->y_scale,
-                .theta = actors[i]->angle
-            });
+            }, &transform);
         }
     }
 }

--- a/examples/overlays/scene/background.cpp
+++ b/examples/overlays/scene/background.cpp
@@ -27,9 +27,9 @@ Background::~Background()
 
 void Background::Draw()
 {
-    //Initialize surface and blit parameters
+    //Initialize surface and blit transform
     surface_t img_surface = sprite_get_pixels(m_image);
-    rdpq_blitparms_t blit_params = {.scale_x = m_scale_x, .scale_y = m_scale_y };
+    rdpq_blit_transform_t blit_transform = {.scale_x = m_scale_x, .scale_y = m_scale_y };
     //Get screen size
     float scr_width = display_get_width();
     float scr_height = display_get_height();
@@ -45,7 +45,7 @@ void Background::Draw()
     //Iterate over visible tiles
     for(int i=0; i<num_tiles_y; i++) {
         for(int j=0; j<num_tiles_x; j++) {
-            rdpq_tex_blit(&img_surface, ofs_x+(j*tile_w), ofs_y+(i*tile_h), &blit_params);
+            rdpq_tex_blit(&img_surface, ofs_x+(j*tile_w), ofs_y+(i*tile_h), NULL, &blit_transform);
         }
     }
 }

--- a/examples/overlays/scene/sprite.cpp
+++ b/examples/overlays/scene/sprite.cpp
@@ -31,15 +31,16 @@ void Sprite::Draw()
 {
     //Get sprite surface
     surface_t surf = sprite_get_pixels(m_image);
-    //Initialize blit parameters to rotate/scale around center
+    //Initialize blit parameters and transform to rotate/scale around center
     rdpq_blitparms_t blit_params = {};
+	rdpq_blit_transform_t blit_transform = {};
     blit_params.cx = surf.width/2;
     blit_params.cy = surf.height/2;
-    blit_params.scale_x = m_scale_x;
-    blit_params.scale_y = m_scale_y;
-    blit_params.theta = m_angle;
+    blit_transform.scale_x = m_scale_x;
+    blit_transform.scale_y = m_scale_y;
+    blit_transform.theta = m_angle;
     //Setup blitting
-    rdpq_tex_blit(&surf, m_pos_x, m_pos_y, &blit_params);
+    rdpq_tex_blit(&surf, m_pos_x, m_pos_y, &blit_params, &blit_transform);
 }
 
 void Sprite::SetPos(float x, float y)

--- a/examples/pixelshader/pixelshader.c
+++ b/examples/pixelshader/pixelshader.c
@@ -98,13 +98,13 @@ int main(void) {
         
         // Draw the background
         rdpq_set_mode_copy(true);
-        rdpq_tex_blit(&bkgsurf, 0, 30, NULL);
+        rdpq_tex_blit(&bkgsurf, 0, 30, NULL, NULL);
 
         if (use_rdp) {
             // Draw the flare using RDP additive blending (will overflow)
             rdpq_set_mode_standard();
             rdpq_mode_blender(RDPQ_BLENDER_ADDITIVE);
-            rdpq_tex_blit(&flrsurf, 30, 60, NULL);
+            rdpq_tex_blit(&flrsurf, 30, 60, NULL, NULL);
             rdpq_detach_show();
         } else {
             // Detach the RDP.

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -88,7 +88,7 @@ void render(int cur_frame)
 
     for (uint32_t i = 0; i < num_objs; i++)
     {
-        rdpq_sprite_blit(brew_sprite, objects[i].x, objects[i].y, &(rdpq_blitparms_t){
+        rdpq_sprite_blit(brew_sprite, objects[i].x, objects[i].y, NULL, &(rdpq_blit_transform_t){
             .scale_x = objects[i].scale_factor, .scale_y = objects[i].scale_factor,
         });
     }

--- a/include/rdpq_sprite.h
+++ b/include/rdpq_sprite.h
@@ -18,6 +18,7 @@
 typedef struct sprite_s sprite_t;
 typedef struct rdpq_texparms_s rdpq_texparms_t;
 typedef struct rdpq_blitparms_s rdpq_blitparms_t;
+typedef struct rdpq_blit_transform_s rdpq_blit_transform_t;
 ///@endcond
 
 /**
@@ -75,11 +76,12 @@ int rdpq_sprite_upload(rdpq_tile_t tile, sprite_t *sprite, const rdpq_texparms_t
  * 
  * Please refer to #rdpq_tex_blit for a full overview of the features.
  * 
- * @param sprite    Sprite to blit
- * @param x0        X coordinate on the framebuffer where to draw the surface
- * @param y0        Y coordinate on the framebuffer where to draw the surface
- * @param parms     Parameters for the blit operation (or NULL for default)
+ * @param sprite        Sprite to blit
+ * @param x0            X coordinate on the framebuffer where to draw the surface
+ * @param y0            Y coordinate on the framebuffer where to draw the surface
+ * @param parms         Parameters for the blit operation (or NULL for default)
+ * @param transform     Transformation for the blit operation (or NULL for default)
  */
-void rdpq_sprite_blit(sprite_t *sprite, float x0, float y0, const rdpq_blitparms_t *parms);
+void rdpq_sprite_blit(sprite_t *sprite, float x0, float y0, const rdpq_blitparms_t *parms, const rdpq_blit_transform_t *transform);
 
 #endif

--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -199,7 +199,7 @@ void rdpq_tex_load_tlut(uint16_t *tlut, int color_idx, int num_colors);
 /**
  * @brief Blitting parameters for #rdpq_tex_blit.
  * 
- * This structure contains all possible parameters for #rdpq_tex_blit.
+ * This structure contains most of the possible parameters for #rdpq_tex_blit.
  * The various fields have been designed so that the 0 value is always the most
  * reasonable default. This means that you can simply initialize the structure
  * to 0 and then change only the fields you need (for instance, through a 
@@ -223,6 +223,17 @@ typedef struct rdpq_blitparms_s {
     bool filtering;     ///< True if texture filtering is enabled (activates workaround for filtering artifacts when splitting textures in chunks)
 } rdpq_blitparms_t;
 
+/**
+ * @brief Blitting transform parameters for #rdpq_tex_blit.
+ * 
+ * This structure contains the scaling and rotation parameters for #rdpq_tex_blit.
+ * These parameters allow controlling the size and angle of a blit onscreen. If the
+ * scale_x and scale_y fields are both 1.0f and the theta field is 0.0f this is
+ * equivalent to no transform at all.
+ * 
+ * See #rdpq_tex_blit for several examples.
+ */
+ 
 typedef struct rdpq_blit_transform_s {
     float scale_x;      ///< Horizontal scale factor to apply to the surface.
     float scale_y;      ///< Vertical scale factor to apply to the surface.

--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -218,17 +218,16 @@ typedef struct rdpq_blitparms_s {
 
     int cx;             ///< Transformation center (aka "hotspot") X coordinate, relative to (s0, t0). Used for all transformations
     int cy;             ///< Transformation center (aka "hotspot") X coordinate, relative to (s0, t0). Used for all transformations
-    float scale_x;      ///< Horizontal scale factor to apply to the surface. If 0, no scaling is performed (the same as 1.0f)
-    float scale_y;      ///< Vertical scale factor to apply to the surface. If 0, no scaling is performed (the same as 1.0f)
-    float theta;        ///< Rotation angle in radians
-
+    
     // FIXME: replace this with CPU tracking of filtering mode?
     bool filtering;     ///< True if texture filtering is enabled (activates workaround for filtering artifacts when splitting textures in chunks)
-
-    // FIXME: remove this?
-    int nx;             ///< Texture horizontal repeat count. If 0, no repetition is performed (the same as 1)
-    int ny;             ///< Texture vertical repeat count. If 0, no repetition is performed (the same as 1)
 } rdpq_blitparms_t;
+
+typedef struct rdpq_blit_transform_s {
+    float scale_x;      ///< Horizontal scale factor to apply to the surface.
+    float scale_y;      ///< Vertical scale factor to apply to the surface.
+    float theta;        ///< Rotation angle in radians
+} rdpq_blit_transform_t;
 
 /**
  * @brief Blit a surface to the active framebuffer
@@ -265,7 +264,7 @@ typedef struct rdpq_blitparms_s {
  * top-left corner (eg: a splashscreen).
  * 
  * @code{.c}
- *     rdpq_tex_blit(splashscreen, 0, 0, NULL);
+ *     rdpq_tex_blit(splashscreen, 0, 0, NULL, NULL);
  * @endcode
  * 
  * This is the same, but the image will be centered on the screen. To do this,
@@ -276,7 +275,7 @@ typedef struct rdpq_blitparms_s {
  *      rdpq_tex_blit(splashscreen, 320/2, 160/2, &(rdpq_blitparms_t){
  *          .cx = splashscreen->width / 2,
  *          .cy = splashscreen->height / 2,
- *      });
+ *      }, NULL);
  * @endcode
  * 
  * This examples scales a 64x64 image to 256x256, putting its center near the
@@ -285,6 +284,7 @@ typedef struct rdpq_blitparms_s {
  * @code{.c}
  *      rdpq_tex_blit(splashscreen, 20, 20, &(rdpq_blitparms_t){
  *          .cx = splashscreen->width / 2, .cy = splashscreen->height / 2,
+ *      }, &(rdpq_blit_transform_t) {
  *          .scale_x = 4.0f, .scale_y = 4.0f,
  *      });
  * @endcode
@@ -298,16 +298,19 @@ typedef struct rdpq_blitparms_s {
  *          .s0 = 32*2, .t0 = 32*4,
  *          .width = 32, .height = 32,
  *          .cx = 16, .cy = 16,
+ *     }, &(rdpq_blit_transform_t) {
+ *          .scale_x = 1.0f, .scale_y = 1.0f,
  *          .theta = M_PI/4,
- *     });
+ *      });
  * @endcode
  * 
- * @param surf           Surface to draw
- * @param x0             X coordinate on the framebuffer where to draw the surface
- * @param y0             Y coordinate on the framebuffer where to draw the surface
- * @param parms          Parameters for the blit operation (or NULL for default)
+ * @param surf			Surface to draw
+ * @param x0			X coordinate on the framebuffer where to draw the surface
+ * @param y0			Y coordinate on the framebuffer where to draw the surface
+ * @param parms			Parameters for the blit operation (or NULL for default)
+ * @param transform		Transformation for the blit operation (or NULL for default)
  */
-void rdpq_tex_blit(const surface_t *surf, float x0, float y0, const rdpq_blitparms_t *parms);
+void rdpq_tex_blit(const surface_t *surf, float x0, float y0, const rdpq_blitparms_t *parms, const rdpq_blit_transform_t *transform);
 
 
 #ifdef __cplusplus

--- a/src/rdpq/rdpq_sprite.c
+++ b/src/rdpq/rdpq_sprite.c
@@ -71,12 +71,12 @@ int rdpq_sprite_upload(rdpq_tile_t tile, sprite_t *sprite, const rdpq_texparms_t
     return nbytes;
 }
 
-void rdpq_sprite_blit(sprite_t *sprite, float x0, float y0, const rdpq_blitparms_t *parms)
+void rdpq_sprite_blit(sprite_t *sprite, float x0, float y0, const rdpq_blitparms_t *parms, const rdpq_blit_transform_t *transform)
 {
     // Upload the palette and configure the render mode
     sprite_upload_palette(sprite, 0);
 
     // Get the sprite surface
     surface_t surf = sprite_get_pixels(sprite);
-    rdpq_tex_blit(&surf, x0, y0, parms);
+    rdpq_tex_blit(&surf, x0, y0, parms, transform);
 }

--- a/tests/test_rdpq_tex.c
+++ b/tests/test_rdpq_tex.c
@@ -250,7 +250,7 @@ void test_rdpq_tex_blit_normal(TestContext *ctx)
                 LOG("    s0/t0/w: %d %d %d\n", s0, t0, width);
                 rdpq_tex_blit(&surf_full, 0, 0, &(rdpq_blitparms_t){
                     .s0 = s0, .width = width, .t0 = t0, .height = tex_width-t0,
-                });
+                }, NULL);
                 rspq_wait();
 
                 ASSERT_SURFACE(&fb, {


### PR DESCRIPTION
The scale_x, scale_y, and theta fields have been moved from rdpq_blitparms_t into a separate struct named rdpq_blit_transform_t which is passed as an additional parameter to rdpq_tex_blit and rdpq_sprite_blit as a pointer. Passing a NULL pointer for this parameter is equivalent to the scale_x and scale_y field of rdpq_blitparms_t being 1.0f and the theta field of rdpq_blitparms_t being 0.0f. The scale_x and scale_y fields no longer treat a value of 0.0f as being equal to 1.0f. The nx and ny fields of rdpq_blitparms_t have also been removed.