### PR TITLE
Merge from preview: asset changes (level 2 & 3)

### DIFF
--- a/include/asset.h
+++ b/include/asset.h
@@ -104,6 +104,7 @@ extern void __asset_init_compression_lvl2(void);
     switch (level) { \
     case 1: break; \
     case 2: __asset_init_compression_lvl2(); break; \
+    case 3: __asset_init_compression_lvl3(); break; \
     default: assertf(0, "Unsupported compression level: %d", level); \
     } \
 })
@@ -129,9 +130,10 @@ void *asset_load(const char *fn, int *sz);
  * automatically uncompressed as it is being read.
  * 
  * Note that since the file might be compressed, the returned
- * FILE* cannot be rewinded, nor seeked backward, as that would be impossible
+ * FILE* cannot be arbitrarily seeked backward, as that would be impossible
  * to do efficiently on a compressed file. Seeking forward is supported and is
- * simulated by reading (decompressing) and discarding data.
+ * simulated by reading (decompressing) and discarding data. You can rewind
+ * the file to the start though, (by using either fseek or rewind).
  * 
  * This behavior of the returned file is enforced also for non compressed
  * assets, so that the code is ready to switch to compressed assets if

--- a/src/asset.c
+++ b/src/asset.c
@@ -1,7 +1,8 @@
 #include "asset.h"
 #include "asset_internal.h"
-#include "compress/lzh5_internal.h"
+#include "compress/aplib_dec_internal.h"
 #include "compress/lz4_dec_internal.h"
+#include "compress/shrinkler_dec_internal.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -26,22 +27,39 @@
  * Only level 1 (LZ4) is always initialized. The other algorithm (LZH5)
  * must be initialized manually via #asset_init_compression.
  */
-static asset_compression_t algos[2] = {
+static asset_compression_t algos[3] = {
     {
         .state_size = DECOMPRESS_LZ4_STATE_SIZE,
         .decompress_init = decompress_lz4_init,
         .decompress_read = decompress_lz4_read,
-        .decompress_full = decompress_lz4_full,
+        .decompress_reset = decompress_lz4_reset,
+        .decompress_full_inplace = decompress_lz4_full_inplace,
     }
 };
 
 void __asset_init_compression_lvl2(void)
 {
     algos[1] = (asset_compression_t){
-        .state_size = DECOMPRESS_LZH5_STATE_SIZE,
-        .decompress_init = decompress_lzh5_init,
-        .decompress_read = decompress_lzh5_read,
-        .decompress_full = decompress_lzh5_full,
+        .state_size = DECOMPRESS_APLIB_STATE_SIZE,
+        .decompress_init = decompress_aplib_init,
+        .decompress_read = decompress_aplib_read,
+        .decompress_reset = decompress_aplib_reset,
+        #if DECOMPRESS_APLIB_FULL_USE_ASM
+        .decompress_full_inplace = decompress_aplib_full_inplace,
+        #else
+        .decompress_full = decompress_aplib_full,
+        #endif
+    };
+}
+
+void __asset_init_compression_lvl3(void)
+{
+    algos[2] = (asset_compression_t){
+        #if DECOMPRESS_SHRINKLER_FULL_USE_ASM
+        .decompress_full_inplace = decompress_shrinkler_full_inplace,
+        #else
+        .decompress_full = decompress_shrinkler_full,
+        #endif
     };
 }
 
@@ -71,16 +89,80 @@ FILE *must_fopen(const char *fn)
     return f;
 }
 
