### PR TITLE
Updated the USB library to match the latest.

### DIFF
--- a/include/usb.h
+++ b/include/usb.h
@@ -20,11 +20,12 @@
     #define CART_SC64      3
     
     // Data types defintions
-    #define DATATYPE_TEXT       0x01
-    #define DATATYPE_RAWBINARY  0x02
-    #define DATATYPE_HEADER     0x03
-    #define DATATYPE_SCREENSHOT 0x04
-    #define DATATYPE_HEARTBEAT  0x05
+    #define DATATYPE_TEXT        0x01
+    #define DATATYPE_RAWBINARY   0x02
+    #define DATATYPE_HEADER      0x03
+    #define DATATYPE_SCREENSHOT  0x04
+    #define DATATYPE_HEARTBEAT   0x05
+    #define DATATYPE_RDBPACKET   0x06
     
     
     /*********************************
@@ -32,8 +33,8 @@
     *********************************/
     
     // Use these to conveniently read the header from usb_poll()
-    #define USBHEADER_GETTYPE(header) ((header & 0xFF000000) >> 24)
-    #define USBHEADER_GETSIZE(header) ((header & 0x00FFFFFF))
+    #define USBHEADER_GETTYPE(header) (((header) & 0xFF000000) >> 24)
+    #define USBHEADER_GETSIZE(header) (((header) & 0x00FFFFFF))
     
     
     /*********************************
@@ -46,7 +47,7 @@
         @return 1 if the USB initialization was successful, 0 if not
     ==============================*/
     
-    extern char usb_initialize();
+    extern char usb_initialize(void);
     
     
     /*==============================
@@ -55,7 +56,7 @@
         @return The CART macro that corresponds to the identified flashcart
     ==============================*/
     
-    extern char usb_getcart();
+    extern char usb_getcart(void);
     
     
     /*==============================
@@ -77,7 +78,7 @@
         @return The data header, or 0
     ==============================*/
     
-    extern unsigned long usb_poll();
+    extern unsigned long usb_poll(void);
     
     
     /*==============================
@@ -113,7 +114,7 @@
         Purges the incoming USB data
     ==============================*/
     
-    extern void usb_purge();
+    extern void usb_purge(void);
 
 
     /*==============================
@@ -122,7 +123,7 @@
         @return 1 if the USB timed out, 0 if not
     ==============================*/
 
-    extern char usb_timedout();
+    extern char usb_timedout(void);
 
 
     /*==============================
@@ -134,6 +135,6 @@
         version.
     ==============================*/
 
-    extern void usb_sendheartbeat();
+    extern void usb_sendheartbeat(void);
 
 #endif

--- a/src/usb.c
+++ b/src/usb.c
@@ -26,7 +26,7 @@ https://github.com/buu342/N64-UNFLoader
 #define DEBUG_ADDRESS (0x04000000 - DEBUG_ADDRESS_SIZE) // Put the debug area at the 64MB - DEBUG_ADDRESS_SIZE area in ROM space
 
 // Data header related
-#define USBHEADER_CREATE(type, left) (((type<<24) | (left & 0x00FFFFFF)))
+#define USBHEADER_CREATE(type, left) ((((type)<<24) | ((left) & 0x00FFFFFF)))
 
 // Protocol related
 #define USBPROTOCOL_VERSION 2
@@ -233,8 +233,8 @@ static void usb_sc64_read(void);
 
 // Function pointers
 void (*funcPointer_write)(int datatype, const void* data, int size);
-u32  (*funcPointer_poll)();
-void (*funcPointer_read)();
+u32  (*funcPointer_poll)(void);
+void (*funcPointer_read)(void);
 
 // USB globals
 static s8 usb_cart = CART_NONE;
@@ -335,7 +335,7 @@ static inline void usb_dma_read(void *ram_address, u32 pi_address, size_t size)
             osPiRawStartDma(OS_READ, pi_address, ram_address, size);
         #else
             osPiStartDma(&dmaIOMessageBuf, OS_MESG_PRI_NORMAL, OS_READ, pi_address, ram_address, size, &dmaMessageQ);
-            osRecvMesg(&dmaMessageQ, NULL, OS_MESG_BLOCK);
+            while (osRecvMesg(&dmaMessageQ, NULL, OS_MESG_NOBLOCK) != 0);
         #endif
     #else
         data_cache_hit_writeback_invalidate(ram_address, size);
