### PR TITLE
Update unstable examples with display filters

### DIFF
--- a/examples/brew-volley/main.c
+++ b/examples/brew-volley/main.c
@@ -453,7 +453,7 @@ int main()
     debug_init_isviewer();
     debug_init_usblog();
 
-    display_init(RESOLUTION_640x480, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE_FETCH_ALWAYS);
+    display_init(RESOLUTION_640x480, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DEDITHER);
 
     controller_init();
     timer_init();

--- a/examples/fontdemo/fontdemo.c
+++ b/examples/fontdemo/fontdemo.c
@@ -85,7 +85,7 @@ int main()
     controller_init();
 
     dfs_init(DFS_DEFAULT_LOCATION);
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
     rdpq_init();
     // rdpq_debug_start();
     // rdpq_debug_log(true);

--- a/examples/gldemo/gldemo.c
+++ b/examples/gldemo/gldemo.c
@@ -114,6 +114,8 @@ void setup()
     glFogf(GL_FOG_END, 20);
     glFogfv(GL_FOG_COLOR, environment_color);
 
+    glEnable(GL_MULTISAMPLE_ARB);
+
     glGenTextures(4, textures);
 
     #if 0
@@ -204,7 +206,7 @@ int main()
     
     dfs_init(DFS_DEFAULT_LOCATION);
 
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE_FETCH_ALWAYS);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE_ANTIALIAS_DEDITHER);
 
     rdpq_init();
     gl_init();

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -100,7 +100,7 @@ int main()
     debug_init_isviewer();
     debug_init_usblog();
     //Init rendering
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
     rdpq_init();
     rdpq_debug_start();
     scr_width = display_get_width();

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -7,7 +7,7 @@ int main()
     debug_init_isviewer();
     debug_init_usblog();
     //Init rendering
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
     rdpq_init();
     rdpq_debug_start();
     //Init miscellaneous system

--- a/examples/pixelshader/pixelshader.c
+++ b/examples/pixelshader/pixelshader.c
@@ -62,7 +62,7 @@ void rsp_blend_process_line(surface_t *dest, int x0, int y0, int numlines) {
 int main(void) {
     debug_init_isviewer();
     debug_init_usblog();
-    display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+    display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
     dfs_init(DFS_DEFAULT_LOCATION);
     controller_init();
     rdpq_init();

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -101,7 +101,7 @@ int main()
     debug_init_isviewer();
     debug_init_usblog();
 
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 
     controller_init();
     timer_init();

--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -23,7 +23,7 @@ int main(void) {
 	debug_init_isviewer();
 	debug_init_usblog();
 
-	display_init(RESOLUTION_320x240, DEPTH_32_BPP, NUM_DISPLAY, GAMMA_NONE, ANTIALIAS_OFF);
+	display_init(RESOLUTION_320x240, DEPTH_32_BPP, NUM_DISPLAY, GAMMA_NONE, FILTERS_DISABLED);
 	dfs_init(DFS_DEFAULT_LOCATION);
 	rdpq_init();
 

--- a/src/display.c
+++ b/src/display.c
@@ -86,15 +86,12 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     /* Minimum is two buffers. */
     __buffers = MAX(1, MIN(NUM_BUFFERS, num_buffers));
 
-
-    if( res.interlaced != INTERLACE_OFF )
-    {
-        /* Serrate on to stop vertical jitter */
-        control |= VI_CTRL_SERRATE;
-    }
+    bool serrate = res.interlaced != INTERLACE_OFF;
+    /* Serrate on to stop vertical jitter */
+    if(serrate) control |= VI_CTRL_SERRATE;
 
     /* Copy over extra initializations */
-    vi_write_config(&vi_config_presets[res.interlaced][tv_type]);
+    vi_write_config(&vi_config_presets[serrate][tv_type]);
 
     /* Figure out control register based on input given */
     switch( bit )


### PR DESCRIPTION
Also since gldemo has to use AA filter anyway might as well turn on AA proper for higher quality 3d examples.
Also fixed a INTERLACE_FULL bug specific to how filters were merged to unstable.