+static void* decompress_inplace(asset_compression_t *algo, const char *fn, FILE *fp, size_t cmp_size, size_t size, int margin)
+{
+    // Consistency check on input data
+    assert(margin >= 0);
+
+    // add 8 because the assembly decompressors do writes up to 8 bytes out-of-bounds,
+    // that could overwrite the input data.
+    margin += 8;
+
+    int bufsize = size + margin;
+    int cmp_offset = bufsize - cmp_size;
+    // Align the source buffer to 4 bytes, so that we can use 32-bit loads (required by shrinkler).
+    // Notice that we need at least 2-byte alignment anyway, for DMA.
+    while (cmp_offset & 3) {
+        cmp_offset++;
+        bufsize++;
+    }
+    if (bufsize & 15) {
+        // In case we need to call invalidate (see below), we need an aligned buffer
+        bufsize += 16 - (bufsize & 15);
+    }
+
+    void *s = memalign(ASSET_ALIGNMENT, bufsize);
+    assertf(s, "asset_load: out of memory");
+    int n;
+
+    #ifdef N64
+    if (fn && strncmp(fn, "rom:/", 5) == 0) {
+        // Invalid the portion of the buffer where we are going to load
+        // the compressed data. This is needed in case the buffer returned
+        // by memalign happens to be in cached already.
+        int align_cmp_offset = cmp_offset & ~15;
+        data_cache_hit_invalidate(s+align_cmp_offset, bufsize-align_cmp_offset);
+
+        // Loading from ROM. This is a common enough situation that we want to optimize it.
+        // Start an asynchronous DMA transfer, so that we can start decompressing as the
+        // data flows in.
+        uint32_t addr = dfs_rom_addr(fn+5) & 0x1FFFFFFF;
+        dma_read_async(s+cmp_offset, addr+sizeof(asset_header_t), cmp_size);
+
+        // Run the decompression racing with the DMA.
+        n = algo->decompress_full_inplace(s+cmp_offset, cmp_size, s, size); (void)n;
+    #else
+    if (false) {
+    #endif
+    } else {
+        // Standard loading via stdio. We have to wait for the whole file to be read.
+        fread(s+cmp_offset, 1, cmp_size, fp);
+
+        // Run the decompression.
+        n = algo->decompress_full_inplace(s+cmp_offset, cmp_size, s, size); (void)n;
+    }
+    assertf(n == size, "asset: decompression error on file %s: corrupted? (%d/%d)", fn, n, size);
+    void *ptr = realloc(s, size); (void)ptr;
+    assertf(s == ptr, "asset: realloc moved the buffer"); // guaranteed by newlib
+    return ptr;
+}
+
 void *asset_load(const char *fn, int *sz)
 {
     uint8_t *s; int size;
     FILE *f = must_fopen(fn);
+
+    // Disable buffering. This is optimal both for the no-compression case
+    // (where we just read the whole file in one go, so we want to avoid
+    // extra memory copies), and for the compressed case (where each
+    // compression algorithm implements its own logic of optimized buffering).
+    setvbuf(f, NULL, _IONBF, 0);
    
     // Check if file is compressed
     asset_header_t header;
     fread(&header, 1, sizeof(asset_header_t), f);
     if (!memcmp(header.magic, ASSET_MAGIC, 3)) {
-        if (header.version != '2') {
+        if (header.version != '3') {
             assertf(0, "unsupported asset version: %c\nMake sure to rebuild libdragon tools and your assets", header.version);
             return NULL;
         }
@@ -90,23 +172,27 @@ void *asset_load(const char *fn, int *sz)
         header.flags = __builtin_bswap16(header.flags);
         header.cmp_size = __builtin_bswap32(header.cmp_size);
         header.orig_size = __builtin_bswap32(header.orig_size);
+        header.inplace_margin = __builtin_bswap32(header.inplace_margin);
         #endif
 
-        assertf(header.algo >= 1 || header.algo <= 2,
+        assertf(header.algo >= 1 || header.algo <= 3,
             "unsupported compression algorithm: %d", header.algo);
-        assertf(algos[header.algo-1].decompress_full, 
+        assertf(algos[header.algo-1].decompress_full || algos[header.algo-1].decompress_full_inplace, 
             "asset: compression level %d not initialized. Call asset_init_compression(%d) at initialization time", header.algo, header.algo);
 
         size = header.orig_size;
-        s = algos[header.algo-1].decompress_full(fn, f, header.cmp_size, size);
+        if ((header.flags & ASSET_FLAG_INPLACE) && algos[header.algo-1].decompress_full_inplace)
+            s = decompress_inplace(&algos[header.algo-1], fn, f, header.cmp_size, size, header.inplace_margin);
+        else
+            s = algos[header.algo-1].decompress_full(fn, f, header.cmp_size, size);
     } else {
         // Allocate a buffer big enough to hold the file.
-        // We force a 16-byte alignment for the buffer so that it's cacheline aligned.
+        // We force a 32-byte alignment for the buffer so that it's aligned to instruction cache lines.
         // This might or might not be useful, but if a binary file is laid out so that it
         // matters, at least we guarantee that. 
         fseek(f, 0, SEEK_END);
         size = ftell(f);
-        s = memalign(16, size);
+        s = memalign(ASSET_ALIGNMENT, size);
 
         fseek(f, 0, SEEK_SET);
         fread(s, 1, size, f);
@@ -131,6 +217,11 @@ static fpos_t seekfn_none(void *c, fpos_t pos, int whence)
     // SEEK_CUR with pos=0 is used as ftell()
     if (whence == SEEK_CUR && pos == 0)
         return ftell(cookie->fp);
+    if (whence == SEEK_SET && pos == 0) {
+        cookie->seeked = false;
+        rewind(cookie->fp);
+        return 0;
+    }
 
     cookie->seeked = true;
     return -1;
@@ -155,6 +246,7 @@ typedef struct  {
     FILE *fp;
     int pos;
     bool seeked;
+    void (*reset)(void *state);
     ssize_t (*read)(void *state, void *buf, size_t len);
     uint8_t state[] alignas(8);
 } cookie_cmp_t;
@@ -175,6 +267,13 @@ static fpos_t seekfn_cmp(void *c, fpos_t pos, int whence)
     // SEEK_CUR with pos=0 is used as ftell()
     if (whence == SEEK_CUR && pos == 0)
         return cookie->pos;
+    if (whence == SEEK_SET && pos == 0 && cookie->reset) {
+        cookie->seeked = false;
+        cookie->pos = 0;
+        fseek(cookie->fp, sizeof(asset_header_t), SEEK_SET);
+        cookie->reset(cookie->state);
+        return 0;
+    }
 
     // We should really have an assert here but unfortunately newlib's fclose
     // also issue a fseek (backward...) as part of a fflush. So we delay the actual
@@ -203,7 +302,7 @@ FILE *asset_fopen(const char *fn, int *sz)
     asset_header_t header;
     fread(&header, 1, sizeof(asset_header_t), f);
     if (!memcmp(header.magic, ASSET_MAGIC, 3)) {
-        if (header.version != '2') {
+        if (header.version != '3') {
             assertf(0, "unsupported asset version: %c\nMake sure to rebuild libdragon tools and your assets", header.version);
             return NULL;
         }
@@ -213,18 +312,23 @@ FILE *asset_fopen(const char *fn, int *sz)
             header.flags = __builtin_bswap16(header.flags);
             header.cmp_size = __builtin_bswap32(header.cmp_size);
             header.orig_size = __builtin_bswap32(header.orig_size);
+            header.inplace_margin = __builtin_bswap32(header.inplace_margin);
         }
 
         cookie_cmp_t *cookie;
 
         assertf(header.algo >= 1 || header.algo <= 2,
             "unsupported compression algorithm: %d", header.algo);
-        assertf(algos[header.algo-1].decompress_init, 
+        assertf(algos[header.algo-1].decompress_full || algos[header.algo-1].decompress_full_inplace, 
             "asset: compression level %d not initialized. Call asset_init_compression(%d) at initialization time", header.algo, header.algo);
+        assertf(algos[header.algo-1].decompress_init, 
+            "asset: compression level %d does not currently support asset_fopen()", header.algo);
 
-        cookie = malloc(sizeof(cookie_cmp_t) + algos[header.algo-1].state_size);
+        int winsize = asset_winsize_from_flags(header.flags);
+        cookie = malloc(sizeof(cookie_cmp_t) + algos[header.algo-1].state_size + winsize);
         cookie->read = algos[header.algo-1].decompress_read;
-        algos[header.algo-1].decompress_init(cookie->state, f);
+        cookie->reset = algos[header.algo-1].decompress_reset;
+        algos[header.algo-1].decompress_init(cookie->state, f, winsize);
 
         cookie->fp = f;
         cookie->pos = 0;

--- a/src/asset_internal.h
+++ b/src/asset_internal.h
@@ -4,31 +4,72 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define ASSET_MAGIC    "DCA"   ///< Magic compressed asset header
+#define ASSET_MAGIC                 "DCA"   ///< Magic compressed asset header
+#define ASSET_FLAG_WINSIZE_MASK     0x0007  ///< Mask to isolate the window size in the flags
+#define ASSET_FLAG_WINSIZE_16K      0x0000  ///< 16 KiB window size
+#define ASSET_FLAG_WINSIZE_8K       0x0001  ///< 8 KiB window size
+#define ASSET_FLAG_WINSIZE_4K       0x0002  ///< 4 KiB window size
+#define ASSET_FLAG_WINSIZE_2K       0x0003  ///< 2 KiB window size
+#define ASSET_FLAG_WINSIZE_32K      0x0004  ///< 32 KiB window size
+#define ASSET_FLAG_WINSIZE_64K      0x0005  ///< 64 KiB window size
+#define ASSET_FLAG_WINSIZE_128K     0x0006  ///< 128 KiB window size
+#define ASSET_FLAG_WINSIZE_256K     0x0007  ///< 256 KiB window size
+#define ASSET_FLAG_INPLACE          0x0100  ///< Decompress in-place
+#define ASSET_ALIGNMENT             32
+
+__attribute__((used))
+static inline int asset_winsize_from_flags(uint16_t flags) {
+    flags &= ASSET_FLAG_WINSIZE_MASK;
+    if (flags & 4) 
+        return (2*1024) << flags;
+    else
+        return (16*1024) >> flags;
+}
+
+__attribute__((used))
+static int asset_winsize_to_flags(int winsize) {
+    if (winsize == 16*1024)  return ASSET_FLAG_WINSIZE_16K;
+    if (winsize == 8*1024)   return ASSET_FLAG_WINSIZE_8K;
+    if (winsize == 4*1024)   return ASSET_FLAG_WINSIZE_4K;
+    if (winsize == 2*1024)   return ASSET_FLAG_WINSIZE_2K;
+    if (winsize == 32*1024)  return ASSET_FLAG_WINSIZE_32K;
+    if (winsize == 64*1024)  return ASSET_FLAG_WINSIZE_64K;
+    if (winsize == 128*1024) return ASSET_FLAG_WINSIZE_128K;
+    if (winsize == 256*1024) return ASSET_FLAG_WINSIZE_256K;
+    return -1;
+}
 
 /** @brief Header of a compressed asset */
 typedef struct {
     char magic[3];          ///< Magic header
     uint8_t version;        ///< Version of the asset header
     uint16_t algo;          ///< Compression algorithm
-    uint16_t flags;         ///< Flags (unused for now)
+    uint16_t flags;         ///< Flags
     uint32_t cmp_size;      ///< Compressed size in bytes
     uint32_t orig_size;     ///< Original size in bytes
+    uint32_t inplace_margin; ///< Margin for in-place decompression
 } asset_header_t;
 
-_Static_assert(sizeof(asset_header_t) == 16, "invalid sizeof(asset_header_t)");
+_Static_assert(sizeof(asset_header_t) == 20, "invalid sizeof(asset_header_t)");
 
 /** @brief A decompression algorithm used by the asset library */
 typedef struct {
-    int state_size;     ///< Size of the decompression state
+    int state_size;     ///< Basic size of the decompression state (without ringbuffer)
 
     /** @brief Initialize the decompression state */
-    void (*decompress_init)(void *state, FILE *fp);
+    void (*decompress_init)(void *state, FILE *fp, int winsize);
+
     /** @brief Partially read a decompressed file from a state */
     ssize_t (*decompress_read)(void *state, void *buf, size_t len);
 
+    /** @brief Reset decompression state after rewind */
+    void (*decompress_reset)(void *state);
+
     /** @brief Decompress a full file in one go */
     void* (*decompress_full)(const char *fn, FILE *fp, size_t cmp_size, size_t len);
+
+    /** @brief Decompress a full file in-place */
+    int (*decompress_full_inplace)(const uint8_t *in, size_t cmp_size, uint8_t *out, size_t len);
 } asset_compression_t;
 
 

--- a/src/audio/ym64.c
+++ b/src/audio/ym64.c
@@ -124,9 +124,9 @@ void ym64player_open(ym64player_t *player, const char *fn, ym64player_songinfo_t
 
 		// Initialize decompressor and re-read the header (this time, it will
 		// be decompressed and we should find a valid YM header).
-		player->decoder = malloc(DECOMPRESS_LZH5_STATE_SIZE);
+		player->decoder = malloc(DECOMPRESS_LZH5_STATE_SIZE + DECOMPRESS_LZH5_DEFAULT_WINDOW_SIZE);
 		offset = 0;
-		decompress_lzh5_init(player->decoder, player->f);
+		decompress_lzh5_init(player->decoder, player->f, DECOMPRESS_LZH5_DEFAULT_WINDOW_SIZE);
 		_ymread(head, 12);
 	}
 

--- a/src/compress/aplib_dec.c
+++ b/src/compress/aplib_dec.c
@@ -1,0 +1,341 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#ifdef N64
+#include "n64sys.h"
+#include "dma.h"
+#include "dragonfs.h"
+#include "debug.h"
+#include <malloc.h>
+#endif
+#include "../utils.h"
+#include "../asset_internal.h"
+#include "aplib_dec_internal.h"
+#include "ringbuf_internal.h"
+
+#define MINMATCH3_OFFSET 1280
+#define MINMATCH4_OFFSET 32000
+
+#if defined(__GNUC__) || defined(__clang__)
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+#else
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+#endif
+
+/** @brief APLib decompressor */
+typedef struct {
+    uint8_t buf[2][128] __attribute__((aligned(16)));   ///< Buffer of loaded data
+    int cur_buf;                                        ///< Current buffer being used
+    uint8_t *buf_ptr;                                   ///< Pointer to data being processed
+    uint8_t *buf_end;                                   ///< Pointer to end of current loaded data
+    uint8_t cc;                                         ///< Current byte being processed
+    int shift;                                          ///< Current bit being processed
+    FILE *f;                                            ///< File being read from
+    uint32_t rom_addr;                                  ///< ROM address being read from (optional)
+    bool eof;                                           ///< Whether the end of the stream has been reached
+    struct {
+        decompress_ringbuf_t ringbuf;                   ///< Ring buffer
+        bool first_literal_done;                        ///< Whether the first literal has been written
+        int nlit;                                       ///< Number of expected literals
+        int match_off;                                  ///< Offset of the match
+        int match_len;                                  ///< Length of the match
+    } partial;                                          ///< Partial decompression state
+} aplib_decompressor_t;
+
+_Static_assert(sizeof(aplib_decompressor_t) <= DECOMPRESS_APLIB_STATE_SIZE, "APLib decompressor state too small");
+
+__attribute__((noinline))
+static void refill(aplib_decompressor_t *d)
+{
+    int buf_size;
+
+    d->cur_buf ^= 1;
+    #ifdef N64
+    if (d->rom_addr) {
+        data_cache_hit_invalidate(d->buf[d->cur_buf^1], sizeof(d->buf[0]));
+        dma_read_raw_async(d->buf[d->cur_buf^1], d->rom_addr, sizeof(d->buf[0]));
+        d->rom_addr += sizeof(d->buf[0]);
+        buf_size = sizeof(d->buf[0]);
+    } else {
+        buf_size = fread(d->buf[d->cur_buf], 1, sizeof(d->buf[0]), d->f);
+    }
+    #else
+    buf_size = fread(d->buf[d->cur_buf], 1, sizeof(d->buf[0]), d->f);
+    #endif
+
+    d->buf_ptr = d->buf[d->cur_buf];
+    d->buf_end = d->buf[d->cur_buf] + buf_size;
+    if (!buf_size) d->eof = true;
+}
+
+static uint8_t readbyte(aplib_decompressor_t *d)
+{
+    if (unlikely(d->buf_ptr >= d->buf_end)) refill(d);
+    return *d->buf_ptr++;
+}
+
+static int readbit(aplib_decompressor_t *d)
+{
+    if (unlikely(d->shift < 0)) {
+        d->shift = 7;
+        d->cc = readbyte(d);
+    }
+    return (d->cc >> d->shift--) & 1;
+}
+
+static inline int readgamma2(aplib_decompressor_t *d)
+{
+    int v = 1;
+    do v = (v << 1) | readbit(d);
+    while (readbit(d));
+    return v;
+}
+
+static void decompress_reset(aplib_decompressor_t *d)
+{
+    d->shift = -1;
+    d->eof = false;
+    d->partial.ringbuf.ringbuf_pos = 0;
+    d->partial.first_literal_done = false;
+    d->partial.nlit = 0;
+    d->partial.match_off = 0;
+    d->partial.match_len = 0;
+    d->buf_ptr = 0;
+    d->buf_end = 0;
+    
+    #ifdef N64
+	if (d->rom_addr) {
+		data_cache_hit_invalidate(d->buf[d->cur_buf^1], sizeof(d->buf[0]));
+		dma_read_raw_async(d->buf[d->cur_buf^1], d->rom_addr, sizeof(d->buf[0]));
+		d->rom_addr += sizeof(d->buf[0]);
+	}
+    #endif
+}
+
+static void decompress_init(aplib_decompressor_t *d, FILE *f, uint32_t rom_addr)
+{
+    memset(d, 0, sizeof(*d));
+    d->f = f;
+    d->rom_addr = rom_addr;
+    decompress_reset(d);
+}
+
+static int decompress_full(aplib_decompressor_t *d, uint8_t *out)
+{
+    uint8_t *out_orig = out;
+    int nlit = 3;
+    int match_off = -1;
+    int match_len = -1;
+
+    *out++ = readbyte(d);
+    while (!d->eof) {
+        if (!readbit(d)) {
+            // 0: literal
+            *out++ = readbyte(d);
+            nlit = 3;
+            // fprintf(stderr, "%x: lit %x\n", out-out_orig-1, out[-1]);
+            continue;
+        }
+        if (!readbit(d)) {
+            // 10: 8+n bits offset
+            int off_hi = readgamma2(d) - nlit;
+            if (off_hi >= 0) {
+                match_off = (off_hi << 8) | readbyte(d);
+                match_len = readgamma2(d);
+                if (match_off < 128 || match_off >= MINMATCH4_OFFSET)
+                    match_len += 2;
+                else if (match_off >= MINMATCH3_OFFSET)
+                    match_len += 1;
+                // fprintf(stderr, "%x: offset8 %x %x\n", out-out_orig,match_off, match_len);
+            } else {
+                // rep-match
+                match_len = readgamma2(d);
+                // fprintf(stderr, "%x: offset8 rep %x\n", out-out_orig, match_len);
+            }
+        } else if (!readbit(d)) {
+            // 110: 7 bits offset + 1 bit length
+            uint8_t cmd = readbyte(d);
+            // fprintf(stderr, "%x: offset7 %02x\n", out-out_orig, cmd);
+            if (cmd == 0) {
+                // end of stream
+                // debugf("EOD\n");
+                // fprintf(stderr, "EOD\n");
+                d->eof = true;
+                break;
+            }
+
+            match_off = cmd >> 1;
+            *out = out[-match_off], out++;
+            *out = out[-match_off], out++;
+            if (cmd & 1)
+            *out = out[-match_off], out++;
+            nlit = 2;
+            continue;
+        } else {
+            // 111: 4 bits offset
+            int match_off2 = readbit(d) << 3;
+            match_off2 |= readbit(d) << 2;
+            match_off2 |= readbit(d) << 1;
+            match_off2 |= readbit(d) << 0;
+            // fprintf(stderr, "%x: offset4 %x\n", out-out_orig, match_off2);
+            nlit = 3;
+            if (match_off2) {
+                *out = out[-match_off2];
+                out++;
+            } else {
+                *out++ = 0;
+            }
+            continue;
+        }
+
+        if (match_off >= match_len) {
+            do {
+                memcpy(out, out - match_off, 8);
+                out += 8;
+                match_len -= 8;
+            } while (match_len > 0);
+            out += match_len;
+        } else {
+            while (match_len-- > 0) {
+                *out = out[-match_off];
+                out++;
+            }
+        }
+        nlit = 2;
+    }
+
+    // fprintf(stderr, "return %x\n", out - out_orig);
+    return out - out_orig;
+}
+
+__attribute__((used))
+static int decompress_aplib_partial(aplib_decompressor_t *d, uint8_t *out, int len)
+{
+    if (!len || d->eof) return 0;
+    uint8_t *out_orig = out;
+    uint8_t *out_end = out + len;
+
+    if (!d->partial.first_literal_done) {
+        *out++ = readbyte(d);
+        __ringbuf_writebyte(&d->partial.ringbuf, out[-1]);
+        d->partial.nlit = 3;
+        d->partial.match_len = 0;
+        d->partial.match_off = -1;
+        d->partial.first_literal_done = true;
+    }
+
+    int nlit = d->partial.nlit;
+    int match_off = d->partial.match_off;
+    int match_len = d->partial.match_len;
+    if (match_len)
+        goto copy_match;
+    
+    while (out < out_end) {
+        if (!readbit(d)) {
+            // 0: literal
+            *out++ = readbyte(d);
+            __ringbuf_writebyte(&d->partial.ringbuf, out[-1]);
+            nlit = 3;
+            continue;
+        }
+        if (!readbit(d)) {
+            // 10: 8+n bits offset
+            int off_hi = readgamma2(d) - nlit;
+            if (off_hi >= 0) {
+                match_off = (off_hi << 8) | readbyte(d);
+                match_len = readgamma2(d);
+                if (match_off < 128 || match_off >= MINMATCH4_OFFSET)
+                    match_len += 2;
+                else if (match_off >= MINMATCH3_OFFSET)
+                    match_len += 1;
+            } else {
+                // rep-match
+                match_len = readgamma2(d);
+            }
+        } else if (!readbit(d)) {
+            // 110: 7 bits offset + 1 bit length
+            uint8_t cmd = readbyte(d);
+            if (cmd == 0) {
+                // end of stream
+                d->eof = true;
+                break;
+            }
+
+            match_off = cmd >> 1;
+            match_len = (cmd & 1) + 2;
+        } else {
+            // 111: 4 bits offset
+            int match_off2 = readbit(d) << 3;
+            match_off2 |= readbit(d) << 2;
+            match_off2 |= readbit(d) << 1;
+            match_off2 |= readbit(d) << 0;
+            nlit = 3;
+            if (match_off2) {
+                __ringbuf_copy(&d->partial.ringbuf, match_off2, out, 1);
+                out++;
+            } else {
+                *out++ = 0;
+                __ringbuf_writebyte(&d->partial.ringbuf, out[-1]);
+            }
+            continue;
+        }
+
+    copy_match:;
+        int copy_len = MIN(out_end - out, match_len);
+        __ringbuf_copy(&d->partial.ringbuf, match_off, out, copy_len);
+        nlit = 2;
+        out += copy_len;
+        match_len -= copy_len;
+    }
+
+    d->partial.nlit = nlit;
+    d->partial.match_off = match_off;
+    d->partial.match_len = match_len;
+
+    return out - out_orig;
+}
+
+void decompress_aplib_init(void *state, FILE *fp, int winsize)
+{
+    aplib_decompressor_t *d = state;
+    decompress_init(d, fp, 0);
+    __ringbuf_init(&d->partial.ringbuf, state+sizeof(aplib_decompressor_t), winsize);
+}
+
+void decompress_aplib_reset(void *state)
+{
+    aplib_decompressor_t *d = state;
+    decompress_reset(d);
+}
+
+ssize_t decompress_aplib_read(void *state, void *buf, size_t len)
+{
+    aplib_decompressor_t *d = state;
+    return decompress_aplib_partial(d, buf, len);
+}
+
+void* decompress_aplib_full(const char *fn, FILE *fp, size_t cmp_size, size_t size)
+{
+    uint32_t rom_addr = 0;
+    #ifdef N64
+	if (strncmp(fn, "rom:/", 5) == 0) {
+		rom_addr = (dfs_rom_addr(fn+5) & 0x1fffffff) + ftell(fp);
+	}
+    #endif
+    void *buf = memalign(ASSET_ALIGNMENT, size + 8);
+    aplib_decompressor_t d;
+    decompress_init(&d, fp, rom_addr);
+    int sz = decompress_full(&d, buf); (void)sz;
+    buf = realloc(buf, size);
+    return buf;
+}
+
+#ifdef N64
+int decompress_aplib_full_inplace(const uint8_t* in, size_t cmp_size, uint8_t *out, size_t size)
+{
+    extern int decompress_aplib_full_fast(const void*, int, void*);
+    return decompress_aplib_full_fast(in, cmp_size, out);
+}
+#endif

--- a/src/compress/aplib_dec_fast.S
+++ b/src/compress/aplib_dec_fast.S
@@ -1,0 +1,242 @@
+#define DMA_RACE_MARGIN     16
+#define PI_STATUS           0xA4600010
+#define PI_DRAM_ADDR        0xA4600000
+
+#define inbuf       $a0
+#define outbuf      $a2
+#define nlit        $t2
+#define cc          $t3
+#define cc_count    $t4
+#define match_off   $t5
+#define match_len   $t6
+#define outbuf_orig $t7
+#define dma_ptr     $t8
+
+#define ra2         $a1
+#define ra3         $a3
+
+# Read one bit from CC, and jump to target if it matches
+# the specified value
+.macro cc_check value, target
+    bltzal cc_count, .Lreadcc
+     addiu cc_count, -1
+    .if \value != 0
+        bltz cc, \target
+    .else
+        bgez cc, \target
+    .endif
+    sll cc, 1
+.endm
+
+# Peek one bit from CC, and run next opcode if it matches
+# the specified value. The bit is not removed from CC.
+.macro cc_peek value
+    bltzal cc_count, .Lreadcc
+     addiu cc_count, -1
+    .if \value != 0
+        bltzl cc, 1f
+    .else
+        bgezl cc, 1f
+    .endif
+1:
+.endm
+
+    .section .text.decompress_aplib_full_fast
+	.p2align 5
+    .globl decompress_aplib_full_fast 
+    .func decompress_aplib_full_fast
+    .set at
+    .set noreorder
+
+decompress_aplib_full_fast:
+    move ra3, $ra
+    move outbuf_orig, outbuf
+    bal .Lwaitdma
+     li dma_ptr, 0
+    b .Lcmd_literal
+     li cc_count, -1
+
+    # Main copy-match loop. This is the basic LZ constrcut, where
+    # we copy match_len bytes from match_off bytes before the current
+    # outbuf pointer. Notice that match_off can be less than match_len
+    # in which case it is mandatory to copy byte by byte for correct
+    # behavior (memmove() vs memcpy()).
+    # We implement 3 different loops for optimization purposes:
+    #  - 1-byte copy loop: copy 1 byte at a time
+    #  - 8-byte copy loop: copy 8 bytes at a time
+    #  - memset loop: read one 1 byte (match_off=1), memset 8 bytes at a time
+    # To make the second and third loop more generally useful, we
+    # allow the code to write past the end of the output buffer (up to 8 bytes).
+.Lmatch:
+    blt match_off, match_len, .Lmatch1_loop_check
+     sub $v0, outbuf, match_off
+.Lmatch8_loop:                                  # 8-byte copy loop
+    ldl $t0, 0($v0)                             # load 8 bytes
+    ldr $t0, 7($v0)
+    addiu $v0, 8
+    sdl $t0, 0(outbuf)                          # store 8 bytes
+    sdr $t0, 7(outbuf)
+    addiu match_len, -8
+    bgtz match_len, .Lmatch8_loop               # check we went past match_len
+     addiu outbuf, 8
+    b .Lloop_lit2                               # jump to main loop
+     addu outbuf, match_len                     # adjust pointer remove extra bytes
+
+.Lmatch1_memset:                                # prepare memset loop (value in t0)
+    dsll $t1, $t0, 8                            # duplicate the LSB into all bytes
+    or $t0, $t1
+    dsll $t1, $t0, 16
+    or $t0, $t1
+    dsll $t1, $t0, 32
+    or $t0, $t1
+.Lmatch1_memset_loop:                           # memset loop
+    sdl $t0, 0(outbuf)                          # store 8 bytes
+    sdr $t0, 7(outbuf)                           
+    addiu match_len, -8                         # adjust match_len
+    bgtz match_len, .Lmatch1_memset_loop        # check we went past match_len
+     addiu outbuf, 8
+    b .Lloop_lit2                               # jump to main loop
+     addu outbuf, match_len                     # adjust pointer remove extra bytes
+
+.Lmatch1_loop_check:                            # 1-byte copy loop
+    beq match_off, 1, .Lmatch1_memset
+.Lmatch1_loop:                                  # 1-byte copy loop
+    lbu $t0, 0($v0)                             # load 1 byte
+    addiu $v0, 1
+    sb $t0, 0(outbuf)                           # store 1 byte
+    addiu match_len, -1
+    bgtz match_len, .Lmatch1_loop               # check we went past match_len
+     addiu outbuf, 1
+
+
+    # Aplib main loop. This is the main loop of the decompressor.
+    # We pattern-match the bits in CC to determine the command.
+.Lloop_lit2:
+    li nlit, 2
+.Lloop:                                         # main loop
+    #tne ra, ra, 0x10
+    sub $t0, inbuf, dma_ptr                     # check if we need to wait for dma
+    bgezal $t0, .Lwaitdma                       # if inbuf >= dma_ptr, wait for dma
+     nop
+    cc_check 0, .Lcmd_literal                   # 0xx => literal
+    cc_check 0, .Lcmd_offset8                   # 10x => offset 8
+    cc_check 0, .Lcmd_offset7                   # 110 => offset 7
+.Lcmd_offset4:                                  # 111 => offset 4
+    li nlit, 3
+    li $v0, 0
+
+    cc_peek 1                                   # if next CC bit is 1
+     ori $v0, 0x8                               #  set bit 0x8 in v0
+    sll cc, 1                                   # shift CC
+    cc_peek 1                                   # if next CC bit is 1
+     ori $v0, 0x4                               #  set bit 0x4 in v0
+    sll cc, 1                                   # shift CC
+    cc_peek 1                                   # if next CC bit is 1
+     ori $v0, 0x2                               #  set bit 0x2 in v0
+    sll cc, 1                                   # shift CC
+    cc_peek 1                                   # if next CC bit is 1
+     ori $v0, 0x1                               #  set bit 0x1 in v0
+    sll cc, 1                                   # shift CC
+
+    beqz $v0, .Loutz                            # if v0 == 0, store zero into outbuf
+     li $t0, 0
+    sub $v0, outbuf, $v0                        # else v0 is the match offset
+    lbu $t0, 0($v0)                             # load byte from match offset
+.Loutz:
+    sb $t0, 0(outbuf)                           # store byte
+    b .Lloop                                    # back to main loop
+     addiu outbuf, 1
+
+.Lcmd_literal:                                  # literal command
+    lbu $t0, 0(inbuf)                           # load byte from inbuf
+    addiu inbuf, 1
+    sb $t0, 0(outbuf)                            # store byte
+    addiu outbuf, 1
+    b .Lloop                                    # back to main loop
+     li nlit, 3
+
+.Lcmd_offset7:                                  # offset 7 command
+    lbu $t0, 0(inbuf)                           # load byte from inbuf
+    addiu inbuf, 1
+    beqz $t0, .Ldone                            # if byte == 0, we're done
+     srl match_off, $t0, 1                      # match_offset is bits 1..7
+    andi $t0, 1                                 # match_len is 2 + bit 0
+    sub $v0, outbuf, match_off                  # compute match pointer
+    lbu $t1, 0($v0)                             # load byte from match pointer
+    addiu outbuf, 2
+    sb $t1, -2(outbuf)                          # store byte
+    lbu $t1, 1($v0)                             # load byte from match pointer + 1
+    beqz $t0, .Lloop_lit2                       # if match_len == 2, back to main loop
+     sb $t1, -1(outbuf)                         # store byte
+    lbu $t1, 2($v0)                             # load byte from match pointer + 2
+    addiu outbuf, 1
+    b .Lloop_lit2                               # back to main loop
+     sb $t1, -1(outbuf)                         # store byte
+
+.Lcmd_offset8:                                  # offset 8 command
+    #tne ra, ra, 0x10
+    bal .Lreadgamma                             # read gamma-encoded value
+     nop
+    sub $v0, nlit                               # if value-nlit < 0, it's a repmatch
+    bltz $v0, .Lrepmatch                        # so jump to repmatch code
+     nop
+    sll match_off, $v0, 8                       # else, it is the MSB of match_off
+    lbu $t0, 0(inbuf)                           # load byte from inbuf (LSB of match off)
+    addiu inbuf, 1
+    bal .Lreadgamma                             # read gamma-encoded value (match_len)
+     or match_off, $t0                          # compute match_off
+    bltl match_off, 128, 1f                     
+     addiu $v0, 2
+1:  bgel match_off, 32000, 1f
+     addiu $v0, 1
+1:  bgel match_off, 1280, 1f
+     addiu $v0, 1
+1:
+.Ljump_match:                                   
+    b .Lmatch                                    # jump to match code
+     move match_len, $v0
+.Lrepmatch:                                      # repmatch: just read mach_len
+    bal .Lreadgamma                              # read gamma-encoded value
+     addiu $ra, -(1f - .Ljump_match)             # when done, return to jump_match
+1:
+
+.Lreadgamma:                                     # read gamma-encoded value
+    move ra2, $ra
+    li $v0, 1                                     # Start from 1
+.Lreadgamma_loop:
+    sll $v0, 1                                   # Shift to make space for new bit
+    cc_check 0, .Lreadgamma_check                # Read one bit from CC
+    ori $v0, 1                                   # If 1, set the LSB
+.Lreadgamma_check:
+    cc_check 1, .Lreadgamma_loop                 # if next CC bit is 0, we are done
+    jr ra2
+     nop
+
+.Lreadcc:                                        # read new CC byte 
+    lwl cc, 0(inbuf)                             # load current byte into MSB
+    addiu inbuf, 1                               # (other read bytes will be ignored)
+    jr $ra
+     li cc_count, 6                              # reset CC counter
+
+.Lwaitdma:
+    li $t1, 0x80000000 - DMA_RACE_MARGIN
+.Lwaitdma_loop:
+    lw $t0, (PI_STATUS)
+    andi $t0, 1
+    beqz $t0, .Lwaitdma_end
+     li dma_ptr, 0xffffffff
+    lw dma_ptr, (PI_DRAM_ADDR)
+    andi $t0, dma_ptr, 0xF
+    xor dma_ptr, $t0
+    addu dma_ptr, $t1
+    ble dma_ptr, inbuf, .Lwaitdma_loop
+     nop
+.Lwaitdma_end:
+    jr $ra
+     nop
+
+.Ldone:
+    jr ra3
+     sub $v0, outbuf, outbuf_orig
+
+    .endfunc

--- a/src/compress/aplib_dec_internal.h
+++ b/src/compress/aplib_dec_internal.h
@@ -1,0 +1,25 @@
+#ifndef LIBDRAGON_COMPRESS_APLIB_DEC_INTERNAL_H
+#define LIBDRAGON_COMPRESS_APLIB_DEC_INTERNAL_H
+
+/** @brief Set to 0 to disable assembly implementation of the full decoder */
+#ifdef N64
+#define DECOMPRESS_APLIB_FULL_USE_ASM             1
+#else
+#define DECOMPRESS_APLIB_FULL_USE_ASM             0
+#endif
+
+#include <stdio.h>
+
+#define DECOMPRESS_APLIB_STATE_SIZE       348
+
+void decompress_aplib_init(void *state, FILE *fp, int winsize);
+ssize_t decompress_aplib_read(void *state, void *buf, size_t len);
+void decompress_aplib_reset(void *state);
+
+#if DECOMPRESS_APLIB_FULL_USE_ASM
+int decompress_aplib_full_inplace(const uint8_t* in, size_t cmp_size, uint8_t *out, size_t size);
+#else
+void* decompress_aplib_full(const char *fn, FILE *fp, size_t cmp_size, size_t size);
+#endif
+
+#endif

--- a/src/compress/lz4_dec_fast.S
+++ b/src/compress/lz4_dec_fast.S
@@ -1,0 +1,156 @@
+##############################################
+#  LZ4 - Fast decompressor in assembly
+##############################################
+
+# NOTE: to optimize for speed, this decompressor can write up to 8 bytes
+# after the end of the output buffer. The outut buffer must have been sized
+# accordingly to accomodate for this.
+
+#define DMA_RACE_MARGIN     16
+#define PI_STATUS           0xA4600010
+#define PI_DRAM_ADDR        0xA4600000
+
+#define MINMATCH    4
+
+#define inbuf       $a0
+#define inbuf_end   $a1
+#define outbuf      $a2
+
+#define match_off   $t5
+#define match_len   $t6
+#define token       $t7
+#define dma_ptr     $t8
+#define outbuf_orig $v1
+
+#define ra3         $t4
+#define ra2         $a3
+
+    .section .text.decompress_lz4_full_fast
+	.p2align 5
+    .globl decompress_lz4_full_fast 
+    .func decompress_lz4_full_fast
+    .set at
+    .set noreorder
+
+decompress_lz4_full_fast:
+    add $a1, $a0                                # calculate end of input buffer
+    move ra3, $ra
+    move outbuf_orig, outbuf
+    li dma_ptr, 0x80000000                      # initialize dma_ptr to force a first check
+
+.Lloop:
+    sub $t0, inbuf, dma_ptr                     # check if we need to wait for dma
+    bgezal $t0, .Lwaitdma                       # if inbuf >= dma_ptr, wait for dma
+     nop
+    lbu token, 0(inbuf)                         # read token byte
+    addiu inbuf, 1
+    srl match_len, token, 4                     # extract literal length
+    beqz match_len, .Lmatches                   # if literal length is 0, jump to matches
+     addiu $t0, match_len, -0xF                 # check if literal length is 15
+    bgezal $t0, .Lread_match_len                # if literal length is 15, read more
+     nop
+    move $v0, inbuf                            # store start of literals into $v0
+    add inbuf, match_len                        # advance inbuf to end of literals
+    sub $t0, inbuf, dma_ptr                     # check if all the literals have been DMA'd
+    bgezal $t0, .Lwaitdma                       # if not, wait for DMA
+     nop
+.Lcopy_lit:
+    ldl $t0, 0($v0)                             # load 8 bytes of literals
+    ldr $t0, 7($v0)
+    addiu $v0, 8
+    sdl $t0, 0(outbuf)                          # store 8 bytes of literals
+    sdr $t0, 7(outbuf)
+    addiu match_len, -8
+    bgez match_len, .Lcopy_lit                  # check if we went past the end of literals
+     addiu outbuf, 8
+    addu outbuf, match_len                      # adjust outbuf to roll back extra copied bytes
+
+.Lmatches:
+    bge inbuf, inbuf_end, .Lend                 # check if we went past the end of the input
+     andi match_len, token, 0xF                 # extract match length    
+    lbu match_off, 1(inbuf)                     # read 16-bit match offset (little endian)
+    lbu $t0, 0(inbuf)
+    addiu inbuf, 2
+    sll match_off, 8
+    or match_off, $t0
+    
+    addiu $t0, match_len, -0xF                  # check if match length is 15
+    bgezal $t0, .Lread_match_len                # if match length is 15, read more
+     addiu match_len, MINMATCH                  # add implicit MINMATCH to match length
+
+.Lmatch:
+    blt match_off, match_len, .Lmatch1_loop_check   # check if we can do 8-byte copy
+     sub $v0, outbuf, match_off                 # calculate start of match
+.Lmatch8_loop:                                  # 8-byte copy loop
+    ldl $t0, 0($v0)                             # load 8 bytes
+    ldr $t0, 7($v0)
+    addiu $v0, 8
+    sdl $t0, 0(outbuf)                          # store 8 bytes
+    sdr $t0, 7(outbuf)
+    addiu match_len, -8
+    bgtz match_len, .Lmatch8_loop               # check we went past match_len
+     addiu outbuf, 8
+    b .Lloop                                    # jump to main loop
+     addu outbuf, match_len                     # adjust pointer remove extra bytes
+
+.Lmatch1_memset:                                # prepare memset loop (value in t0)
+    dsll $t1, $t0, 8                            # duplicate the LSB into all bytes
+    or $t0, $t1
+    dsll $t1, $t0, 16
+    or $t0, $t1
+    dsll $t1, $t0, 32
+    or $t0, $t1
+.Lmatch1_memset_loop:                           # memset loop
+    sdl $t0, 0(outbuf)                          # store 8 bytes
+    sdr $t0, 7(outbuf)                           
+    addiu match_len, -8                         # adjust match_len
+    bgtz match_len, .Lmatch1_memset_loop        # check we went past match_len
+     addiu outbuf, 8
+    b .Lloop                                    # jump to main loop
+     addu outbuf, match_len                     # adjust pointer remove extra bytes
+
+.Lmatch1_loop_check:                            # 1-byte copy loop
+    beq match_off, 1, .Lmatch1_memset           # if match_off is 1, it's a memset
+.Lmatch1_loop:                                  # 1-byte copy loop
+    lbu $t0, 0($v0)                             # load 1 byte
+    addiu $v0, 1
+    sb $t0, 0(outbuf)                           # store 1 byte
+    addiu match_len, -1
+    bgtz match_len, .Lmatch1_loop               # check we went past match_len
+     addiu outbuf, 1
+    b .Lloop                                    # jump to main loop
+     nop
+
+.Lend:
+    jr ra3
+     sub $v0, outbuf, outbuf_orig               # return number of bytes written
+
+.Lread_match_len:                               # read extended match length
+    move ra2, $ra
+.Lread_match_len_loop:
+    sub $t0, inbuf, dma_ptr                     # check if we need to wait for dma
+    bgezal $t0, .Lwaitdma                       # if inbuf >= dma_ptr, wait for dma
+     nop
+    lbu $t0, 0(inbuf)                           # read 1 byte
+    addiu inbuf, 1
+    beq $t0, 0xFF, .Lread_match_len_loop        # if byte is 0xFF, continue reading
+     add match_len, $t0                         # add to match_len
+    jr ra2
+     nop
+
+.Lwaitdma:
+    li $t1, 0x80000000 - DMA_RACE_MARGIN
+.Lwaitdma_loop:
+    lw $t0, (PI_STATUS)
+    andi $t0, 1
+    beqz $t0, .Lwaitdma_end
+     li dma_ptr, 0xffffffff
+    lw dma_ptr, (PI_DRAM_ADDR)
+    andi $t0, dma_ptr, 0xF
+    xor dma_ptr, $t0
+    addu dma_ptr, $t1
+    ble dma_ptr, inbuf, .Lwaitdma_loop
+     nop
+.Lwaitdma_end:
+    jr $ra
+     nop

--- a/src/compress/lz4_dec_internal.h
+++ b/src/compress/lz4_dec_internal.h
@@ -52,17 +52,16 @@
  * @param src_size      Size of the compressed data in bytes
  * @param dst           Pointer to destination buffer (decompressed data)
  * @param dst_size      Size of the destination buffer in bytes
- * @param dma_race      If true, the source data is currently being DMA'd.
  * @return int          Number of bytes decompressed, or -1 on error.
  */
-int decompress_lz4_full_mem(const unsigned char *src, int src_size,
-    unsigned char *dst, int dst_size, bool dma_race);
+int decompress_lz4_full_inplace(const uint8_t *src, size_t src_size, uint8_t *dst, size_t dst_size);
 
 
-#define DECOMPRESS_LZ4_STATE_SIZE  (16552)
+#define DECOMPRESS_LZ4_STATE_SIZE  176
 
-void decompress_lz4_init(void *state, FILE *fp);
+void decompress_lz4_init(void *state, FILE *fp, int winsize);
 ssize_t decompress_lz4_read(void *state, void *buf, size_t len);
+void decompress_lz4_reset(void *state);
 void* decompress_lz4_full(const char *fn, FILE *fp, size_t cmp_size, size_t size);
 
 #endif

--- a/src/compress/lzh5_internal.h
+++ b/src/compress/lzh5_internal.h
@@ -14,9 +14,10 @@ extern "C" {
  * Note that this can still be allocated on the stack, as the stack size
  * configured by libdragon is 64KB.
  */
-#define DECOMPRESS_LZH5_STATE_SIZE    24000
+#define DECOMPRESS_LZH5_STATE_SIZE            (6096+16)
+#define DECOMPRESS_LZH5_DEFAULT_WINDOW_SIZE   (8192)
 
-void decompress_lzh5_init(void *state, FILE *fp);
+void decompress_lzh5_init(void *state, FILE *fp, int winsize);
 ssize_t decompress_lzh5_read(void *state, void *buf, size_t len);
 int decompress_lzh5_pos(void *state);
 

--- a/src/compress/ringbuf.c
+++ b/src/compress/ringbuf.c
@@ -1,18 +1,23 @@
 #include "ringbuf_internal.h"
 #include "../utils.h"
+#include <assert.h>
 
-void __ringbuf_init(decompress_ringbuf_t *ringbuf)
+void __ringbuf_init(decompress_ringbuf_t *ringbuf, uint8_t *buf, int size)
 {
+    assert(size > 0);
+    assert((size & (size-1)) == 0); // check if power of two
+    ringbuf->ringbuf = buf;
+    ringbuf->ringbuf_size = size ;
     ringbuf->ringbuf_pos = 0;
 }
 
 void __ringbuf_write(decompress_ringbuf_t *ringbuf, uint8_t *src, int count)
 {
     while (count > 0) {
-        int n = MIN(count, RING_BUFFER_SIZE - ringbuf->ringbuf_pos);
+        int n = MIN(count, ringbuf->ringbuf_size - ringbuf->ringbuf_pos);
         memcpy(ringbuf->ringbuf + ringbuf->ringbuf_pos, src, n);
         ringbuf->ringbuf_pos += n;
-        ringbuf->ringbuf_pos &= RING_BUFFER_SIZE-1;
+        ringbuf->ringbuf_pos &= ringbuf->ringbuf_size - 1;
         src += n;
         count -= n;
     }
@@ -20,12 +25,12 @@ void __ringbuf_write(decompress_ringbuf_t *ringbuf, uint8_t *src, int count)
 
 void __ringbuf_copy(decompress_ringbuf_t *ringbuf, int copy_offset, uint8_t *dst, int count)
 {
-    int ringbuf_copy_pos = (ringbuf->ringbuf_pos - copy_offset) & (RING_BUFFER_SIZE-1);
+    int ringbuf_copy_pos = (ringbuf->ringbuf_pos - copy_offset) & (ringbuf->ringbuf_size - 1);
     int dst_pos = 0;
     while (count > 0) {
         int wn = count;
-        wn = wn < RING_BUFFER_SIZE - ringbuf_copy_pos     ? wn : RING_BUFFER_SIZE - ringbuf_copy_pos;
-        wn = wn < RING_BUFFER_SIZE - ringbuf->ringbuf_pos ? wn : RING_BUFFER_SIZE - ringbuf->ringbuf_pos;
+        wn = wn < ringbuf->ringbuf_size - ringbuf_copy_pos     ? wn : ringbuf->ringbuf_size - ringbuf_copy_pos;
+        wn = wn < ringbuf->ringbuf_size - ringbuf->ringbuf_pos ? wn : ringbuf->ringbuf_size - ringbuf->ringbuf_pos;
         count -= wn;
 
         // Check if there's an overlap in the ring buffer between read and write pos, in which
@@ -36,7 +41,7 @@ void __ringbuf_copy(decompress_ringbuf_t *ringbuf, int copy_offset, uint8_t *dst
                 // Copy 8 bytes at at time, using a unaligned memory access (LDL/LDR/SDL/SDR)
                 typedef uint64_t u_uint64_t __attribute__((aligned(1)));
                 uint64_t value = *(u_uint64_t*)&ringbuf->ringbuf[ringbuf_copy_pos];
-                *(u_uint64_t*)&dst[dst_pos] = value;
+                if(dst) *(u_uint64_t*)&dst[dst_pos] = value;
                 *(u_uint64_t*)&ringbuf->ringbuf[ringbuf->ringbuf_pos] = value;
 
                 ringbuf_copy_pos += 8;
@@ -49,7 +54,7 @@ void __ringbuf_copy(decompress_ringbuf_t *ringbuf, int copy_offset, uint8_t *dst
         // Finish copying the remaining bytes
         while (wn > 0) {
             uint8_t value = ringbuf->ringbuf[ringbuf_copy_pos];
-            dst[dst_pos] = value;
+            if(dst) dst[dst_pos] = value;
             ringbuf->ringbuf[ringbuf->ringbuf_pos] = value;
 
             ringbuf_copy_pos += 1;
@@ -58,7 +63,7 @@ void __ringbuf_copy(decompress_ringbuf_t *ringbuf, int copy_offset, uint8_t *dst
             wn -= 1;
         }
 
-        ringbuf_copy_pos %= RING_BUFFER_SIZE;
-        ringbuf->ringbuf_pos %= RING_BUFFER_SIZE;
+        ringbuf_copy_pos &= ringbuf->ringbuf_size - 1;
+        ringbuf->ringbuf_pos &= ringbuf->ringbuf_size - 1;
     }
 }

--- a/src/compress/ringbuf_internal.h
+++ b/src/compress/ringbuf_internal.h
@@ -3,26 +3,22 @@
 
 #include <stdint.h>
 
-///< Size of the ring buffer in bytes. This happens to work for both lz4 and lzh5
-#ifndef RING_BUFFER_SIZE
-#define RING_BUFFER_SIZE    (16 * 1024)
-#endif
-
 /**
  * @brief A ring buffer used for streaming decompression.
  */
 typedef struct {
-	uint8_t ringbuf[RING_BUFFER_SIZE];      ///< The ring buffer itself
+	uint8_t* ringbuf;                       ///< The ring buffer itself
+    unsigned int ringbuf_size;              ///< Size of the ring buffer (power of two)
 	unsigned int ringbuf_pos;               ///< Current write position in the ring buffer
 } decompress_ringbuf_t;
 
 
-void __ringbuf_init(decompress_ringbuf_t *ringbuf);
+void __ringbuf_init(decompress_ringbuf_t *ringbuf, uint8_t *buf, int winsize);
 
-inline void __ringbuf_writebyte(decompress_ringbuf_t *ringbuf, uint8_t byte)
+static inline void __ringbuf_writebyte(decompress_ringbuf_t *ringbuf, uint8_t byte)
 {
     ringbuf->ringbuf[ringbuf->ringbuf_pos++] = byte;
-    ringbuf->ringbuf_pos &= (RING_BUFFER_SIZE - 1);
+    ringbuf->ringbuf_pos &= ringbuf->ringbuf_size-1;
 }
 
 /**

--- a/src/compress/shrinkler_dec.c
+++ b/src/compress/shrinkler_dec.c
@@ -1,0 +1,201 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef N64
+#include "debug.h"
+#else
+
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+#else
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+#endif
+
+#if defined(__LITTLE_ENDIAN__)
+#define read32be(ptr) __builtin_bswap32(*(uint32_t*)(ptr))
+#else
+#define read32be(ptr) (*(uint32_t*)(ptr))
+#endif
+
+#define ADJUST_SHIFT 4
+
+#define NUM_SINGLE_CONTEXTS 1
+#define NUM_CONTEXT_GROUPS 4
+#define CONTEXT_GROUP_SIZE 256
+#define NUM_CONTEXTS  (NUM_SINGLE_CONTEXTS + NUM_CONTEXT_GROUPS * CONTEXT_GROUP_SIZE)
+
+
+#define CONTEXT_KIND 0
+#define CONTEXT_REPEATED -1
+
+#define CONTEXT_GROUP_LIT 0
+#define CONTEXT_GROUP_OFFSET 2
+#define CONTEXT_GROUP_LENGTH 3
+
+/** @brief Decompressor state (for assembly) */
+typedef struct {
+    uint16_t contexts[NUM_CONTEXTS];    ///< Probability contexts
+} shrinkler_asm_state_t;
+
+/** @brief Decompressor state (for C) */
+typedef struct {
+    uint16_t contexts[NUM_CONTEXTS];    ///< Probability contexts
+    unsigned intervalsize;              ///< Current interval size
+    uint64_t intervalvalue;             ///< Current interval value
+
+    uint8_t *src;                       ///< Pointer to the input data
+    int bits_left;                      ///< Number of bits left in the interval
+} shrinkler_ctx_t;
+
+static void shr_decode_init(shrinkler_ctx_t *ctx, uint8_t *src) {
+    for (int i=0; i<NUM_CONTEXTS; i++)
+        ctx->contexts[i] = 0x8000;
+    
+    ctx->intervalsize = 1;
+    ctx->intervalvalue = 0;
+    ctx->src = src;
+    ctx->bits_left = 0;
+
+    // Adjust for 64-bit values
+    for (int i=0;i<4;i++)
+        ctx->intervalvalue = (ctx->intervalvalue << 8) | *ctx->src++;
+    ctx->intervalvalue <<= 31;
+    ctx->bits_left = 1;
+    ctx->intervalsize = 0x8000;
+}
+
+static inline int shr_decode_bit(shrinkler_ctx_t *ctx, int context_index) {
+    while ((ctx->intervalsize < 0x8000)) {
+        if (unlikely(ctx->bits_left == 0)) {
+            ctx->intervalvalue |= read32be(ctx->src);
+            ctx->src += 4;
+            ctx->bits_left = 32;
+        }
+        ctx->bits_left -= 1;
+        ctx->intervalsize <<= 1;
+        ctx->intervalvalue <<= 1;
+    }
+
+    unsigned prob = ctx->contexts[context_index];
+    unsigned intervalvalue = ctx->intervalvalue >> 48;
+    unsigned threshold = (ctx->intervalsize * prob) >> 16;
+
+    if (intervalvalue >= threshold) {
+        // Zero
+        ctx->intervalvalue -= (uint64_t)threshold << 48;
+        ctx->intervalsize -= threshold;
+        ctx->contexts[context_index] = prob - (prob >> ADJUST_SHIFT);
+        return 0;
+    } else {
+        // One
+        ctx->intervalsize = threshold;
+        ctx->contexts[context_index] = prob + (0xffff >> ADJUST_SHIFT) - (prob >> ADJUST_SHIFT);
+        return 1;
+    }
+}
+
+static inline int shr_decode_number(shrinkler_ctx_t *ctx, int base_context) {
+    int context;
+    int i;
+    for (i = 0 ;; i++) {
+        context = base_context + (i * 2 + 2);
+        if (shr_decode_bit(ctx, context) == 0) break;
+    }
+
+    int number = 1;
+    for (; i >= 0 ; i--) {
+        context = base_context + (i * 2 + 1);
+        int bit = shr_decode_bit(ctx, context);
+        number = (number << 1) | bit;
+    }
+
+    return number;
+}
+
+static inline int lzDecode(shrinkler_ctx_t *ctx, int context) {
+    return shr_decode_bit(ctx, NUM_SINGLE_CONTEXTS + context);
+}
+
+static inline int lzDecodeNumber(shrinkler_ctx_t *ctx, int context_group) {
+    return shr_decode_number(ctx, NUM_SINGLE_CONTEXTS + (context_group << 8));
+}
+
+int shr_unpack(uint8_t *dst, uint8_t *src)
+{
+    const int parity_mask = 1;
+
+    uint8_t *dst_start = dst;
+    shrinkler_ctx_t ctx;
+    shr_decode_init(&ctx, src);
+
+    bool ref = false;
+    bool prev_was_ref = false;
+    int offset = 0;
+
+    while (1) {
+        if (ref) {
+            bool repeated = false;
+            if (!prev_was_ref) {
+                repeated = lzDecode(&ctx, CONTEXT_REPEATED);
+            }
+            if (!repeated) {
+                offset = lzDecodeNumber(&ctx, CONTEXT_GROUP_OFFSET) - 2;
+                if (offset == 0)
+                    break;
+            }
+            int length = lzDecodeNumber(&ctx, CONTEXT_GROUP_LENGTH);
+            prev_was_ref = true;
+            if (offset > 8) 
+                while (length >= 8) {
+                    memcpy(dst, dst - offset, 8);
+                    dst += 8;
+                    length -= 8;
+                }            
+            while (length--) {
+                *dst = dst[-offset];
+                dst++;
+            }
+        } else {
+            int parity = (dst - dst_start) & parity_mask;
+            int context = 1;
+            for (int i = 7 ; i >= 0 ; i--) {
+                int bit = lzDecode(&ctx, (parity << 8) | context);
+                context = (context << 1) | bit;
+            }
+            uint8_t lit = context;
+            *dst++ = lit;
+            prev_was_ref = false;
+        }
+        int parity = (dst - dst_start) & parity_mask;
+        ref = lzDecode(&ctx, CONTEXT_KIND + (parity << 8));
+    }
+    
+    return dst - dst_start;
+}
+
+void* decompress_shrinkler_full(const char *fn, FILE *fp, size_t cmp_size, size_t size)
+{
+    void *in = malloc(cmp_size);
+    fread(in, 1, cmp_size, fp);
+
+    void *out = malloc(size);
+    if (!out) return 0;
+    int dec_size = shr_unpack(out, in); (void)dec_size;
+    assertf(dec_size == size, "Shrinkler size:%d exp:%d", dec_size, size);
+    free(in);
+    return out;
+}
+
+#ifdef N64
+int decompress_shrinkler_full_inplace(const uint8_t* in, size_t cmp_size, uint8_t *out, size_t size)
+{
+    extern int decompress_shrinkler_full_fast(const uint8_t* in, int insize, uint8_t *out);
+    return decompress_shrinkler_full_fast(in, cmp_size, out);
+}
+#endif

--- a/src/compress/shrinkler_dec_fast.S
+++ b/src/compress/shrinkler_dec_fast.S
@@ -1,0 +1,266 @@
+##############################################
+#  Shrinkler - Fast decompressor in assembly
+#
+#  This decompressor implements the following variant of Shrinkler:
+#    * Forward decoding
+#    * Parity mask: 1. This has been tested to provide
+#      the best compression ratio on average.
+##############################################
+
+#define inbuf           $a0
+#define outbuf          $a2
+
+#define intervalsize    $t2   
+#define intervalvalue   $t3
+#define nbits           $t4
+#define match_off       $t5
+#define prev_match      $t6
+#define lit_len         $t7
+#define match_len       $t7
+#define num_len         $t7
+#define ctx             $t8
+#define outbuf_orig     $t9
+#define parity          $v1
+
+#define ra2             $a1
+#define lit_ctx         $a1
+#define ra3             $a3
+
+#define ROUND_UP(n,d)   (((n) + (d) - 1) / (d) * (d))
+
+#define DMA_RACE_MARGIN             16
+#define PI_REGS             0xA4600000
+#define PI_STATUS                 0x10
+#define PI_DRAM_ADDR              0x00
+
+#define ADJUST_SHIFT                4
+#define NUM_SINGLE_CONTEXTS         1
+#define NUM_CONTEXT_GROUPS          4
+#define CONTEXT_GROUP_SIZE          256
+#define NUM_CONTEXTS                (NUM_SINGLE_CONTEXTS + NUM_CONTEXT_GROUPS * CONTEXT_GROUP_SIZE)
+
+#define CONTEXT_KIND             (0 + 1)
+#define CONTEXT_REPEATED         (-1 + 1)
+#define CONTEXT_GROUP_OFFSET     ((2<<8) + 1)
+#define CONTEXT_GROUP_LENGTH     ((3<<8) + 1)
+
+    .section .text.decompress_shrinkler_full_fast
+	.p2align 5
+    .globl decompress_shrinkler_full_fast 
+    .func decompress_shrinkler_full_fast
+    .set at
+    .set noreorder
+
+decompress_shrinkler_full_fast:
+    move outbuf_orig, outbuf
+    addiu $t1, $sp, -16
+    addiu $sp, $sp, -ROUND_UP(NUM_CONTEXTS*2, 8)-16
+    move $t0, $sp
+    li $t2, 0x80008000
+.Linit_contexts_loop:
+    sw $t2, 0($t0)
+    sw $t2, 4($t0)
+    blt $t0, $t1, .Linit_contexts_loop
+     addiu $t0, 8
+    # For Shrinkler, we don't do real DMA racing becuase the algorithm
+    # is so slow that PI DMA is always faster. The only real risk is
+    # at the very beginning: if this code is already in cache, we might
+    # fetch the first word before the DMA has written it. So we just
+    # wait for the DMA to write a little bit, and then we start decoding.
+    li $t2, PI_REGS
+.Lwaitdma_loop:
+    lw $t0, PI_STATUS($t2)
+    andi $t0, 1
+    beqz $t0, .Linitial_setup
+    lw $t1, PI_DRAM_ADDR($t2)
+    addu $t1, 0x80000000 - DMA_RACE_MARGIN
+    ble $t1, inbuf, .Lwaitdma_loop
+.Linitial_setup:
+     move ra3, $ra
+    lwu intervalvalue, 0(inbuf)
+    addiu inbuf, 4
+    dsll intervalvalue, 31
+    li nbits, 1
+    li intervalsize, 0x8000
+    li parity, CONTEXT_KIND*2
+    b .Lliteral
+     li $v0, 1
+
+.Lloop:
+    li $v0, 0
+    bal .Llzdecode
+     addu ctx, parity, $sp
+    bnez $v0, .Lmatch
+     xori $v0, 1
+
+.Lliteral:
+    li prev_match, 0
+    li lit_len, 7
+    addu lit_ctx, parity, $sp
+.Lliteral_loop:
+    sll $v0, 1
+    bal .Llzdecode
+     addu ctx, lit_ctx, $v0
+    bnez lit_len, .Lliteral_loop
+     addiu lit_len, -1
+
+    xori parity, 0x200
+    sb $v0, 0(outbuf)
+    b .Lloop
+     addiu outbuf, 1
+
+.Lmatch:
+    bgezal prev_match, .Llzdecode
+     addiu ctx, $sp, CONTEXT_REPEATED*2 
+    sll $v0, 31
+    addiu ctx, $sp, CONTEXT_GROUP_OFFSET*2
+    bgezal $v0, .Llzdecode_number
+     addiu $v0, match_off, 2
+    addiu $v0, -2
+    beqz $v0, .Lend
+     move match_off, $v0
+    bal .Llzdecode_number
+     addiu ctx, $sp, CONTEXT_GROUP_LENGTH*2
+    move match_len, $v0
+    andi $t0, match_len, 1
+    sll $t0, 9
+    xor parity, $t0
+    li prev_match, 1<<31
+    blt match_off, match_len, .Lmatch1_loop_check   # check if we can do 8-byte copy
+     sub $v0, outbuf, match_off                 # calculate start of match
+.Lmatch8_loop:                                  # 8-byte copy loop
+    ldl $t0, 0($v0)                             # load 8 bytes
+    ldr $t0, 7($v0)
+    addiu $v0, 8
+    sdl $t0, 0(outbuf)                          # store 8 bytes
+    sdr $t0, 7(outbuf)
+    addiu match_len, -8
+    bgtz match_len, .Lmatch8_loop               # check we went past match_len
+     addiu outbuf, 8
+    b .Lloop                                    # jump to main loop
+     addu outbuf, match_len                     # adjust pointer remove extra bytes
+
+.Lmatch1_memset:                                # prepare memset loop (value in t0)
+    dsll $t1, $t0, 8                            # duplicate the LSB into all bytes
+    or $t0, $t1
+    dsll $t1, $t0, 16
+    or $t0, $t1
+    dsll $t1, $t0, 32
+    or $t0, $t1
+.Lmatch1_memset_loop:                           # memset loop
+    sdl $t0, 0(outbuf)                          # store 8 bytes
+    sdr $t0, 7(outbuf)                           
+    addiu match_len, -8                         # adjust match_len
+    bgtz match_len, .Lmatch1_memset_loop        # check we went past match_len
+     addiu outbuf, 8
+    b .Lloop                                    # jump to main loop
+     addu outbuf, match_len                     # adjust pointer remove extra bytes
+
+.Lmatch1_loop_check:                            # 1-byte copy loop
+    beq match_off, 1, .Lmatch1_memset           # if match_off is 1, it's a memset
+.Lmatch1_loop:                                  # 1-byte copy loop
+    lbu $t0, 0($v0)                             # load 1 byte
+    addiu $v0, 1
+    sb $t0, 0(outbuf)                           # store 1 byte
+    addiu match_len, -1
+    bgtz match_len, .Lmatch1_loop               # check we went past match_len
+     addiu outbuf, 1
+    b .Lloop                                    # jump to main loop
+     nop
+
+.Lend:
+    addiu $sp, $sp, ROUND_UP(NUM_CONTEXTS*2, 8)+16
+    jr ra3
+     sub $v0, outbuf, outbuf_orig
+
+###################################################
+# Function: .Llzdecode_number
+#   Arithmetic decoder of a variable sized number
+#
+# Input:
+#  * ctx: first context to use
+# Output:
+#  * $v0: decoded number
+# Destroy:
+#  * $t0, $t1
+#  * num_len ($t7) (aliased with all other len variables)
+#
+###################################################
+
+.Llzdecode_number:
+    move ra2, $ra
+    li num_len, 0
+.Llzdecode_number_len:
+    li $v0, 0
+    bal .Llzdecode
+     addiu ctx, 2*2
+    bnez $v0, .Llzdecode_number_len
+     addiu num_len, 1
+    li $v0, 1
+    addiu ctx, -1*2
+.Llzdecode_number_value:
+    sll $v0, 1
+    bal .Llzdecode
+     addiu num_len, -1
+    bnez num_len, .Llzdecode_number_value
+     addiu ctx, -2*2
+.Llzdecode_number_end:
+    jr ra2
+     nop
+
+###################################################
+# Function: .Llzdecode
+#   Arithmetic decoder of one bit
+#
+# Input: 
+#   * ctx: context to use
+#   * $v0: value to modify
+# Return:
+#   * $v0: set last bit to 1 if dcoded bit is 1,
+#          otherwise leave it unchanged
+# Destroy:
+#   * $t0, $t1
+###################################################
+
+    .set noat
+.Llzdecode:
+    sll intervalsize, 16
+    bltz intervalsize, .Llzdecode_prob
+     lhu $t0, 0(ctx)
+.Llzdecode_bit_loop:
+    bnez nbits, .Llzdecode_next_bit
+     addiu nbits, -1
+    lwu $at, 0(inbuf)
+    addiu inbuf, 4
+    or intervalvalue, $at
+    li nbits, 31
+.Llzdecode_next_bit:     
+    sll intervalsize, 1
+    bgez intervalsize, .Llzdecode_bit_loop
+     dsll intervalvalue, 1
+.Llzdecode_prob:
+    dsrl $at, intervalvalue, 48
+    multu intervalsize, $t0
+    srl intervalsize, 16
+    mfhi $t1
+
+    sub $at, $t1
+    bgez $at, .Llzdecode_prob_false
+     srl $at, $t0, ADJUST_SHIFT
+
+.Llzdecode_prob_true:
+    move intervalsize, $t1
+    sub $t0, $at
+    addiu $t0, (0xffff >> ADJUST_SHIFT)
+    sh $t0, 0(ctx)
+    jr $ra
+     ori $v0, 1
+
+.Llzdecode_prob_false:
+    sub intervalsize, $t1
+    dsll $t1, $t1, 48
+    dsubu intervalvalue, $t1
+    sub $t0, $at
+    jr $ra
+     sh $t0, 0(ctx)
+    .set at

--- a/src/compress/shrinkler_dec_internal.h
+++ b/src/compress/shrinkler_dec_internal.h
@@ -1,0 +1,20 @@
+#ifndef LIBDRAGON_COMPRESS_SHRINKLER_DEC_INTERNAL_H
+#define LIBDRAGON_COMPRESS_SHRINKLER_DEC_INTERNAL_H
+
+/** @brief Set to 0 to disable assembly implementation of the full decoder */
+#ifdef N64
+#define DECOMPRESS_SHRINKLER_FULL_USE_ASM             1
+#else
+#define DECOMPRESS_SHRINKLER_FULL_USE_ASM             0
+#endif
+
+#define DECOMPRESS_SHRINKLER_STATE_SIZE       512
+
+#if DECOMPRESS_SHRINKLER_FULL_USE_ASM
+int decompress_shrinkler_full_inplace(const uint8_t* in, size_t cmp_size, uint8_t *out, size_t size);
+#else
+void* decompress_shrinkler_full(const char *fn, FILE *fp, size_t cmp_size, size_t size);
+#endif
+
+#endif
+

--- a/tools/audioconv64/conv_ym64.c
+++ b/tools/audioconv64/conv_ym64.c
@@ -160,7 +160,7 @@ int ym_convert(const char *infn, const char *outfn) {
         // https://github.com/fragglet/lhasa, stored in lzh5.h.
         fseek(ym_f, head[0]+2, SEEK_SET);
         ym_compressed = true;
-        decompress_lzh5_init(ym_decoder, ym_f);
+        decompress_lzh5_init(ym_decoder, ym_f, DECOMPRESS_LZH5_DEFAULT_WINDOW_SIZE);
         ymread(head, 12);
     }
 

--- a/tools/common/assetcomp.c
+++ b/tools/common/assetcomp.c
@@ -3,30 +3,105 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "../common/binout.h"
-#include "../common/lzh5_compress.c"
+#include "binout.h"
+#include "aplib_compress.h"
+#include "shrinkler_compress.h"
+#undef SWAP
+#undef MIN_MATCH_SIZE
 #undef MIN
 #undef MAX
 #include "../../src/asset.c"
-#include "../../src/compress/lzh5.c"
+#include "../../src/compress/aplib_dec.c"
+#include "../../src/compress/shrinkler_dec.c"
 #include "../../src/compress/lz4_dec.c"
 #include "../../src/compress/ringbuf.c"
 #undef MIN
 #undef MAX
 #undef LZ4_DECOMPRESS_INPLACE_MARGIN
 
-#ifndef LZ4_SRC_INCLUDED
-#define LZ4_DISTANCE_MAX 16384
-#include "../common/lz4/lz4.c"
-#endif
-#include "../common/lz4/lz4hc.c"
-#undef MIN
-#undef MAX
+#include "lz4_compress.h"
 
+void asset_compress_mem(int compression, const uint8_t *data, int sz, uint8_t **output, int *cmp_size, int *winsize, int *margin)
+{
+    switch (compression) {
+    case 1: { // lz4hc
+        // Default for LZ4HC is 8 KiB, which makes sense given the little
+        // data cache of VR4300 to improve decompression speed.
+        if (*winsize == 0) {
+            *winsize = 8*1024;
+            while (sz < *winsize && *winsize > 2*1024)
+                *winsize /= 2;
+        }
 
-bool asset_compress(const char *infn, const char *outfn, int compression)
+        // The actual max distance of the LZ4 format is 64KiB-1, make sure we
+        // don't go over that.
+        if (*winsize > 64*1024) *winsize = 64*1024;
+        lz4_distance_max = *winsize;
+        if (lz4_distance_max > 65535) lz4_distance_max = 65535;
+
+        int cmp_max_size = LZ4_COMPRESSBOUND(sz);
+        *output = malloc(cmp_max_size);
+
+        // Compress the file. Use compression level LZ4HC_CLEVEL_MAX and
+        // "favor decompression speed", as we prefer to leave a bit of
+        // compression ratio on the table in exchange for faster decompression.
+        LZ4_streamHC_t* state = LZ4_createStreamHC();
+        LZ4_setCompressionLevel(state, LZ4HC_CLEVEL_MAX);
+        LZ4_favorDecompressionSpeed(state, 1);
+        *cmp_size = LZ4_compress_HC_continue(state, (char*)data, (char*)*output, sz, cmp_max_size);
+        LZ4_freeStreamHC(state);
+        assert(*cmp_size <= cmp_max_size);
+        *margin = LZ4_DECOMPRESS_INPLACE_MARGIN(*cmp_size);
+    }   break;
+    case 2: { // aplib
+        if (*winsize == 0) {
+            *winsize = 256*1024;
+            while (sz < *winsize && *winsize > 2*1024)
+                *winsize /= 2;
+        }
+    
+        apultra_stats stats;
+        int max_cmp_size = apultra_get_max_compressed_size(sz);
+        *output = calloc(1, max_cmp_size);  // note: apultra.c clears the buffer, not sure why
+        *cmp_size = apultra_compress(data, *output, sz, max_cmp_size, 
+            0,          // flags
+            *winsize,    // window size
+            0,          // dictionary size
+            NULL,       // progress callback
+            &stats);
+
+        *margin = stats.safe_dist + *cmp_size - sz;
+    }   break;
+    case 3: { // shrinkler
+        *winsize = 256*1024; // FIXME
+        int inplace_margin;
+        *output = shrinkler_compress(data, sz, 3, cmp_size, &inplace_margin);
+        // Shrinkler seems to return negative margin values because we asked to
+        // verify using 4 byte reads. Just clamp to zero.
+        *margin = inplace_margin > 0 ? inplace_margin : 0;
+    }   break;
+    default:
+        assert(0);
+    }  
+}
+
+/**
+ * @brief Compress or recompress a file in the libdragon asset format.
+ * 
+ * @param infn          Input file to (re-)compress
+ * @param outfn         Output file
+ * @param compression   Requested compression level (0 = none, 1 = lz4hc, 2 = lzh5)
+ * @param winsize       If zero, the compressor will choose the best window size
+ *                      for optimal compression ratio/dec-speed. If not zero, the specified
+ *                      window size will be used for compression. This can be useful
+ *                      to decrease the amount of RAM used by the decompressor.
+ * @return true         File was compressed correctly
+ * @return false        Error compressing the file
+ */
+bool asset_compress(const char *infn, const char *outfn, int compression, int winsize)
 {
     asset_init_compression(2);
+    asset_init_compression(3);
 
     // Make sure the file exists before calling asset_load,
     // which would just assert.
@@ -37,9 +112,27 @@ bool asset_compress(const char *infn, const char *outfn, int compression)
     }
     fclose(in);
 
+    if (winsize && asset_winsize_to_flags(winsize) < 0) {
+        fprintf(stderr, "unsupported window size: %d\n", winsize);
+        fprintf(stderr, "supported window sizes: 2, 4, 8, 16, 32, 64, 128, 256\n");
+        return false;
+    }
+
+    // Load the file. This will transparently decompresses it if it was compressed,
+    // so that this function can be used to also recompress an already compressed
+    // file.
     int sz;
     uint8_t *data = asset_load(infn, &sz);
 
+    // The caller specified a certain window size. We can still silently decrease it
+    // if the file is smaller, as there is no functional difference and we can save
+    // some RAM at decompression time.
+    if (winsize) {
+        while (sz < winsize && winsize > 2*1024)
+            winsize /= 2;
+    }
+
+    // FIXME: use asset_compress_mem() instead of duplicating the code here
     switch (compression) {
     case 0: { // none
         FILE *out = fopen(outfn, "wb");
@@ -50,49 +143,89 @@ bool asset_compress(const char *infn, const char *outfn, int compression)
         fwrite(data, 1, sz, out);
         fclose(out);
     }   break;
-    case 2: { // lzh5
-        char *tmpfn = NULL;
-        asprintf(&tmpfn, "%s.tmp", outfn);
-        FILE *out = fopen(tmpfn, "wb");
-        if (!out) {
-            fprintf(stderr, "error opening output file: %s\n", tmpfn);
-            return 1;
+    case 3: { // shrinkler
+        winsize = 256*1024; // FIXME
+        int cmp_size; int inplace_margin;
+        uint8_t *output = shrinkler_compress(data, sz, 3, &cmp_size, &inplace_margin);
+        // Shrinkler seems to return negative margin values because we asked to
+        // verify using 4 byte reads. Just clamp to zero.
+        inplace_margin = inplace_margin > 0 ? inplace_margin : 0;
+
+        FILE *out = fopen(outfn, "wb");
+        fwrite("DCA3", 1, 4, out);
+        w16(out, 3); // algo
+        w16(out, asset_winsize_to_flags(winsize) | ASSET_FLAG_INPLACE); // flags
+        w32(out, cmp_size); // cmp_size
+        w32(out, sz); // dec_size
+        w32(out, inplace_margin); // inplace margin
+        fwrite(output, 1, cmp_size, out);
+        fclose(out);
+        free(output);
+    }   break;
+    case 2: { // aplib
+        if (winsize == 0) {
+            winsize = 256*1024;
+            while (sz < winsize && winsize > 2*1024)
+                winsize /= 2;
         }
-        fwrite(data, 1, sz, out);
-        fclose(out);
+    
+        apultra_stats stats;
+        int max_cmp_size = apultra_get_max_compressed_size(sz);
+        void *output = calloc(1, max_cmp_size);  // note: apultra.c clears the buffer, not sure why
+        int cmp_size = apultra_compress(data, output, sz, max_cmp_size, 
+            0,          // flags
+            winsize,    // window size
+            0,          // dictionary size
+            NULL,       // progress callback
+            &stats);
 
-        in = fopen(tmpfn, "rb");
-        out = fopen(outfn, "wb");
-        fwrite("DCA2", 1, 4, out);
+        int inplace_margin = stats.safe_dist + cmp_size - sz;
+        FILE *out = fopen(outfn, "wb");
+        fwrite("DCA3", 1, 4, out);
         w16(out, 2); // algo
-        w16(out, 0); // flags
-        int w_cmp_size = w32_placeholder(out); // cmp_size
-        int w_dec_size = w32_placeholder(out); // dec_size
-
-        unsigned int crc, dsize, csize;
-        lzh5_init(LZHUFF5_METHOD_NUM);
-        lzh5_encode(in, out, &crc, &csize, &dsize);
-
-        w32_at(out, w_cmp_size, csize);
-        w32_at(out, w_dec_size, dsize);
-
-        fclose(in);
+        w16(out, asset_winsize_to_flags(winsize) | ASSET_FLAG_INPLACE); // flags
+        w32(out, cmp_size); // cmp_size
+        w32(out, sz); // dec_size
+        w32(out, inplace_margin); // inplace margin
+        fwrite(output, 1, cmp_size, out);
         fclose(out);
-        remove(tmpfn);
-        free(tmpfn);
+        free(output);
     }   break;
     case 1: { // lz4hc
+        // Default for LZ4HC is 8 KiB, which makes sense given the little
+        // data cache of VR4300 to improve decompression speed.
+        if (winsize == 0) {
+            winsize = 8*1024;
+            while (sz < winsize && winsize > 2*1024)
+                winsize /= 2;
+        }
+
+        // The actual max distance of the LZ4 format is 64KiB-1, make sure we
+        // don't go over that.
+        if (winsize > 64*1024) winsize = 64*1024;
+        lz4_distance_max = winsize;
+        if (lz4_distance_max > 65535) lz4_distance_max = 65535;
+
         int cmp_max_size = LZ4_COMPRESSBOUND(sz);
         void *output = malloc(cmp_max_size);
-        int cmp_size = LZ4_compress_HC((char*)data, output, sz, cmp_max_size, LZ4HC_CLEVEL_MAX);
+
+        // Compress the file. Use compression level LZ4HC_CLEVEL_MAX and
+        // "favor decompression speed", as we prefer to leave a bit of
+        // compression ratio on the table in exchange for faster decompression.
+        LZ4_streamHC_t* state = LZ4_createStreamHC();
+        LZ4_setCompressionLevel(state, LZ4HC_CLEVEL_MAX);
+        LZ4_favorDecompressionSpeed(state, 1);
+        int cmp_size = LZ4_compress_HC_continue(state, (char*)data, output, sz, cmp_max_size);
+        LZ4_freeStreamHC(state);
         assert(cmp_size <= cmp_max_size);
 
         FILE *out = fopen(outfn, "wb");
-        fwrite("DCA2", 1, 4, out);
+        fwrite("DCA3", 1, 4, out);
         w16(out, 1); // algo
-        w16(out, 0); // flags
+        w16(out, asset_winsize_to_flags(winsize) | ASSET_FLAG_INPLACE); // flags
         w32(out, cmp_size); // cmp_size
         w32(out, sz); // dec_size
+        w32(out, LZ4_DECOMPRESS_INPLACE_MARGIN(cmp_size)); // inplace margin
         fwrite(output, 1, cmp_size, out);
         fclose(out);
         free(output);

--- a/tools/common/assetcomp.h
+++ b/tools/common/assetcomp.h
@@ -2,7 +2,12 @@
 #define COMMON_ASSETCOMP_H
 
 #define DEFAULT_COMPRESSION     1
+#define MAX_COMPRESSION         3
 
-bool asset_compress(const char *infn, const char *outfn, int compression);
+// Default window size for streaming decompression (asset_fopen())
+#define DEFAULT_WINSIZE_STREAMING    (4*1024)
+
+bool asset_compress(const char *infn, const char *outfn, int compression, int winsize);
+void asset_compress_mem(int compression, const uint8_t *inbuf, int size, uint8_t **outbuf, int *cmp_size, int *winsize, int *margin);
 
 #endif

--- a/tools/mkasset/mkasset.c
+++ b/tools/mkasset/mkasset.c
@@ -7,6 +7,8 @@
 #include "../common/binout.c"
 #include "../common/assetcomp.h"
 
+#include "../../src/asset_internal.h"
+
 bool flag_verbose = false;
 
 void print_args(char * name)
@@ -14,13 +16,17 @@ void print_args(char * name)
     fprintf(stderr, "%s -- Libdragon asset compression tool\n\n", name);
     fprintf(stderr, "This tool can be used to compress/decompress arbitrary asset files in a format\n");
     fprintf(stderr, "that can be loaded by the libdragon library. To open the compressed\n");
-    fprintf(stderr, "files, use asset_open() or asset_load().\n\n");
+    fprintf(stderr, "files, use asset_fopen() or asset_load().\n\n");
     fprintf(stderr, "Usage: %s [flags] <input files...>\n", name);
     fprintf(stderr, "\n");
     fprintf(stderr, "Command-line flags:\n");
-    fprintf(stderr, "   -v/--verbose          Verbose output\n");
-    fprintf(stderr, "   -o/--output <dir>     Specify output directory (default: .)\n");
-    fprintf(stderr, "   -c/--compress <algo>  Compression: 0=none, 1=lha, 2=lzh5 (default: %d)\n", DEFAULT_COMPRESSION);
+    fprintf(stderr, "   -v/--verbose            Verbose output\n");
+    fprintf(stderr, "   -o/--output <dir>       Specify output directory (default: .)\n");
+    fprintf(stderr, "   -c/--compress <algo>    Compression level 0-%d (default: %d)\n", MAX_COMPRESSION, DEFAULT_COMPRESSION);
+    fprintf(stderr, "   -w/--winsize <window>   Maximum size of the matching window in KiB. (default: %d)\n", DEFAULT_WINSIZE_STREAMING/1024);
+    fprintf(stderr, "\nSupported window sizes: 2, 4, 8, 16, 32, 64, 128, 256\n");
+    fprintf(stderr, "The window size affects the memory used by asset_fopen() only.\n");
+    fprintf(stderr, "If you only use asset_load(), use the biggest window (256 KiB) to improve ratio.\n");
     fprintf(stderr, "\n");
 }
 
@@ -28,6 +34,7 @@ int main(int argc, char *argv[])
 {
     char *infn = NULL, *outdir = ".", *outfn = NULL;
     int compression = DEFAULT_COMPRESSION;
+    int winsize = DEFAULT_WINSIZE_STREAMING;
 
     if (argc < 2) {
         print_args(argv[0]);
@@ -41,6 +48,22 @@ int main(int argc, char *argv[])
                 return 0;
             } else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) {
                 flag_verbose = true;
+            } else if (!strcmp(argv[i], "-w") || !strcmp(argv[i], "--window")) {
+                if (++i == argc) {
+                    fprintf(stderr, "missing argument for %s\n", argv[i-1]);
+                    return 1;
+                }
+                char extra;
+                if (sscanf(argv[i], "%d%c", &winsize, &extra) != 1) {
+                    fprintf(stderr, "invalid argument for %s: %s\n", argv[i-1], argv[i]);
+                    return 1;
+                }            
+                winsize = winsize * 1024;
+                if (asset_winsize_to_flags(winsize) < 0) {
+                    fprintf(stderr, "unsupported window size: %d\n", winsize);
+                    fprintf(stderr, "supported window sizes: 2, 4, 8, 16, 32, 64, 128, 256\n");
+                    return 1;
+                }    
             } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
                 if (++i == argc) {
                     fprintf(stderr, "missing argument for %s\n", argv[i-1]);
@@ -57,7 +80,7 @@ int main(int argc, char *argv[])
                     fprintf(stderr, "invalid argument for %s: %s\n", argv[i-1], argv[i]);
                     return 1;
                 }
-                if (compression < 0 || compression > 2) {
+                if (compression < 0 || compression > MAX_COMPRESSION) {
                     fprintf(stderr, "invalid compression algorithm: %d\n", compression);
                     return 1;
                 }
@@ -77,7 +100,7 @@ int main(int argc, char *argv[])
         if (flag_verbose)
             printf("Compressing: %s => %s [algo=%d]\n", infn, outfn, compression);
 
-        asset_compress(infn, outfn, compression);
+        asset_compress(infn, outfn, compression, winsize);
 
         free(outfn);
     }

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -22,7 +22,6 @@
 
 // Compression library
 #include "../common/assetcomp.h"
-#include "../common/assetcomp.c"
 
 // Bring in tex_format_t definition
 #include "surface.h"
@@ -1597,7 +1596,7 @@ int main(int argc, char *argv[])
             if (compression) {
                 struct stat st_decomp = {0}, st_comp = {0};
                 stat(outfn, &st_decomp);
-                asset_compress(outfn, outfn, compression);
+                asset_compress(outfn, outfn, compression, 0);
                 stat(outfn, &st_comp);
                 if (flag_verbose)
                     fprintf(stderr, "compressed: %s (%d -> %d, ratio %.1f%%)\n", outfn,


### PR DESCRIPTION
This is a huge merge from preview that was not practical to further split down. It does three main things:

 * Introduce a new level 3 algorithm based on Shrinkler (https://github.com/askeksa/Shrinkler). The core algorithm is a stripped down version of LZMA and in fact it is competitive with xz for small files like those normally used on N64. Decompression speed is quite slow though.
 * Change level 2 algorithm from lha-lh5 to aplib. Aplib is a very good, LZ-only algorithm. The speed is higher than lh5, but the ratios are impressively high (higher than gzip for small compressible files like those used on N64 for graphics), thanks to the apultra library that does an optimal parsing.

This commit also does further changes that are hard to split has they are overlaid with the above two changes:

 * It allows the window size to be specified at compression time (eg: via mkasset) so to be able to control the size of the buffer allocated during asset_fopen, and at the same achieve optimal compression for files that will be loaded via asset_load where no extra memory is required.
 * It adds very fast, optimized, assembly implementations for all 3 decompression algorithms to boost speed even more at runtime. The assembly versions are very short, self-contained, have no dependencies, are relocatable in memory, and also handle DMA racing.

The commit brought in by this commit underwent extensive testing in the preview branch and should be quite stable.

More information on compression in libdragon can be found in the wiki page: https://github.com/DragonMinded/libdragon/wiki/Compression