### PR TITLE
Fix mksprite support for legacy slices syntax

### DIFF
--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -1280,6 +1280,9 @@ int convert(const char *infn, const char *outfn, const parms_t *pm) {
         }
     }
 
+    // Legacy support for old mksprite usage
+    if (pm->hslices) spr.hslices = pm->hslices;
+    if (pm->vslices) spr.vslices = pm->vslices;
     // Autodetection of optimal slice size. TODO: this could be improved
     // by calculating actual memory occupation of each slice, to minimize the
     // number of TMEM loads.


### PR DESCRIPTION
I'm trying to refactor FlappyBird to work on unstable, and I've hit a regression: `mksprite` claims to still support the old usage (`<bit depth> [<horizontal slices> <vertical slices>] <input png> <output file>`) but that's producing sprite files with the wrong slicing.

It looks like the old usage is allowed, but the hslices and vslices arguments are ignored.

@rasky 

Discord context: https://discord.com/channels/205520502922543113/974342113850445874/1153757834383728710