### PR TITLE
Follow-up: Fix missing declaration in get_keys_pressed; update deprecation notice

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -278,7 +278,7 @@ struct controller_data get_keys_up( void );
 __attribute__((deprecated("use joypad_get_buttons_held instead")))
 struct controller_data get_keys_held( void );
 
-__attribute__((deprecated("use joypad_get_buttons instead")))
+__attribute__((deprecated("use joypad_get_inputs instead")))
 struct controller_data get_keys_pressed( void );
 
 __attribute__((deprecated("use joypad_get_identifier instead")))

--- a/src/controller.c
+++ b/src/controller.c
@@ -366,6 +366,7 @@ struct controller_data get_keys_held( void )
  */
 struct controller_data get_keys_pressed( void )
 {
+    joypad_inputs_t inputs;
     joypad_buttons_t buttons;
     struct controller_data ret = { 0 };
 

--- a/src/controller.c
+++ b/src/controller.c
@@ -372,7 +372,7 @@ struct controller_data get_keys_pressed( void )
 
     JOYPAD_PORT_FOREACH (port)
     {
-        joypad_inputs_t inputs = joypad_get_inputs(port);
+        inputs = joypad_get_inputs(port);
         buttons = inputs.__buttons;
         controller_data_from_joypad_buttons(port, &ret, &buttons);
         ret.c[port].x = inputs.stick_x;


### PR DESCRIPTION
This was missed in #437 -- sorry: I tried to clean up the commit to remove a bunch of extraneous whitespace trimming that my editor did automatically, and this line got lost in the shuffle.

Also, updated the deprecation notice for `get_keys_pressed` to match the updated documentation in #437 