### PR TITLE
Fix the default reset procedure

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -226,7 +226,7 @@ void wait_ms( unsigned long wait_ms );
  * The system will recover after a reset or power cycle.
  * 
  */
-void die();
+void die(void);
 
 /**
  * @brief Force a data cache invalidate over a memory region

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -217,6 +217,18 @@ void wait_ticks( unsigned long wait );
 void wait_ms( unsigned long wait_ms );
 
 /**
+ * @brief Force a complete halt of all processors
+ *
+ * @note It should occur whenever a reset has been triggered 
+ * and its past its RESET_TIME_LENGTH grace time period.
+ * This function will shut down the RSP and the CPU, blank the VI.
+ * Eventually the RDP will flush and complete its work as well.
+ * The system will recover after a reset or power cycle.
+ * 
+ */
+void die();
+
+/**
  * @brief Force a data cache invalidate over a memory region
  *
  * Use this to force the N64 to update cache from RDRAM.

--- a/src/display.c
+++ b/src/display.c
@@ -70,7 +70,7 @@ static void __display_callback()
         TICKS_FROM_MS(VI_PERIOD_PAL) : 
         TICKS_FROM_MS(VI_PERIOD_NTSC_MPAL);
 
-    if(exception_reset_time() + next_call >= RESET_TIME_LENGTH) halt();
+    if(exception_reset_time() + next_call >= RESET_TIME_LENGTH) die();
 
     /* Least significant bit of the current line register indicates
        if the currently displayed field is odd or even. */

--- a/src/display.c
+++ b/src/display.c
@@ -47,6 +47,8 @@ static uint32_t frame_times[FPS_WINDOW];
 static int frame_times_index = 0;
 /** @brief Current duration of the frame window (time elapsed for FPS_WINDOW frames) */
 static uint32_t frame_times_duration;
+/** @brief Auto detected TV region for display */
+static uint32_t __tv_type;
 
 /** @brief Get the next buffer index (with wraparound) */
 static inline int buffer_next(int idx) {
@@ -63,6 +65,13 @@ static inline int buffer_next(int idx) {
  */
 static void __display_callback()
 {
+    // If a reset has occured and its the last VI interrupt before RESET_TIME_LENGTH grace period, stop all work and exit
+    uint32_t next_call = __tv_type == TV_PAL? 
+        TICKS_FROM_MS(VI_PERIOD_PAL) : 
+        TICKS_FROM_MS(VI_PERIOD_NTSC_MPAL);
+
+    if(exception_reset_time() + next_call >= RESET_TIME_LENGTH) halt();
+
     /* Least significant bit of the current line register indicates
        if the currently displayed field is odd or even. */
     bool field = (*VI_V_CURRENT) & 1;
@@ -84,7 +93,7 @@ static void __display_callback()
 
 void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma_t gamma, filter_options_t filters )
 {
-    uint32_t tv_type = get_tv_type();
+    __tv_type = get_tv_type();
     uint32_t control = !sys_bbplayer()? VI_PIXEL_ADVANCE_DEFAULT : VI_PIXEL_ADVANCE_BBPLAYER;
 
     /* Can't have the video interrupt happening here */
@@ -98,7 +107,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     if(serrate) control |= VI_CTRL_SERRATE;
 
     /* Copy over extra initializations */
-    vi_write_config(&vi_config_presets[serrate][tv_type]);
+    vi_write_config(&vi_config_presets[serrate][__tv_type]);
 
     /* Figure out control register based on input given */
     switch( bit )

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <malloc.h>
 #include "n64sys.h"
@@ -367,17 +368,18 @@ void wait_ms( unsigned long wait_ms )
  * The system will recover after a reset or power cycle.
  * 
  */
-__attribute__((noreturn)) void die(){
+__attribute__((noreturn)) void die(void){
+    // Can't have any interrupts here
+    disable_interrupts();
     // Halt the RSP
     *SP_STATUS = SP_WSTATUS_SET_HALT;
     // Flush the RDP
     *DP_STATUS = DP_WSTATUS_SET_FLUSH | DP_WSTATUS_SET_FREEZE;
+    *DP_STATUS = DP_WSTATUS_RESET_FLUSH | DP_WSTATUS_RESET_FREEZE;
     // Shut the video off
     *VI_CTRL = *VI_CTRL & (~VI_CTRL_TYPE);
-    // Can't have any interrupts here
-    disable_interrupts();
-    // Spin infinitely
-    while(true){};
+    // Terminate the CPU execution
+    abort();
 }
 
 

--- a/src/vi.h
+++ b/src/vi.h
@@ -194,9 +194,9 @@ static const vi_config_t vi_config_presets[2][3] = {
 #define VI_HSYNC_WIDTH_PAL                  58
 
 /** @brief VI period for showing one NTSC and MPAL picture in ms. */
-#define VI_PERIOD_NTSC_MPAL                 (1000/60)
+#define VI_PERIOD_NTSC_MPAL                 ((float)1000/60)
 /** @brief VI period for showing one PAL picture in ms. */
-#define VI_PERIOD_PAL                       (1000/50)
+#define VI_PERIOD_PAL                       ((float)1000/50)
 
 /**  Under VI_X_SCALE   */
 /** @brief VI_X_SCALE Register: set 1/horizontal scale up factor (value is converted to 2.10 format) */

--- a/src/vi.h
+++ b/src/vi.h
@@ -193,6 +193,11 @@ static const vi_config_t vi_config_presets[2][3] = {
 /** @brief VI_BURST Register: PAL default horizontal sync width in pixels. */
 #define VI_HSYNC_WIDTH_PAL                  58
 
+/** @brief VI period for showing one NTSC and MPAL picture in ms. */
+#define VI_PERIOD_NTSC_MPAL                 (1000/60)
+/** @brief VI period for showing one PAL picture in ms. */
+#define VI_PERIOD_PAL                       (1000/50)
+
 /**  Under VI_X_SCALE   */
 /** @brief VI_X_SCALE Register: set 1/horizontal scale up factor (value is converted to 2.10 format) */
 #define VI_X_SCALE_SET(value)               (( 1024*(value) + 320 ) / 640)


### PR DESCRIPTION
Added a die() function in the n64sys.h that is used whenever a reset button is pressed. Its triggered from a VI interrupt.

This will cause the N64 to gracefully shut down its processors just before a hard reset occurs, so that it will not crash or have unexpected results. 

The reset procedure still supports user behavior up to 200ms for special effects if need be.