### PR TITLE
mixer: Add helper function for common pattern when playing audio

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -358,6 +358,18 @@ void mixer_unthrottle(void);
 void mixer_poll(int16_t *out, int nsamples);
 
 /**
+ * @brief Request the mixer to try and write audio samples to be played,
+ * if possible.
+ * 
+ * This function is a user helper for asking the mixer and audio subsystems
+ * to play audio during a game frame. You should call this function many times
+ * during one frame (eg. during the render step or after processing each game
+ * object) as many times as necessary. Not polling the audio subsystem often
+ * enough will result in audio stutter. 
+ */
+void mixer_try_play();
+
+/**
  * @brief Callback invoked by mixer_poll at a specified time
  * 
  * A MixerEvent is a callback that is invoked during mixer_poll at a specified

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -750,3 +750,13 @@ void mixer_poll(int16_t *out16, int num_samples) {
 		}
 	}
 }
+
+void mixer_try_play()
+{
+    if (audio_can_write())
+    {
+        short *buf = audio_write_begin();
+        mixer_poll(buf, audio_get_buffer_length());
+        audio_write_end();
+    }
+}


### PR DESCRIPTION
There's a common sequence of calls that users are advised to call many times a frame in order to satiate the audio processing and avoid audio stutter. This PR adds an `audio_poll` API to libdragon that performs this action to streamline this pattern for users and clarify what the intended use of the audio subsystem is, in a similar vein to the `display_get` function from the display subsystem.

Addendum: The pattern relevant to this function is expected to disappear once audio is handled in a separate thread. Therefore, this function shouldn't be stabilized so that it can be deprecated and removed when threading support is added.