### PR TITLE
Fix n64.mk dfs target nested directories

### DIFF
--- a/examples/dfsdemo/Makefile
+++ b/examples/dfsdemo/Makefile
@@ -9,6 +9,7 @@ OBJS = $(BUILD_DIR)/dfsdemo.o
 dfsdemo.z64: N64_ROM_TITLE = "DragonFS Demo"
 dfsdemo.z64: $(BUILD_DIR)/dfsdemo.dfs
 
+$(BUILD_DIR)/dfsdemo.dfs: filesystem/a_directory/a_file.txt
 $(BUILD_DIR)/dfsdemo.dfs: $(wildcard filesystem/*)
 $(BUILD_DIR)/dfsdemo.elf: $(OBJS)
 

--- a/examples/dfsdemo/filesystem/a_directory/a_file.txt
+++ b/examples/dfsdemo/filesystem/a_directory/a_file.txt
@@ -1,0 +1,1 @@
+Hello from a subdirectory!

--- a/n64.mk
+++ b/n64.mk
@@ -1,6 +1,9 @@
 BUILD_DIR ?= .
 SOURCE_DIR ?= .
 
+# Override this if your project uses a different directory for your DFS filesystem root
+N64_MKDFS_ROOT ?= filesystem
+
 N64_ROM_TITLE = "Made with libdragon" # Override this with the name of your game or project
 N64_ROM_SAVETYPE = # Supported savetypes: none eeprom4k eeprom16 sram256k sram768k sram1m flashram
 N64_ROM_RTC = # Set to true to enable the Joybus Real-Time Clock
@@ -102,12 +105,7 @@ RSPASFLAGS+=-MMD
 %.dfs:
 	@mkdir -p $(dir $@)
 	@echo "    [DFS] $@"
-	set -e; \
-	MKDFSROOT="$(shell python3 -c 'import os.path; print( os.path.commonpath( """$^""".split() ) ) ')"; \
-	if [ -z "$$MKDFSROOT" ]; then \
-		echo "Error creating filesystem: DFS files must share a common root directory"; exit 1; \
-	fi; \
-	$(N64_MKDFS) $@ "$$MKDFSROOT" >/dev/null
+	$(N64_MKDFS) $@ "$(N64_MKDFS_ROOT)" >/dev/null
 
 # Assembly rule. We use .S for both RSP and MIPS assembly code, and we differentiate
 # using the prefix of the filename: if it starts with "rsp", it is RSP ucode, otherwise

--- a/n64.mk
+++ b/n64.mk
@@ -102,7 +102,12 @@ RSPASFLAGS+=-MMD
 %.dfs:
 	@mkdir -p $(dir $@)
 	@echo "    [DFS] $@"
-	$(N64_MKDFS) $@ $(<D) >/dev/null
+	set -e; \
+	MKDFSROOT="$(shell python3 -c 'import os.path; print( os.path.commonpath( """$^""".split() ) ) ')"; \
+	if [ -z "$$MKDFSROOT" ]; then \
+		echo "Error creating filesystem: DFS files must share a common root directory"; exit 1; \
+	fi; \
+	$(N64_MKDFS) $@ "$$MKDFSROOT" >/dev/null
 
 # Assembly rule. We use .S for both RSP and MIPS assembly code, and we differentiate
 # using the prefix of the filename: if it starts with "rsp", it is RSP ucode, otherwise


### PR DESCRIPTION
The `n64.mk` rule for `%.dfs` makes an unreliable assumption that the ROM filesystem is flat. If prerequisites are nested in subdirectories of the filesystem root, this rule has unexpected behavior:

```make
%.dfs:
    @mkdir -p $(dir $@)
    @echo "    [DFS] $@"
    $(N64_MKDFS) $@ $(<D) >/dev/null
```

`$(<D)` gets the directory part of the first prerequisite. This only works correctly if the first prerequisite is in the root of the DFS filesystem. Ideally, this rule would use the common prefix of all prerequisites, but this is not trivial to do in a Makefile and has the potential to run up against command-line length limits.

This PR introduces a new `n64.mk` configuration variable: `N64_MKDFS_ROOT`, which defaults to "filesystem".
LibDragon projects will need to update their Makefile if they do not follow this convention.

Context from Discord: https://discord.com/channels/205520502922543113/974342113850445874/1152363061475278980