### PR TITLE
Add dithering mode support to OpenGL

### DIFF
--- a/include/GL/gl.h
+++ b/include/GL/gl.h
@@ -7,6 +7,7 @@
 typedef struct surface_s surface_t;
 typedef struct sprite_s sprite_t;
 typedef struct rdpq_texparms_s rdpq_texparms_t;
+typedef enum   rdpq_dither_s rdpq_dither_t;
 
 #include <GL/gl_enums.h>
 
@@ -24,6 +25,7 @@ typedef struct rdpq_texparms_s rdpq_texparms_t;
 #define GL_N64_half_fixed_point         1
 #define GL_N64_reduced_aliasing         1
 #define GL_N64_interpenetrating         1
+#define GL_N64_dither_mode              1
 
 /* Data types */
 
@@ -471,6 +473,10 @@ void glFogf(GLenum pname, GLfloat param);
 
 void glFogiv(GLenum pname, const GLint *params);
 void glFogfv(GLenum pname, const GLfloat *params);
+
+/* Dithering */
+
+void glDitherModeN64(rdpq_dither_t mode);
 
 /* Scissor test */
 

--- a/src/GL/gl.c
+++ b/src/GL/gl.c
@@ -131,6 +131,8 @@ void gl_init()
     server_state->light_ambient[2] = 0x1999; // 0.2
     server_state->light_ambient[3] = 0x7FFF; // 1.0
 
+    server_state->dither_mode = (SOM_RGBDITHER_SQUARE | SOM_ALPHADITHER_SAME) >> 32;
+
     gl_overlay_id = rspq_overlay_register(&rsp_gl);
     glp_overlay_id = rspq_overlay_register(&rsp_gl_pipeline);
     gl_rsp_state = PhysicalAddr(rspq_overlay_get_state(&rsp_gl));
@@ -417,6 +419,10 @@ void glClearDepth(GLclampd d)
     
     color_t clear_depth = color_from_packed16(d * 0xFFFC);
     gl_set_word(GL_UPDATE_NONE, offsetof(gl_server_state_t, clear_depth), color_to_packed32(clear_depth));
+}
+
+void glDitherModeN64(rdpq_dither_t mode){
+    gl_set_word(GL_UPDATE_NONE, offsetof(gl_server_state_t, dither_mode), mode);
 }
 
 void glFlush(void)

--- a/src/GL/gl.c
+++ b/src/GL/gl.c
@@ -131,7 +131,7 @@ void gl_init()
     server_state->light_ambient[2] = 0x1999; // 0.2
     server_state->light_ambient[3] = 0x7FFF; // 1.0
 
-    server_state->dither_mode = (SOM_RGBDITHER_SQUARE | SOM_ALPHADITHER_SAME) >> 32;
+    server_state->dither_mode = DITHER_SQUARE_SQUARE << (SOM_ALPHADITHER_SHIFT - 32);
 
     gl_overlay_id = rspq_overlay_register(&rsp_gl);
     glp_overlay_id = rspq_overlay_register(&rsp_gl_pipeline);
@@ -422,7 +422,7 @@ void glClearDepth(GLclampd d)
 }
 
 void glDitherModeN64(rdpq_dither_t mode){
-    gl_set_word(GL_UPDATE_NONE, offsetof(gl_server_state_t, dither_mode), mode);
+    gl_set_word(GL_UPDATE_NONE, offsetof(gl_server_state_t, dither_mode), mode << (SOM_ALPHADITHER_SHIFT - 32));
 }
 
 void glFlush(void)

--- a/src/GL/gl_internal.h
+++ b/src/GL/gl_internal.h
@@ -544,6 +544,7 @@ typedef struct {
     uint32_t clear_color;
     uint32_t clear_depth;
     uint32_t palette_ptr;
+    uint32_t dither_mode;
     uint16_t fb_size[2];
     uint16_t depth_func;
     uint16_t alpha_func;

--- a/src/GL/rsp_gl.S
+++ b/src/GL/rsp_gl.S
@@ -682,7 +682,6 @@ gl_matrix_palette_loop:
     beqz t1, 1f
     li t0, (SOM_RGBDITHER_NONE | SOM_ALPHADITHER_NONE) >> 32
     lw t0, %lo(GL_STATE_DITHER_MODE)
-    sll t0, SOM_ALPHADITHER_SHIFT - 32
 1:
     or modes0, t0
 

--- a/src/GL/rsp_gl.S
+++ b/src/GL/rsp_gl.S
@@ -40,6 +40,7 @@
     GL_STATE_FILL_COLOR:    .word   0
     GL_STATE_FILL_DEPTH:    .word   0
     GL_STATE_PALETTE_PTR:   .word   0
+    GL_STATE_DITHER_MODE:   .word   0
     GL_STATE_FB_SIZE:       .half   0, 0
     GL_STATE_DEPTH_FUNC:    .half   0
     GL_STATE_ALPHA_FUNC:    .half   0
@@ -680,7 +681,8 @@ gl_matrix_palette_loop:
     andi t1, state_flags, FLAG_DITHER
     beqz t1, 1f
     li t0, (SOM_RGBDITHER_NONE | SOM_ALPHADITHER_NONE) >> 32
-    li t0, (SOM_RGBDITHER_SQUARE | SOM_ALPHADITHER_SAME) >> 32
+    lw t0, %lo(GL_STATE_DITHER_MODE)
+    sll t0, SOM_ALPHADITHER_SHIFT - 32
 1:
     or modes0, t0
 


### PR DESCRIPTION
OGL only has a single toggle to enable/disable dithering, this N64 extension exposes a dither mode controlled by rdpq_dither_t, the same that is used in rdpq