### PR TITLE
Add package dependencies

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -133,6 +133,7 @@ jobs:
             --url "$Package_Url" \
             --maintainer "$Package_Maintainer" \
             --deb-no-default-config-files \
+            --depends build-essential libpng-dev \
             $Package_Source_Directory=$Package_Installation_Directory/ \
             $Package_Name-env.sh=/etc/profile.d/$Package_Name-env.sh
 
@@ -148,6 +149,7 @@ jobs:
             --description "$Package_Description" \
             --url "$Package_Url" \
             --maintainer "$Package_Maintainer" \
+            --depends libpng-dev \
             $Package_Source_Directory=$Package_Installation_Directory/ \
             $Package_Name-env.sh=/etc/profile.d/$Package_Name-env.sh
         continue-on-error: true


### PR DESCRIPTION
(This a copy of my PR from rasky fork which still seems valid)

Adds package dependencies required by the libdragon toolchain.

This "should" fix issues reported here: https://discord.com/channels/205520502922543113/974342113850445874/1074452868469362709

NOTE: only valid for `trunk` as `Unstable` removes the need for `LibPng`!

But unable to test, so would be worth someone trying on a clean install.