### PR TITLE
display: Add option to set half or full interlaced video mode

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -46,6 +46,16 @@ typedef struct surface_s surface_t;
  * @{
  */
 
+/** @brief Valid interlace modes */
+typedef enum {
+    /** @brief Video output is not interlaced */
+    INTERLACE_OFF,
+    /** @brief Video output is interlaced and buffer is swapped on odd and even fields */
+    INTERLACE_HALF,
+    /** @brief Video output is interlaced and buffer is swapped only on even fields */
+    INTERLACE_FULL,
+} interlace_mode_t;
+
 /**
  * @brief Video resolution structure
  *
@@ -57,25 +67,25 @@ typedef struct {
     int32_t width;
     /** @brief Screen height (must be between 1 and 600) */
     int32_t height;
-    /** @brief True if interlaced mode enabled */
-    bool interlaced;
+    /** @brief Interlace mode */
+    interlace_mode_t interlaced;
 } resolution_t;
 
 ///@cond
 #define const static const /* fool doxygen to document these static members */
 ///@endcond
 /** @brief 256x240 mode */
-const resolution_t RESOLUTION_256x240 = {256, 240, false};
+const resolution_t RESOLUTION_256x240 = {256, 240, INTERLACE_OFF};
 /** @brief 320x240 mode */
-const resolution_t RESOLUTION_320x240 = {320, 240, false};
+const resolution_t RESOLUTION_320x240 = {320, 240, INTERLACE_OFF};
 /** @brief 512x240 mode, high-res progressive */
-const resolution_t RESOLUTION_512x240 = {512, 240, false};
+const resolution_t RESOLUTION_512x240 = {512, 240, INTERLACE_OFF};
 /** @brief 640x240 mode, high-res progressive */
-const resolution_t RESOLUTION_640x240 = {640, 240, false};
+const resolution_t RESOLUTION_640x240 = {640, 240, INTERLACE_OFF};
 /** @brief 512x480 mode, interlaced */
-const resolution_t RESOLUTION_512x480 = {512, 480, true};
+const resolution_t RESOLUTION_512x480 = {512, 480, INTERLACE_HALF};
 /** @brief 640x480 mode, interlaced */
-const resolution_t RESOLUTION_640x480 = {640, 480, true};
+const resolution_t RESOLUTION_640x480 = {640, 480, INTERLACE_HALF};
 #undef const
 
 /** @brief Valid bit depths */

--- a/src/display.c
+++ b/src/display.c
@@ -84,6 +84,8 @@ static uint32_t __bitdepth;
 static uint32_t __width;
 /** @brief Currently active video height (calculated) */
 static uint32_t __height;
+/** @brief Currently active video interlace mode */
+static interlace_mode_t __interlace_mode = INTERLACE_OFF;
 /** @brief Number of active buffers */
 static uint32_t __buffers = NUM_BUFFERS;
 /** @brief Pointer to uncached 16-bit aligned version of buffers */
@@ -173,11 +175,14 @@ static void __display_callback()
     bool interlaced = reg_base[0] & (1<<6);
 
     /* Check if the next buffer is ready to be displayed, otherwise just
-       leave up the current frame */
-    int next = buffer_next(now_showing);
-    if (ready_mask & (1 << next)) {
-        now_showing = next;
-        ready_mask &= ~(1 << next);
+       leave up the current frame. If full interlace mode is selected
+       then don't update the buffer until two fields were displayed. */
+    if (!(__interlace_mode == INTERLACE_FULL && field)) {
+        int next = buffer_next(now_showing);
+        if (ready_mask & (1 << next)) {
+            now_showing = next;
+            ready_mask &= ~(1 << next);
+        }
     }
 
     __write_dram_register(__safe_buffer[now_showing] + (interlaced && !field ? __width * __bitdepth : 0));
@@ -196,7 +201,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     __buffers = MAX(1, MIN(NUM_BUFFERS, num_buffers));
 
 
-    if( res.interlaced )
+    if( res.interlaced != INTERLACE_OFF )
     {
         /* Serrate on to stop vertical jitter */
         control |= 0x40;
@@ -301,6 +306,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     __width = res.width;
     __height = res.height;
     __bitdepth = ( bit == DEPTH_16_BPP ) ? 2 : 4;
+    __interlace_mode = res.interlaced;
 
     surfaces = malloc(sizeof(surface_t) * __buffers);
 


### PR DESCRIPTION
This PR adds option to set "half" and "full" interlaced video modes in `display_init` function. `INTERLACE_HALF` behaves the same way as old setting (`interlaced = true`) and means that `display_try_get` returns new free buffer even if only half of the screen was displayed. `INTERLACE_FULL` on the other hand halves the refresh rate allowing to display whole 640x480 buffer to the screen split into two fields.