### PR TITLE
Add size parameter to mpeg2_open

### DIFF
--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -37,7 +37,7 @@ int main(void) {
 	fclose(f);
 
 	mpeg2_t mp2;
-	mpeg2_open(&mp2, "rom:/movie.m1v");
+	mpeg2_open(&mp2, "rom:/movie.m1v", display_get_width(), display_get_height());
 
 	wav64_t music;
 	wav64_open(&music, "movie.wav64");

--- a/include/mpeg2.h
+++ b/include/mpeg2.h
@@ -21,7 +21,7 @@ typedef struct {
 	yuv_blitter_t yuv_blitter;
 } mpeg2_t;
 
-void mpeg2_open(mpeg2_t *mp2, const char *fn);
+void mpeg2_open(mpeg2_t *mp2, const char *fn, int output_width, int output_height);
 float mpeg2_get_framerate(mpeg2_t *mp2);
 bool mpeg2_next_frame(mpeg2_t *mp2);
 void mpeg2_draw_frame(mpeg2_t *mp2, display_context_t disp);

--- a/src/video/mpeg2.c
+++ b/src/video/mpeg2.c
@@ -93,7 +93,7 @@ void rsp_mpeg1_set_quant_matrix(bool intra, const uint8_t quant_mtx[64]) {
 #define PL_MPEG_IMPLEMENTATION
 #include "pl_mpeg/pl_mpeg.h"
 
-void mpeg2_open(mpeg2_t *mp2, const char *fn) {
+void mpeg2_open(mpeg2_t *mp2, const char *fn, int output_width, int output_height) {
 	memset(mp2, 0, sizeof(mpeg2_t));
 
 	rsp_mpeg1_init();
@@ -126,7 +126,7 @@ void mpeg2_open(mpeg2_t *mp2, const char *fn) {
 		// Create a YUV blitter for this resolution
 		mp2->yuv_blitter = yuv_blitter_new_fmv(
 			width, height,
-			display_get_width(), display_get_height(),
+			output_width, output_height,
 			NULL);
 	}
 


### PR DESCRIPTION
Adds an output size parameter for an MPEG video.
This allows it to be rendered to a smaller surface that is not the same size as the currently display.