### PR TITLE
Fix "extern void" in macro

### DIFF
--- a/include/asset.h
+++ b/include/asset.h
@@ -55,6 +55,9 @@
 extern "C" {
 #endif
 
+/// @private
+extern void __asset_init_compression_lvl2(void);
+
 /**
  * @brief Enable a non-default compression level
  * 
@@ -80,10 +83,7 @@ extern "C" {
 #define asset_init_compression(level) ({ \
     switch (level) { \
     case 1: break; \
-    case 2: { \
-        extern void __asset_init_compression_lvl2(void); \
-        __asset_init_compression_lvl2(); \
-    } break; \
+    case 2: __asset_init_compression_lvl2(); break; \
     default: assertf(0, "Unsupported compression level: %d", level); \
     } \
 })


### PR DESCRIPTION
Avoids issues with C++ namespaces during link-time.