### PR TITLE
Implement way to mark DSO Dependencies for DSOs

### DIFF
--- a/dso.ld
+++ b/dso.ld
@@ -65,7 +65,12 @@ SECTIONS {
     .lit4 : {
         *(.lit4)
     }
-    
+
+    /* Write DSO Dependency data */
+    .dsodep : {
+        KEEP(*(.dsodep))
+    }
+
     /* Write bss sections */
     .sbss (NOLOAD) : {
         *(.sbss)

--- a/examples/overlays/scene/scene.cpp
+++ b/examples/overlays/scene/scene.cpp
@@ -21,8 +21,7 @@ SceneBase::~SceneBase()
 
 void SceneMgr::Init()
 {
-    //Load as global to expose its symbols to other overlays
-    scene_common_ovl = dlopen("rom:/scene_common.dso", RTLD_GLOBAL);
+
 }
 
 void SceneMgr::SetNextScene(std::string name)

--- a/examples/overlays/scene/scene/bg_test.cpp
+++ b/examples/overlays/scene/scene/bg_test.cpp
@@ -1,6 +1,8 @@
 #include <libdragon.h>
 #include "bg_test.h"
 
+DL_DSO_DEPENDENCY("rom:/scene_common.dso");
+
 BGTest::BGTest()
 {
     //Load background and crosshair images

--- a/examples/overlays/scene/scene/sprite_test.cpp
+++ b/examples/overlays/scene/scene/sprite_test.cpp
@@ -1,6 +1,8 @@
 #include <libdragon.h>
 #include "sprite_test.h"
 
+DL_DSO_DEPENDENCY("rom:/scene_common.dso");
+
 //List of sprite filenames
 const std::string sprite_filenames[SpriteTest::NUM_SPRITE_IMAGES] = {
     "rom:/ball_rectangle.sprite",

--- a/include/dlfcn.h
+++ b/include/dlfcn.h
@@ -36,6 +36,9 @@ typedef struct {
     void       *dli_saddr;
 } Dl_info;
 
+#define DL_DSO_DEPENDENCY(name) \
+    static __attribute__((section(".dsodep"), used)) const char *__PPCAT(__dsodep_, __COUNTER__) = name
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/dlfcn.h
+++ b/include/dlfcn.h
@@ -36,6 +36,8 @@ typedef struct {
     void       *dli_saddr;
 } Dl_info;
 
+/** @brief Add DSO file to load before this DSO. */
+
 #define DL_DSO_DEPENDENCY(name) \
     static __attribute__((section(".dsodep"), used)) const char *__PPCAT(__dsodep_, __COUNTER__) = name
 

--- a/n64.mk
+++ b/n64.mk
@@ -55,7 +55,7 @@ N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS)
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_LDFLAGS = -g -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections --wrap __do_global_ctors
-N64_DSOLDFLAGS = --emit-relocs --unresolved-symbols=ignore-all --nmagic -T$(N64_LIBDIR)/dso.ld
+N64_DSOLDFLAGS = --gc-sections --gc-keep-exported --emit-relocs --unresolved-symbols=ignore-all --nmagic -T$(N64_LIBDIR)/dso.ld
 
 N64_TOOLFLAGS = --title $(N64_ROM_TITLE)
 N64_TOOLFLAGS += $(if $(N64_ROM_HEADER),--header $(N64_ROM_HEADER))

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -76,6 +76,13 @@ static dso_sym_t *mainexe_sym_table;
 /** @brief Number of symbols in main executable symbol table */
 static uint32_t mainexe_sym_count;
 
+/**
+ * @brief Insert module into module list
+ * 
+ * This function is non-static only to help debuggers support overlays.
+ *
+ * @param module  Pointer to module
+ */
 void __attribute__((noinline)) __dl_insert_module(dl_module_t *module)
 {
     dl_module_t *prev = __dl_list_tail;
@@ -92,6 +99,13 @@ void __attribute__((noinline)) __dl_insert_module(dl_module_t *module)
 	__dl_num_loaded_modules++; //Mark one more loaded module
 }
 
+/**
+ * @brief Remove module from module list
+ * 
+ * This function is non-static only to help debuggers support overlays.
+ *
+ * @param module  Pointer to module
+ */
 void __attribute__((noinline)) __dl_remove_module(dl_module_t *module)
 {
     dl_module_t *next = module->next;

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -76,7 +76,7 @@ static dso_sym_t *mainexe_sym_table;
 /** @brief Number of symbols in main executable symbol table */
 static uint32_t mainexe_sym_count;
 
-static void insert_module(dl_module_t *module)
+void __attribute__((noinline)) __dl_insert_module(dl_module_t *module)
 {
     dl_module_t *prev = __dl_list_tail;
     //Insert module at end of list
@@ -92,7 +92,7 @@ static void insert_module(dl_module_t *module)
 	__dl_num_loaded_modules++; //Mark one more loaded module
 }
 
-static void remove_module(dl_module_t *module)
+void __attribute__((noinline)) __dl_remove_module(dl_module_t *module)
 {
     dl_module_t *next = module->next;
     dl_module_t *prev = module->prev;
@@ -419,7 +419,7 @@ void *dlopen(const char *filename, int mode)
         //Add module handle to list
         handle->ref_count = 1;
 		__dl_lookup_module = lookup_module;
-        insert_module(handle);
+        __dl_insert_module(handle);
         //Start running module
         start_module(handle);
     }
@@ -527,7 +527,7 @@ static void close_module(dl_module_t *module)
     //Deinitialize module
     end_module(module);
     //Remove module from memory
-    remove_module(module);
+    __dl_remove_module(module);
     free(module);
 }
 

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -79,7 +79,7 @@ static uint32_t mainexe_sym_count;
 /**
  * @brief Insert module into module list
  * 
- * This function is non-static only to help debuggers support overlays.
+ * This function is non-static to help debuggers support overlays.
  *
  * @param module  Pointer to module
  */
@@ -102,7 +102,7 @@ void __attribute__((noinline)) __dl_insert_module(dl_module_t *module)
 /**
  * @brief Remove module from module list
  * 
- * This function is non-static only to help debuggers support overlays.
+ * This function is non-static to help debuggers support overlays.
  *
  * @param module  Pointer to module
  */

--- a/src/dlfcn_internal.h
+++ b/src/dlfcn_internal.h
@@ -33,4 +33,7 @@ extern dl_module_t *__dl_list_tail;
 /** @brief Number of loaded modules */
 extern size_t __dl_num_loaded_modules;
 
+/** @brief Checks if module handle is valid */
+extern bool __dl_is_valid_handle(void *handle);
+
 #endif

--- a/src/dso_format.h
+++ b/src/dso_format.h
@@ -47,6 +47,8 @@ typedef struct dso_module_s {
     uint32_t ehframe_obj[6];    ///< Exception frame object
     uint32_t sym_romofs;        ///< Debug symbol data rom address
     uint32_t mode;              ///< Dynamic library flags
+    char **dso_deps;            ///< List of DSO Dependencies
+    uint32_t dso_dep_count;     ///< Number of DSO Dependencies
 } dso_module_t;
 
 /** @brief Information to load main executable symbol table */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ include $(N64_INST)/include/n64.mk
 all: testrom.z64 testrom_emu.z64
 
 MAIN_ELF_EXTERNS := $(BUILD_DIR)/testrom.externs
-DSO_MODULES = dl_test_syms.dso dl_test_relocs.dso dl_test_imports.dso dl_test_ctors.dso
+DSO_MODULES = dl_test_syms.dso dl_test_relocs.dso dl_test_imports.dso dl_test_ctors.dso dl_test_deps.dso
 DSO_LIST = $(addprefix filesystem/, $(DSO_MODULES))
 
 $(BUILD_DIR)/testrom.dfs: $(wildcard filesystem/*) $(DSO_LIST)
@@ -51,6 +51,7 @@ filesystem/dl_test_syms.dso: $(BUILD_DIR)/dl_test_syms.o
 filesystem/dl_test_relocs.dso: $(BUILD_DIR)/dl_test_relocs.o
 filesystem/dl_test_imports.dso: $(BUILD_DIR)/dl_test_imports.o
 filesystem/dl_test_ctors.dso: $(BUILD_DIR)/dl_test_ctors.o
+filesystem/dl_test_deps.dso: $(BUILD_DIR)/dl_test_deps.o
 
 clean:
 	rm -rf $(BUILD_DIR) testrom.z64 testrom_emu.z64

--- a/tests/dl_test_deps.c
+++ b/tests/dl_test_deps.c
@@ -1,0 +1,7 @@
+#include <libdragon.h>
+
+DL_DSO_DEPENDENCY("rom:/dl_test_syms.dso");
+
+extern int dl_test_ptr;
+
+int *dl_test_value = &dl_test_ptr;

--- a/tests/dl_test_syms.S
+++ b/tests/dl_test_syms.S
@@ -16,4 +16,4 @@ DLTestSym:
 .balign 4
 .global dl_test_ptr
 dl_test_ptr:
-.word 0
+.word 0x12345678

--- a/tests/test_dl.c
+++ b/tests/test_dl.c
@@ -121,3 +121,15 @@ void test_dl_syms(TestContext *ctx) {
 	//Check if correct symbol is found
 	ASSERT(strcmp(test_sym, "dl_test_sym") == 0 && strcmp(test_sym2, "DLTestSym") == 0, "Symbol searches do not work properly");
 }
+
+void test_dl_dsodeps(TestContext *ctx) {
+	//Open module
+	void *handle = dlopen("rom:/dl_test_deps.dso", RTLD_GLOBAL);
+	DEFER(dlclose(handle));
+	int **test_ptr = dlsym(handle, "dl_test_value");
+	//Check if correct symbol is found
+	ASSERT(__dl_num_loaded_modules == 2, "DSO dependencies didn't load");
+	ASSERT(*test_ptr, "DSO dependencies didn't resolve properly");
+	ASSERT((*test_ptr)[0] == 0x12345678, "DSO dependencies didn't load properly");
+}
+

--- a/tests/test_dl.c
+++ b/tests/test_dl.c
@@ -59,8 +59,8 @@ void test_dlclose(TestContext *ctx) {
 
 void test_dlsym_rtld_default(TestContext *ctx) {
 	//Open both modules with their symbols exported
-	void *handle1 = dlopen("rom:/dl_test_syms.dso", RTLD_GLOBAL);
-	void *handle2 = dlopen("rom:/dl_test_imports.dso", RTLD_GLOBAL);
+	void *handle1 = dlopen("rom:/dl_test_imports.dso", RTLD_GLOBAL);
+	void *handle2 = dlopen("rom:/dl_test_syms.dso", RTLD_GLOBAL);
 	DEFER(dlclose(handle2));
 	DEFER(dlclose(handle1));
 	//Do RTLD_DEFAULT symbol search of known duplicate symbol

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -320,7 +320,7 @@ static const struct Testsuite
 	TEST_FUNC(test_rdpq_attach_stack,             0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_tex_upload,            0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_tex_upload_multi,      0, TEST_FLAGS_NO_BENCHMARK),
-	TEST_FUNC(test_rdpq_tex_blit_normal,       0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_rdpq_tex_blit_normal,       0, TEST_FLAGS_NO_BENCHMARK | TEST_FLAGS_NO_EMULATOR),
 	TEST_FUNC(test_rdpq_tex_multi_i4,          0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_sprite_upload,         0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_sprite_lod,            0, TEST_FLAGS_NO_BENCHMARK),
@@ -341,6 +341,7 @@ static const struct Testsuite
 	TEST_FUNC(test_dlsym_rtld_default,           0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dlclose,           0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dl_ctors,           0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_dl_dsodeps,           0, TEST_FLAGS_NO_BENCHMARK),
 };
 
 int main() {

--- a/tools/mkdfs/mkdfs.c
+++ b/tools/mkdfs/mkdfs.c
@@ -20,14 +20,14 @@ uint8_t *dfs = NULL;
 uint32_t fs_size = 0;
 
 /* Offset from start of filesystem */
-inline uint32_t sector_offset(void *sector)
+static inline uint32_t sector_offset(void *sector)
 {
     uint32_t x = (uint8_t *)sector - dfs;
 
     return x;
 }
 
-inline void *sector_to_memory(uint32_t offset)
+static inline void *sector_to_memory(uint32_t offset)
 {
     return (void *)(dfs + offset);
 }


### PR DESCRIPTION
The macro is DL_DSO_DEPENDENCY. I also implemented garbage collection for DSOs (will only do something if you apply visibility attributes). DSO dependencies are DSOs that this DSO depends on and will load before this DSO. Test is not implemented. It currently does not do circular dependency detection.