### PR TITLE
libdragon build Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,11 @@ install-mk: $(INSTALLDIR)/include/n64.mk
 $(INSTALLDIR)/include/n64.mk: n64.mk
 # Always update timestamp of n64.mk. This make sure that further targets
 # depending on install-mk won't always try to re-install it.
+	mkdir -p $(INSTALLDIR)/include
 	install -cv -m 0644 n64.mk $(INSTALLDIR)/include/n64.mk
 
 install: install-mk libdragon
+	mkdir -p $(INSTALLDIR)/mips64-elf/lib
 	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a
 	install -Cv -m 0644 n64.ld $(INSTALLDIR)/mips64-elf/lib/n64.ld
 	install -Cv -m 0644 rsp.ld $(INSTALLDIR)/mips64-elf/lib/rsp.ld

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ BUILD_DIR = build
 include n64.mk
 INSTALLDIR = $(N64_INST)
 
-LIBDRAGON_CFLAGS = -I$(CURDIR)/src -I$(CURDIR)/include -ffile-prefix-map=$(CURDIR)=libdragon
+# Don't use the installed include files (e.g. /opt/libdragon/mips64-elf/include) for building libdragon,
+# use the source ones instead (./include)
+N64_INCLUDEDIR = $(CURDIR)/include
+
+LIBDRAGON_CFLAGS = -I$(CURDIR)/src -ffile-prefix-map=$(CURDIR)=libdragon
 
 # Activate N64 toolchain for libdragon build
 libdragon: CC=$(N64_CC)

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ BUILD_DIR = build
 include n64.mk
 INSTALLDIR = $(N64_INST)
 
-# Don't use the installed include files (e.g. /opt/libdragon/mips64-elf/include) for building libdragon,
-# use the source ones instead (./include)
+# N64_INCLUDEDIR is normally (when building roms) a path to the installed include files
+# (e.g. /opt/libdragon/mips64-elf/include), set in n64.mk
+# When building libdragon, override it to use the source include files instead (./include)
 N64_INCLUDEDIR = $(CURDIR)/include
 
 LIBDRAGON_CFLAGS = -I$(CURDIR)/src -ffile-prefix-map=$(CURDIR)=libdragon

--- a/n64.mk
+++ b/n64.mk
@@ -62,7 +62,7 @@ CXXFLAGS+=-MMD
 ASFLAGS+=-MMD
 RSPASFLAGS+=-MMD
 
-N64_CXXFLAGS := $(N64_CFLAGS)
+N64_CXXFLAGS = $(N64_CFLAGS)
 N64_CFLAGS += -std=gnu99
 
 # Change all the dependency chain of z64 ROMs to use the N64 toolchain.

--- a/n64.mk
+++ b/n64.mk
@@ -35,10 +35,12 @@ N64_TOOL = $(N64_BINDIR)/n64tool
 N64_SYM = $(N64_BINDIR)/n64sym
 N64_AUDIOCONV = $(N64_BINDIR)/audioconv64
 
-N64_CFLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
-N64_CFLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
-N64_CFLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map=$(CURDIR)=
-N64_CFLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
+N64_C_AND_CXX_FLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
+N64_C_AND_CXX_FLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
+N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map=$(CURDIR)=
+N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
+N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu99
+N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS)
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_LDFLAGS = -g -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections --wrap __do_global_ctors
@@ -61,9 +63,6 @@ CFLAGS+=-MMD
 CXXFLAGS+=-MMD
 ASFLAGS+=-MMD
 RSPASFLAGS+=-MMD
-
-N64_CXXFLAGS = $(N64_CFLAGS)
-N64_CFLAGS += -std=gnu99
 
 # Change all the dependency chain of z64 ROMs to use the N64 toolchain.
 %.z64: CC=$(N64_CC)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,6 +4,7 @@ all: chksum64 dumpdfs ed64romconfig mkdfs mksprite n64tool n64sym audioconv64
 
 .PHONY: install
 install: all
+	mkdir -p $(INSTALLDIR)/bin
 	install -m 0755 chksum64 ed64romconfig n64tool n64sym $(INSTALLDIR)/bin
 	$(MAKE) -C dumpdfs install
 	$(MAKE) -C mkdfs install


### PR DESCRIPTION
# Remove installed headers from the include path when building libdragon

```c
    [CC] src/debug.c
In file included from src/debug.c:21:
/home/dragorn421/Documents/libragon/install/mips64-elf/include/usb.h:80:12: error: unknown type name 'u32'
   80 |     extern u32 usb_poll(void);
      |            ^~~
make: *** [n64.mk:151: build/debug.o] Error 1
```
I'm not inquiring about the error, I caused it and can fix it and understand why it's there,
but
why is it including `/home/dragorn421/Documents/libragon/install/mips64-elf/include/usb.h` instead of `/home/dragorn421/Documents/libragon/include/usb.h`=`./include/usb.h`

this is fixed e.g. by
- moving the "local" include path in front of the other args which include the include path under `$(N64_INST)`
```diff
$ git diff Makefile
diff --git a/Makefile b/Makefile
index 0acfd4b8..04dbb1c1 100755
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ libdragon: CC=$(N64_CC)
 libdragon: CXX=$(N64_CXX)
 libdragon: AS=$(N64_AS)
 libdragon: LD=$(N64_LD)
-libdragon: CFLAGS+=$(N64_CFLAGS) $(LIBDRAGON_CFLAGS)
+libdragon: CFLAGS+=$(LIBDRAGON_CFLAGS) $(N64_CFLAGS)
 libdragon: CXXFLAGS+=$(N64_CXXFLAGS) $(LIBDRAGON_CFLAGS)
 libdragon: ASFLAGS+=$(N64_ASFLAGS) $(LIBDRAGON_CFLAGS)
 libdragon: RSPASFLAGS+=$(N64_RSPASFLAGS) $(LIBDRAGON_CFLAGS)
```
- or no-op-ifying the `-I$(N64_INCLUDEDIR)` in `N64_CFLAGS`:
```diff
$ git diff Makefile
diff --git a/Makefile b/Makefile
index 0acfd4b8..f17e4ef4 100755
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BUILD_DIR = build
 include n64.mk
 INSTALLDIR = $(N64_INST)
 
+N64_INCLUDEDIR = _somenamethatdoesntexist_
 LIBDRAGON_CFLAGS = -I$(CURDIR)/src -I$(CURDIR)/include -ffile-prefix-map=$(CURDIR)=libdragon
 
 # Activate N64 toolchain for libdragon build
```

TLDR should libdragon have `$(N64_INST)/mips64-elf/include` on its include path (it currently does and it's earlier than the rest of the include path)

Rasky said probably not and I agree

I went with another way to fix it in the PR, have N64_INCLUDEDIR point to the source includes (whereas typically it points to the installed includes)

# Add mkdir-ing install folders

This is an issue when N64_INST != N64_GCCPREFIX and installing libdragon to a N64_INST where gcc/binutils hasn't been installed