### PR TITLE
Improve examples Makefiles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -27,17 +27,15 @@ EXAMPLES += videoplayer
 EXAMPLES += vrutest
 EXAMPLES += vtest
 
-# Populated by evaluating the EXAMPLE_template macro for each example
-all:
-clean:
+all: $(EXAMPLES)
+clean: $(foreach example,$(EXAMPLES),$(example)-clean)
+.PHONY: all clean
 
-define EXAMPLE_template =
+define EXAMPLE_template
 $(1):
 	$$(MAKE) -C $(1)
 $(1)-clean:
 	$$(MAKE) -C $(1) clean
-all: $(1)
-clean: $(1)-clean
 .PHONY: $(1) $(1)-clean
 endef
 

--- a/examples/videoplayer/Makefile
+++ b/examples/videoplayer/Makefile
@@ -3,6 +3,7 @@ include $(N64_INST)/include/n64.mk
 
 MOVIE_FILE=caminandes.ogv
 MOVIE_URL=https://archive.org/download/CaminandesLlamigos/Caminandes_%20Llamigos-1080p.ogv
+DFS_FILES=filesystem/movie.m1v filesystem/movie.wav64
 
 src = videoplayer.c
 
@@ -14,7 +15,7 @@ videoplayer.z64: $(BUILD_DIR)/videoplayer.dfs
 $(BUILD_DIR)/videoplayer.elf: $(src:%.c=$(BUILD_DIR)/%.o)
 
 # If the movie file could not be encoded, build the ROM without it.
-$(BUILD_DIR)/videoplayer.dfs: filesystem/movie.m1v filesystem/movie.wav64
+$(BUILD_DIR)/videoplayer.dfs: $(DFS_FILES)
 	if [ ! -s "$<" ]; then rm -f "$<" ; fi
 	$(N64_MKDFS) "$@" filesystem >/dev/null
 
@@ -57,19 +58,21 @@ movie.wav: $(MOVIE_FILE)
 		touch "$@" ; \
 	fi
 
-# Download the movie file if wget or curl is available
+# Download the movie file if wget or curl is available and it isn't already downloaded
 $(MOVIE_FILE):
-	if command -v wget ; then \
-		wget -O "$@" "$(MOVIE_URL)"  ; \
-	elif command -v curl ; then \
-		curl -Lo "$@" "$(MOVIE_URL)" ; \
-	else \
-		echo "videoplayer: Skipping sample movie download because wget or curl are not installed" ; \
-		touch "$@" ; \
+	if [ ! -e "$@" ]; then \
+		if command -v wget ; then \
+			wget -O "$@" "$(MOVIE_URL)"  ; \
+		elif command -v curl ; then \
+			curl -Lo "$@" "$(MOVIE_URL)" ; \
+		else \
+			echo "videoplayer: Skipping sample movie download because wget or curl are not installed" ; \
+			touch "$@" ; \
+		fi ; \
 	fi
 
 clean:
-	rm -rf $(BUILD_DIR) $(MOVIE_FILE) *.wav filesystem videoplayer.z64
+	rm -rf $(BUILD_DIR) $(MOVIE_FILE) $(DFS_FILES) movie.wav videoplayer.z64
 
 -include $(wildcard $(BUILD_DIR)/*.d)
 


### PR DESCRIPTION
* 4c8e706764cfe597caba08f7ab35e7c1848df0ce Fixes Make 3.8 compatibility issues in examples Makefile
  * Due to GPLv3 licensing concerns, macOS still ships with Make 3.81. Latest GNU Make is 4.4.1
* 2b1b2db39eef84940f1e21af4b8cbde29754d3e4 Improves videoplayer example Makefile based on feedback from @rasky 
  *  `make -B` no longer redownloads the movie file
  * `make clean` only deletes files generated by the Makefile