### PR TITLE
n64.mk: also link in additional .a files dependencies

### DIFF
--- a/n64.mk
+++ b/n64.mk
@@ -162,9 +162,11 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp
 # between ld when it comes to global ctors dtors. Also see __do_global_ctors
 	EXTERNS_FILE="$(filter %.externs, $^)"; \
 	if [ -z "$$EXTERNS_FILE" ]; then \
-		$(CXX) -o $@ $(filter %.o, $^) -lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
+		$(CXX) -o $@ $(filter %.o, $^) $(filter-out $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a, $(filter %.a, $^)) \
+			-lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
 	else \
-		$(CXX) -o $@ $(filter %.o, $^) -lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-T"$$EXTERNS_FILE" -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
+		$(CXX) -o $@ $(filter %.o, $^) $(filter-out $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a, $(filter %.a, $^)) \
+			-lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-T"$$EXTERNS_FILE" -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
 	fi
 	$(N64_SIZE) -G $@
 


### PR DESCRIPTION
Adds
```mk
$(filter-out $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a, $(filter %.a, $^))
```
to the input files to the linker

The interesting bit is `$(filter %.a, $^)`, to list the .a files the .elf depends on

The (unfortunately large) `$(filter-out $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a, ...)` part is filtering out the libdragon archives which are linked with `-l` flags and which the elf also depends upon