### PR TITLE
Add `glTexSizeN64`

### DIFF
--- a/examples/gldemo/gldemo.c
+++ b/examples/gldemo/gldemo.c
@@ -187,6 +187,36 @@ void render()
     glDisable(GL_LIGHTING);
     render_primitives(rotation);
 
+    // Draw a primitive with GL_RDPQ_TEXTURING_N64
+    glEnable(GL_RDPQ_TEXTURING_N64);
+    glEnable(GL_RDPQ_MATERIAL_N64);
+
+    // When rendering with GL_RDPQ_TEXTURING_N64 we need to manualy specify the
+    // tile size and if a 0.5 offset should be used since the ucode itself cannot
+    // determine these. Here we set the tile size to be 32x32 and we apply an offset
+    // since we are using bilinear texture filtering
+    glTexSizeN64(32, 32);
+    rdpq_sprite_upload(TILE0, sprites[0], &(rdpq_texparms_t){.s.repeats = REPEAT_INFINITE, .t.repeats = REPEAT_INFINITE});
+    rdpq_set_mode_standard();
+    rdpq_mode_filter(FILTER_BILINEAR);
+
+    glBegin(GL_TRIANGLE_FAN);
+        glTexCoord2f(0.0f, 0.0f);
+        glVertex3f(-5.5f, 1.0f, -1.0f);
+
+        glTexCoord2f(0.0f, 1.0f);
+        glVertex3f(-5.5f, 1.0f, 1.0f);
+
+        glTexCoord2f(1.0f, 1.0f);
+        glVertex3f(-3.5f, 1.0f, 1.0f);
+
+        glTexCoord2f(1.0f, 0.0f);
+        glVertex3f(-3.5f, 1.0f, -1.0f);
+    glEnd();
+
+    glDisable(GL_RDPQ_TEXTURING_N64);
+    glDisable(GL_RDPQ_MATERIAL_N64);
+
     gl_context_end();
 
     rdpq_detach_show();

--- a/include/GL/gl.h
+++ b/include/GL/gl.h
@@ -470,6 +470,8 @@ GLboolean glIsTexture(GLuint texture);
 #define glCopyTexSubImage1D(target, level, xoffset, x, y, width) _GL_UNSUPPORTED(glCopyTexSubImage1D)
 #define glCopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height) _GL_UNSUPPORTED(glCopyTexSubImage2D)
 
+void glTexSizeN64(GLushort width, GLushort height);
+
 /* Fog */
 
 void glFogi(GLenum pname, GLint param);

--- a/src/GL/gl.c
+++ b/src/GL/gl.c
@@ -508,6 +508,13 @@ bool gl_storage_resize(gl_storage_t *storage, uint32_t new_size)
     return true;
 }
 
+void glTexSizeN64(GLushort width, GLushort height)
+{
+    width <<= TEX_COORD_SHIFT;
+    height <<= TEX_COORD_SHIFT;
+    gl_set_word(GL_UPDATE_NONE, offsetof(gl_server_state_t, tex_size[0]), (width << 16) | height);
+}
+
 extern inline uint32_t next_pow2(uint32_t v);
 extern inline bool is_in_heap_memory(void *ptr);
 extern inline void gl_set_flag_raw(gl_update_func_t update_func, uint32_t offset, uint32_t flag, bool value);

--- a/src/GL/rsp_gl.S
+++ b/src/GL/rsp_gl.S
@@ -925,6 +925,7 @@ gl_mergemask:
     and t2, modes0, ~(RDPQ_TEXTURING_MASK)
     or  modes0, t1, t2
 
+
 1:
 
     lw t0, %lo(RDPQ_OTHER_MODES) + 0x0
@@ -965,10 +966,33 @@ GLCmd_PreInitPipeTex:
     # (FLAG2_USE_RDPQ_TEXTURING)
     lw state_flags2, %lo(GL_STATE_FLAGS2)
     andi t1, state_flags2, FLAG2_USE_RDPQ_TEXTURING
-    bnez t1, RSPQ_Loop
-
-    # Get pointer to active texture state in DMEM
+    beqz t1, 2f
     lw state_flags, %lo(GL_STATE_FLAGS)
+
+    or state_flags, FLAG_TEXTURE_ACTIVE
+    sw state_flags, %lo(GL_STATE_FLAGS)
+
+    # If bilinear sampling is active, texture coords need to be offset by half a texel,
+    # which is 0x10 in s10.5
+    lw t2, %lo(RDPQ_OTHER_MODES) + 0x4
+    and t2, (SOM_SAMPLE_BILINEAR >> 32)
+    sll t2, t2, (SOM_SAMPLE_SHIFT - 32 + 1)
+
+    andi t3, state_flags2, FLAG2_TEX_FLIP_T
+    lh t6, %lo(GL_STATE_TEX_SIZE) + 2
+    sll t1, t2, TEX_BILINEAR_OFFSET_SHIFT
+    neg t1, t1
+    beqz t7, 1f
+    sh t1, %lo(GL_STATE_TEX_OFFSET) + 0
+    sra t6, 1
+    sub t1, t6
+
+1:
+    sh t1, %lo(GL_STATE_TEX_OFFSET) + 2
+    j RSPQ_Loop
+
+2:
+    # Get pointer to active texture state in DMEM
     li active_tex_id, %lo(GL_STATE_TEXTURE_IDS) + 0x4
     andi t1, state_flags, FLAG_TEXTURE_2D
     bnez t1, 1f


### PR DESCRIPTION
Add new `glTexSizeN64` api which can be used with GL_RDPQ_TEXTURING_N64 to set internal texture state on the rsp.

When I started implementing this I realized no ucode changes were required and that the internal state on the rsp could be programmed through the existing `GL_CMD_SET_*` commands.

I also added an example of the commands in use to the gldemo example so its more clear how to use it.