### PR TITLE
Accept a BASE_DIR for examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,3 @@
-BASE_DIR=.
 EXAMPLES = audioplayer cpptest ctest dfsdemo eepromfstest mixertest mptest mputest rspqdemo spritemap test timers vrutest vtest ucodetest
 
 all: $(EXAMPLES)
@@ -7,7 +6,11 @@ clean: $(foreach example,$(EXAMPLES),$(example)-clean)
 
 define EXAMPLE_template
 $(1):
+ifdef $(BASE_DIR)
 	$$(MAKE) -C $(1) SOURCE_DIR=$(BASE_DIR)/$(1)
+else
+	$$(MAKE) -C $(1)
+endif
 $(1)-clean:
 	$$(MAKE) -C $(1) clean
 .PHONY: $(1) $(1)-clean

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,3 +1,4 @@
+BASE_DIR=.
 EXAMPLES = audioplayer cpptest ctest dfsdemo eepromfstest mixertest mptest mputest rspqdemo spritemap test timers vrutest vtest ucodetest
 
 all: $(EXAMPLES)
@@ -6,7 +7,7 @@ clean: $(foreach example,$(EXAMPLES),$(example)-clean)
 
 define EXAMPLE_template
 $(1):
-	$$(MAKE) -C $(1)
+	$$(MAKE) -C $(1) SOURCE_DIR=$(BASE_DIR)/$(1)
 $(1)-clean:
 	$$(MAKE) -C $(1) clean
 .PHONY: $(1) $(1)-clean


### PR DESCRIPTION
Currently the docker project replicates each and every example in its own Makefile: https://github.com/anacierdem/libdragon-docker/blob/b7fa4e8fc592e597040cb296bbc16d6bf840df53/Makefile#L92. Even though this might be improved with `call`, it would be better to just use libdragon's make recipe. OTOH, it currently does not provide a convenient way to override the SOURCE_DIR without naming the test folder. Using external SOURCE_DIR is useful to change gcc logs for error matching on vscode.

This small change introduces a new `BASE_DIR` parameter that will be used as the prefix for each example build so that external tools can override the base path as they see fit. This will make it possible to remove those example references from docker repository Makefile.