### PR TITLE
Enable FatFS chmod

### DIFF
--- a/src/fatfs/ffconf.h
+++ b/src/fatfs/ffconf.h
@@ -52,7 +52,7 @@
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
 
-#define FF_USE_CHMOD	0
+#define FF_USE_CHMOD	1
 /* This option switches attribute manipulation functions, f_chmod() and f_utime().
 /  (0:Disable or 1:Enable) Also FF_FS_READONLY needs to be 0 to enable this option. */
 


### PR DESCRIPTION
Enable FatFS to allow file attribute changes as required by https://github.com/Polprzewodnikowy/N64FlashcartMenu/issues/26

(targets unstable branch as that is what is currently required).