### PR TITLE
Address warnings on building libdragon

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -61,12 +61,12 @@ inline uint32_t color_to_packed32(color_t c) {
 }
 /** @brief Create a #color_t from the 16-bit packed format used by a #FMT_RGBA16 surface (RGBA 5551) */
 inline color_t color_from_packed16(uint16_t c) {
-    return (color_t){ .r=((c>>11)&0x1F)<<3, .g=((c>>6)&0x1F)<<3, .b=((c>>1)&0x1F)<<3, .a=(c&0x1) ? 0xFF : 0 };
+    return (color_t){ .r=(uint8_t)(((c>>11)&0x1F)<<3), .g=(uint8_t)(((c>>6)&0x1F)<<3), .b=(uint8_t)(((c>>1)&0x1F)<<3), .a=(uint8_t)((c&0x1) ? 0xFF : 0) };
 }
 
 /** @brief Create a #color_t from the 32-bit packed format used by a #FMT_RGBA32 surface (RGBA 8888) */
 inline color_t color_from_packed32(uint32_t c) {
-    return (color_t){ .r=(c>>24)&0xFF, .g=(c>>16)&0xFF, .b=(c>>8)&0xFF, .a=c&0xFF };
+    return (color_t){ .r=(uint8_t)(c>>24), .g=(uint8_t)(c>>16), .b=(uint8_t)(c>>8), .a=(uint8_t)c };
 }
 
 uint32_t graphics_make_color( int r, int g, int b, int a );

--- a/include/rdpq_mode.h
+++ b/include/rdpq_mode.h
@@ -692,7 +692,7 @@ inline void rdpq_mode_alphacompare(int threshold) {
         __rdpq_mode_change_som(SOM_ALPHACOMPARE_MASK, 0);
     } else if (threshold > 0) {
         __rdpq_mode_change_som(SOM_ALPHACOMPARE_MASK, SOM_ALPHACOMPARE_THRESHOLD);
-        rdpq_set_blend_color(RGBA32(0,0,0,threshold));
+        rdpq_set_blend_color(RGBA32(0,0,0,(uint8_t)threshold));
     } else {
         __rdpq_mode_change_som(SOM_ALPHACOMPARE_MASK, SOM_ALPHACOMPARE_NOISE);
     }

--- a/include/surface.h
+++ b/include/surface.h
@@ -165,7 +165,7 @@ typedef struct surface_s
  * 
  * @see #surface_make_linear
  */
