### PR TITLE
Improve mempak source documentation

### DIFF
--- a/include/mempak.h
+++ b/include/mempak.h
@@ -1,21 +1,21 @@
 /**
  * @file mempak.h
- * @brief Mempak Filesystem Routines
- * @ingroup mempak
+ * @brief Controller Pak Filesystem Routines
+ * @ingroup controllerpak
  */
 #ifndef __LIBDRAGON_MEMPAK_H
 #define __LIBDRAGON_MEMPAK_H
 
 /**
- * @addtogroup mempak
+ * @addtogroup controlllerpak
  * @{
  */
 
-/** @brief Size in bytes of a Mempak block */
+/** @brief Size in bytes of a Controller Pak block */
 #define MEMPAK_BLOCK_SIZE   256
 
 /**
- * @brief Structure representing a save entry in a mempak
+ * @brief Structure representing a save entry on a Controller Pak
  */
 typedef struct entry_structure
 {
@@ -44,7 +44,7 @@ typedef struct entry_structure
      * </pre>
      *
      * The space character is also allowed.  Any other character will be
-     * converted to a space before writing to the mempak.
+     * converted to a space before writing to the Controller Pak.
      */
     char name[19];
 } entry_structure_t;
@@ -67,6 +67,6 @@ int delete_mempak_entry( int controller, entry_structure_t *entry );
 }
 #endif
 
-/** @} */ /* mempak */
+/** @} */ /* controllerpak */
 
 #endif

--- a/include/mempak.h
+++ b/include/mempak.h
@@ -7,7 +7,7 @@
 #define __LIBDRAGON_MEMPAK_H
 
 /**
- * @addtogroup controlllerpak
+ * @addtogroup controllerpak
  * @{
  */
 

--- a/src/mempak.c
+++ b/src/mempak.c
@@ -1,7 +1,7 @@
 /**
  * @file mempak.c
- * @brief Mempak Filesystem Routine
- * @ingroup mempak
+ * @brief Controller Pak Filesystem Routine
+ * @ingroup controllerpak
  */
 #include <string.h>
 #include "libdragon.h"
