### PR TITLE
Fix Restore VI active check based on set color depth mode

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -254,10 +254,10 @@ void display_close()
     __width = 0;
     __height = 0;
 
-    // If display is active, wait for vblank before touching the registers
+    /* If display is active, wait for vblank before touching the registers */
     if( vi_is_active() ) { vi_wait_for_vblank(); }
 
-    vi_write_safe(VI_H_VIDEO, 0);
+    vi_set_blank_image();
     vi_write_dram_register( 0 );
 
     if( surfaces )

--- a/src/vi.h
+++ b/src/vi.h
@@ -259,7 +259,7 @@ static inline void vi_wait_for_vblank()
 /** @brief Return true if VI is sending a video signal (16-bit or 32-bit color set) */
 static inline bool vi_is_active()
 {
-    return ((*VI_CTRL & VI_CTRL_TYPE) > VI_CTRL_TYPE_BLANK? true : false);
+    return (*VI_CTRL & VI_CTRL_TYPE) != VI_CTRL_TYPE_BLANK;
 }
 
 /** @brief Set active image width to 0, which keeps VI signal active but only sending a blank image */

--- a/src/vi.h
+++ b/src/vi.h
@@ -138,6 +138,8 @@ static const vi_config_t vi_config_presets[2][3] = {
 #define VI_GAMMA_ENABLE                     (1<<3)
 /** @brief VI_CTRL Register setting: enable gamma correction filter and hardware dither the least significant color bit on output. */
 #define VI_GAMMA_DITHER_ENABLE              (1<<2)
+/** @brief VI_CTRL Register setting: framebuffer source format */
+#define VI_CTRL_TYPE                        (0b11)
 /** @brief VI_CTRL Register setting: set the framebuffer source as 32-bit. */
 #define VI_CTRL_TYPE_32_BPP                 (0b11)
 /** @brief VI_CTRL Register setting: set the framebuffer source as 16-bit (5-5-5-3). */
@@ -254,11 +256,18 @@ static inline void vi_wait_for_vblank()
     while(*VI_V_CURRENT != VI_V_CURRENT_VBLANK ) {  }
 }
 
-/** @brief Return true if VI is active (VI_H_VIDEO != 0) */
+/** @brief Return true if VI is sending a video signal (16-bit or 32-bit color set) */
 static inline bool vi_is_active()
 {
-    return (*VI_H_VIDEO? true : false);
+    return ((*VI_CTRL & VI_CTRL_TYPE) > VI_CTRL_TYPE_BLANK? true : false);
 }
+
+/** @brief Set active image width to 0, which keeps VI signal active but only sending a blank image */
+static inline void vi_set_blank_image()
+{
+    vi_write_safe(VI_H_VIDEO, 0);
+}
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Earlier H_VIDEO-based check introduced a regression that sometimes caused real hardware to hang when changing video resolution. A filter PR reverted this commit.