### PR TITLE
examples: Remove deprecations from examples

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -78,10 +78,10 @@ enum Page page_intro(void) {
 	display_show(disp);
 
 	while (1) {
-		controller_scan();
-		struct controller_data ckeys = get_keys_down();
+		joypad_poll();
+		joypad_buttons_t ckeys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
 
-		if (ckeys.c[0].start) {
+		if (ckeys.start) {
 			return PAGE_MENU;
 		}
 	}
@@ -145,19 +145,19 @@ enum Page page_menu(void) {
 	display_show(disp);
 
 	while (1) {
-		controller_scan();
-		struct controller_data ckeys = get_keys_down();
+		joypad_poll();
+		joypad_buttons_t ckeys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
 
-		if (ckeys.c[0].up)      { menu_sel -= 1; break; }
-		if (ckeys.c[0].down)    { menu_sel += 1; break; }
-		if (ckeys.c[0].left)    { menu_sel -= COL_ROWS; break; }
-		if (ckeys.c[0].right)   { menu_sel += COL_ROWS; break; }
-		if (ckeys.c[0].C_up)    { menu_sel = 0; break; }
-		if (ckeys.c[0].C_down)  { menu_sel = num_songs-1; break; }
-		if (ckeys.c[0].C_left)  { menu_sel -= COL_ROWS*NUM_COLUMNS; break; }
-		if (ckeys.c[0].C_right) { menu_sel += COL_ROWS*NUM_COLUMNS; break; }
+		if (ckeys.d_up)      { menu_sel -= 1; break; }
+		if (ckeys.d_down)    { menu_sel += 1; break; }
+		if (ckeys.d_left)    { menu_sel -= COL_ROWS; break; }
+		if (ckeys.d_right)   { menu_sel += COL_ROWS; break; }
+		if (ckeys.c_up)    { menu_sel = 0; break; }
+		if (ckeys.c_down)  { menu_sel = num_songs-1; break; }
+		if (ckeys.c_left)  { menu_sel -= COL_ROWS*NUM_COLUMNS; break; }
+		if (ckeys.c_right) { menu_sel += COL_ROWS*NUM_COLUMNS; break; }
 
-		if (ckeys.c[0].A) {
+		if (ckeys.a) {
 			cur_rom = songfiles[menu_sel];
 			chselect = 0;
 			return PAGE_SONG;
@@ -333,47 +333,47 @@ enum Page page_song(void) {
 			}
 			first_loop = false;
 
-			controller_scan();
-			struct controller_data ckeys = get_keys_down();
-			if (ckeys.c[0].left || ckeys.c[0].right) {
+			joypad_poll();
+			joypad_buttons_t ckeys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+			if (ckeys.d_left || ckeys.d_right) {
 				if (song_type == SONG_XM) {				
 					int patidx;
 					xm64player_tell(&xm, &patidx, NULL, NULL);
-					if (ckeys.c[0].left && patidx > 0) patidx--;
-					if (ckeys.c[0].right && patidx < xm_get_module_length(xm.ctx)-1) patidx++;
+					if (ckeys.d_left && patidx > 0) patidx--;
+					if (ckeys.d_right && patidx < xm_get_module_length(xm.ctx)-1) patidx++;
 					xm64player_seek(&xm, patidx, 0, 0);
 					break;
 				} else if (song_type == SONG_YM && !ym.decoder) {
 					int pos, len;
 					ym64player_duration(&ym, &len, NULL);
 					ym64player_tell(&ym, &pos, NULL);
-					if (ckeys.c[0].left && pos >= 0x200) pos -= 0x200;
-					if (ckeys.c[0].right && pos <= len-0x200) pos += 0x200;
+					if (ckeys.d_left && pos >= 0x200) pos -= 0x200;
+					if (ckeys.d_right && pos <= len-0x200) pos += 0x200;
 					ym64player_seek(&ym, pos);
 					break;
 				}
 			}
 
 			if (song_type == SONG_XM) {			
-				if (ckeys.c[0].up && screen_first_inst > 0) {
+				if (ckeys.d_up && screen_first_inst > 0) {
 					screen_first_inst--;
 					break;
 				}
-				if (ckeys.c[0].down && screen_first_inst < xm.ctx->module.num_instruments-1) {
+				if (ckeys.d_down && screen_first_inst < xm.ctx->module.num_instruments-1) {
 					screen_first_inst++;
 					break;
 				}
 			}
 
-			if (ckeys.c[0].C_left && chselect > 0) { chselect--; break; }
-			if (ckeys.c[0].C_right && chselect < song_channels-1) { chselect++; break; }
-			if (ckeys.c[0].C_down) {
+			if (ckeys.c_left && chselect > 0) { chselect--; break; }
+			if (ckeys.c_right && chselect < song_channels-1) { chselect++; break; }
+			if (ckeys.c_down) {
 				mute[chselect] = !mute[chselect];
 				if (song_type == SONG_XM)
 					xm_mute_channel(xm.ctx, chselect+1, mute[chselect]);
 				break;
 			}
-			if (ckeys.c[0].C_up) { 
+			if (ckeys.c_up) { 
 				mute[chselect] = !mute[chselect];
 				for (int i=0;i<song_channels;i++) {
 					if (i != chselect)
@@ -384,7 +384,7 @@ enum Page page_song(void) {
 				break;
 			}
 
-			if (ckeys.c[0].B) {
+			if (ckeys.b) {
 				if (song_type == SONG_XM)
 					xm64player_close(&xm);
 				else
@@ -396,7 +396,7 @@ enum Page page_song(void) {
 }
 
 int main(void) {
-	controller_init();
+	joypad_init();
 	debug_init_isviewer();
 	debug_init_usblog();
 

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -49,7 +49,7 @@ int main(void)
 {
     debug_init_isviewer();
     debug_init_usblog();
-    controller_init();
+    joypad_init();
 
     auto localClass = std::make_unique<TestClass>();
 
@@ -66,9 +66,9 @@ int main(void)
         printf("\nPress A to crash (test uncaught C++ exceptions)\n");
         console_render();
 
-        controller_scan();
-        struct controller_data keys = get_keys_down();
-        if (keys.c[0].A)
+        joypad_poll();
+        joypad_buttons_t keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+        if (keys.a)
             localClass->crash();
         
     }

--- a/examples/customfont/customfont.c
+++ b/examples/customfont/customfont.c
@@ -9,8 +9,8 @@ int main(void)
     /* Initialize peripherals */
     display_init( RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
     dfs_init( DFS_DEFAULT_LOCATION );
-    rdp_init();
-    controller_init();
+    rdpq_init();
+    joypad_init();
     timer_init();
 
     /* Read in the custom font */

--- a/examples/dfsdemo/dfsdemo.c
+++ b/examples/dfsdemo/dfsdemo.c
@@ -215,7 +215,7 @@ int main(void)
     console_init();
 
     /* Initialize key detection */
-    controller_init();
+    joypad_init();
 
     if(dfs_init( DFS_DEFAULT_LOCATION ) != DFS_ESUCCESS)
     {
@@ -239,22 +239,22 @@ int main(void)
             display_dir(list, cursor, page, MAX_LIST, count);
             console_render();
 
-            controller_scan();
-            struct controller_data keys = get_keys_down();
+            joypad_poll();
+            joypad_buttons_t keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
 
-            if(keys.c[0].up)
+            if(keys.d_up)
             {
                 cursor--;
                 new_scroll_pos(&cursor, &page, MAX_LIST, count);
             }
 
-            if(keys.c[0].down)
+            if(keys.d_down)
             {
                 cursor++;
                 new_scroll_pos(&cursor, &page, MAX_LIST, count);
             }
 
-            if(keys.c[0].C_right && list[cursor].type == DT_REG)
+            if(keys.c_right && list[cursor].type == DT_REG)
             {
                 /* Concatenate to make file */
                 char path[512];
@@ -284,10 +284,10 @@ int main(void)
                                 s = s_next_line + 1;
 
                                 wait_ms(100);
-                                controller_scan();
-                                while (!get_keys_pressed().c[0].A) {
+                                joypad_poll();
+                                while (!joypad_get_buttons(JOYPAD_PORT_1).a) {
                                     wait_ms(10);
-                                    controller_scan();
+                                    joypad_poll();
                                 }
                             }
                         }
@@ -301,16 +301,16 @@ int main(void)
 
                 printf("Press B to quit\n");
                 console_render();
-                controller_scan();
-                while (!get_keys_down().c[0].B) {
+                joypad_poll();
+                while (!joypad_get_buttons(JOYPAD_PORT_1).b) {
                     wait_ms(10);
-                    controller_scan();
+                    joypad_poll();
                 }
 
                 continue;
             }
 
-            if(keys.c[0].L)
+            if(keys.l)
             {
                 /* Open the SD card */
                 strcpy( dir, "sd://" );
@@ -323,7 +323,7 @@ int main(void)
                 cursor = 0;
             }
 
-            if(keys.c[0].R)
+            if(keys.r)
             {
                 /* Open the ROM FS card */
                 strcpy( dir, "rom://" );
@@ -336,7 +336,7 @@ int main(void)
                 cursor = 0;
             }
 
-            if(keys.c[0].A && list[cursor].type == DT_DIR)
+            if(keys.a && list[cursor].type == DT_DIR)
             {
                 /* Change directories */
                 chdir(list[cursor].filename);
@@ -349,7 +349,7 @@ int main(void)
                 cursor = 0;
             }
 
-            if(keys.c[0].B)
+            if(keys.b)
             {
                 /* Up! */
                 chdir("..");

--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -38,12 +38,12 @@ typedef struct
 static void press_a_to_continue(void)
 {
     printf( "Press A to continue\n" );
-    struct controller_data keys;
+    joypad_buttons_t keys;
     while (1)
     {
-        controller_scan();
-        keys = get_keys_down();
-        if (keys.c[0].A)
+        joypad_poll();
+        keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+        if (keys.a)
         {
             console_clear();
             break;
@@ -55,17 +55,17 @@ static void keep_or_erase_data(void)
 {
     printf( "Press A to keep EEPROM data\n" );
     printf( "Press B to erase EEPROM data\n" );
-    struct controller_data keys;
+    joypad_buttons_t keys;
     while (1)
     {
-        controller_scan();
-        keys = get_keys_down();
-        if (keys.c[0].A)
+        joypad_poll();
+        keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+        if (keys.a)
         {
             console_clear();
             break;
         }
-        if (keys.c[0].B)
+        if (keys.b)
         {   
             printf( "Wiping EEPROM...\n" );
             eepfs_wipe();
@@ -454,7 +454,7 @@ int main(void)
 {
     /* Initialize peripherals */
     console_init();
-    controller_init();
+    joypad_init();
 
     console_set_render_mode(RENDER_AUTOMATIC);
     console_clear();

--- a/examples/fontdemo/fontdemo.c
+++ b/examples/fontdemo/fontdemo.c
@@ -82,7 +82,7 @@ int main()
 {
     debug_init_isviewer();
     debug_init_usblog();
-    controller_init();
+    joypad_init();
 
     dfs_init(DFS_DEFAULT_LOCATION);
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
@@ -151,12 +151,12 @@ int main()
             }
         }
 
-        controller_scan();
-        struct controller_data keys = get_keys_held();
-        if (keys.c[0].C_up) { box_height += 2; }
-        if (keys.c[0].C_down) { box_height -= 2; }
-        if (keys.c[0].C_left) { box_width += 2; }
-        if (keys.c[0].C_right) { box_width -= 2; }
+        joypad_poll();
+        joypad_buttons_t keys = joypad_get_buttons_held(JOYPAD_PORT_1);
+        if (keys.c_up) { box_height += 2; }
+        if (keys.c_down) { box_height -= 2; }
+        if (keys.c_left) { box_width += 2; }
+        if (keys.c_right) { box_width -= 2; }
         box_height = MAX(1, box_height);
         box_width = MAX(1, box_width);
 

--- a/examples/loadspritefromsd/loadspritefromsd.c
+++ b/examples/loadspritefromsd/loadspritefromsd.c
@@ -69,7 +69,7 @@ int main(void) {
 	/* Initialize peripherals */
 	display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
 	dfs_init(DFS_DEFAULT_LOCATION);
-	controller_init();
+	joypad_init();
 
 	/* This will initialize the SD filesystem using 'sd:/' to identify it */
 	/* This path has to be the same used by the sprites when loading */
@@ -83,11 +83,7 @@ int main(void) {
 
 	/* Main loop test */
 	while (1) {
-		static display_context_t disp = 0;
-
-		/* Grab a render buffer */
-		while (!(disp = display_lock()))
-			;
+		surface_t* disp = display_get();
 
 		/* Clear the screen */
 		graphics_fill_screen(disp, 0);
@@ -106,10 +102,10 @@ int main(void) {
 		display_show(disp);
 
 		/* Do we need to change the sprite? */
-		controller_scan();
-		struct controller_data keys = get_keys_down();
+		joypad_poll();
+		joypad_buttons_t keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
 
-		if (keys.c[0].start) {
+		if (keys.start) {
 			/* Load the next sprite */
 			const int id = (cur_sprite + 1) % MAX_SPRITES;
 			load_sprite(id);

--- a/examples/overlays/actor/actor.h
+++ b/examples/overlays/actor/actor.h
@@ -7,7 +7,7 @@
 struct actor_s;
 
 typedef void (*init_func_t)(struct actor_s *);
-typedef bool (*update_func_t)(struct actor_s *, struct controller_data);
+typedef bool (*update_func_t)(struct actor_s *, joypad_buttons_t);
 
 typedef struct actor_s {
     void *ovl_handle;

--- a/examples/overlays/actor/circle.c
+++ b/examples/overlays/actor/circle.c
@@ -32,7 +32,7 @@ static void apply_accel(float *pos, float *origin_pos, float *vel, float accel)
     *pos += *vel;
 }
 
-static bool update(actor_t *actor, struct controller_data pressed_keys)
+static bool update(actor_t *actor, joypad_buttons_t pressed_keys)
 {
     circle_actor_t *this = (circle_actor_t *)actor;
     apply_accel(&actor->x, &this->home_x, &this->vel_x, 0.2f);
@@ -42,7 +42,7 @@ static bool update(actor_t *actor, struct controller_data pressed_keys)
         return false;
     }
     //Fast forward to flickering when pressing B
-    if(pressed_keys.c[0].B) {
+    if(pressed_keys.b) {
         this->num_ticks = SPAWN_DURATION-FLICKER_DURATION;
     }
     if(this->num_ticks > SPAWN_DURATION-FLICKER_DURATION) {

--- a/examples/overlays/actor/n64brew.c
+++ b/examples/overlays/actor/n64brew.c
@@ -36,11 +36,11 @@ static void do_crash()
     debugf((char *)0x1);
 }
 
-static bool update(actor_t *actor, struct controller_data pressed_keys)
+static bool update(actor_t *actor, joypad_buttons_t pressed_keys)
 {
     n64brew_actor_t *this = (n64brew_actor_t *)actor;
     do_rotation(this);
-    if(pressed_keys.c[0].C_right) {
+    if(pressed_keys.c_right) {
         do_crash();
     }
     //Despawn after existing for too long
@@ -48,7 +48,7 @@ static bool update(actor_t *actor, struct controller_data pressed_keys)
         return false;
     }
     //Fast forward to flickering when pressing C-up
-    if(pressed_keys.c[0].C_up) {
+    if(pressed_keys.c_up) {
         this->num_ticks = SPAWN_DURATION-FLICKER_DURATION;
     }
     if(this->num_ticks > SPAWN_DURATION-FLICKER_DURATION) {

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -76,7 +76,7 @@ static void draw_actors()
     }
 }
 
-static void update_actors(struct controller_data keys)
+static void update_actors(joypad_buttons_t keys)
 {
     for(int i=0; i<MAX_ACTORS; i++) {
         if(actors[i]) {
@@ -107,17 +107,16 @@ int main()
     scr_height = display_get_height();
     //Init miscellaneous system
     dfs_init(DFS_DEFAULT_LOCATION);
-    controller_init();
+    joypad_init();
     //Setup scene
     create_actor(2, scr_width/2, scr_height/2);
     while(1) {
         surface_t *disp;
         //Update controller
-        struct controller_data keys;
-        controller_scan();
-        keys = get_keys_down();
+        joypad_poll();
+        joypad_buttons_t keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
         //Do actor spawning
-        if(keys.c[0].A) {
+        if(keys.a) {
             //Spawn a random actor somewhere in the middle 80% of the screen
             float pos_x = (((float)rand()/RAND_MAX)*(scr_width*0.8f))+(scr_width*0.1f);
             float pos_y = (((float)rand()/RAND_MAX)*(scr_height*0.8f))+(scr_height*0.1f);

--- a/examples/overlays/actor/triangle.c
+++ b/examples/overlays/actor/triangle.c
@@ -41,12 +41,12 @@ static bool do_vanish(triangle_actor_t *this)
     return true;
 }
 
-static bool update(actor_t *actor, struct controller_data pressed_keys)
+static bool update(actor_t *actor, joypad_buttons_t pressed_keys)
 {
     triangle_actor_t *this = (triangle_actor_t *)actor;
     do_animation(this);
     //Activate vanish when pressing Z
-    if(pressed_keys.c[0].Z) {
+    if(pressed_keys.z) {
         this->vanish = true;
     }
     return do_vanish(this);

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -12,7 +12,7 @@ int main()
     rdpq_debug_start();
     //Init miscellaneous system
     dfs_init(DFS_DEFAULT_LOCATION);
-    controller_init();
+    joypad_init();
     //Init scene manager to load bg_test as first scene
     SceneMgr::Init();
     SceneMgr::SetNextScene("bg_test");
@@ -20,7 +20,7 @@ int main()
         //Load new scene
         SceneMgr::LoadNextScene();
         while(!SceneMgr::ChangingScene()) {
-            controller_scan(); //Read controller
+            joypad_poll(); //Read controller
             SceneMgr::Update(); //Update scene
             //Draw scene
             surface_t *disp = display_get();

--- a/examples/overlays/scene/scene/bg_test.cpp
+++ b/examples/overlays/scene/scene/bg_test.cpp
@@ -22,14 +22,14 @@ BGTest::~BGTest()
 
 void BGTest::UpdateZoom()
 {
-    struct controller_data cont_data = get_keys_held();
+    joypad_buttons_t cont_data = joypad_get_buttons_held(JOYPAD_PORT_1);
     //Calculate next zoom (exponential)
     float new_zoom = m_zoom;
-    if(cont_data.c[0].L) {
+    if(cont_data.l) {
         //Zoom out
         new_zoom *= ZOOM_SPEED;
     }
-    if(cont_data.c[0].R) {
+    if(cont_data.r) {
         //Zoom in
         new_zoom /= ZOOM_SPEED;
     }
@@ -46,10 +46,10 @@ void BGTest::UpdateZoom()
 
 void BGTest::UpdatePos()
 {
-    struct controller_data cont_data = get_keys_held();
+    joypad_inputs_t cont_data = joypad_get_inputs(JOYPAD_PORT_1);
     //Move by analog stick position
-    int8_t stick_x = cont_data.c[0].x;
-    int8_t stick_y = cont_data.c[0].y;
+    int8_t stick_x = cont_data.stick_x;
+    int8_t stick_y = cont_data.stick_y;
     if(abs(stick_x) >= STICK_DEADZONE) {
         m_pos_x += stick_x*MOVE_SPEED/m_zoom;
     }
@@ -60,8 +60,8 @@ void BGTest::UpdatePos()
 
 void BGTest::UpdateCenterPos()
 {
-    struct controller_data cont_data = get_keys_held();
-    if(cont_data.c[0].C_up) {
+    joypad_buttons_t cont_data = joypad_get_buttons_held(JOYPAD_PORT_1);
+    if(cont_data.c_up) {
         //Move center position up
         m_center_pos_y -= CENTER_MOVE_SPEED;
         m_pos_y -= CENTER_MOVE_SPEED/m_zoom;
@@ -69,7 +69,7 @@ void BGTest::UpdateCenterPos()
             m_center_pos_y = CENTER_MARGIN_H;
         }
     }
-    if(cont_data.c[0].C_down) {
+    if(cont_data.c_down) {
         //Move center position down
         m_center_pos_y += CENTER_MOVE_SPEED;
         m_pos_y += CENTER_MOVE_SPEED/m_zoom;
@@ -77,7 +77,7 @@ void BGTest::UpdateCenterPos()
             m_center_pos_y = display_get_height()-CENTER_MARGIN_H;
         }
     }
-    if(cont_data.c[0].C_left) {
+    if(cont_data.c_left) {
         //Move center position left
         m_center_pos_x -= CENTER_MOVE_SPEED;
         m_pos_x -= CENTER_MOVE_SPEED/m_zoom;
@@ -85,7 +85,7 @@ void BGTest::UpdateCenterPos()
             m_center_pos_x = CENTER_MARGIN_W;
         }
     }
-    if(cont_data.c[0].C_right) {
+    if(cont_data.c_right) {
         //Move center position right
         m_center_pos_x += CENTER_MOVE_SPEED;
         m_pos_x += CENTER_MOVE_SPEED/m_zoom;
@@ -108,8 +108,8 @@ void BGTest::UpdateBackground()
 void BGTest::Update()
 {
     //Load next scene if start is pressed
-    struct controller_data cont_data = get_keys_down();
-    if(cont_data.c[0].start) {
+    joypad_buttons_t cont_data = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+    if(cont_data.start) {
         SceneMgr::SetNextScene("sprite_test");
         return;
     }

--- a/examples/overlays/scene/scene/sprite_test.cpp
+++ b/examples/overlays/scene/scene/sprite_test.cpp
@@ -38,17 +38,17 @@ SpriteTest::~SpriteTest()
 
 void SpriteTest::Update()
 {
-    struct controller_data cont_data = get_keys_down();
-    if(cont_data.c[0].start) {
+    joypad_buttons_t cont_data = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+    if(cont_data.start) {
         SceneMgr::SetNextScene("bg_test");
         return;
     }
     //Add new sprite when pressing A
-    if(cont_data.c[0].A && m_num_sprites < MAX_SPRITES) {
+    if(cont_data.a && m_num_sprites < MAX_SPRITES) {
         SpawnSprite();
     }
     //Remove last sprite when pressing B
-    if(cont_data.c[0].B && m_num_sprites > 0) {
+    if(cont_data.b && m_num_sprites > 0) {
         m_num_sprites--;
     }
     UpdateSprites();

--- a/examples/pixelshader/pixelshader.c
+++ b/examples/pixelshader/pixelshader.c
@@ -64,7 +64,7 @@ int main(void) {
     debug_init_usblog();
     display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
     dfs_init(DFS_DEFAULT_LOCATION);
-    controller_init();
+    joypad_init();
     rdpq_init();
     rdpq_debug_start();
 
@@ -132,9 +132,9 @@ int main(void) {
         rspq_wait();
         last_frame = TICKS_READ() - cur_frame;
 
-        controller_scan();
-        struct controller_data keys = get_keys_down();
-        if (keys.c[0].A) {
+        joypad_poll();
+        joypad_buttons_t keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+        if (keys.a) {
             use_rdp = !use_rdp;
         }
     }

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -103,7 +103,7 @@ int main()
 
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 
-    controller_init();
+    joypad_init();
     timer_init();
 
     uint32_t display_width = display_get_width();
@@ -181,14 +181,14 @@ int main()
     {
         render(cur_frame);
 
-        controller_scan();
-        struct controller_data ckeys = get_keys_down();
+        joypad_poll();
+        joypad_buttons_t ckeys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
 
-        if (ckeys.c[0].C_up && num_objs < NUM_OBJECTS) {
+        if (ckeys.c_up && num_objs < NUM_OBJECTS) {
             ++num_objs;
         }
 
-        if (ckeys.c[0].C_down && num_objs > 1) {
+        if (ckeys.c_down && num_objs > 1) {
             --num_objs;
         }
 

--- a/examples/test/test.c
+++ b/examples/test/test.c
@@ -40,7 +40,7 @@ int main(void)
     /* Initialize peripherals */
     display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
     dfs_init( DFS_DEFAULT_LOCATION );
-    controller_init();
+    joypad_init();
 
     /* Read in sprite */
     sprite_t *mario = read_sprite( "rom://mario.sprite" );
@@ -119,10 +119,10 @@ int main(void)
         display_show(disp);
 
         /* Do we need to switch video displays? */
-        controller_scan();
-        struct controller_data keys = get_keys_down();
+        joypad_poll();
+        joypad_buttons_t keys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
 
-        if( keys.c[0].up )
+        if( keys.d_up )
         {
             display_close();
 
@@ -130,7 +130,7 @@ int main(void)
             display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
 
-        if( keys.c[0].down )
+        if( keys.d_down )
         {
             display_close();
 
@@ -138,7 +138,7 @@ int main(void)
             display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
 
-        if( keys.c[0].left )
+        if( keys.d_left )
         {
             display_close();
 
@@ -146,7 +146,7 @@ int main(void)
             display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
         }
 
-        if( keys.c[0].right )
+        if( keys.d_right )
         {
             display_close();
 

--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -19,7 +19,7 @@ void video_poll(void) {
 }
 
 int main(void) {
-	controller_init();
+	joypad_init();
 	debug_init_isviewer();
 	debug_init_usblog();
 

--- a/examples/vtest/vtest.c
+++ b/examples/vtest/vtest.c
@@ -5,209 +5,98 @@
 #include <stdint.h>
 #include <libdragon.h>
 
-/* hardware definitions */
-// Pad buttons
-#define A_BUTTON(a)     ((a) & 0x8000)
-#define B_BUTTON(a)     ((a) & 0x4000)
-#define Z_BUTTON(a)     ((a) & 0x2000)
-#define START_BUTTON(a) ((a) & 0x1000)
-
-// D-Pad
-#define DU_BUTTON(a)    ((a) & 0x0800)
-#define DD_BUTTON(a)    ((a) & 0x0400)
-#define DL_BUTTON(a)    ((a) & 0x0200)
-#define DR_BUTTON(a)    ((a) & 0x0100)
-
-// Triggers
-#define TL_BUTTON(a)    ((a) & 0x0020)
-#define TR_BUTTON(a)    ((a) & 0x0010)
-
-// Yellow C buttons
-#define CU_BUTTON(a)    ((a) & 0x0008)
-#define CD_BUTTON(a)    ((a) & 0x0004)
-#define CL_BUTTON(a)    ((a) & 0x0002)
-#define CR_BUTTON(a)    ((a) & 0x0001)
-
-#define PAD_DEADZONE     5
-#define PAD_ACCELERATION 10
-#define PAD_CHECK_TIME   40
-
-
-unsigned short gButtons = 0;
-struct controller_data gKeys;
-
-volatile int gTicks;                    /* incremented every vblank */
-
-/* input - do getButtons() first, then getAnalogX() and/or getAnalogY() */
-unsigned short getButtons(int pad)
+void printText(surface_t* dc, char *msg, int x, int y)
 {
-    // Read current controller status
-    controller_scan();
-    gKeys = get_keys_pressed();
-    return (unsigned short)(gKeys.c[0].data >> 16);
-}
-
-unsigned char getAnalogX(int pad)
-{
-    return (unsigned char)gKeys.c[pad].x;
-}
-
-unsigned char getAnalogY(int pad)
-{
-    return (unsigned char)gKeys.c[pad].y;
-}
-
-display_context_t lockVideo(int wait)
-{
-    display_context_t dc;
-
-    if (wait)
-        dc = display_get();
-    else
-        dc = display_try_get();
-    return dc;
-}
-
-void unlockVideo(display_context_t dc)
-{
-    if (dc)
-        display_show(dc);
-}
-
-/* text functions */
-void drawText(display_context_t dc, char *msg, int x, int y)
-{
-    if (dc)
-        graphics_draw_text(dc, x, y, msg);
-}
-
-void printText(display_context_t dc, char *msg, int x, int y)
-{
-    if (dc)
-        graphics_draw_text(dc, x*8, y*8, msg);
-}
-
-/* vblank callback */
-void vblCallback(void)
-{
-    gTicks++;
-}
-
-void delay(int cnt)
-{
-    int then = gTicks + cnt;
-    while (then > gTicks) ;
-}
-
-/* initialize console hardware */
-void init_n64(void)
-{
-    /* Initialize peripherals */
-    display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
-
-    register_VI_handler(vblCallback);
-
-    controller_init();
+    graphics_draw_text(dc, x*8, y*8, msg);
 }
 
 /* main code entry point */
 int main(void)
 {
-    display_context_t _dc;
     char temp[128];
-	int res = 0;
-	unsigned short buttons, previous = 0;
+    int res = 0;
 
-    init_n64();
+    /* Initialize peripherals */
+    display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+
+    joypad_init();
 
     while (1)
     {
-		int j;
-		int width[6] = { 320, 640, 256, 512, 512, 640 };
-		int height[6] = { 240, 480, 240, 480, 240, 240 };
-		unsigned int color;
+        int width[6] = { 320, 640, 256, 512, 512, 640 };
+        int height[6] = { 240, 480, 240, 480, 240, 240 };
 
-        _dc = lockVideo(1);
-		color = graphics_make_color(0xCC, 0xCC, 0xCC, 0xFF);
-		graphics_fill_screen(_dc, color);
+        surface_t* display = display_get();
+        uint32_t color = graphics_make_color(0xCC, 0xCC, 0xCC, 0xFF);
+        graphics_fill_screen(display, color);
 
-		color = graphics_make_color(0xFF, 0xFF, 0xFF, 0xFF);
-		graphics_draw_line(_dc, 0, 0, width[res]-1, 0, color);
-		graphics_draw_line(_dc, width[res]-1, 0, width[res]-1, height[res]-1, color);
-		graphics_draw_line(_dc, width[res]-1, height[res]-1, 0, height[res]-1, color);
-		graphics_draw_line(_dc, 0, height[res]-1, 0, 0, color);
+        color = graphics_make_color(0xFF, 0xFF, 0xFF, 0xFF);
+        graphics_draw_line(display, 0, 0, width[res]-1, 0, color);
+        graphics_draw_line(display, width[res]-1, 0, width[res]-1, height[res]-1, color);
+        graphics_draw_line(display, width[res]-1, height[res]-1, 0, height[res]-1, color);
+        graphics_draw_line(display, 0, height[res]-1, 0, 0, color);
 
-		graphics_draw_line(_dc, 0, 0, width[res]-1, height[res]-1, color);
-		graphics_draw_line(_dc, 0, height[res]-1, width[res]-1, 0, color);
+        graphics_draw_line(display, 0, 0, width[res]-1, height[res]-1, color);
+        graphics_draw_line(display, 0, height[res]-1, width[res]-1, 0, color);
 
-		color = graphics_make_color(0x00, 0x00, 0x00, 0xFF);
-		graphics_set_color(color, 0);
+        color = graphics_make_color(0x00, 0x00, 0x00, 0xFF);
+        graphics_set_color(color, 0);
 
-        printText(_dc, "Video Resolution Test", width[res]/16 - 10, 3);
-		switch (res)
-		{
-			case 0:
-				printText(_dc, "320x240p", width[res]/16 - 3, 5);
-				break;
-			case 1:
-				printText(_dc, "640x480i", width[res]/16 - 3, 5);
-				break;
-			case 2:
-				printText(_dc, "256x240p", width[res]/16 - 3, 5);
-				break;
-			case 3:
-				printText(_dc, "512x480i", width[res]/16 - 3, 5);
-				break;
-			case 4:
-				printText(_dc, "512x240p", width[res]/16 - 3, 5);
-				break;
-			case 5:
-				printText(_dc, "640x240p", width[res]/16 - 3, 5);
-				break;
-		}
-
-		for (j=0; j<8; j++)
-		{
-			sprintf(temp, "Line %d", j);
-			printText(_dc, temp, 3, j);
-			sprintf(temp, "Line %d", height[res]/8 - j - 1);
-			printText(_dc, temp, 3, height[res]/8 - j - 1);
-		}
-		printText(_dc, "0123456789", 0, 16);
-		printText(_dc, "9876543210", width[res]/8 - 10, 16);
-
-        unlockVideo(_dc);
-
-        while (1)
+        printText(display, "Video Resolution Test", width[res]/16 - 10, 3);
+        switch (res)
         {
-            // wait for change in buttons
-            buttons = getButtons(0);
-            if (buttons ^ previous)
+            case 0:
+                printText(display, "320x240p", width[res]/16 - 3, 5);
                 break;
-            delay(1);
+            case 1:
+                printText(display, "640x480i", width[res]/16 - 3, 5);
+                break;
+            case 2:
+                printText(display, "256x240p", width[res]/16 - 3, 5);
+                break;
+            case 3:
+                printText(display, "512x480i", width[res]/16 - 3, 5);
+                break;
+            case 4:
+                printText(display, "512x240p", width[res]/16 - 3, 5);
+                break;
+            case 5:
+                printText(display, "640x240p", width[res]/16 - 3, 5);
+                break;
         }
 
-        if (A_BUTTON(buttons ^ previous))
+        for (int j = 0; j < 8; j++)
         {
-            // A changed
-            if (!A_BUTTON(buttons))
-			{
-				resolution_t mode[6] = {
-					RESOLUTION_320x240,
-					RESOLUTION_640x480,
-					RESOLUTION_256x240,
-					RESOLUTION_512x480,
-					RESOLUTION_512x240,
-					RESOLUTION_640x240,
-				};
-				res++;
-				res %= 6;
-				display_close();
-				display_init(mode[res], DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
-			}
-		}
+            sprintf(temp, "Line %d", j);
+            printText(display, temp, 3, j);
+            sprintf(temp, "Line %d", height[res]/8 - j - 1);
+            printText(display, temp, 3, height[res]/8 - j - 1);
+        }
+        printText(display, "0123456789", 0, 16);
+        printText(display, "9876543210", width[res]/8 - 10, 16);
 
-        previous = buttons;
+        display_show(display);
+
+        joypad_poll();
+
+        joypad_buttons_t buttons = joypad_get_buttons_pressed(JOYPAD_PORT_1);
+
+        // A changed
+        if (buttons.a)
+        {
+            resolution_t mode[6] = {
+                RESOLUTION_320x240,
+                RESOLUTION_640x480,
+                RESOLUTION_256x240,
+                RESOLUTION_512x480,
+                RESOLUTION_512x240,
+                RESOLUTION_640x240,
+            };
+            res++;
+            res %= 6;
+            display_close();
+            display_init(mode[res], DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
+        }
     }
 
     return 0;

--- a/include/debugcpp.h
+++ b/include/debugcpp.h
@@ -15,7 +15,7 @@
 
     #define console_init() ({ __debug_init_cpp(); console_init(); })
     #define dfs_init(a) ({ __debug_init_cpp(); dfs_init(a);})
-    #define controller_init() ({ __debug_init_cpp(); controller_init(); })
+    #define joypad_init() ({ __debug_init_cpp(); joypad_init(); })
     #define timer_init() ({ __debug_init_cpp(); timer_init(); })
     #define display_init(a,b,c,d,e) ({ __debug_init_cpp(); display_init(a,b,c,d,e); })
     #define debug_init_isviewer() ({ __debug_init_cpp(); debug_init_isviewer(); })


### PR DESCRIPTION
(this PR assumes #475 , please merge that first)

This pull request removes deprecated functions from most examples, getting rid of warnings during build process. The following exceptions have not been modified:

1. controllertest - The point of this example is to demonstrate the (now deprecated) controller module so I feel like changing it would defeat the purpose. I'll leave it up to the maintainers whether to remove it completely or to keep it around to help ensure backwards compatibility.
2. vrutest - Joypad module doesn't have an API to detect the VRU (VRU is missing in the `joypad_accessory_type_t` enum). As per #430 , VRU support is under consideration and needs to be figured out first. Until that comes to pass, any warnings emitted by vrutest will serve as rightful reminders that it's not quite up to the same outstanding standard as other libdragon features.

Other considerations:

1. spritemap - I only changed the necessary minimum to get rid of warnings, keeping in most of the rdp module functions used since that seemed to me to be the point of the example (since rdpq is covered in its own example).
2. vtest - This example was written using now _very_ archaic patterns (lockVideo, manual checking of "pressed" button state). Unlike with spritemap, I opted to update this to use newer patterns, losing about 100 LoC in the process.
