### PR TITLE
Implement buffer loading functions for sprites/fonts

### DIFF
--- a/include/rdpq_font.h
+++ b/include/rdpq_font.h
@@ -9,6 +9,7 @@ struct rdpq_font_s;
 typedef struct rdpq_font_s rdpq_font_t;
 
 rdpq_font_t* rdpq_font_load(const char *fn);
+rdpq_font_t* rdpq_font_load_buf(void *buf, int sz);
 void rdpq_font_free(rdpq_font_t *fnt);
 
 void rdpq_font_begin(color_t color);

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -59,8 +59,9 @@ typedef struct sprite_s
     uint32_t data[0];
 } sprite_t;
 
-#define SPRITE_FLAGS_TEXFORMAT     0x1F  ///< Pixel format of the sprite
-#define SPRITE_FLAGS_EXT           0x80  ///< Sprite contains extended information (new format)
+#define SPRITE_FLAGS_TEXFORMAT      0x1F    ///< Pixel format of the sprite
+#define SPRITE_FLAGS_OWNEDBUFFER    0x20    ///< Flag specifying that the sprite buffer must be freed by sprite_free
+#define SPRITE_FLAGS_EXT            0x80    ///< Sprite contains extended information (new format)
 
 /**
  * @brief Load a sprite from a filesystem (eg: ROM)
@@ -77,6 +78,24 @@ typedef struct sprite_s
  * @return sprite_t*   The loaded sprite
  */
 sprite_t *sprite_load(const char *fn);
+
+/**
+ * @brief Load a sprite from a buffer
+ * 
+ * This function loads a sprite from a buffer corresponding to sprite
+ * file data in memory. The function also performs any necessary processing
+ * to load the sprite file data.
+ * 
+ * sprite_load_buf functions in-place which means it does not allocate another
+ * buffer for the loaded sprite. So, sprite_free will not remove the sprite data
+ * from memory. This means that the input buffer must be freed manually after
+ * sprite_free is called.
+ *
+ * @param buf           Pointer to the sprite file data
+ * @param sz            Size of the sprite file buffer (0=unknown)
+ * @return sprite_t*    The loaded sprite
+ */
+sprite_t *sprite_load_buf(void *buf, int sz);
 
 /** @brief Deallocate a sprite */
 void sprite_free(sprite_t *sprite);

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -92,7 +92,7 @@ sprite_t *sprite_load(const char *fn);
  * sprite_free is called.
  *
  * @param buf           Pointer to the sprite file data
- * @param sz            Size of the sprite file buffer (0=unknown)
+ * @param sz            Size of the sprite file buffer
  * @return sprite_t*    The loaded sprite
  */
 sprite_t *sprite_load_buf(void *buf, int sz);

--- a/src/rdpq/rdpq_font.c
+++ b/src/rdpq/rdpq_font.c
@@ -53,7 +53,9 @@ rdpq_font_t* rdpq_font_load_buf(void *buf, int sz)
         fnt->atlases[i].buf = PTR_DECODE(fnt, fnt->atlases[i].buf);
     }
     fnt->magic = FONT_MAGIC_LOADED;
-    data_cache_hit_writeback(fnt, sz);
+    if(sz != 0) {
+        data_cache_hit_writeback(fnt, sz);
+    }
     return fnt;
 }
 

--- a/src/rdpq/rdpq_font.c
+++ b/src/rdpq/rdpq_font.c
@@ -41,6 +41,7 @@ static rdpq_tile_t atlas_activate(atlas_t *atlas)
 rdpq_font_t* rdpq_font_load_buf(void *buf, int sz)
 {
     rdpq_font_t *fnt = buf;
+    assertf(sz >= sizeof(rdpq_font_t), "Font buffer too small (sz=%d)", sz);
     if(fnt->magic == FONT_MAGIC_LOADED) {
         assertf(0, "Trying to load already loaded font data (buf=%p, sz=%08x)", buf, sz);
     }
@@ -53,9 +54,7 @@ rdpq_font_t* rdpq_font_load_buf(void *buf, int sz)
         fnt->atlases[i].buf = PTR_DECODE(fnt, fnt->atlases[i].buf);
     }
     fnt->magic = FONT_MAGIC_LOADED;
-    if(sz != 0) {
-        data_cache_hit_writeback(fnt, sz);
-    }
+    data_cache_hit_writeback(fnt, sz);
     return fnt;
 }
 

--- a/src/rdpq/rdpq_font.c
+++ b/src/rdpq/rdpq_font.c
@@ -38,15 +38,6 @@ static rdpq_tile_t atlas_activate(atlas_t *atlas)
     return draw_ctx.atlas_tile;
 }
 
-static void atlas_flush_all(rdpq_font_t *fnt)
-{
-    for(uint32_t i=0; i<fnt->num_atlases; i++) {
-        atlas_t *atlas = &fnt->atlases[i];
-        int buf_size = atlas->height*TEX_FORMAT_PIX2BYTES(atlas->fmt, atlas->width);
-        data_cache_hit_writeback(atlas->buf, buf_size);
-    }
-}
-
 rdpq_font_t* rdpq_font_load_buf(void *buf, int sz)
 {
     rdpq_font_t *fnt = buf;
@@ -62,12 +53,7 @@ rdpq_font_t* rdpq_font_load_buf(void *buf, int sz)
         fnt->atlases[i].buf = PTR_DECODE(fnt, fnt->atlases[i].buf);
     }
     fnt->magic = FONT_MAGIC_LOADED;
