### PR TITLE
Resolve joypad_inputs_t ambiguity with x, y fields

### DIFF
--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -62,17 +62,17 @@ void print_joypad_inputs(joypad_inputs_t inputs)
     );
     printf(
         "D-U:%d D-D:%d D-L:%d D-R:%d C-U:%d C-D:%d C-L:%d C-R:%d\n",
-        inputs.d_up, inputs.d_down,
-        inputs.d_left, inputs.d_right,
-        inputs.c_up, inputs.c_down,
-        inputs.c_left, inputs.c_right
+        inputs.btn.d_up, inputs.btn.d_down,
+        inputs.btn.d_left, inputs.btn.d_right,
+        inputs.btn.c_up, inputs.btn.c_down,
+        inputs.btn.c_left, inputs.btn.c_right
     );
     printf(
         "A:%d B:%d X:%d Y:%d L:%d R:%d Z:%d Start:%d\n",
-        inputs.a, inputs.b,
-        inputs.x, inputs.y,
-        inputs.l, inputs.r,
-        inputs.z, inputs.start
+        inputs.btn.a, inputs.btn.b,
+        inputs.btn.x, inputs.btn.y,
+        inputs.btn.l, inputs.btn.r,
+        inputs.btn.z, inputs.btn.start
     );
 }
 