@@ -651,7 +651,7 @@ void usb_read(void* buffer, int nbytes)
         }
         
         // Copy from the USB buffer to the supplied buffer
-        memcpy(buffer+read, usb_buffer+copystart, block);
+        memcpy((void*)(((u32)buffer)+read), usb_buffer+copystart, block);
         
         // Increment/decrement all our counters
         read += block;
@@ -729,7 +729,7 @@ char usb_timedout()
     version.
 ==============================*/
 
-void usb_sendheartbeat()
+void usb_sendheartbeat(void)
 {
     u8 buffer[4];
 
@@ -921,7 +921,7 @@ static u32 usb_64drive_cui_read(u32 offset)
 
 static void usb_64drive_write(int datatype, const void* data, int size)
 {
-    int left = size;
+    s32 left = size;
     u32 pi_address = D64_BASE + DEBUG_ADDRESS;
 
     // Return if previous transfer timed out
@@ -942,16 +942,16 @@ static void usb_64drive_write(int datatype, const void* data, int size)
 
         // Copy data to PI DMA aligned buffer
         memcpy(usb_buffer, data, block);
-
-        // If the data was not 32-bit aligned, pad the buffer
-        while (block % 4)
+        
+        // Pad the buffer with zeroes if it wasn't 4 byte aligned
+        while (block%4)
             usb_buffer[block++] = 0;
 
         // Copy block of data from RDRAM to SDRAM
         usb_dma_write(usb_buffer, pi_address, ALIGN(block, 2));
 
         // Update pointers and variables
-        data += block;
+        data = (void*)(((u32)data) + block);
         left -= block;
         pi_address += block;
     }
@@ -1153,7 +1153,10 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
         // Set USB to write mode with the new address and wait for USB to end (or stop if it times out)
         usb_io_write(ED_REG_USBCFG, ED_USBMODE_WR | baddr);
         if (usb_everdrive_usbbusy())
+        {
+            usb_didtimeout = TRUE;
             return;
+        }
         
         // Keep track of what we've read so far
         left -= block;
@@ -1173,10 +1176,10 @@ static void usb_everdrive_write(int datatype, const void* data, int size)
 
 static u32 usb_everdrive_poll(void)
 {
-    int   len;
-    int   offset = 0;
-    char  buffaligned[32];
-    char* buff = (char*)OS_DCACHE_ROUNDUP_ADDR(buffaligned);
+    int len;
+    int offset = 0;
+    unsigned char  buffaligned[32];
+    unsigned char* buff = (unsigned char*)OS_DCACHE_ROUNDUP_ADDR(buffaligned);
     
     // Wait for the USB to be ready
     if (usb_everdrive_usbbusy())
@@ -1192,8 +1195,8 @@ static u32 usb_everdrive_poll(void)
         return 0;
         
     // Store information about the incoming data
-    usb_datatype = (int)buff[4];
-    usb_datasize = (int)buff[5]<<16 | (int)buff[6]<<8 | (int)buff[7]<<0;
+    usb_datatype = buff[4];
+    usb_datasize = (buff[5] << 16) | (buff[6] << 8) | (buff[7] << 0);
     usb_dataleft = usb_datasize;
     usb_readblock = -1;
     
@@ -1360,7 +1363,7 @@ static void usb_sc64_write(int datatype, const void* data, int size)
         usb_dma_write(usb_buffer, pi_address, ALIGN(block, 2));
 
         // Update pointers and variables
-        data += block;
+        data = (void*)(((u32)data) + block);
         left -= block;
         pi_address += block;
     }


### PR DESCRIPTION
The two main changes to the USB library itself are:
* Fixed casts, types, and a bunch of other stuff that conflicted with other compilers, mainly IDO. (https://github.com/buu342/N64-UNFLoader/pull/113 https://github.com/buu342/N64-UNFLoader/pull/116). This is mostly unrelated to Libdragon.
* Fixed EverDrive timeout not working properly (https://github.com/buu342/N64-UNFLoader/issues/114). This is already fixed on Libdragon's end, I just took a while to copy the changes over to UNFLoader.

The big and important change is to usb.h, where the `DATATYPE_RDBPACKET` data type is now defined. This data type is required to get UNFLoader's GDB communication to work.