### PR TITLE
Update build-toolchain.sh for mac os

### DIFF
--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -59,6 +59,10 @@ download () {
     fi
 }
 
+if [[ "$PLATFORM" != 'darwin' ]]; then
+    GCC_CONFIGURE_ARGS+=("--with-system-zlib")
+fi
+
 # Compilation on macOS via homebrew
 if [[ $OSTYPE == 'darwin'* ]]; then
     if ! command_exists brew; then
@@ -69,7 +73,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
 
     # Install required dependencies. gsed is really required, the others are optionals
     # and just speed up build.
-    brew install -q gmp mpfr libmpc gsed
+    brew install -q gmp mpfr libmpc gsed gcc isl libpng lz4 make mpc texinfo zlib
 
     # FIXME: we could avoid download/symlink GMP and friends for a cross-compiler
     # but we need to symlink them for the canadian compiler.
@@ -82,6 +86,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         "--with-gmp=$(brew --prefix)"
         "--with-mpfr=$(brew --prefix)"
         "--with-mpc=$(brew --prefix)"
+        "--with-zlib=$(brew --prefix)"
     )
 
     # Install GNU sed as default sed in PATH. GCC compilation fails otherwise,
@@ -211,8 +216,7 @@ pushd gcc_compile_target
     --disable-threads \
     --disable-win32-registry \
     --disable-nls \
-    --disable-werror \
-    --with-system-zlib
+    --disable-werror 
 make all-gcc -j "$JOBS"
 make install-gcc || sudo make install-gcc || su -c "make install-gcc"
 make all-target-libgcc -j "$JOBS"

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -59,10 +59,6 @@ download () {
     fi
 }
 
-if [[ "$PLATFORM" != 'darwin' ]]; then
-    GCC_CONFIGURE_ARGS+=("--with-system-zlib")
-fi
-
 # Compilation on macOS via homebrew
 if [[ $OSTYPE == 'darwin'* ]]; then
     if ! command_exists brew; then
@@ -93,8 +89,10 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     # because it does not work with BSD sed.
     PATH="$(brew --prefix gsed)/libexec/gnubin:$PATH"
     export PATH
+else
+    # Configure GCC arguments for non-macOS platforms
+    GCC_CONFIGURE_ARGS+=("--with-system-zlib")
 fi
-
 # Create build path and enter it
 mkdir -p "$BUILD_PATH"
 cd "$BUILD_PATH"


### PR DESCRIPTION
This request will resolve 
https://github.com/DragonMinded/libdragon/issues/461

It also addresses the isl issue - but only for mac os.
https://github.com/DragonMinded/libdragon/issues/460

My proposed changes:

1) Add additional homebrew dependencies for mac os
 - they are specified in the libdragon compile from source guide, but it is more foolproof to add them in the configure script.

2) Require homebrew install of zlib on mac os.
- The system zlib throws a build error.

3) Remove the requirement for system zlib if on mac os.
- I made a platform check that uses system zlib if not on darwin, as I did not want to break other platforms.

I tested this by first removing all homebrew packages:

```
while [[ `brew list | wc -l` -ne 0 ]]; do
    for EACH in `brew list`; do
        brew uninstall --force --ignore-dependencies $EACH
    done
done
```

Then I cloned my modified repo and ran build-toolchain.sh on my m2 pro macbook running Mac OS Sonoma 14.2.1. Libdragon was able to successfully build without issue using these modifications. 

Previously I would get errors not being able to find certain tools (like zlib, gcc, binutils, etc.). These errors are addressed by adding to the brew install -q command.

Please note, that I did not test other platforms. I am not sure if this will break regular mac os intel builds or non-mac os builds.