@@ -9,21 +9,21 @@
 #include <unistd.h>
 
 /**
- * @defgroup mempak Mempak Filesystem Routines
+ * @defgroup Controller Pak Filesystem Routines
  * @ingroup controller
- * @brief Managed mempak interface.
+ * @brief Managed Controller Pak interface.
  *
- * The mempak system is a subsystem of the @ref controller.  Before attempting to
- * read from or write to a mempak, be sure you have initialized the Joypad subsystem
- * with #joypad_init and verified that you have a mempak in the correct controller
+ * The Controller Pak system is a subsystem of the @ref controller. Before attempting to
+ * read from or write to a Controller Pak, be sure you have initialized the Joypad subsystem
+ * with #joypad_init and verified that you have a Controller Pak in the correct controller
  * using #joypad_get_accessory_type.
  *
- * To read and write to the mempak in an organized way compatible with official software,
- * first check that the mempak is valid using #validate_mempak.  If the mempack is
- * invalid, it will need to be formatted using #format_mempak.  Once the mempak is
+ * To read and write to the Controller Pak in an organized way compatible with official software,
+ * first check that the Controller Pak is valid using #validate_mempak.  If the Controller Pak is
+ * invalid, it will need to be formatted using #format_mempak.  Once the Controller Pak is
  * considered valid, existing notes can be enumerated using #get_mempak_entry.  To
  * read the data associated with a note, use #read_mempak_entry_data.  To write a
- * new note to the mempak, use #write_mempak_entry_data.  Note that there is no append
+ * new note to the Controller Pak, use #write_mempak_entry_data.  Note that there is no append
  * functionality so if a note is being updated, ensure you have deleted the old note
  * first using #delete_mempak_entry.  Code should be careful to check how many blocks
  * are free before writing using #get_mempak_free_space.
@@ -47,9 +47,9 @@
 /** @} */
 
 /**
- * @brief Read a sector from a mempak
+ * @brief Read a sector from a Controller Pak
  *
- * This will read a sector from a mempak.  Sectors on mempaks are always 256 bytes
+ * This will read a sector from a Controller Pak. Sectors on Controller Paks are always 256 bytes
  * in size.
  *
  * @param[in]  controller
@@ -68,7 +68,7 @@ int read_mempak_sector( int controller, int sector, uint8_t *sector_data )
     if( sector < 0 || sector >= 128 ) { return -1; }
     if( sector_data == 0 ) { return -1; }
 
-    /* Sectors are 256 bytes, a mempak reads 32 bytes at a time */
+    /* Sectors are 256 bytes, a Controller Pak reads 32 bytes at a time */
     for( int i = 0; i < 8; i++ )
     {
         if( joybus_accessory_read( controller, (sector * MEMPAK_BLOCK_SIZE) + (i * 32), sector_data + (i * 32) ) )
@@ -82,9 +82,9 @@ int read_mempak_sector( int controller, int sector, uint8_t *sector_data )
 }
 
 /**
- * @brief Write a sector to a mempak
+ * @brief Write a sector to a Controller Pak
  *
- * This will write a sector to a mempak.  Sectors on mempaks are always 256 bytes
+ * This will write a sector to a Controller Pak.  Sectors on Controller Paks are always 256 bytes
  * in size.
  *
  * @param[in]  controller
@@ -103,7 +103,7 @@ int write_mempak_sector( int controller, int sector, uint8_t *sector_data )
     if( sector < 0 || sector >= 128 ) { return -1; }
     if( sector_data == 0 ) { return -1; }
 
-    /* Sectors are 256 bytes, a mempak writes 32 bytes at a time */
+    /* Sectors are 256 bytes, a Controller Pak writes 32 bytes at a time */
     for( int i = 0; i < 8; i++ )
     {
         if( joybus_accessory_write( controller, (sector * MEMPAK_BLOCK_SIZE) + (i * 32), sector_data + (i * 32) ) )
@@ -137,10 +137,10 @@ static uint16_t __get_header_checksum( uint16_t *block )
 }
 
 /**
- * @brief Check a mempak header for validity
+ * @brief Check a Controller Pak header for validity
  *
  * @param[in] sector
- *            A sector containing a mempak header
+ *            A sector containing a Controller Pak header
  *
  * @retval 0 if the header is valid
  * @retval -1 if the header is invalid
@@ -196,7 +196,7 @@ static uint8_t __get_toc_checksum( uint8_t *sector )
 }
 
 /**
- * @brief Check a mempak TOC sector for validity
+ * @brief Check a Controller Pak TOC sector for validity
  *
  * @param[in] sector
  *            A sector containing a TOC
@@ -220,10 +220,10 @@ static int __validate_toc( uint8_t *sector )
 }
 
 /**
- * @brief Convert a N64 mempak character to ASCII
+ * @brief Convert a Controller Pak character to ASCII
  *
  * @param[in] c
- *            A character read from a mempak entry title
+ *            A character read from a Controller Pak entry title
  *
  * @return ASCII equivalent of character read
  */
