### PR TITLE
fix inverted NULL check in n64dso

### DIFF
--- a/tools/n64dso/n64dso.c
+++ b/tools/n64dso/n64dso.c
@@ -113,7 +113,7 @@ elf_info_t *elf_info_init(const char *filename)
 void elf_info_free(elf_info_t *elf_info)
 {
     //Close attached file
-    if(!elf_info->file) {
+    if(elf_info->file) {
         fclose(elf_info->file);
     }
     //Free symbol arrays


### PR DESCRIPTION
In the n64dso tool, there is a line of code that checks if a file is null before closing it. Instead of closing if the file is not null, it only closes if the file *is* null, which should not be the case, and causes this tool to fail to compile for me. This small fix removes this error.