### PR TITLE
Compatibility hack for analog values in `get_keys_{down,up,held}`

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -292,6 +292,7 @@ void controller_scan( void ) { joypad_poll(); }
  */
 struct controller_data get_keys_down( void )
 {
+    joypad_inputs_t inputs;
     joypad_buttons_t buttons;
     struct controller_data ret = { 0 };
 
@@ -299,6 +300,11 @@ struct controller_data get_keys_down( void )
     {
         buttons = joypad_get_buttons_pressed(port);
         controller_data_from_joypad_buttons(port, &ret, &buttons);
+        // COMPATIBILITY HACK: Always use the current analog stick values.
+        // It's not "correct", but it's less-surprising than any alternative.
+        inputs = joypad_get_inputs(port);
+        ret.c[port].x = inputs.stick_x;
+        ret.c[port].y = inputs.stick_y;
     }
 
     return ret;
@@ -317,6 +323,7 @@ struct controller_data get_keys_down( void )
  */
 struct controller_data get_keys_up( void )
 {
+    joypad_inputs_t inputs;
     joypad_buttons_t buttons;
     struct controller_data ret = { 0 };
 
@@ -324,6 +331,11 @@ struct controller_data get_keys_up( void )
     {
         buttons = joypad_get_buttons_released(port);
         controller_data_from_joypad_buttons(port, &ret, &buttons);
+        // COMPATIBILITY HACK: Always use the current analog stick values.
+        // It's not "correct", but it's less-surprising than any alternative.
+        inputs = joypad_get_inputs(port);
+        ret.c[port].x = inputs.stick_x;
+        ret.c[port].y = inputs.stick_y;
     }
 
     return ret;
@@ -342,6 +354,7 @@ struct controller_data get_keys_up( void )
  */
 struct controller_data get_keys_held( void )
 {
+    joypad_inputs_t inputs;
     joypad_buttons_t buttons;
     struct controller_data ret = { 0 };
 
@@ -349,6 +362,11 @@ struct controller_data get_keys_held( void )
     {
         buttons = joypad_get_buttons_held(port);
         controller_data_from_joypad_buttons(port, &ret, &buttons);
+        // COMPATIBILITY HACK: Always use the current analog stick values.
+        // It's not "correct", but it's less-surprising than any alternative.
+        inputs = joypad_get_inputs(port);
+        ret.c[port].x = inputs.stick_x;
+        ret.c[port].y = inputs.stick_y;
     }
 
     return ret;


### PR DESCRIPTION
Prior to Joypad subsystem, the Controller subsystem's implementation of `get_keys_down`, `get_keys_up`, and `get_keys_held` would mangle the analog stick values by transforming them with bitwise operations.

Initially, the approach to fix this bug was to zero out the analog values, but user feedback has indicated that a better approach is to always return the current analog values instead.

Discord context: https://discord.com/channels/205520502922543113/974342113850445874/1153334007514284065