@@ -283,15 +283,15 @@ static char __n64_to_ascii( char c )
 }
 
 /**
- * @brief Convert an ASCII character to a N64 mempak character
+ * @brief Convert an ASCII character to a Controller Pak character
  *
- * If the character passed in is one that the N64 mempak doesn't support, this
+ * If the character passed in is one that the Controller Pak doesn't support, this
  * function will default to a space.
  *
  * @param[in] c
  *            An ASCII character
  *
- * @return A N64 mempak character equivalent to the ASCII character passed in
+ * @return A Controller Pak character equivalent to the ASCII character passed in
  */
 static char __ascii_to_n64( char c )
 {
@@ -349,10 +349,10 @@ static char __ascii_to_n64( char c )
 }
 
 /**
- * @brief Check a region read from a mempak entry for validity
+ * @brief Check a region read from a Controller Pak entry for validity
  *
  * @param[in] region
- *            A region read from a mempak entry
+ *            A region read from a Controller Pak entry
  *
  * @retval 0 if the region is valid
  * @retval -1 if the region is invalid
@@ -385,11 +385,11 @@ static int __validate_region( uint8_t region )
 /**
  * @brief Parse a note structure from a TOC
  *
- * Given a note block read from a mempak TOC, parse and return a structure
+ * Given a note block read from a Controller Pak TOC, parse and return a structure
  * representing the data.
  *
  * @param[in]  tnote
- *             32 bytes read from a mempak TOC
+ *             32 bytes read from a Controller Pak TOC
  * @param[out] note
  *             Parsed note structure
  *
@@ -454,14 +454,14 @@ static int __read_note( uint8_t *tnote, entry_structure_t *note )
 }
 
 /**
- * @brief Create a note structure for a mempak TOC
+ * @brief Create a note structure for a Controller Pak TOC
  *
- * Given a valid note structure, format it for writing to a mempak TOC
+ * Given a valid note structure, format it for writing to a Controller Pak TOC
  *
  * @param[in]  note
  *             Valid note structure to convert
  * @param[out] out_note
- *             32 bytes ready to be written to a mempak TOC
+ *             32 bytes ready to be written to a Controller Pak TOC
  *
  * @retval 0 if the note was converted properly
  * @retval -1 if the parameters were invalid
@@ -565,7 +565,7 @@ static int __get_num_pages( uint8_t *sector, int inode )
 }
 
 /**
- * @brief Get number of free blocks on a mempak
+ * @brief Get number of free blocks on a Controller Pak
  *
  * @param[in] sector
  *            A valid TOC block to examine
@@ -649,8 +649,8 @@ static int __get_note_block( uint8_t *sector, int inode, int block )
  * @param[in] controller
  *            The controller (0-3) to inspect for a valid TOC
  *
- * @retval -2 the mempak was not inserted or was bad
- * @retval -3 the mempak was unformatted or the header was invalid
+ * @retval -2 the Controller Pak was not inserted or was bad
+ * @retval -3 the Controller Pak was unformatted or the header was invalid
  * @retval 1 the first sector has a valid TOC
  * @retval 2 the second sector has a valid TOC
  */
