### PR TITLE
Adjust iQue Player CPU frequency, introduce `RCP_FREQUENCY`

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -23,6 +23,11 @@
 extern int __bbplayer;
 
 /**
+ * @brief Frequency of the RCP
+ */
+#define RCP_FREQUENCY    (__bbplayer ? 96000000 : 62500000)
+
+/**
  * @brief Frequency of the MIPS R4300 CPU
  */
 #define CPU_FREQUENCY    (__bbplayer ? 144000000 : 93750000)

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -25,8 +25,7 @@ extern int __bbplayer;
 /**
  * @brief Frequency of the MIPS R4300 CPU
  */
-#define CPU_FREQUENCY    (__bbplayer ? 140625000 : 93750000)
-
+#define CPU_FREQUENCY    (__bbplayer ? 144000000 : 93750000)
 
 /**
  * @brief void pointer to cached and non-mapped memory start address


### PR DESCRIPTION
Based on iQue Player reverse engineering efforts, it was noticed that the COP0 Count conversion performed in their SDK function to make N64 games work with minimal changes was `N64_COUNT = IQUE_COUNT * 125 / 192`. This strongly suggests that the iQue Player operates at exactly 144MHz instead of the commonly cited 140.625MHz if the conversion is to be accurate to N64. This PR updates the iQue Player CPU frequency to 144MHz.

Additionally, the COP0 Count and DP Clock registers were sampled on hardware (thanks @Jhynjhiruu for running this test a while back!) and their rates compared:
![clocks](https://github.com/DragonMinded/libdragon/assets/17233964/beb5e620-edff-4cff-821c-9141be786e25)
(note that this plot accounts for the fact that COP0 Count runs at half-PClock speed by multiplying the measured value by 2 prior to plotting)

The ratio is still `1 : 1.5` as on N64, suggesting that the RCP has been clocked up to 96MHz, contrary to the common belief that the RCP clock frequency was left unchanged. This PR also introduces `RCP_FREQUENCY` to resolve to the correct frequency value based on the detected console.