-inline surface_t surface_make(void *buffer, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride) {
+inline surface_t surface_make(void *buffer, tex_format_t format, uint16_t width, uint16_t height, uint16_t stride) {
     return (surface_t){
         .flags = format,
         .width = width,
@@ -192,7 +192,7 @@ inline surface_t surface_make(void *buffer, tex_format_t format, uint32_t width,
  * 
  * @see #surface_make
  */
-inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint32_t width, uint32_t height) {
+inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint16_t width, uint16_t height) {
     return surface_make(buffer, format, width, height, TEX_FORMAT_PIX2BYTES(format, width));
 }
 
@@ -213,7 +213,7 @@ inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint32_t
  * @param[in]  height   Height in pixels
  * @return              The initialized surface
  */
-surface_t surface_alloc(tex_format_t format, uint32_t width, uint32_t height);
+surface_t surface_alloc(tex_format_t format, uint16_t width, uint16_t height);
 
 /**
  * @brief Initialize a surface_t structure, pointing to a rectangular portion of another
@@ -230,7 +230,7 @@ surface_t surface_alloc(tex_format_t format, uint32_t width, uint32_t height);
  * @return              The initialized surface
  */
 surface_t surface_make_sub(surface_t *parent, 
-    uint32_t x0, uint32_t y0, uint32_t width, uint32_t height);
+    uint16_t x0, uint16_t y0, uint16_t width, uint16_t height);
 
 /**
  * @brief Free the buffer allocated in a surface.
@@ -290,9 +290,9 @@ inline bool surface_has_owned_buffer(const surface_t *surface)
  * @see #surface_make_placeholder_linear
  * @see #rdpq_set_lookup_address
  */
-inline surface_t surface_make_placeholder(int index, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride) {
+inline surface_t surface_make_placeholder(int index, tex_format_t format, uint16_t width, uint16_t height, uint16_t stride) {
     return (surface_t){
-        .flags = format | (index << 8),
+        .flags = (uint16_t)(format | ((index & 0xF) << 8)),
         .width = width,
         .height = height,
         .stride = stride,
@@ -315,14 +315,14 @@ inline surface_t surface_make_placeholder(int index, tex_format_t format, uint32
  * 
  * @see #surface_make_placeholder
  */
-inline surface_t surface_make_placeholder_linear(int index, tex_format_t format, uint32_t width, uint32_t height) {
+inline surface_t surface_make_placeholder_linear(int index, tex_format_t format, uint16_t width, uint16_t height) {
     return surface_make_placeholder(index, format, width, height, TEX_FORMAT_PIX2BYTES(format, width));
 }
 
 /**
  * @brief Returns the lookup index of a placeholder surface
  * 
- * If ths surface is a placeholder, this function returns the associated lookup
+ * If the surface is a placeholder, this function returns the associated lookup
  * index that will be used to retrieve the actual surface at playback time.
  * Otherwise, if it is a normal surface, this function will return 0.
  * 

--- a/src/surface.c
+++ b/src/surface.c
@@ -9,6 +9,7 @@
 #include "debug.h"
 #include <assert.h>
 #include <string.h>
+#include <inttypes.h>
 
 const char* tex_format_name(tex_format_t fmt)
 {
@@ -28,7 +29,7 @@ const char* tex_format_name(tex_format_t fmt)
     }
 }
 
-surface_t surface_alloc(tex_format_t format, uint32_t width, uint32_t height)
+surface_t surface_alloc(tex_format_t format, uint16_t width, uint16_t height)
 {
     // A common mistake is to call surface_alloc with the wrong argument order.
     // Try to catch it by checking that the format is not valid.
@@ -53,14 +54,14 @@ void surface_free(surface_t *surface)
     memset(surface, 0, sizeof(surface_t));
 }
 
-surface_t surface_make_sub(surface_t *parent, uint32_t x0, uint32_t y0, uint32_t width, uint32_t height)
+surface_t surface_make_sub(surface_t *parent, uint16_t x0, uint16_t y0, uint16_t width, uint16_t height)
 {
     assert(x0 + width <= parent->width);
     assert(y0 + height <= parent->height);
 
     tex_format_t fmt = surface_get_format(parent);
     assertf(TEX_FORMAT_BITDEPTH(fmt) != 4 || (x0 & 1) == 0,
-        "cannot create a subsurface with an odd X offset (%ld) in a 4bpp surface", x0);
+        "cannot create a subsurface with an odd X offset (%" PRId16 ") in a 4bpp surface", x0);
 
     surface_t sub;
     sub.buffer = parent->buffer + y0 * parent->stride + TEX_FORMAT_PIX2BYTES(fmt, x0);
@@ -71,7 +72,7 @@ surface_t surface_make_sub(surface_t *parent, uint32_t x0, uint32_t y0, uint32_t
     return sub;
 }
 
-extern inline surface_t surface_make(void *buffer, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride);
+extern inline surface_t surface_make(void *buffer, tex_format_t format, uint16_t width, uint16_t height, uint16_t stride);
 extern inline tex_format_t surface_get_format(const surface_t *surface);
-extern inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint32_t width, uint32_t height);
+extern inline surface_t surface_make_linear(void *buffer, tex_format_t format, uint16_t width, uint16_t height);
 extern inline bool surface_has_owned_buffer(const surface_t *surface);

--- a/tools/n64sym.c
+++ b/tools/n64sym.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <assert.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -171,6 +172,7 @@ void symbol_add(const char *elf, uint32_t addr, bool is_func)
         // First line is the function name. If instead it's the dummy 0x0 address,
         // it means that we're done.
         int n = getline(&line_buf, &line_buf_size, addr2line_r);
+        assert(n != -1);
         if (strncmp(line_buf, "0x00000000", 10) == 0) break;
 
         // If the function of name is longer than 64 bytes, truncate it. This also
@@ -180,7 +182,8 @@ void symbol_add(const char *elf, uint32_t addr, bool is_func)
         if (n-1 > flag_max_sym_len) strcpy(&func[flag_max_sym_len-3], "...");
 
         // Second line is the file name and line number
-        getline(&line_buf, &line_buf_size, addr2line_r);
+        int ret = getline(&line_buf, &line_buf_size, addr2line_r);
+        assert(ret != -1);
         char *colon = strrchr(line_buf, ':');
         char *file = strndup(line_buf, colon - line_buf);
         int line = atoi(colon + 1);


### PR DESCRIPTION
Addresses the following warnings:

for n64 code (reported as errors due to a -Werror in the corresponding example's Makefile):

<details>

```
/opt/n64/libragon/mips64-elf/include/graphics.h: In function 'color_t color_from_packed16(uint16_t)':
/opt/n64/libragon/mips64-elf/include/graphics.h:62:40: error: narrowing conversion of '(((int)(((short unsigned int)((int)(c >> 11))) & 31)) << 3)' from 'int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   62 |     return (color_t){ .r=((c>>11)&0x1F)<<3, .g=((c>>6)&0x1F)<<3, .b=((c>>1)&0x1F)<<3, .a=(c&0x1) ? 0xFF : 0 };
      |                          ~~~~~~~~~~~~~~^~~
/opt/n64/libragon/mips64-elf/include/graphics.h:62:61: error: narrowing conversion of '(((int)(((short unsigned int)((int)(c >> 6))) & 31)) << 3)' from 'int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   62 |     return (color_t){ .r=((c>>11)&0x1F)<<3, .g=((c>>6)&0x1F)<<3, .b=((c>>1)&0x1F)<<3, .a=(c&0x1) ? 0xFF : 0 };
      |                                                ~~~~~~~~~~~~~^~~
/opt/n64/libragon/mips64-elf/include/graphics.h:62:82: error: narrowing conversion of '(((int)(((short unsigned int)((int)(c >> 1))) & 31)) << 3)' from 'int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   62 |     return (color_t){ .r=((c>>11)&0x1F)<<3, .g=((c>>6)&0x1F)<<3, .b=((c>>1)&0x1F)<<3, .a=(c&0x1) ? 0xFF : 0 };
      |                                                                     ~~~~~~~~~~~~~^~~
/opt/n64/libragon/mips64-elf/include/graphics.h:62:98: error: narrowing conversion of '((((int)(((short unsigned int)((int)c)) & 1)) != 0) ? 255 : 0)' from 'int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   62 |     return (color_t){ .r=((c>>11)&0x1F)<<3, .g=((c>>6)&0x1F)<<3, .b=((c>>1)&0x1F)<<3, .a=(c&0x1) ? 0xFF : 0 };
      |                                                                                          ~~~~~~~~^~~~~~~~~~
/opt/n64/libragon/mips64-elf/include/graphics.h: In function 'color_t color_from_packed32(uint32_t)':
/opt/n64/libragon/mips64-elf/include/graphics.h:67:33: error: narrowing conversion of '((c >> 24) & 255)' from 'long unsigned int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   67 |     return (color_t){ .r=(c>>24)&0xFF, .g=(c>>16)&0xFF, .b=(c>>8)&0xFF, .a=c&0xFF };
      |                          ~~~~~~~^~~~~
/opt/n64/libragon/mips64-elf/include/graphics.h:67:50: error: narrowing conversion of '((c >> 16) & 255)' from 'long unsigned int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   67 |     return (color_t){ .r=(c>>24)&0xFF, .g=(c>>16)&0xFF, .b=(c>>8)&0xFF, .a=c&0xFF };
      |                                           ~~~~~~~^~~~~
/opt/n64/libragon/mips64-elf/include/graphics.h:67:66: error: narrowing conversion of '((c >> 8) & 255)' from 'long unsigned int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   67 |     return (color_t){ .r=(c>>24)&0xFF, .g=(c>>16)&0xFF, .b=(c>>8)&0xFF, .a=c&0xFF };
      |                                                            ~~~~~~^~~~~
/opt/n64/libragon/mips64-elf/include/graphics.h:67:77: error: narrowing conversion of '(c & 255)' from 'long unsigned int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
   67 |     return (color_t){ .r=(c>>24)&0xFF, .g=(c>>16)&0xFF, .b=(c>>8)&0xFF, .a=c&0xFF };
      |                                                                            ~^~~~~
In file included from /opt/n64/libragon/mips64-elf/include/libdragon.h:58:
/opt/n64/libragon/mips64-elf/include/surface.h: In function 'surface_t surface_make(void*, tex_format_t, uint32_t, uint32_t, uint32_t)':
/opt/n64/libragon/mips64-elf/include/surface.h:168:18: error: narrowing conversion of 'width' from 'uint32_t' {aka 'long unsigned int'} to 'uint16_t' {aka 'short unsigned int'} [-Werror=narrowing]
  168 |         .width = width,
      |                  ^~~~~
/opt/n64/libragon/mips64-elf/include/surface.h:169:19: error: narrowing conversion of 'height' from 'uint32_t' {aka 'long unsigned int'} to 'uint16_t' {aka 'short unsigned int'} [-Werror=narrowing]
  169 |         .height = height,
      |                   ^~~~~~
/opt/n64/libragon/mips64-elf/include/surface.h:170:19: error: narrowing conversion of 'stride' from 'uint32_t' {aka 'long unsigned int'} to 'uint16_t' {aka 'short unsigned int'} [-Werror=narrowing]
  170 |         .stride = stride,
      |                   ^~~~~~
```

</details>

for tools:

<details>

```
n64sym.c: In function ‘symbol_add’:
n64sym.c:136:13: warning: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  136 |             asprintf(&addrbin, "%s/bin/mips64-elf-addr2line", n64_inst);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
n64sym.c:183:9: warning: ignoring return value of ‘getline’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  183 |         getline(&line_buf, &line_buf_size, addr2line_r);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
n64sym.c:205:5: warning: ignoring return value of ‘getline’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  205 |     getline(&line_buf, &line_buf_size, addr2line_r);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
n64sym.c:206:5: warning: ignoring return value of ‘getline’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  206 |     getline(&line_buf, &line_buf_size, addr2line_r);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    [AR] libdragon.a
n64sym.c: In function ‘elf_find_callsites’:
n64sym.c:213:5: warning: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  213 |     asprintf(&cmd, "%s/bin/mips64-elf-objdump -d %s", n64_inst, elf);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

</details>