@@ -707,17 +707,17 @@ static int __get_valid_toc( int controller )
 }
 
 /**
- * @brief Return whether a mempak is valid
+ * @brief Return whether a Controller Pak is valid
  *
- * This function will return whether the mempak in a particular controller
+ * This function will return whether the Controller Pak in a particular controller
  * is formatted and valid.
  *
  * @param[in] controller
  *            The controller (0-3) to validate
  *
- * @retval 0 if the mempak is valid and ready to be used
- * @retval -2 if the mempak is not present or couldn't be read
- * @retval -3 if the mempak is bad or unformatted
+ * @retval 0 if the Controller Pak is valid and ready to be used
+ * @retval -2 if the Controller Pak is not present or couldn't be read
+ * @retval -3 if the Controller Pak is bad or unformatted
  */
 int validate_mempak( int controller )
 {
@@ -736,9 +736,9 @@ int validate_mempak( int controller )
 }
 
 /**
- * @brief Read an entry on a mempak
+ * @brief Read an entry on a Controller Pak
  *
- * Given an entry index (0-15), return the entry as found on the mempak.  If
+ * Given an entry index (0-15), return the entry as found on the Controller Pak.  If
  * the entry is blank or invalid, the valid flag is cleared.
  *
  * @param[in]  controller
@@ -750,7 +750,7 @@ int validate_mempak( int controller )
  *
  * @retval 0 if the entry was read successfully
  * @retval -1 if the entry is out of bounds or entry_data is null
- * @retval -2 if the mempak is bad or not present
+ * @retval -2 if the Controller Pak is bad or not present
  */
 int get_mempak_entry( int controller, int entry, entry_structure_t *entry_data )
 {
@@ -760,15 +760,15 @@ int get_mempak_entry( int controller, int entry, entry_structure_t *entry_data )
     if( entry < 0 || entry > 15 ) { return -1; }
     if( entry_data == 0 ) { return -1; }
 
-    /* Make sure mempak is valid */
+    /* Make sure Controller Pak is valid */
     if( (toc = __get_valid_toc( controller )) <= 0 )
     {
-        /* Bad mempak or was removed, return */
+        /* Bad Controller Pak or was removed, return */
         return -2;
     }
 
     /* Entries are spread across two sectors, but we can luckly grab just one
-       with a single mempak read */
+       with a single Controller Pak read */
     if( joybus_accessory_read( controller, (3 * MEMPAK_BLOCK_SIZE) + (entry * 32), data ) )
     {
         /* Couldn't read note database */
@@ -807,7 +807,7 @@ int get_mempak_entry( int controller, int entry, entry_structure_t *entry_data )
 }
 
 /**
- * @brief Return the number of free blocks on a mempak
+ * @brief Return the number of free blocks on a Controller Pak
  *
  * Note that a block is identical in size to a sector.  To calculate the number of
  * bytes free, multiply the return of this function by #MEMPAK_BLOCK_SIZE.
@@ -822,10 +822,10 @@ int get_mempak_free_space( int controller )
     uint8_t data[MEMPAK_BLOCK_SIZE];
     int toc;
 
-    /* Make sure mempak is valid */
+    /* Make sure Controller Pak is valid */
     if( (toc = __get_valid_toc( controller )) <= 0 )
     {
-        /* Bad mempak or was removed, return */
+        /* Bad Controller Pak or was removed, return */
         return -2;
     }
 
@@ -840,16 +840,16 @@ int get_mempak_free_space( int controller )
 }
 
 /**
- * @brief Format a ControllerPak (mempak)
+ * @brief Format a Controller Pak
  *
- * Formats a ControllerPak (mempak). This should only be done to totally wipe and re-initialize
+ * Formats a Controller Pak. This should only be done to totally wipe and re-initialize
  * the filesystem in case of a blank or corrupt Pak after a repair has failed.
  *
  * @param[in] controller
  *            The Controller (0-3) that the CPak is inserted.
  *
- * @retval 0 if the CPak was formatted successfully.
- * @retval -2 if the CPak was not present or couldn't be formatted.
+ * @retval 0 if the Controller Pak was formatted successfully.
+ * @retval -2 if the Controller Pak was not present or couldn't be formatted.
  */
 int format_mempak( int controller )
 {
@@ -928,9 +928,9 @@ int format_mempak( int controller )
 }
 
 /**
- * @brief Read the data associated with an entry on a mempak
+ * @brief Read the data associated with an entry on a Controller Pak
  *
- * Given a valid mempak entry fetched by get_mempak_entry, retrieves the contents
+ * Given a valid Controller Pak entry fetched by get_mempak_entry, retrieves the contents
  * of the entry.  The calling function must ensure that enough room is available in
  * the passed in buffer for the entire entry.  The entry structure itself contains
  * the number of blocks used to store the data which can be multiplied by
@@ -946,7 +946,7 @@ int format_mempak( int controller )
  *
  * @retval 0 if the entry was successfully read
  * @retval -1 if input parameters were out of bounds or the entry was corrupted somehow
- * @retval -2 if the mempak was not present or bad
+ * @retval -2 if the Controller Pak was not present or bad
  * @retval -3 if the data couldn't be read
  */
 int read_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *data )
