### PR TITLE
Unstable: Fix Windows tools CI

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 
@@ -24,7 +24,7 @@ jobs:
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@1.9.4
+        uses: mattnotmitt/doxygen-action@1.9.5
         with:
           doxyfile-path: 'doxygen-public.conf'
 

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -24,7 +24,7 @@ jobs:
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@1.9.5
+        uses: mattnotmitt/doxygen-action@1.9.4
         with:
           doxyfile-path: 'doxygen-public.conf'
 

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 
+      - name: Download and extract latest toolchain
+        shell: msys2 {0}
+        run: |
+          curl -o gcc-toolchain-mips64-win64.zip https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
+          unzip gcc-toolchain-mips64-win64.zip -d "gcc-toolchain-mips64"
+          rm -f gcc-toolchain-mips64-win64.zip
+
+
       - name: Correct MSYS2 pthread.h to allow static libraries (otherwise you would need to use a lib DLL, rather than it being built into the EXE.)
         shell: msys2 {0}
         run: |

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -21,7 +21,7 @@ jobs:
             mingw-w64-${{ matrix.arch }}-toolchain
           update: true
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Download and extract latest toolchain
         shell: msys2 {0}
         run: |
-          curl -L -o gcc-toolchain-mips64-win64.zip https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
-          unzip gcc-toolchain-mips64-win64.zip -d "gcc-toolchain-mips64"
+          curl -Lo gcc-toolchain-mips64-win64.zip https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
+          unzip gcc-toolchain-mips64-win64.zip -d gcc-toolchain-mips64
           rm -f gcc-toolchain-mips64-win64.zip
 
 

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -19,7 +19,6 @@ jobs:
           install: >-
             base-devel
             mingw-w64-${{ matrix.arch }}-toolchain
-            unzip
           update: true
 
       - uses: actions/checkout@v4
@@ -29,9 +28,9 @@ jobs:
       - name: Download and extract latest toolchain
         shell: msys2 {0}
         run: |
-          curl -o gcc-toolchain-mips64-win64.zip https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
-          unzip gcc-toolchain-mips64-win64.zip -d "gcc-toolchain-mips64"
-          rm -f gcc-toolchain-mips64-win64.zip
+          curl -o "gcc-toolchain-mips64-win64.zip" https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
+          tar -zxvf "gcc-toolchain-mips64-win64.zip"
+          rm -f "gcc-toolchain-mips64-win64.zip"
 
 
       - name: Correct MSYS2 pthread.h to allow static libraries (otherwise you would need to use a lib DLL, rather than it being built into the EXE.)

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -19,6 +19,7 @@ jobs:
           install: >-
             base-devel
             mingw-w64-${{ matrix.arch }}-toolchain
+            unzip
           update: true
 
       - uses: actions/checkout@v4
@@ -28,9 +29,9 @@ jobs:
       - name: Download and extract latest toolchain
         shell: msys2 {0}
         run: |
-          curl -o "gcc-toolchain-mips64-win64.zip" https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
-          tar -zxvf "gcc-toolchain-mips64-win64.zip"
-          rm -f "gcc-toolchain-mips64-win64.zip"
+          curl -L -o gcc-toolchain-mips64-win64.zip https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-win64.zip
+          unzip gcc-toolchain-mips64-win64.zip -d "gcc-toolchain-mips64"
+          rm -f gcc-toolchain-mips64-win64.zip
 
 
       - name: Correct MSYS2 pthread.h to allow static libraries (otherwise you would need to use a lib DLL, rather than it being built into the EXE.)
@@ -41,7 +42,7 @@ jobs:
       - name: Build ${{ matrix.build }}
         shell: msys2 {0}
         run: |
-          make ${{ matrix.build }}
+          N64_INST=$(pwd)/gcc-toolchain-mips64 make ${{ matrix.build }}
 
       - name: "Upload ${{ matrix.build }} executables"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -19,6 +19,7 @@ jobs:
           install: >-
             base-devel
             mingw-w64-${{ matrix.arch }}-toolchain
+            unzip
           update: true
 
       - uses: actions/checkout@v4

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Using a full fetch so that the diff action can run.
 
@@ -51,12 +51,12 @@ jobs:
       # use from registry o/w
       - name: Set up Docker Build
         if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         if: ${{ steps.path_diff.outputs.changed == 1 }}
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ steps.vars.outputs.repository_name }}
           # latest tag is handled separately
@@ -65,7 +65,7 @@ jobs:
 
       - name: Log in to the container registry
         if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and push image
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           # Only push image if this is a push event. Otherwise it will fail because
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
@@ -91,7 +91,7 @@ jobs:
       # cached, it should not take long to build.
       - name: Load image for libdragon build
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           # Do not push the image yet, we also want to make sure libdragon builds
           # with the fresh image.
@@ -125,7 +125,7 @@ jobs:
       # build with this freshly built image.
       - name: Push latest image
         if: ${{ steps.path_diff.outputs.changed == 1 && github.ref == steps.vars.outputs.default_ref }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ghcr.io/${{ steps.vars.outputs.repository_name }}:latest

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1 # we only require the last check-in, unless we want to create a changelog.
 
@@ -187,7 +187,7 @@ jobs:
     needs: Build-Toolchain
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Download Windows artifact
         id: download-windows-artifact


### PR DESCRIPTION
The latest tools in unstable require use of the MIPS GCC toolchain.

It seems that environment variables are not carried across tasks, so uses it directly for the makefile build.

Also updates GitHub actions in all of the CI with the exception of doxygen-action (as it fails build).