@@ -109,11 +109,11 @@ int main(void)
 
             if (rumble_supported)
             {
-                if (inputs.a && !rumble_active)
+                if (inputs.btn.a && !rumble_active)
                 {
                     joypad_set_rumble_active(port, true);
                 }
-                else if (!inputs.a && rumble_active)
+                else if (!inputs.btn.a && rumble_active)
                 {
                     joypad_set_rumble_active(port, false);
                 }

--- a/include/controller.h
+++ b/include/controller.h
@@ -278,7 +278,7 @@ struct controller_data get_keys_up( void );
 __attribute__((deprecated("use joypad_get_buttons_held instead")))
 struct controller_data get_keys_held( void );
 
-__attribute__((deprecated("use joypad_get_buttons instead")))
+__attribute__((deprecated("use joypad_get_inputs instead")))
 struct controller_data get_keys_pressed( void );
 
 __attribute__((deprecated("use joypad_get_identifier instead")))

--- a/include/joypad.h
+++ b/include/joypad.h
@@ -232,81 +232,10 @@ typedef union joypad_buttons_u
 /** @brief Joypad Inputs Unified State Structure */
 typedef struct __attribute__((packed)) joypad_inputs_s
 {
-    /// @cond
-    union
-    {
-    /// @endcond
-        /// @cond
-        joypad_buttons_t __buttons;
-        struct __attribute__((packed))
-        {
-        /// @endcond
-            /** @brief State of the A button */
-            unsigned a : 1;
-            /** @brief State of the B button */
-            unsigned b : 1;
-            /** @brief State of the Z button */
-            unsigned z : 1;
-            /** @brief State of the Start button */
-            unsigned start : 1;
-            /** @brief State of the D-Pad Up button */
-            unsigned d_up : 1;
-            /** @brief State of the D-Pad Down button */
-            unsigned d_down : 1;
-            /** @brief State of the D-Pad Left button */
-            unsigned d_left : 1;
-            /** @brief State of the D-Pad Right button */
-            unsigned d_right : 1;
-            /**
-             * @brief State of the Y button.
-             * 
-             * This input only exists on GameCube controllers.
-             */
-            unsigned y : 1;
-            /**
-             * @brief State of the X button.
-             * 
-             * This input only exists on GameCube controllers.
-             */
-            unsigned x : 1;
-            /** @brief State of the digital L trigger */
-            unsigned l : 1;
-            /** @brief State of the digital R trigger */
-            unsigned r : 1;
-            /**
-             * @brief State of the C-Up button.
-             * 
-             * For GameCube controllers, the value will be
-             * emulated based on the C-Stick Y axis position.
-             */
-            unsigned c_up : 1;
-            /**
-             * @brief State of the C-Down button.
-             * 
-             * For GameCube controllers, the value will be
-             * emulated based on the C-Stick Y axis position.
-             */
-            unsigned c_down : 1;
-            /**
-             * @brief State of the C-Left button.
-             * 
-             * For GameCube controllers, the value will be
-             * emulated based on the C-Stick X axis position.
-             */
-            unsigned c_left : 1;
-            /**
-             * @brief State of the C-Right button.
-             * 
-             * For GameCube controllers, the value will be
-             * emulated based on the C-Stick X axis position.
-             */
-            unsigned c_right : 1;
-        /// @cond
-        };
-        /// @endcond
-    /// @cond
-    };
-    /// @endcond
+    /**
+     * @brief Structure containing digital button inputs state.
+     */
+    joypad_buttons_t btn;
     /**
      * @brief Position of the analog joystick X axis. (-127, +127)
      * 

--- a/src/controller.c
+++ b/src/controller.c
@@ -366,6 +366,7 @@ struct controller_data get_keys_held( void )
  */
 struct controller_data get_keys_pressed( void )
 {
+    joypad_inputs_t inputs;
     joypad_buttons_t buttons;
     struct controller_data ret = { 0 };
 

--- a/src/controller.c
+++ b/src/controller.c
@@ -373,7 +373,7 @@ struct controller_data get_keys_pressed( void )
     JOYPAD_PORT_FOREACH (port)
     {
         inputs = joypad_get_inputs(port);
-        buttons = inputs.__buttons;
+        buttons = inputs.btn;
         controller_data_from_joypad_buttons(port, &ret, &buttons);
         ret.c[port].x = inputs.stick_x;
         ret.c[port].y = inputs.stick_y;

--- a/src/controller.c
+++ b/src/controller.c
@@ -372,7 +372,7 @@ struct controller_data get_keys_pressed( void )
 
     JOYPAD_PORT_FOREACH (port)
     {
-        joypad_inputs_t inputs = joypad_get_inputs(port);
+        inputs = joypad_get_inputs(port);
         buttons = inputs.__buttons;
         controller_data_from_joypad_buttons(port, &ret, &buttons);
         ret.c[port].x = inputs.stick_x;

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -527,7 +527,7 @@ static void inspector(exception_t* ex, enum Mode mode) {
         while (1) {
             // Read controller using #joypad_read_n64_inputs, which works also when
             // the interrupts are disabled and when #joypad_init has not been called.
-            joypad_buttons_t key_new = joypad_read_n64_inputs(JOYPAD_PORT_1).__buttons;
+            joypad_buttons_t key_new = joypad_read_n64_inputs(JOYPAD_PORT_1).btn;
             if (key_new.raw != key_old.raw) {
                 key_pressed = (joypad_buttons_t){ .raw = key_new.raw & ~key_old.raw };
                 key_old = key_new;

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -126,22 +126,24 @@ static joypad_inputs_t joypad_inputs_from_n64_controller_read(
     int analog_r = cmd->recv.r ? JOYPAD_RANGE_GCN_TRIGGER_MAX : 0;
 
     return (joypad_inputs_t){
-        .a = cmd->recv.a,
-        .b = cmd->recv.b,
-        .z = cmd->recv.z,
-        .start = cmd->recv.start,
-        .d_up = cmd->recv.d_up,
-        .d_down = cmd->recv.d_down,
-        .d_left = cmd->recv.d_left,
-        .d_right = cmd->recv.d_right,
-        .y = 0,
-        .x = 0,
-        .l = cmd->recv.l,
-        .r = cmd->recv.r,
-        .c_up = cmd->recv.c_up,
-        .c_down = cmd->recv.c_down,
-        .c_left = cmd->recv.c_left,
-        .c_right = cmd->recv.c_right,
+        .btn = {
+            .a = cmd->recv.a,
+            .b = cmd->recv.b,
+            .z = cmd->recv.z,
+            .start = cmd->recv.start,
+            .d_up = cmd->recv.d_up,
+            .d_down = cmd->recv.d_down,
+            .d_left = cmd->recv.d_left,
+            .d_right = cmd->recv.d_right,
+            .y = 0,
+            .x = 0,
+            .l = cmd->recv.l,
+            .r = cmd->recv.r,
+            .c_up = cmd->recv.c_up,
+            .c_down = cmd->recv.c_down,
+            .c_left = cmd->recv.c_left,
+            .c_right = cmd->recv.c_right,
+        },
         .stick_x = cmd->recv.stick_x,
         .stick_y = cmd->recv.stick_y,
         .cstick_x = cstick_x,
@@ -179,22 +181,24 @@ static joypad_inputs_t joypad_inputs_from_gcn_controller_read(
     int analog_r = CLAMP_ANALOG_TRIGGER(cmd->recv.analog_r - origin->analog_r);
 
     return (joypad_inputs_t){
-        .a = cmd->recv.a,
-        .b = cmd->recv.b,
-        .z = cmd->recv.z,
-        .start = cmd->recv.start,
-        .d_up    = cmd->recv.d_up,
-        .d_down  = cmd->recv.d_down,
-        .d_left  = cmd->recv.d_left,
-        .d_right = cmd->recv.d_right,
-        .y = cmd->recv.y,
-        .x = cmd->recv.x,
-        .l = cmd->recv.l,
-        .r = cmd->recv.r,
-        .c_up    = cstick_y > +cstick_threshold,
-        .c_down  = cstick_y < -cstick_threshold,
-        .c_left  = cstick_x < -cstick_threshold,
-        .c_right = cstick_x > +cstick_threshold,
+        .btn = {
+            .a = cmd->recv.a,
+            .b = cmd->recv.b,
+            .z = cmd->recv.z,
+            .start = cmd->recv.start,
+            .d_up    = cmd->recv.d_up,
+            .d_down  = cmd->recv.d_down,
+            .d_left  = cmd->recv.d_left,
+            .d_right = cmd->recv.d_right,
+            .y = cmd->recv.y,
+            .x = cmd->recv.x,
+            .l = cmd->recv.l,
+            .r = cmd->recv.r,
+            .c_up    = cstick_y > +cstick_threshold,
+            .c_down  = cstick_y < -cstick_threshold,
+            .c_left  = cstick_x < -cstick_threshold,
+            .c_right = cstick_x > +cstick_threshold,
+        },
         .stick_x = stick_x,
         .stick_y = stick_y,
         .cstick_x = cstick_x,
@@ -788,15 +792,15 @@ joypad_buttons_t joypad_get_buttons(joypad_port_t port)
 {
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
-    return joypad_devices_cold[port].current.__buttons;
+    return joypad_devices_cold[port].current.btn;
 }
 
 joypad_buttons_t joypad_get_buttons_pressed(joypad_port_t port)
 {
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
-    const uint16_t current = joypad_devices_cold[port].current.__buttons.raw;
-    const uint16_t previous = joypad_devices_cold[port].previous.__buttons.raw;
+    const uint16_t current = joypad_devices_cold[port].current.btn.raw;
+    const uint16_t previous = joypad_devices_cold[port].previous.btn.raw;
     return (joypad_buttons_t){ .raw = current & ~previous };
 }
 
@@ -804,8 +808,8 @@ joypad_buttons_t joypad_get_buttons_released(joypad_port_t port)
 {
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
-    const uint16_t current = joypad_devices_cold[port].current.__buttons.raw;
-    const uint16_t previous = joypad_devices_cold[port].previous.__buttons.raw;
+    const uint16_t current = joypad_devices_cold[port].current.btn.raw;
+    const uint16_t previous = joypad_devices_cold[port].previous.btn.raw;
     return (joypad_buttons_t){ .raw = ~(current & previous) };
 }
 
@@ -813,8 +817,8 @@ joypad_buttons_t joypad_get_buttons_held(joypad_port_t port)
 {
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
-    const uint16_t current = joypad_devices_cold[port].current.__buttons.raw;
-    const uint16_t previous = joypad_devices_cold[port].previous.__buttons.raw;
+    const uint16_t current = joypad_devices_cold[port].current.btn.raw;
+    const uint16_t previous = joypad_devices_cold[port].previous.btn.raw;
     return (joypad_buttons_t){ .raw = current & previous };
 }
 


### PR DESCRIPTION
(Stacked on top of #438) 

The presence of `x` and `y` button fields in `joypad_inputs_t` is already causing confusion for people migrating from Controller subsystem.

In `struct SI_condat` the `x` and `y` fields are used for analog stick values. In `joypad_inputs_t` those are now called `stick_x` and `stick_y`.

If a developer makes the very easy mistake of using `inputs.x` instead of `inputs.stick_x`, the compiler can't help them.

In order to make a clear distinction, I think the best thing to do here is to make it more explicit that `x` and `y` are now buttons by nesting button access in a `joypad_buttons_t btn` field.

This will unfortunately cause some churn for early adopters, but I think it’s the right move under the principle of least-surprise.

My original intention with flattening the `joypad_inputs_t` namespace was to make it super-convenient for developers, but it turns out that convenience just makes it too easy to get the usage wrong.