-    if(sz == 0) {
-        atlas_flush_all(fnt);
-    } else {
-        data_cache_hit_writeback(fnt, sz);
-    }
-    
+    data_cache_hit_writeback(fnt, sz);
     return fnt;
 }
 

--- a/src/rdpq/rdpq_font.c
+++ b/src/rdpq/rdpq_font.c
@@ -75,6 +75,7 @@ static void font_unload(rdpq_font_t *fnt)
     fnt->glyphs = PTR_ENCODE(fnt, fnt->glyphs);
     fnt->atlases = PTR_ENCODE(fnt, fnt->atlases);
     fnt->kerning = PTR_ENCODE(fnt, fnt->kerning);
+    fnt->magic = FONT_MAGIC_V0;
 }
 
 void rdpq_font_free(rdpq_font_t *fnt)

--- a/src/rdpq/rdpq_font_internal.h
+++ b/src/rdpq/rdpq_font_internal.h
@@ -2,7 +2,13 @@
 #define __RDPQ_FONT_INTERNAL_H
 
 /** @brief font64 file magic header */
-#define FONT_MAGIC_V0            0x464E5448 // "FNT0"
+#define FONT_MAGIC_V0           0x464E5448 // "FNTH"
+
+/** @brief font64 loaded font buffer magic */
+#define FONT_MAGIC_LOADED       0x464E544C // "FNTL"
+
+/** @brief font64 owned font buffer magic */
+#define FONT_MAGIC_OWNED        0x464E544F // "FNTO"
 
 /** @brief A range of codepoint (part of #rdpq_font_t) */
 typedef struct {

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -67,7 +67,8 @@ static void flush_sprite_pixels(sprite_t *s)
     for(int i=0; i<8; i++) {
         surface_t surface = sprite_get_lod_pixels(s, i);
         if(surface.buffer) {
-            int buf_size = surface.height*TEX_FORMAT_PIX2BYTES(surface.format, surface.width);
+            tex_format_t format = surface_get_format(&surface);
+            int buf_size = surface.height*TEX_FORMAT_PIX2BYTES(format, surface.width);
             data_cache_hit_writeback(surface.buffer, buf_size);
         }
     }
@@ -95,14 +96,14 @@ sprite_t *sprite_load(const char *fn)
 {
     int sz;
     void *buf = asset_load(fn, &sz);
-    sprite_t *s = sprite_load_buf(buf, sz)
+    sprite_t *s = sprite_load_buf(buf, sz);
     s->flags |= SPRITE_FLAGS_OWNEDBUFFER;
     return s;
 }
 
 void sprite_free(sprite_t *s)
 {
-    if(sprite->flags & SPRITE_FLAGS_OWNEDBUFFER) {
+    if(s->flags & SPRITE_FLAGS_OWNEDBUFFER) {
         #ifndef NDEBUG
         //To help debugging, zero the sprite structure as well
         memset(s, 0, sizeof(sprite_t));

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -49,44 +49,11 @@ bool __sprite_upgrade(sprite_t *sprite)
     return false;
 }
 
-static void flush_sprite_palette(sprite_t *s)
-{
-    uint16_t *palette = sprite_get_palette(s);
-    if(palette) {
-        tex_format_t format = sprite_get_format(s);
-        int num_entries = 256;
-        if(format == FMT_CI4) {
-            num_entries = 16;
-        }
-        data_cache_hit_writeback(palette, num_entries*sizeof(uint16_t));
-    }
-}
-
-static void flush_sprite_pixels(sprite_t *s)
-{
-    for(int i=0; i<8; i++) {
-        surface_t surface = sprite_get_lod_pixels(s, i);
-        if(surface.buffer) {
-            tex_format_t format = surface_get_format(&surface);
-            int buf_size = surface.height*TEX_FORMAT_PIX2BYTES(format, surface.width);
-            data_cache_hit_writeback(surface.buffer, buf_size);
-        }
-    }
-}
-
-static void flush_sprite(sprite_t *s)
-{
-    flush_sprite_palette(s);
-    flush_sprite_pixels(s);
-}
-
 sprite_t *sprite_load_buf(void *buf, int sz)
 {
     sprite_t *s = buf;
     __sprite_upgrade(s);
-    if(sz == 0) {
-        flush_sprite(s);
-    } else {
+    if(sz != 0) {
         data_cache_hit_writeback(s, sz);
     }
     return s;

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -52,10 +52,9 @@ bool __sprite_upgrade(sprite_t *sprite)
 sprite_t *sprite_load_buf(void *buf, int sz)
 {
     sprite_t *s = buf;
+    assertf(sz >= sizeof(sprite_t), "Sprite buffer too small (sz=%d)", sz);
     __sprite_upgrade(s);
-    if(sz != 0) {
-        data_cache_hit_writeback(s, sz);
-    }
+    data_cache_hit_writeback(s, sz);
     return s;
 }
 


### PR DESCRIPTION
The functions take in a pointer to a buffer and a size and return the buffer used for the sprite or font. Loading using these functions means that the buffer will be made reloadable when calling their free functions.