@@ -963,7 +963,7 @@ int read_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *d
     /* Grab the TOC sector so we can get to the individual blocks the data comprises of */
     if( (toc = __get_valid_toc( controller )) <= 0 )
     {
-        /* Bad mempak or was removed, return */
+        /* Bad Controller Pak or was removed, return */
         return -2;
     }
 
@@ -991,10 +991,10 @@ int read_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *d
 }
 
 /**
- * @brief Write associated data to a mempak entry
+ * @brief Write associated data to a Controller Pak entry
  *
- * Given a mempak entry structure with a valid region, name and block count, writes the
- * entry and associated data to the mempak.  This function will not overwrite any existing
+ * Given a Controller Pak entry structure with a valid region, name and block count, writes the
+ * entry and associated data to the Controller Pak.  This function will not overwrite any existing
  * user data.  To update an existing entry, use #delete_mempak_entry followed by
  * #write_mempak_entry_data with the same entry structure.
  *
@@ -1007,8 +1007,8 @@ int read_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *d
  *
  * @retval 0 if the entry was created and written successfully
  * @retval -1 if the parameters were invalid or the note has no length
- * @retval -2 if the mempak wasn't present or was bad
- * @retval -3 if there was an error writing to the mempak
+ * @retval -2 if the Controller Pak wasn't present or was bad
+ * @retval -3 if there was an error writing to the Controller Pak
  * @retval -4 if there wasn't enough space to store the note
  * @retval -5 if there is no room in the TOC to add a new entry
  */
@@ -1027,7 +1027,7 @@ int write_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *
     /* Grab valid TOC */
     if( (toc = __get_valid_toc( controller )) <= 0 )
     {
-        /* Bad mempak or was removed, return */
+        /* Bad Controller Pak or was removed, return */
         return -2;
     }
 
@@ -1142,7 +1142,7 @@ int write_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *
     /* Convert entry structure to proper entry data */
     __write_note( entry, tmp_data );
 
-    /* Store entry to empty slot on mempak */
+    /* Store entry to empty slot on Controller Pak */
     if( joybus_accessory_write( controller, (3 * MEMPAK_BLOCK_SIZE) + (entry->entry_id * 32), tmp_data ) )
     {
         /* Couldn't update note database */
@@ -1153,19 +1153,19 @@ int write_mempak_entry_data( int controller, entry_structure_t *entry, uint8_t *
 }
 
 /**
- * @brief Delete a mempak entry and associated data
+ * @brief Delete a Controller Pak entry and associated data
  *
- * Given a valid mempak entry fetched by #get_mempak_entry, removes the entry and frees
+ * Given a valid Controller Pak entry fetched by #get_mempak_entry, removes the entry and frees
  * all associated blocks.
  *
  * @param[in] controller
  *            The controller (0-3) to delete the note from
  * @param[in] entry
- *            The entry structure that is to be deleted from the mempak
+ *            The entry structure that is to be deleted from the Controller Pak
  *
  * @retval 0 if the entry was deleted successfully
  * @retval -1 if the entry was invalid
- * @retval -2 if the mempak was bad or not present
+ * @retval -2 if the Controller Pak was bad or not present
  */
 int delete_mempak_entry( int controller, entry_structure_t *entry )
 {
@@ -1179,7 +1179,7 @@ int delete_mempak_entry( int controller, entry_structure_t *entry )
     if( entry->entry_id > 15 ) { return -1; }
     if( entry->inode < BLOCK_VALID_FIRST || entry->inode > BLOCK_VALID_LAST ) { return -1; }
 
-    /* Ensure that the entry passed in matches what's on the mempak */
+    /* Ensure that the entry passed in matches what's on the Controller Pak */
     if( joybus_accessory_read( controller, (3 * MEMPAK_BLOCK_SIZE) + (entry->entry_id * 32), data ) )
     {
         /* Couldn't read note database */


### PR DESCRIPTION
Changes the names in the source from "mempak" to "Controller Pak" as the correct naming convention.