### PR TITLE
Fix get_keys_pressed shim missing analog stick values

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,7 @@
 EXAMPLES += audioplayer
 EXAMPLES += brew-volley
 #EXAMPLES += compression # Disabled due to missing assets
+EXAMPLES += controllertest
 EXAMPLES += cpptest
 EXAMPLES += ctest
 EXAMPLES += customfont

--- a/examples/controllertest/Makefile
+++ b/examples/controllertest/Makefile
@@ -1,0 +1,17 @@
+all: controllertest.z64
+.PHONY: all
+
+BUILD_DIR = build
+include $(N64_INST)/include/n64.mk
+
+OBJS = $(BUILD_DIR)/controllertest.o
+
+controllertest.z64: N64_ROM_TITLE = "Controller Test"
+
+$(BUILD_DIR)/controllertest.elf: $(OBJS)
+
+clean:
+	rm -rf $(BUILD_DIR) *.z64
+.PHONY: clean
+
+-include $(wildcard $(BUILD_DIR)/*.d)

--- a/examples/controllertest/controllertest.c
+++ b/examples/controllertest/controllertest.c
@@ -1,0 +1,81 @@
+/**
+ * @file controllertest.c
+ * @author Christopher Bonhage (me@christopherbonhage.com)
+ * @brief N64 test ROM for Controller subsystem
+ */
+
+#include <string.h>
+#include <libdragon.h>
+
+const char *format_accessory_type(int accessory_type)
+{
+    switch (accessory_type)
+    {
+    case ACCESSORY_NONE:
+        return "None        ";
+    case ACCESSORY_MEMPAK:
+        return "Memory      ";
+    case ACCESSORY_RUMBLEPAK:
+        return "Rumble Pak  ";
+    case ACCESSORY_TRANSFERPAK:
+        return "Transfer Pak";
+    case ACCESSORY_VRU:
+        return "VRU         ";
+    default:
+        return "Unknown     ";
+    }
+}
+
+void print_inputs(_SI_condat *inputs)
+{
+    printf(
+        "Stick: %+04d,%+04d\n",
+        inputs->x, inputs->y
+    );
+    printf(
+        "D-U:%d D-D:%d D-L:%d D-R:%d C-U:%d C-D:%d C-L:%d C-R:%d\n",
+        inputs->up, inputs->down,
+        inputs->left, inputs->right,
+        inputs->C_up, inputs->C_down,
+        inputs->C_left, inputs->C_right
+    );
+    printf(
+        "A:%d B:%d L:%d R:%d Z:%d Start:%d\n",
+        inputs->A, inputs->B,
+        inputs->L, inputs->R,
+        inputs->Z, inputs->start
+    );
+}
+
+int main(void)
+{
+    timer_init();
+    controller_init();
+    debug_init_isviewer();
+    console_init();
+    console_set_render_mode(RENDER_MANUAL);
+    console_set_debug(false);
+
+    while (1)
+    {
+        console_clear();
+
+        printf("LibDragon Controller Subsystem Test\n\n");
+
+        controller_scan();
+        struct controller_data inputs = get_keys_pressed();
+
+        for (int port = 0; port < 4; port++)
+        {
+            int accessory_type = identify_accessory(port);
+
+            printf("Port %d ", port + 1);
+            printf("Accessory: %s ", format_accessory_type(accessory_type));
+            printf("\n");
+            print_inputs(&inputs.c[port]);
+            printf("\n");
+        }
+
+        console_render();
+    }
+}

--- a/src/controller.c
+++ b/src/controller.c
@@ -57,20 +57,17 @@ static inline void controller_data_from_joypad_buttons(
 )
 {
     struct SI_condat * c = &out->c[port];
-    struct SI_condat_gc * gc = &out->gc[port];
 
-    gc->a = c->A = buttons->a;
-    gc->b = c->B = buttons->b;
-    gc->z = c->Z = buttons->z;
-    gc->start = c->start = buttons->start;
-    gc->up = c->up = buttons->d_up;
-    gc->down = c->down = buttons->d_down;
-    gc->left = c->left = buttons->d_left;
-    gc->right = c->right = buttons->d_right;
-    gc->x = buttons->x;
-    gc->y = buttons->y;
-    gc->l = c->L = buttons->l;
-    gc->r = c->R = buttons->r;
+    c->A = buttons->a;
+    c->B = buttons->b;
+    c->Z = buttons->z;
+    c->start = buttons->start;
+    c->up = buttons->d_up;
+    c->down = buttons->d_down;
+    c->left = buttons->d_left;
+    c->right = buttons->d_right;
+    c->L = buttons->l;
+    c->R = buttons->r;
     c->C_up = buttons->c_up;
     c->C_down = buttons->c_down;
     c->C_left = buttons->c_left;
@@ -365,7 +362,7 @@ struct controller_data get_keys_held( void )
  *
  * @return A structure representing which buttons were pressed
  * 
- * @deprecated Use #joypad_get_buttons instead
+ * @deprecated Use #joypad_get_inputs instead
  */
 struct controller_data get_keys_pressed( void )
 {
@@ -374,8 +371,11 @@ struct controller_data get_keys_pressed( void )
 
     JOYPAD_PORT_FOREACH (port)
     {
-        buttons = joypad_get_buttons(port);
+        inputs = joypad_get_inputs(port);
+        buttons = inputs.__buttons;
         controller_data_from_joypad_buttons(port, &ret, &buttons);
+        ret.c[port].x = inputs.stick_x;
+        ret.c[port].y = inputs.stick_y;
     }
 
     return ret;


### PR DESCRIPTION
Also adds an example for verifying controller subsystem inputs

This PR fixes a gap in the Controller subsystem's compatibility shim.

Analog stick values are intentionally omitted from `get_keys_down`, `get_keys_up` and `get_keys_held` (which used to suffer from bitwise transformation bugs for analog values).

However, analog stick values were accidentally omitted from `get_keys_pressed` (which does not perform bitwise transformations of input data, and is supposed to return current analog stick values).

Additionally, this PR removes shimming Joypad inputs into `struct SI_condat_gc`, which is not supportable. Origins cannot be handled correctly for GC analog values, and reading GameCube controllers was never supported by these APIs.