### PR TITLE
Minor joybus subsystem cleanup

### DIFF
--- a/include/interrupt.h
+++ b/include/interrupt.h
@@ -6,6 +6,8 @@
 #ifndef __LIBDRAGON_INTERRUPT_H
 #define __LIBDRAGON_INTERRUPT_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/controller.c
+++ b/src/controller.c
@@ -7,7 +7,7 @@
 #include "controller.h"
 #include "interrupt.h"
 #include "joybus.h"
-#include "joybusinternal.h"
+#include "joybus_internal.h"
 #include "debug.h"
 #include <string.h>
 #include <stdbool.h>

--- a/src/joybus.c
+++ b/src/joybus.c
@@ -1,11 +1,14 @@
 /**
  * @file joybus.c
  * @brief Joybus Subsystem
- * @ingroup lowlevel
+ * @ingroup joybus
  */
 
 #include <string.h>
+
 #include "libdragon.h"
+
+#include "joybus_internal.h"
 #include "regsinternal.h"
 
 /**
@@ -85,9 +88,17 @@ typedef struct {
 } joybus_msg_t;
 
 #define MAX_JOYBUS_MSGS            8    ///< Maximum number of pending joybus messages
+
+/**
+ * @anchor JOYBUS_STATE
+ * @name Joybus internal state machine values
+ * 
+ * @{
+ */
 #define JOYBUS_STATE_IDLE          0    ///< Joybus state: idle (no pending messages)
 #define JOYBUS_STATE_SENDING       1    ///< JoyBus state: sending a message to PIF
 #define JOYBUS_STATE_RECEIVING     2    ///< JoyBus state: receiving a reply from PIF
+/** @} */ /* JOYBUS_STATE */
 
 /** @brief Joybus temporary output buffer */
 static uint64_t joybus_outbuf[JOYBUS_BLOCK_DWORDS] __attribute__((aligned(16)));

--- a/src/joybus.c
+++ b/src/joybus.c
@@ -4,11 +4,14 @@
  * @ingroup joybus
  */
 
+#include <assert.h>
 #include <string.h>
 
-#include "libdragon.h"
-
+#include "debug.h"
+#include "interrupt.h"
+#include "joybus.h"
 #include "joybus_internal.h"
+#include "n64sys.h"
 #include "regsinternal.h"
 
 /**

--- a/src/joybus_internal.h
+++ b/src/joybus_internal.h
@@ -1,0 +1,14 @@
+/**
+ * @file joybus_internal.h
+ * @brief Joybus internal API
+ * @ingroup joybus
+ */
+
+#ifndef __LIBDRAGON_JOYBUS_INTERNAL_H
+#define __LIBDRAGON_JOYBUS_INTERNAL_H
+
+#include <stdint.h>
+
+void joybus_exec_async(const void * input, void (*callback)(uint64_t *output, void *ctx), void *ctx);
+
+#endif

--- a/src/joybusinternal.h
+++ b/src/joybusinternal.h
@@ -1,6 +1,0 @@
-#ifndef __LIBDRAGON_JOYBUSINTERNAL_H
-#define __LIBDRAGON_JOYBUSINTERNAL_H
-
-void joybus_exec_async(const void * input, void (*callback)(uint64_t *output, void *ctx), void *ctx);
-
-#endif


### PR DESCRIPTION
This is some groundwork for my upcoming Joypad subsystem that doesn't depend on any of the larger changes.

* Renames `joybusinternal.h` to `joybus_internal.h` for consistency with `backtrace_internal.h`, `exception_internal.h`, and `rompak_internal.h`
* Removes `#include "libdragon.h"` from `joybus.c` and replaces it with the individual header files that the module depends on.
* Wraps the `JOYBUS_STATE_*` macros in a Doxygen member group (it just looks nicer in the generated docs).
* Associates the Joybus Subsystem-related files with the `joybus` group in Doxygen
* Fixes missing `#include <stdint.h>` in `interrupt.h`