### PR TITLE
Unstable: Update Dockerfile image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # V0 - Use this comment to force a re-build without changing the contents
 
 # Stage 1 - Build the toolchain
-FROM ubuntu:18.04
+FROM ubuntu:latest
 ARG N64_INST=/n64_toolchain
 ENV N64_INST=${N64_INST}
 
@@ -19,7 +19,7 @@ RUN ./build-toolchain.sh
 RUN rm -rf ${N64_INST}/share/locale/*
 
 # Stage 2 - Prepare minimal image
-FROM ubuntu:18.04
+FROM ubuntu:latest
 ARG N64_INST=/n64_toolchain
 ENV N64_INST=${N64_INST}
 ENV PATH="${N64_INST}/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # V0 - Use this comment to force a re-build without changing the contents
 
 # Stage 1 - Build the toolchain
-FROM ubuntu:latest
+FROM ubuntu:22.04
 ARG N64_INST=/n64_toolchain
 ENV N64_INST=${N64_INST}
 
@@ -19,7 +19,7 @@ RUN ./build-toolchain.sh
 RUN rm -rf ${N64_INST}/share/locale/*
 
 # Stage 2 - Prepare minimal image
-FROM ubuntu:latest
+FROM ubuntu:22.04
 ARG N64_INST=/n64_toolchain
 ENV N64_INST=${N64_INST}
 ENV PATH="${N64_INST}/bin:$PATH"


### PR DESCRIPTION
Use the latest image rather than an EOL version.

The solution could be to adjust (at minimum) `FROM ubuntu:18.04` in `Dockerfile` to be `FROM ubuntu:22.04`, but we are not doing anything that "should" require it being fixed to a specific version.

Although this PR targets the Unstable branch, it is equally valid (and should have no issues) with main/stable/trunk.

Fixes #466 