### PR TITLE
Revamped display antialiasing options into filters

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -401,7 +401,7 @@ int main(void) {
 	debug_init_isviewer();
 	debug_init_usblog();
 
-	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 	dfs_init(DFS_DEFAULT_LOCATION);
 
 	char sbuf[1024];

--- a/examples/customfont/customfont.c
+++ b/examples/customfont/customfont.c
@@ -7,7 +7,7 @@
 int main(void)
 {
     /* Initialize peripherals */
-    display_init( RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
     dfs_init( DFS_DEFAULT_LOCATION );
     rdp_init();
     controller_init();

--- a/examples/loadspritefromsd/loadspritefromsd.c
+++ b/examples/loadspritefromsd/loadspritefromsd.c
@@ -67,7 +67,7 @@ void load_sprite(int id) {
 
 int main(void) {
 	/* Initialize peripherals */
-	display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+	display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
 	dfs_init(DFS_DEFAULT_LOCATION);
 	controller_init();
 

--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -9,7 +9,7 @@ int main(void) {
 	debug_init_usblog();
 	debug_init_isviewer();
 	controller_init();
-	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 
 	int ret = dfs_init(DFS_DEFAULT_LOCATION);
 	assert(ret == DFS_ESUCCESS);

--- a/examples/rtctest/rtctest.c
+++ b/examples/rtctest/rtctest.c
@@ -210,7 +210,7 @@ void update_joystick_directions( void )
 
 int main(void)
 {
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
     controller_init();
     timer_init();
 

--- a/examples/spritemap/spritemap.c
+++ b/examples/spritemap/spritemap.c
@@ -16,7 +16,7 @@ int main(void)
     int mode = 0;
 
     /* Initialize peripherals */
-    display_init( RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
     dfs_init( DFS_DEFAULT_LOCATION );
     rdp_init();
     controller_init();

--- a/examples/test/test.c
+++ b/examples/test/test.c
@@ -38,7 +38,7 @@ sprite_t *read_sprite( const char * const spritename )
 int main(void)
 {
     /* Initialize peripherals */
-    display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
     dfs_init( DFS_DEFAULT_LOCATION );
     controller_init();
 
@@ -127,7 +127,7 @@ int main(void)
             display_close();
 
             res = RESOLUTION_640x480;
-            display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
 
         if( keys.c[0].down )
@@ -135,7 +135,7 @@ int main(void)
             display_close();
 
             res = RESOLUTION_320x240;
-            display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
 
         if( keys.c[0].left )
@@ -143,7 +143,7 @@ int main(void)
             display_close();
 
             bit = DEPTH_16_BPP;
-            display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
 
         if( keys.c[0].right )
@@ -151,7 +151,7 @@ int main(void)
             display_close();
 
             bit = DEPTH_32_BPP;
-            display_init( res, bit, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
     }
 }

--- a/examples/vtest/vtest.c
+++ b/examples/vtest/vtest.c
@@ -103,7 +103,7 @@ void delay(int cnt)
 void init_n64(void)
 {
     /* Initialize peripherals */
-    display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
 
     register_VI_handler(vblCallback);
 
@@ -203,7 +203,7 @@ int main(void)
 				res++;
 				res %= 6;
 				display_close();
-				display_init(mode[res], DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+				display_init(mode[res], DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
 			}
 		}
 

--- a/include/display.h
+++ b/include/display.h
@@ -98,7 +98,16 @@ typedef enum
     GAMMA_CORRECT_DITHER
 } gamma_t;
 
-/** @brief Valid display filter options */
+/** @brief Valid display filter options.
+ * 
+ * Libdragon uses preconfigured options for enabling certain 
+ * combinations of Video Interface filters due to a large number of wrong/invalid configurations 
+ * with very strict conditions, and to simplify the options for the user.
+ * 
+ * Like for example antialiasing requiring resampling; dedithering not working with 
+ * resampling, unless always fetching; always enabling divot filter under AA etc.
+ * 
+ * The options below provide all possible configurations that are deemed useful in development. */
 typedef enum
 {
     /** @brief All display filters are disabled */
@@ -108,6 +117,8 @@ typedef enum
      * (which is always NTSC 640x480 or PAL 640x512). 
      * This option enables a bilinear interpolation that can be used during this resize. */
     FILTERS_RESAMPLE,
+    /** @brief Reconstruct a 32-bit output from dithered 16-bit framebuffer. */
+    FILTERS_DEDITHER,
     /** @brief Resize the output image with a bilinear filter (see #FILTERS_RESAMPLE). 
      * Add a video interface anti-aliasing pass with a divot filter. 
      * To be able to see correct anti-aliased output, this display filter must be enabled,

--- a/include/display.h
+++ b/include/display.h
@@ -119,6 +119,7 @@ typedef enum
     FILTERS_RESAMPLE_ANTIALIAS_DEDITHER
 } filter_options_t;
 
+///@cond
 /** 
  * @brief Display anti-aliasing options (DEPRECATED: Use #filter_options_t instead)
  * 
@@ -145,6 +146,8 @@ typedef filter_options_t antialias_t;
  * @see #filter_options_t
  */
 #define ANTIALIAS_RESAMPLE_FETCH_ALWAYS FILTERS_RESAMPLE_ANTIALIAS_DEDITHER
+
+///@endcond
 
 /** 
  * @brief Display context (DEPRECATED: Use #surface_t instead)

--- a/include/display.h
+++ b/include/display.h
@@ -89,26 +89,62 @@ typedef enum
 /** @brief Valid gamma correction settings */
 typedef enum
 {
-    /** @brief Uncorrected gamma */
+    /** @brief Uncorrected gamma, should be used by default and with assets built by libdragon tools */
     GAMMA_NONE,
-    /** @brief Corrected gamma */
+    /** @brief Corrected gamma, should be used on a 32-bit framebuffer
+     * only if linear color space and accurate blending is important */
     GAMMA_CORRECT,
-    /** @brief Corrected gamma with hardware dither */
+    /** @brief Corrected gamma with hardware dithered output */
     GAMMA_CORRECT_DITHER
 } gamma_t;
 
-/** @brief Valid antialiasing settings */
+/** @brief Valid display filter options */
 typedef enum
 {
-    /** @brief No anti-aliasing */
-    ANTIALIAS_OFF,
-    /** @brief Resampling anti-aliasing */
-    ANTIALIAS_RESAMPLE,
-    /** @brief Anti-aliasing and resampling with fetch-on-need */
-    ANTIALIAS_RESAMPLE_FETCH_NEEDED,
-    /** @brief Anti-aliasing and resampling with fetch-always */
-    ANTIALIAS_RESAMPLE_FETCH_ALWAYS
-} antialias_t;
+    /** @brief All display filters are disabled */
+    FILTERS_DISABLED,
+    /** @brief Resize the output image with a bilinear filter. 
+     * In general, VI is in charge of resizing the framebuffer to fit the TV resolution 
+     * (which is always NTSC 640x480 or PAL 640x512). 
+     * This option enables a bilinear interpolation that can be used during this resize. */
+    FILTERS_RESAMPLE,
+    /** @brief Resize the output image with a bilinear filter (see #FILTERS_RESAMPLE). 
+     * Add a video interface anti-aliasing pass with a divot filter. 
+     * To be able to see correct anti-aliased output, this display filter must be enabled,
+     * along with anti-aliased rendering of surfaces. */
+    FILTERS_RESAMPLE_ANTIALIAS,
+    /** @brief Resize the output image with a bilinear filter (see #FILTERS_RESAMPLE). 
+     * Add a video interface anti-aliasing pass with a divot filter (see #FILTERS_RESAMPLE_ANTIALIAS).
+     * Reconstruct a 32-bit output from dithered 16-bit framebuffer. */
+    FILTERS_RESAMPLE_ANTIALIAS_DEDITHER
+} filter_options_t;
+
+/** 
+ * @brief Display anti-aliasing options (DEPRECATED: Use #filter_options_t instead)
+ * 
+ * @see #filter_options_t
+ */
+typedef filter_options_t antialias_t;
+/** @brief Display no anti-aliasing (DEPRECATED: Use #FILTERS_DISABLED instead)
+ * 
+ * @see #filter_options_t
+ */
+#define ANTIALIAS_OFF                   FILTERS_DISABLED
+/** @brief Display resampling anti-aliasing (DEPRECATED: Use #FILTERS_RESAMPLE instead)
+ * 
+ * @see #filter_options_t
+ */
+#define ANTIALIAS_RESAMPLE              FILTERS_RESAMPLE
+/** @brief Display anti-aliasing and resampling with fetch-on-need (DEPRECATED: Use #FILTERS_RESAMPLE_ANTIALIAS instead)
+ * 
+ * @see #filter_options_t
+ */
+#define ANTIALIAS_RESAMPLE_FETCH_NEEDED FILTERS_RESAMPLE_ANTIALIAS
+/** @brief Display anti-aliasing and resampling with fetch-always (DEPRECATED: Use #FILTERS_RESAMPLE_ANTIALIAS_DEDITHER instead)
+ * 
+ * @see #filter_options_t
+ */
+#define ANTIALIAS_RESAMPLE_FETCH_ALWAYS FILTERS_RESAMPLE_ANTIALIAS_DEDITHER
 
 /** 
  * @brief Display context (DEPRECATED: Use #surface_t instead)
@@ -139,10 +175,10 @@ extern "C" {
  *            so that slowdowns don't impact too much.
  * @param[in] gamma
  *            The requested gamma setting
- * @param[in] aa
- *            The requested anti-aliasing setting
+ * @param[in] filters
+ *            The requested display filtering options, see #filter_options_t
  */
-void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, antialias_t aa );
+void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, filter_options_t filters );
 
 /**
  * @brief Close the display

--- a/include/display.h
+++ b/include/display.h
@@ -92,7 +92,7 @@ typedef enum
     /** @brief Uncorrected gamma, should be used by default and with assets built by libdragon tools */
     GAMMA_NONE,
     /** @brief Corrected gamma, should be used on a 32-bit framebuffer
-     * only if linear color space and accurate blending is important */
+     * only when assets have been produced in linear color space and accurate blending is important */
     GAMMA_CORRECT,
     /** @brief Corrected gamma with hardware dithered output */
     GAMMA_CORRECT_DITHER

--- a/include/vi.h
+++ b/include/vi.h
@@ -114,20 +114,20 @@ static const vi_config_t vi_config_presets[2][3] = {
 #define VI_TV_TYPES_INTERLACE 3
 
 /** Under VI_CTRL */
-#define VI_DEDITHER_FILTER_ENABLE           1<<16
-#define VI_PIXEL_ADVANCE_DEFAULT            0b0011 << 12
-#define VI_PIXEL_ADVANCE_BBPLAYER           0b0001 << 12
-#define VI_AA_MODE_NONE                     0b11 << 8
-#define VI_AA_MODE_RESAMPLE                 0b10 << 8
-#define VI_AA_MODE_RESAMPLE_FETCH_NEEDED    0b01 << 8
-#define VI_AA_MODE_RESAMPLE_FETCH_ALWAYS    0b00 << 8
-#define VI_CTRL_SERRATE                     1<<6
-#define VI_DIVOT_ENABLE                     1<<4
-#define VI_GAMMA_ENABLE                     1<<3
-#define VI_GAMMA_DITHER_ENABLE              1<<2
-#define VI_CTRL_TYPE_32_BIT                 0b11
-#define VI_CTRL_TYPE_16_BIT                 0b10
-#define VI_CTRL_TYPE_BLANK                  0b00
+#define VI_DEDITHER_FILTER_ENABLE           (1<<16)
+#define VI_PIXEL_ADVANCE_DEFAULT            (0b0011 << 12)
+#define VI_PIXEL_ADVANCE_BBPLAYER           (0b0001 << 12)
+#define VI_AA_MODE_NONE                     (0b11 << 8)
+#define VI_AA_MODE_RESAMPLE                 (0b10 << 8)
+#define VI_AA_MODE_RESAMPLE_FETCH_NEEDED    (0b01 << 8)
+#define VI_AA_MODE_RESAMPLE_FETCH_ALWAYS    (0b00 << 8)
+#define VI_CTRL_SERRATE                     (1<<6)
+#define VI_DIVOT_ENABLE                     (1<<4)
+#define VI_GAMMA_ENABLE                     (1<<3)
+#define VI_GAMMA_DITHER_ENABLE              (1<<2)
+#define VI_CTRL_TYPE_32_BIT                 (0b11)
+#define VI_CTRL_TYPE_16_BIT                 (0b10)
+#define VI_CTRL_TYPE_BLANK                  (0b00)
 
 /** Under VI_ORIGIN  */
 #define VI_ORIGIN_SET(value)      ((value & 0xFFFFFF) << 0)

--- a/include/vi.h
+++ b/include/vi.h
@@ -160,7 +160,7 @@ static const vi_config_t vi_config_presets[2][3] = {
 #define VI_HSYNC_WIDTH_PAL                  58
 
 /**  Under VI_X_SCALE   */
-#define VI_X_SCALE_SET(value)               (( 1024*value + 320 ) / 640)
+#define VI_X_SCALE_SET(value)               (( 1024*(value) + 320 ) / 640)
 
 /**  Under VI_Y_SCALE   */
 #define VI_Y_SCALE_SET(value)               (( 1024*value + 120 ) / 240)

--- a/include/vi.h
+++ b/include/vi.h
@@ -163,7 +163,7 @@ static const vi_config_t vi_config_presets[2][3] = {
 #define VI_X_SCALE_SET(value)               (( 1024*(value) + 320 ) / 640)
 
 /**  Under VI_Y_SCALE   */
-#define VI_Y_SCALE_SET(value)               (( 1024*value + 120 ) / 240)
+#define VI_Y_SCALE_SET(value)               (( 1024*(value) + 120 ) / 240)
 
 /**
  * @brief Write a set of video registers to the VI

--- a/include/vi.h
+++ b/include/vi.h
@@ -66,7 +66,7 @@ volatile vi_register_t* VI_X_SCALE      =  &((volatile vi_register_t*)VI_REGISTE
 volatile vi_register_t* VI_Y_SCALE      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[13];
 
 /** @brief VI register by index (0-13)*/
-#define VI_TO_REGISTER(index) ((index >= 0 && index <= VI_REGISTERS_COUNT)? &VI_REGISTERS[index] : NULL)
+#define VI_TO_REGISTER(index) (((index) >= 0 && (index) <= VI_REGISTERS_COUNT)? &VI_REGISTERS[index] : NULL)
 
 /** @brief VI index from register */
 #define VI_TO_INDEX(reg) ((reg - VI_REGISTERS));

--- a/include/vi.h
+++ b/include/vi.h
@@ -34,36 +34,36 @@ typedef struct vi_config_s{
     vi_register_t regs[VI_REGISTERS_COUNT];
 } vi_config_t;
 
-volatile vi_register_t* VI_REGISTERS  =  ((volatile vi_register_t*)VI_REGISTERS_ADDR);
+volatile vi_register_t* VI_REGISTERS    =  ((volatile vi_register_t*)VI_REGISTERS_ADDR);
 /** @brief VI Index register of controlling general display filters/bitdepth configuration */
-#define VI_CTRL        (&VI_REGISTERS[0])
+volatile vi_register_t* VI_CTRL         =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[0];
 /** @brief VI Index register of RDRAM base address of the video output Frame Buffer. This can be changed as needed to implement double or triple buffering. */
-#define VI_ORIGIN       (&VI_REGISTERS[1])
+volatile vi_register_t* VI_ORIGIN       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[1];
 /** @brief VI Index register of width in pixels of the frame buffer. */
-#define VI_WIDTH        (&VI_REGISTERS[2])
+volatile vi_register_t* VI_WIDTH        =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[2];
 /** @brief VI Index register of vertical interrupt. */
-#define VI_V_INTR       (&VI_REGISTERS[3])
+volatile vi_register_t* VI_V_INTR       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[3];
 /** @brief VI Index register of the current half line, sampled once per line. */
-#define VI_V_CURRENT    (&VI_REGISTERS[4])
+volatile vi_register_t* VI_V_CURRENT    =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[4];
 /** @brief VI Index register of sync/burst values */
-#define VI_BURST        (&VI_REGISTERS[5])
+volatile vi_register_t* VI_BURST        =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[5];
 /** @brief VI Index register of total visible and non-visible lines. 
  * This should match either NTSC (non-interlaced: 0x20D, interlaced: 0x20C) or PAL (non-interlaced: 0x271, interlaced: 0x270) */
-#define VI_V_SYNC       (&VI_REGISTERS[6])
+volatile vi_register_t* VI_V_SYNC       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[6];
 /** @brief VI Index register of total width of a line */
-#define VI_H_SYNC       (&VI_REGISTERS[7])
+volatile vi_register_t* VI_H_SYNC       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[7];
 /** @brief VI Index register of an alternate scanline length for one scanline during vsync. */
-#define VI_H_SYNC_LEAP  (&VI_REGISTERS[8])
+volatile vi_register_t* VI_H_SYNC_LEAP  =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[8];
 /** @brief VI Index register of start/end of the active video image, in screen pixels */
-#define VI_H_VIDEO      (&VI_REGISTERS[9])
+volatile vi_register_t* VI_H_VIDEO      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[9];
 /** @brief VI Index register of start/end of the active video image, in screen half-lines. */
-#define VI_V_VIDEO      (&VI_REGISTERS[10])
+volatile vi_register_t* VI_V_VIDEO      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[10];
 /** @brief VI Index register of start/end of the color burst enable, in half-lines. */
-#define VI_V_BURST      (&VI_REGISTERS[11])
+volatile vi_register_t* VI_V_BURST      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[11];
 /** @brief VI Index register of horizontal subpixel offset and 1/horizontal scale up factor. */
-#define VI_X_SCALE      (&VI_REGISTERS[12])
+volatile vi_register_t* VI_X_SCALE      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[12];
 /** @brief VI Index register of vertical subpixel offset and 1/vertical scale up factor. */
-#define VI_Y_SCALE      (&VI_REGISTERS[13])
+volatile vi_register_t* VI_Y_SCALE      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[13];
 
 /** @brief VI register by index (0-13)*/
 #define VI_TO_REGISTER(index) ((index >= 0 && index <= VI_REGISTERS_COUNT)? &VI_REGISTERS[index] : NULL)

--- a/include/vi.h
+++ b/include/vi.h
@@ -1,0 +1,224 @@
+/**
+ * @file vi.h
+ * @brief Video Interface Subsystem
+ * @ingroup display
+ */
+#ifndef __LIBDRAGON_VI_H
+#define __LIBDRAGON_VI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "regsinternal.h"
+#include "n64sys.h"
+#include "display.h"
+#include "interrupt.h"
+#include "utils.h"
+#include "debug.h"
+#include "surface.h"
+#include "vi.h"
+
+/**
+ * @addtogroup display
+ * @{
+ */
+
+/** @brief Register uncached location in memory of VI */
+#define VI_REGISTERS_ADDR       0xA4400000
+/** @brief Number of useful 32-bit registers at the register base */
+#define VI_REGISTERS_COUNT      14
+
+/**
+ * @brief Video Interface register structure
+ *
+ * Whenever trying to configure VI registers, 
+ * this struct and its index definitions below can be very useful 
+ * in writing comprehensive and verbose code.
+ */
+typedef struct vi_config_s{
+    uint32_t regs[VI_REGISTERS_COUNT];
+} vi_config_t;
+
+/** @brief VI Index register of controlling general display filters/bitdepth configuration */
+#define VI_CTRL         0
+/** @brief VI Index register of RDRAM base address of the video output Frame Buffer. This can be changed as needed to implement double or triple buffering. */
+#define VI_ORIGIN       1
+/** @brief VI Index register of width in pixels of the frame buffer. */
+#define VI_WIDTH        2
+/** @brief VI Index register of vertical interrupt. */
+#define VI_V_INTR       3
+/** @brief VI Index register of the current half line, sampled once per line. */
+#define VI_V_CURRENT    4
+/** @brief VI Index register of sync/burst values */
+#define VI_BURST        5
+/** @brief VI Index register of total visible and non-visible lines. 
+ * This should match either NTSC (non-interlaced: 0x20D, interlaced: 0x20C) or PAL (non-interlaced: 0x271, interlaced: 0x270) */
+#define VI_V_SYNC       6
+/** @brief VI Index register of total width of a line */
+#define VI_H_SYNC       7
+/** @brief VI Index register of an alternate scanline length for one scanline during vsync. */
+#define VI_H_SYNC_LEAP  8
+/** @brief VI Index register of start/end of the active video image, in screen pixels */
+#define VI_H_VIDEO      9
+/** @brief VI Index register of start/end of the active video image, in screen half-lines. */
+#define VI_V_VIDEO      10
+/** @brief VI Index register of start/end of the color burst enable, in half-lines. */
+#define VI_V_BURST      11
+/** @brief VI Index register of horizontal subpixel offset and 1/horizontal scale up factor. */
+#define VI_X_SCALE      12
+/** @brief VI Index register of vertical subpixel offset and 1/vertical scale up factor. */
+#define VI_Y_SCALE      13
+
+/**
+ * @name Video Mode Register Presets
+ * @brief Presets to use when setting a particular video mode
+ * @{
+ */
+static const vi_config_t vi_ntsc_p = {.regs = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000002,
+    0x00000000, 0x03e52239, 0x0000020d, 0x00000c15,
+    0x0c150c15, 0x006c02ec, 0x002501ff, 0x000e0204,
+    0x00000000, 0x00000000 }};
+static const vi_config_t vi_pal_p =  {.regs = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000002,
+    0x00000000, 0x0404233a, 0x00000271, 0x00150c69,
+    0x0c6f0c6e, 0x00800300, 0x005f0239, 0x0009026b,
+    0x00000000, 0x00000000 }};
+static const vi_config_t vi_mpal_p = {.regs = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000002,
+    0x00000000, 0x04651e39, 0x0000020d, 0x00040c11,
+    0x0c190c1a, 0x006c02ec, 0x002501ff, 0x000e0204,
+    0x00000000, 0x00000000 }};
+static const vi_config_t vi_ntsc_i = {.regs = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000002,
+    0x00000000, 0x03e52239, 0x0000020c, 0x00000c15,
+    0x0c150c15, 0x006c02ec, 0x002301fd, 0x000e0204,
+    0x00000000, 0x00000000 }};
+static const vi_config_t vi_pal_i = {.regs = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000002,
+    0x00000000, 0x0404233a, 0x00000270, 0x00150c69,
+    0x0c6f0c6e, 0x00800300, 0x005d0237, 0x0009026b,
+    0x00000000, 0x00000000 }};
+static const vi_config_t vi_mpal_i = {.regs = {
+    0x00000000, 0x00000000, 0x00000000, 0x00000002,
+    0x00000000, 0x04651e39, 0x0000020c, 0x00000c10,
+    0x0c1c0c1c, 0x006c02ec, 0x002301fd, 0x000b0202,
+    0x00000000, 0x00000000 }};
+/** @} */
+
+/** @brief Register initial value array */
+static const vi_config_t vi_config_presets[2][3] = {
+    {vi_pal_p, vi_ntsc_p, vi_mpal_p},
+    {vi_pal_i, vi_ntsc_i, vi_mpal_i}
+};
+
+#define VI_TV_TYPES_INTERLACE 3
+
+/** Under VI_CTRL */
+#define VI_DEDITHER_FILTER_ENABLE           1<<16
+#define VI_PIXEL_ADVANCE_DEFAULT            0b0011 << 12
+#define VI_PIXEL_ADVANCE_BBPLAYER           0b0001 << 12
+#define VI_AA_MODE_NONE                     0b11 << 8
+#define VI_AA_MODE_RESAMPLE                 0b10 << 8
+#define VI_AA_MODE_RESAMPLE_FETCH_NEEDED    0b01 << 8
+#define VI_AA_MODE_RESAMPLE_FETCH_ALWAYS    0b00 << 8
+#define VI_CTRL_SERRATE                     1<<6
+#define VI_DIVOT_ENABLE                     1<<4
+#define VI_GAMMA_ENABLE                     1<<3
+#define VI_GAMMA_DITHER_ENABLE              1<<2
+#define VI_CTRL_TYPE_32_BIT                 0b11
+#define VI_CTRL_TYPE_16_BIT                 0b10
+#define VI_CTRL_TYPE_BLANK                  0b00
+
+/** Under VI_ORIGIN  */
+#define VI_ORIGIN_SET(value)      ((value & 0xFFFFFF) << 0)
+
+/** Under VI_WIDTH   */
+#define VI_WIDTH_SET(value)       ((value & 0xFFF) << 0)
+
+/** Under VI_V_CURRENT  */
+#define VI_V_CURRENT_VBLANK     2
+
+/** Under VI_V_INTR    */
+#define VI_V_INTR_SET(value)      ((value & 0x3FF) << 0)
+#define VI_V_INTR_DEFAULT         0x3FF
+
+/** Under VI_BURST     */
+#define VI_BURST_START(value)      ((value & 0x3F) << 20)
+#define VI_VSYNC_WIDTH(value)      ((value & 0x7)  << 16)
+#define VI_BURST_WIDTH(value)      ((value & 0xFF) << 8)
+#define VI_HSYNC_WIDTH(value)      ((value & 0xFF) << 0)
+
+#define VI_BURST_START_NTSC     62
+#define VI_VSYNC_WIDTH_NTSC     5
+#define VI_BURST_WIDTH_NTSC     34
+#define VI_HSYNC_WIDTH_NTSC     57
+
+#define VI_BURST_START_PAL      64
+#define VI_VSYNC_WIDTH_PAL      4
+#define VI_BURST_WIDTH_PAL      35
+#define VI_HSYNC_WIDTH_PAL      58
+
+
+inline volatile uint32_t *vi_register(int index) {
+    return &(((uint32_t *)VI_REGISTERS_ADDR)[index]);
+}
+
+/**
+ * @brief Write a set of video registers to the VI
+ *
+ * @param[in] config
+ *            A pointer to a set of register values to be written
+ */
+inline void vi_configure_registers(vi_config_t *config)
+{
+    /* This should never happen */
+    assert(config);
+
+    /* Just straight copy */
+    for( int i = 0; i < VI_REGISTERS_COUNT; i++ )
+    {
+        /* Don't clear interrupts */
+        if( i == 3 ) { continue; }
+        if( i == 4 ) { continue; }
+
+        *vi_register(i) = config->regs[i];
+        MEMORY_BARRIER();
+    }
+}
+
+/**
+ * @brief Update the framebuffer pointer in the VI
+ *
+ * @param[in] dram_val
+ *            The new framebuffer to use for display.  Should be aligned and uncached.
+ */
+static void vi_write_dram_register( void const * const dram_val )
+{
+    *vi_register(VI_ORIGIN) = VI_ORIGIN_SET(PhysicalAddr(dram_val));
+    MEMORY_BARRIER();
+}
+
+/** @brief Wait until entering the vblank period */
+static void vi_wait_for_vblank()
+{
+    while(*vi_register(VI_V_CURRENT) != VI_V_CURRENT_VBLANK ) {  }
+}
+
+/** @brief Return true if VI is active (H_VIDEO != 0) */
+static inline bool vi_is_active()
+{
+    return (*vi_register(VI_H_VIDEO)? true : false);
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */ /* vi */
+
+#endif

--- a/include/vi.h
+++ b/include/vi.h
@@ -69,7 +69,7 @@ volatile vi_register_t* VI_Y_SCALE      =  &((volatile vi_register_t*)VI_REGISTE
 #define VI_TO_REGISTER(index) (((index) >= 0 && (index) <= VI_REGISTERS_COUNT)? &VI_REGISTERS[index] : NULL)
 
 /** @brief VI index from register */
-#define VI_TO_INDEX(reg) ((reg - VI_REGISTERS));
+#define VI_TO_INDEX(reg) ((reg) - VI_REGISTERS)
 
 /**
  * @name Video Mode Register Presets

--- a/src/console.c
+++ b/src/console.c
@@ -178,7 +178,7 @@ void console_init()
 {
     /* In case they initialized the display already */
     display_close();
-    display_init( RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
+    display_init( RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
 
     render_buffer = malloc(CONSOLE_SIZE);
 

--- a/src/display.c
+++ b/src/display.c
@@ -9,12 +9,12 @@
 #include <string.h>
 #include "regsinternal.h"
 #include "n64sys.h"
+#include "vi.h"
 #include "display.h"
 #include "interrupt.h"
 #include "utils.h"
 #include "debug.h"
 #include "surface.h"
-#include "vi.h"
 
 /** @brief Maximum number of video backbuffers */
 #define NUM_BUFFERS         32

--- a/src/display.c
+++ b/src/display.c
@@ -166,7 +166,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
             break;
         case FILTERS_RESAMPLE_ANTIALIAS:
             /* Set AA on resample and fetch as well as divot on */
-            control |= VI_AA_MODE_RESAMPLE_FETCH_NEEDED;
+            control |= VI_AA_MODE_RESAMPLE_FETCH_NEEDED | VI_DIVOT_ENABLE;
 
             break;
         case FILTERS_RESAMPLE_ANTIALIAS_DEDITHER:
@@ -176,8 +176,8 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
             /* Enable dither filter in 16bpp mode to give gradients
                a slightly smoother look */
             if ( bit == DEPTH_16_BPP ) 
-                 control |= VI_AA_MODE_RESAMPLE_FETCH_ALWAYS | VI_DEDITHER_FILTER_ENABLE; 
-            else control |= VI_AA_MODE_RESAMPLE_FETCH_NEEDED;
+                 control |= VI_AA_MODE_RESAMPLE_FETCH_ALWAYS | VI_DEDITHER_FILTER_ENABLE | VI_DIVOT_ENABLE; 
+            else control |= VI_AA_MODE_RESAMPLE_FETCH_NEEDED | VI_DIVOT_ENABLE;
             break;
     }
 

--- a/src/display.c
+++ b/src/display.c
@@ -14,67 +14,11 @@
 #include "utils.h"
 #include "debug.h"
 #include "surface.h"
+#include "vi.h"
 
 /** @brief Maximum number of video backbuffers */
 #define NUM_BUFFERS         32
 
-/** @brief Register location in memory of VI */
-#define REGISTER_BASE       0xA4400000
-/** @brief Number of 32-bit registers at the register base */
-#define REGISTER_COUNT      14
-
-/** 
- * @brief Return the uncached memory address of a cached address
- *
- * @param[in] x 
- *            The cached address
- *
- * @return The uncached address
- */
-#define UNCACHED_ADDR(x)    ((void *)(((uint32_t)(x)) | 0xA0000000))
-
-/**
- * @name Video Mode Register Presets
- * @brief Presets to use when setting a particular video mode
- * @{
- */
-static const uint32_t ntsc_p[] = {
-    0x00000000, 0x00000000, 0x00000000, 0x00000002,
-    0x00000000, 0x03e52239, 0x0000020d, 0x00000c15,
-    0x0c150c15, 0x006c02ec, 0x002501ff, 0x000e0204,
-    0x00000000, 0x00000000 };
-static const uint32_t pal_p[] = {
-    0x00000000, 0x00000000, 0x00000000, 0x00000002,
-    0x00000000, 0x0404233a, 0x00000271, 0x00150c69,
-    0x0c6f0c6e, 0x00800300, 0x005f0239, 0x0009026b,
-    0x00000000, 0x00000000 };
-static const uint32_t mpal_p[] = {
-    0x00000000, 0x00000000, 0x00000000, 0x00000002,
-    0x00000000, 0x04651e39, 0x0000020d, 0x00040c11,
-    0x0c190c1a, 0x006c02ec, 0x002501ff, 0x000e0204,
-    0x00000000, 0x00000000 };
-static const uint32_t ntsc_i[] = {
-    0x00000000, 0x00000000, 0x00000000, 0x00000002,
-    0x00000000, 0x03e52239, 0x0000020c, 0x00000c15,
-    0x0c150c15, 0x006c02ec, 0x002301fd, 0x000e0204,
-    0x00000000, 0x00000000 };
-static const uint32_t pal_i[] = {
-    0x00000000, 0x00000000, 0x00000000, 0x00000002,
-    0x00000000, 0x0404233a, 0x00000270, 0x00150c69,
-    0x0c6f0c6e, 0x00800300, 0x005d0237, 0x0009026b,
-    0x00000000, 0x00000000 };
-static const uint32_t mpal_i[] = {
-    0x00000000, 0x00000000, 0x00000000, 0x00000002,
-    0x00000000, 0x04651e39, 0x0000020c, 0x00000c10,
-    0x0c1c0c1c, 0x006c02ec, 0x002301fd, 0x000b0202,
-    0x00000000, 0x00000000 };
-/** @} */
-
-/** @brief Register initial value array */
-static const uint32_t * const reg_values[] = {
-    pal_p, ntsc_p, mpal_p,
-    pal_i, ntsc_i, mpal_i,
-};
 
 static surface_t *surfaces;
 /** @brief Currently active bit depth */
@@ -103,73 +47,16 @@ static inline int buffer_next(int idx) {
 }
 
 /**
- * @brief Write a set of video registers to the VI
- *
- * @param[in] registers
- *            A pointer to a set of register values to be written
- */
-static void __write_registers( uint32_t const * const registers )
-{
-    volatile uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
-
-    /* This should never happen */
-    if( !registers ) { return; }
-
-    /* Just straight copy */
-    for( int i = 0; i < REGISTER_COUNT; i++ )
-    {
-        /* Don't clear interrupts */
-        if( i == 3 ) { continue; }
-        if( i == 4 ) { continue; }
-
-        reg_base[i] = registers[i];
-        MEMORY_BARRIER();
-    }
-}
-
-/**
- * @brief Update the framebuffer pointer in the VI
- *
- * @param[in] dram_val
- *            The new framebuffer to use for display.  Should be aligned and uncached.
- */
-static void __write_dram_register( void const * const dram_val )
-{
-    volatile uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
-
-    reg_base[1] = PhysicalAddr(dram_val);
-    MEMORY_BARRIER();
-}
-
-/** @brief Wait until entering the vblank period */
-static void __wait_for_vblank()
-{
-    volatile uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
-
-    while( reg_base[4] != 2 ) {  }
-}
-
-/** @brief Return true if VI is active (H_VIDEO != 0) */
-static inline bool __is_vi_active()
-{
-    volatile uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
-
-    return (reg_base[9] != 0);
-}
-
-/**
  * @brief Interrupt handler for vertical blank
  *
  * If there is another frame to display, display the frame
  */
 static void __display_callback()
 {
-    volatile uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
-
     /* Least significant bit of the current line register indicates
        if the currently displayed field is odd or even. */
-    bool field = reg_base[4] & 1;
-    bool interlaced = reg_base[0] & (1<<6);
+    bool field = (*vi_register(VI_V_CURRENT)) & 1;
+    bool interlaced = (*vi_register(VI_CTRL)) & (VI_CTRL_SERRATE);
 
     /* Check if the next buffer is ready to be displayed, otherwise just
        leave up the current frame */
@@ -179,14 +66,14 @@ static void __display_callback()
         ready_mask &= ~(1 << next);
     }
 
-    __write_dram_register(__safe_buffer[now_showing] + (interlaced && !field ? __width * __bitdepth : 0));
+    vi_write_dram_register(__safe_buffer[now_showing] + (interlaced && !field ? __width * __bitdepth : 0));
 }
 
 void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, filter_options_t filters )
 {
-    uint32_t registers[REGISTER_COUNT];
+    vi_config_t config;
     uint32_t tv_type = get_tv_type();
-    uint32_t control = !sys_bbplayer() ? 0x3000 : 0x1000;
+    uint32_t control = !sys_bbplayer()? VI_PIXEL_ADVANCE_DEFAULT : VI_PIXEL_ADVANCE_BBPLAYER;
 
     /* Can't have the video interrupt happening here */
     disable_interrupts();
@@ -198,21 +85,20 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     if( res.interlaced )
     {
         /* Serrate on to stop vertical jitter */
-        control |= 0x40;
-        tv_type += 3;
+        control |= VI_CTRL_SERRATE;
     }
 
     /* Copy over to temporary for extra initializations */
-    memcpy( registers, reg_values[tv_type], sizeof( uint32_t ) * REGISTER_COUNT );
+    config = vi_config_presets[res.interlaced][tv_type];
 
     /* Figure out control register based on input given */
     switch( bit )
     {
         case DEPTH_16_BPP:
-            control |= 0x2;
+            control |= VI_CTRL_TYPE_16_BIT;
             break;
         case DEPTH_32_BPP:
-            control |= 0x3;
+            control |= VI_CTRL_TYPE_32_BIT;
             break;
     }
 
@@ -222,11 +108,11 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
             /* Nothing to set here */
             break;
         case GAMMA_CORRECT:
-            control |= 0x8;
+            control |= VI_GAMMA_ENABLE;
             break;
         case GAMMA_CORRECT_DITHER:
-            control |= 0xC;
-            break;
+            control |= VI_GAMMA_ENABLE | VI_GAMMA_DITHER_ENABLE;
+            break;  
     }
 
     switch( filters )
@@ -255,12 +141,12 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
             }
 
             /* Set AA off flag */
-            control |= 0x300;
+            control |= VI_AA_MODE_NONE;
 
             break;
         case FILTERS_RESAMPLE:
             /* Set AA on resample */
-            control |= 0x200;
+            control |= VI_AA_MODE_RESAMPLE;
 
             /* Dither filter should not be enabled with this AA mode
                as it will cause ugly vertical streaks */
@@ -273,14 +159,14 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
                 assertf(res.width > 320,
                     "FILTERS_DEDITHER is not supported by the hardware for widths <= 320.\n"
                     "Please use FILTERS_RESAMPLE instead.");
-                control |= 0x10300;
+                control |= VI_AA_MODE_NONE | VI_DEDITHER_FILTER_ENABLE;
             }
-            else control |= 0x300;
+            else control |= VI_AA_MODE_NONE;
 
             break;
         case FILTERS_RESAMPLE_ANTIALIAS:
             /* Set AA on resample and fetch as well as divot on */
-            control |= 0x110;
+            control |= VI_AA_MODE_RESAMPLE_FETCH_NEEDED;
 
             break;
         case FILTERS_RESAMPLE_ANTIALIAS_DEDITHER:
@@ -289,13 +175,14 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
 
             /* Enable dither filter in 16bpp mode to give gradients
                a slightly smoother look */
-            if ( bit == DEPTH_16_BPP ) control |= 0x10010; 
-            else control |= 0x110;
+            if ( bit == DEPTH_16_BPP ) 
+                 control |= VI_AA_MODE_RESAMPLE_FETCH_ALWAYS | VI_DEDITHER_FILTER_ENABLE; 
+            else control |= VI_AA_MODE_RESAMPLE_FETCH_NEEDED;
             break;
     }
 
     /* Set the control register in our template */
-    registers[0] = control;
+    config.regs[VI_CTRL] = control;
 
     /* Calculate width and scale registers */
     assertf(res.width > 0 && res.width <= 800, "invalid width");
@@ -308,9 +195,9 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     {
         assertf(res.width % 2 == 0, "width must be divisible by 2 for 32-bit depth");
     }
-    registers[2] = res.width;
-    registers[12] = ( 1024*res.width + 320 ) / 640;
-    registers[13] = ( 1024*res.height + 120 ) / 240;
+    config.regs[VI_WIDTH] = res.width;
+    config.regs[VI_X_SCALE] = ( 1024*res.width + 320 ) / 640;
+    config.regs[VI_Y_SCALE] = ( 1024*res.height + 120 ) / 240;
 
     /* Set up the display */
     __width = res.width;
@@ -340,16 +227,16 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
 
     /* Show our screen normally. If display is already active, do that during vblank
        to avoid confusing the VI chip with in-frame modifications. */
-    if ( __is_vi_active() ) { __wait_for_vblank(); }
+    if ( vi_is_active() ) { vi_wait_for_vblank(); }
 
-    registers[1] = PhysicalAddr(__safe_buffer[0]);
-    __write_registers( registers );
+    config.regs[VI_ORIGIN] = PhysicalAddr(__safe_buffer[0]);
+    vi_configure_registers(&config);
 
     enable_interrupts();
 
     /* Set which line to call back on in order to flip screens */
     register_VI_handler( __display_callback );
-    set_VI_interrupt( 1, 0x2 );
+    set_VI_interrupt( 1, VI_V_CURRENT_VBLANK );
 }
 
 void display_close()
@@ -368,11 +255,10 @@ void display_close()
     __height = 0;
 
     // If display is active, wait for vblank before touching the registers
-    if( __is_vi_active() ) { __wait_for_vblank(); }
+    if( vi_is_active() ) { vi_wait_for_vblank(); }
 
-    volatile uint32_t *reg_base = (uint32_t *)REGISTER_BASE;
-    reg_base[9] = 0;
-    __write_dram_register( 0 );
+    *vi_register(VI_H_VIDEO) = 0;
+    vi_write_dram_register( 0 );
 
     if( surfaces )
     {

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -422,7 +422,7 @@ static void inspector(exception_t* ex, enum Mode mode) {
     in_inspector = true;
 
 	display_close();
-	display_init(RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+	display_init(RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
 
 	enum Page {
 		PAGE_EXCEPTION,

--- a/src/vi.h
+++ b/src/vi.h
@@ -32,6 +32,8 @@ typedef struct vi_config_s{
     uint32_t regs[VI_REGISTERS_COUNT];
 } vi_config_t;
 
+/** @brief Base pointer to hardware Video interface registers that control various aspects of VI configuration.
+ * Shouldn't be used by itself, use VI_ registers to get/set their values. */
 #define VI_REGISTERS      ((volatile uint32_t*)VI_REGISTERS_ADDR)
 /** @brief VI Index register of controlling general display filters/bitdepth configuration */
 #define VI_CTRL           (&VI_REGISTERS[0])

--- a/src/vi.h
+++ b/src/vi.h
@@ -113,54 +113,88 @@ static const vi_config_t vi_config_presets[2][3] = {
 };
 
 /** Under VI_CTRL */
+
+/** @brief VI_CTRL Register setting: enable dedither filter. */
 #define VI_DEDITHER_FILTER_ENABLE           (1<<16)
+/** @brief VI_CTRL Register setting: default value for pixel advance. */
 #define VI_PIXEL_ADVANCE_DEFAULT            (0b0011 << 12)
+/** @brief VI_CTRL Register setting: default value for pixel advance on iQue. */
 #define VI_PIXEL_ADVANCE_BBPLAYER           (0b0001 << 12)
+/** @brief VI_CTRL Register setting: disable AA / resamp. */
 #define VI_AA_MODE_NONE                     (0b11 << 8)
+/** @brief VI_CTRL Register setting: disable AA / enable resamp. */
 #define VI_AA_MODE_RESAMPLE                 (0b10 << 8)
+/** @brief VI_CTRL Register setting: enable AA / enable resamp, fetch pixels when needed. */
 #define VI_AA_MODE_RESAMPLE_FETCH_NEEDED    (0b01 << 8)
+/** @brief VI_CTRL Register setting: enable AA / enable resamp, fetch pixels always. */
 #define VI_AA_MODE_RESAMPLE_FETCH_ALWAYS    (0b00 << 8)
+/** @brief VI_CTRL Register setting: enable interlaced output. */
 #define VI_CTRL_SERRATE                     (1<<6)
+/** @brief VI_CTRL Register setting: enable divot filter (fixes 1 pixel holes after AA). */
 #define VI_DIVOT_ENABLE                     (1<<4)
+/** @brief VI_CTRL Register setting: enable gamma correction filter. */
 #define VI_GAMMA_ENABLE                     (1<<3)
+/** @brief VI_CTRL Register setting: enable gamma correction filter and hardware dither the least significant color bit on output. */
 #define VI_GAMMA_DITHER_ENABLE              (1<<2)
+/** @brief VI_CTRL Register setting: set the framebuffer source as 32-bit. */
 #define VI_CTRL_TYPE_32_BPP                 (0b11)
+/** @brief VI_CTRL Register setting: set the framebuffer source as 16-bit (5-5-5-3). */
 #define VI_CTRL_TYPE_16_BPP                 (0b10)
+/** @brief VI_CTRL Register setting: set the framebuffer source as blank (no data and no sync, TV screens will either show static or nothing). */
 #define VI_CTRL_TYPE_BLANK                  (0b00)
 
 /** Under VI_ORIGIN  */
+/** @brief VI_ORIGIN Register: set the address of a framebuffer. */
 #define VI_ORIGIN_SET(value)                ((value & 0xFFFFFF) << 0)
 
 /** Under VI_WIDTH   */
+/** @brief VI_ORIGIN Register: set the width of a framebuffer. */
 #define VI_WIDTH_SET(value)                 ((value & 0xFFF) << 0)
 
 /** Under VI_V_CURRENT  */
+/** @brief VI_V_CURRENT Register: default value for vblank begin line. */
 #define VI_V_CURRENT_VBLANK                 2
 
 /** Under VI_V_INTR    */
+/** @brief VI_V_INTR Register: set value for vertical interrupt. */
 #define VI_V_INTR_SET(value)                ((value & 0x3FF) << 0)
+/** @brief VI_V_INTR Register: default value for vertical interrupt. */
 #define VI_V_INTR_DEFAULT                   0x3FF
 
 /** Under VI_BURST     */
+/** @brief VI_BURST Register: set start of color burst in pixels from hsync. */
 #define VI_BURST_START(value)               ((value & 0x3F) << 20)
+/** @brief VI_BURST Register: set vertical sync width in half lines. */
 #define VI_VSYNC_WIDTH(value)               ((value & 0x7)  << 16)
+/** @brief VI_BURST Register: set color burst width in pixels. */
 #define VI_BURST_WIDTH(value)               ((value & 0xFF) << 8)
+/** @brief VI_BURST Register: set horizontal sync width in pixels. */
 #define VI_HSYNC_WIDTH(value)               ((value & 0xFF) << 0)
 
+/** @brief VI_BURST Register: NTSC default start of color burst in pixels from hsync. */
 #define VI_BURST_START_NTSC                 62
+/** @brief VI_BURST Register: NTSC default vertical sync width in half lines. */
 #define VI_VSYNC_WIDTH_NTSC                 5
+/** @brief VI_BURST Register: NTSC default color burst width in pixels. */
 #define VI_BURST_WIDTH_NTSC                 34
+/** @brief VI_BURST Register: NTSC default horizontal sync width in pixels. */
 #define VI_HSYNC_WIDTH_NTSC                 57
 
+/** @brief VI_BURST Register: PAL default start of color burst in pixels from hsync. */
 #define VI_BURST_START_PAL                  64
+/** @brief VI_BURST Register: PAL default vertical sync width in half lines. */
 #define VI_VSYNC_WIDTH_PAL                  4
+/** @brief VI_BURST Register: PAL default color burst width in pixels.  */
 #define VI_BURST_WIDTH_PAL                  35
+/** @brief VI_BURST Register: PAL default horizontal sync width in pixels. */
 #define VI_HSYNC_WIDTH_PAL                  58
 
 /**  Under VI_X_SCALE   */
+/** @brief VI_X_SCALE Register: set 1/horizontal scale up factor (value is converted to 2.10 format) */
 #define VI_X_SCALE_SET(value)               (( 1024*(value) + 320 ) / 640)
 
 /**  Under VI_Y_SCALE   */
+/** @brief VI_Y_SCALE Register: set 1/vertical scale up factor (value is converted to 2.10 format) */
 #define VI_Y_SCALE_SET(value)               (( 1024*(value) + 120 ) / 240)
 
 /**

--- a/src/vi.h
+++ b/src/vi.h
@@ -16,8 +16,6 @@
  * @{
  */
 
-typedef uint32_t vi_register_t;
-
 /** @brief Register uncached location in memory of VI */
 #define VI_REGISTERS_ADDR       0xA4400000
 /** @brief Number of useful 32-bit registers at the register base */
@@ -31,39 +29,39 @@ typedef uint32_t vi_register_t;
  * in writing comprehensive and verbose code.
  */
 typedef struct vi_config_s{
-    vi_register_t regs[VI_REGISTERS_COUNT];
+    uint32_t regs[VI_REGISTERS_COUNT];
 } vi_config_t;
 
-volatile vi_register_t* VI_REGISTERS    =  ((volatile vi_register_t*)VI_REGISTERS_ADDR);
+#define VI_REGISTERS      ((volatile uint32_t*)VI_REGISTERS_ADDR)
 /** @brief VI Index register of controlling general display filters/bitdepth configuration */
-volatile vi_register_t* VI_CTRL         =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[0];
+#define VI_CTRL           (&VI_REGISTERS[0])
 /** @brief VI Index register of RDRAM base address of the video output Frame Buffer. This can be changed as needed to implement double or triple buffering. */
-volatile vi_register_t* VI_ORIGIN       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[1];
+#define VI_ORIGIN         (&VI_REGISTERS[1])
 /** @brief VI Index register of width in pixels of the frame buffer. */
-volatile vi_register_t* VI_WIDTH        =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[2];
+#define VI_WIDTH          (&VI_REGISTERS[2])
 /** @brief VI Index register of vertical interrupt. */
-volatile vi_register_t* VI_V_INTR       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[3];
+#define VI_V_INTR         (&VI_REGISTERS[3])
 /** @brief VI Index register of the current half line, sampled once per line. */
-volatile vi_register_t* VI_V_CURRENT    =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[4];
+#define VI_V_CURRENT      (&VI_REGISTERS[4])
 /** @brief VI Index register of sync/burst values */
-volatile vi_register_t* VI_BURST        =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[5];
+#define VI_BURST          (&VI_REGISTERS[5])
 /** @brief VI Index register of total visible and non-visible lines. 
  * This should match either NTSC (non-interlaced: 0x20D, interlaced: 0x20C) or PAL (non-interlaced: 0x271, interlaced: 0x270) */
-volatile vi_register_t* VI_V_SYNC       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[6];
+#define VI_V_SYNC         (&VI_REGISTERS[6])
 /** @brief VI Index register of total width of a line */
-volatile vi_register_t* VI_H_SYNC       =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[7];
+#define VI_H_SYNC         (&VI_REGISTERS[7])
 /** @brief VI Index register of an alternate scanline length for one scanline during vsync. */
-volatile vi_register_t* VI_H_SYNC_LEAP  =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[8];
+#define VI_H_SYNC_LEAP    (&VI_REGISTERS[8])
 /** @brief VI Index register of start/end of the active video image, in screen pixels */
-volatile vi_register_t* VI_H_VIDEO      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[9];
+#define VI_H_VIDEO        (&VI_REGISTERS[9])
 /** @brief VI Index register of start/end of the active video image, in screen half-lines. */
-volatile vi_register_t* VI_V_VIDEO      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[10];
+#define VI_V_VIDEO        (&VI_REGISTERS[10])
 /** @brief VI Index register of start/end of the color burst enable, in half-lines. */
-volatile vi_register_t* VI_V_BURST      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[11];
+#define VI_V_BURST        (&VI_REGISTERS[11])
 /** @brief VI Index register of horizontal subpixel offset and 1/horizontal scale up factor. */
-volatile vi_register_t* VI_X_SCALE      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[12];
+#define VI_X_SCALE        (&VI_REGISTERS[12])
 /** @brief VI Index register of vertical subpixel offset and 1/vertical scale up factor. */
-volatile vi_register_t* VI_Y_SCALE      =  &((volatile vi_register_t*)VI_REGISTERS_ADDR)[13];
+#define VI_Y_SCALE        (&VI_REGISTERS[13])
 
 /** @brief VI register by index (0-13)*/
 #define VI_TO_REGISTER(index) (((index) >= 0 && (index) <= VI_REGISTERS_COUNT)? &VI_REGISTERS[index] : NULL)
@@ -173,7 +171,7 @@ static const vi_config_t vi_config_presets[2][3] = {
  * @param[in] value
  *            Value to be written to the register
  */
-inline void vi_write_safe(volatile vi_register_t *reg, uint32_t value){
+inline void vi_write_safe(volatile uint32_t *reg, uint32_t value){
     assert(reg); /* This should never happen */
     *reg = value;
     MEMORY_BARRIER();


### PR DESCRIPTION
- The current display options include "anti-aliasing" settings that are cryptic and don't match expectations, this PR fixes any confusion about what is actually happening to the output with selected display filtering options.
- This PR changes and deprecates antialias_t (used only in display_init) into filter_options_t with similar options (deprecated AA options are mapped to them directly) and verbose comments, explaining each filter.
- filter_options_t is an enum with only valid and useful filtering options, such as resampling, AA and de-dithering.
- Also updated gamma comments to better illustrate their use-cases.