### PR TITLE
Preview merge: misc merge train

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -134,15 +134,23 @@ extern char __bss_end[];
 #define MEMORY_BARRIER() asm volatile ("" : : : "memory")
 
 /**
- * @brief Returns the COP0 register $9 (count).
+ * @brief Returns the 32-bit hardware tick counter
  *
- * The coprocessor 0 (system control coprocessor - COP0) register $9 is
- * incremented at "half maximum instruction issue rate" which is the processor
- * clock speed (93.75MHz) divided by two. (also see TICKS_PER_SECOND) It will
- * always produce a 32-bit unsigned value which overflows back to zero in
- * 91.625 seconds. The counter will increment irrespective of instructions
- * actually being executed. This macro is for reading that value.
- * Do not use for comparison without special handling.
+ * This macro returns the current value of the hardware tick counter,
+ * present in the CPU coprocessor 0. The counter increments at half of the
+ * processor clock speed (see #TICKS_PER_SECOND), and overflows every
+ * 91.625 seconds.
+ * 
+ * It is fine to use this hardware counter for measuring small time intervals,
+ * as long as #TICKS_DISTANCE or #TICKS_BEFORE are used to compare different
+ * counter reads, as those macros correctly handle overflows.
+ * 
+ * Most users might find more convenient to use #get_ticks(), a similar function
+ * that returns a 64-bit counter with the same frequency that never overflows.
+ * 
+ * @see #TICKS_BEFORE
+ * @see #TICKS_DISTANCE
+ * @see #get_ticks
  */
 #define TICKS_READ() C0_COUNT()
 
@@ -154,7 +162,7 @@ extern char __bss_end[];
 #define TICKS_PER_SECOND (CPU_FREQUENCY/2)
 
 /**
- * @brief The signed difference of time between "from" and "to".
+ * @brief Calculate the time passed between two ticks
  *
  * If "from" is before "to", the distance in time is positive,
  * otherwise it is negative.
@@ -168,16 +176,36 @@ extern char __bss_end[];
  * @brief Returns true if "t1" is before "t2".
  *
  * This is similar to t1 < t2, but it correctly handles timer overflows
- * which are very frequent. Notice that the N64 counter overflows every
+ * which are very frequent. Notice that the hardware counter overflows every
  * ~91 seconds, so it's not possible to compare times that are more than
  * ~45 seconds apart.
+ * 
+ * Use #get_ticks() to get a 64-bit counter that never overflows.
+ * 
+ * @see #get_ticks
  */
 #define TICKS_BEFORE(t1, t2) ({ TICKS_DISTANCE(t1, t2) > 0; })
 
 /**
- * @brief Returns equivalent count ticks for the given millis.
+ * @brief Returns equivalent count ticks for the given milliseconds.
  */
-#define TICKS_FROM_MS(val) ((uint32_t)((val) * (TICKS_PER_SECOND / 1000)))
+#define TICKS_FROM_MS(val) (((val) * (TICKS_PER_SECOND / 1000)))
+
+/**
+ * @brief Returns equivalent count ticks for the given microseconds.
+ */
+#define TICKS_FROM_US(val) (((val) * (8 * TICKS_PER_SECOND / 1000000) / 8))
+
+/**
+ * @brief Returns equivalent count ticks for the given microseconds.
+ */
+#define TICKS_TO_US(val) (((val) * 8 / (8 * TICKS_PER_SECOND / 1000000)))
+
+/**
+ * @brief Returns equivalent count ticks for the given microseconds.
+ */
+#define TICKS_TO_MS(val) (((val) / (TICKS_PER_SECOND / 1000)))
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -190,30 +218,49 @@ void sys_set_boot_cic(int bc);
 /**
  * @brief Read the number of ticks since system startup
  *
- * @note Also see the TICKS_READ macro
+ * The frequency of this counter is #TICKS_PER_SECOND. The counter will
+ * never overflow, being a 64-bit number.
  *
  * @return The number of ticks since system startup
  */
-inline volatile unsigned long get_ticks(void)
-{
-    return TICKS_READ();
-}
+uint64_t get_ticks(void);
+
+/**
+ * @brief Read the number of microseconds since system startup
+ *
+ * This is similar to #get_ticks, but converts the result in integer
+ * microseconds for convenience.
+ * 
+ * @return The number of microseconds since system startup
+ */
+uint64_t get_ticks_us(void);
 
 /**
  * @brief Read the number of millisecounds since system startup
- *
- * @note It will wrap back to 0 after about 91.6 seconds.
- * Also see the TICKS_READ macro. Do not use for comparison
- * without special handling.
- *
+ * 
+ * This is similar to #get_ticks, but converts the result in integer
+ * milliseconds for convenience.
+ * 
  * @return The number of millisecounds since system startup
  */
-inline volatile unsigned long get_ticks_ms(void)
-{
-    return TICKS_READ() / (TICKS_PER_SECOND / 1000);
-}
+uint64_t get_ticks_ms(void);
 
+/**
+ * @brief Spin wait until the number of ticks have elapsed
+ *
+ * @param[in] wait
+ *            Number of ticks to wait
+ *            Maximum accepted value is 0xFFFFFFFF ticks
+ */
 void wait_ticks( unsigned long wait );
+
+/**
+ * @brief Spin wait until the number of milliseconds have elapsed
+ *
+ * @param[in] wait_ms
+ *            Number of milliseconds to wait
+ *            Maximum accepted value is 91625 ms
+ */
 void wait_ms( unsigned long wait_ms );
 
 /**

--- a/n64.mk
+++ b/n64.mk
@@ -114,7 +114,7 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.S
 		DATASECTION="$(basename $@).data"; \
 		BINARY="$(basename $@).elf"; \
 		echo "    [RSP] $<"; \
-		$(N64_CC) $(RSPASFLAGS) -L$(N64_LIBDIR) -nostartfiles -Wl,-Trsp.ld -Wl,--gc-sections -o $@ $<; \
+		$(N64_CC) $(RSPASFLAGS) -L$(N64_LIBDIR) -nostartfiles -Wl,-Trsp.ld -Wl,--gc-sections  -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map -o $@ $<; \
 		mv "$@" $$BINARY; \
 		$(N64_OBJCOPY) -O binary -j .text $$BINARY $$TEXTSECTION.bin; \
 		$(N64_OBJCOPY) -O binary -j .data $$BINARY $$DATASECTION.bin; \

--- a/n64.mk
+++ b/n64.mk
@@ -38,6 +38,7 @@ N64_AUDIOCONV = $(N64_BINDIR)/audioconv64
 N64_C_AND_CXX_FLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)
 N64_C_AND_CXX_FLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
 N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=
+N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
 N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu99
 N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS)

--- a/n64.mk
+++ b/n64.mk
@@ -40,6 +40,7 @@ N64_C_AND_CXX_FLAGS += -falign-functions=32   # NOTE: if you change this, also c
 N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=
 N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
 N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
+N64_C_AND_CXX_FLAGS += -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-parameter -Wno-error=unused-but-set-parameter -Wno-error=unused-label -Wno-error=unused-local-typedefs -Wno-error=unused-const-variable
 N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu99
 N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS)
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)

--- a/src/debug.c
+++ b/src/debug.c
@@ -409,15 +409,15 @@ static int __fat_findfirst(char *name, dir_t *dir)
 }
 
 static filesystem_t fat_fs = {
-	__fat_open,
-	__fat_fstat,
-	__fat_lseek,
-	__fat_read,
-	__fat_write,
-	__fat_close,
-	__fat_unlink,
-	__fat_findfirst,
-	__fat_findnext
+	.open = __fat_open,
+	.fstat = __fat_fstat,
+	.lseek = __fat_lseek,
+	.read = __fat_read,
+	.write = __fat_write,
+	.close = __fat_close,
+	.unlink = __fat_unlink,
+	.findfirst = __fat_findfirst,
+	.findnext = __fat_findnext,
 };
 
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -389,8 +389,18 @@ static int __fat_findnext(dir_t *dir)
 {
 	FILINFO info;
 	FRESULT res = f_readdir(&find_dir, &info);
-	if (res != FR_OK)
+	if (res != FR_OK) {
 		return -1;
+	}
+
+	// Check if we reached the end of the directory
+	if (info.fname[0] == 0) {
+		res = f_closedir(&find_dir);
+		if (res != FR_OK) {
+			return -1;
+		}
+		return -1;
+	}
 
 	strlcpy(dir->d_name, info.fname, sizeof(dir->d_name));
 	if (info.fattrib & AM_DIR)
@@ -403,8 +413,9 @@ static int __fat_findnext(dir_t *dir)
 static int __fat_findfirst(char *name, dir_t *dir)
 {
 	FRESULT res = f_opendir(&find_dir, name);
-	if (res != FR_OK)
+	if (res != FR_OK) {
 		return -1;
+	}
 	return __fat_findnext(dir);
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -118,9 +118,6 @@ static int __interrupt_depth = -1;
  */
 static int __interrupt_sr = 0;
 
-/** @brief tick at which interrupts were disabled. */
-uint32_t interrupt_disabled_tick = 0;
-
 /**
  * @brief Structure of an interrupt callback
  */
@@ -882,8 +879,6 @@ void disable_interrupts()
            So put an explicit barrier. */
         MEMORY_BARRIER();
         __interrupt_sr = sr;
-
-        interrupt_disabled_tick = TICKS_READ();
     }
 
     /* Ensure that we remember nesting levels */

--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -201,6 +201,12 @@ interrupt:
 	# a single variable will suffice.
 	sw sp, interrupt_exception_frame
 
+	# Update the 64-bit tick counter. We do this every interrupt so that the
+	# counter is always valid, even if it is not called for more than 99 seconds
+	# (during which the 32-bit counter would overflow).
+	jal get_ticks
+	nop
+
 	/* check for "pre-NMI" (reset) */
 	andi t0, cause, 0x1000
 	beqz t0, notprenmi

--- a/src/system.c
+++ b/src/system.c
@@ -1237,7 +1237,7 @@ int dir_findfirst( const char * const path, dir_t *dir )
     filesystem_t *fs = __get_fs_pointer_by_name( path );
     int mapping = __get_fs_link_by_name( path );
 
-    if( fs == 0 )
+    if( fs == 0 || mapping < 0 || dir == 0 )
     {
         errno = EINVAL;
         return -1;
@@ -1250,7 +1250,7 @@ int dir_findfirst( const char * const path, dir_t *dir )
         return -1;
     }
 
-    return fs->findfirst( (char *)path + + __strlen( filesystems[mapping].prefix ), dir );
+    return fs->findfirst( (char *)path + __strlen( filesystems[mapping].prefix ) - 1, dir );
 }
 
 /**
@@ -1271,7 +1271,7 @@ int dir_findnext( const char * const path, dir_t *dir )
 {
     filesystem_t *fs = __get_fs_pointer_by_name( path );
 
-    if( fs == 0 )
+    if( fs == 0 || dir == 0 )
     {
         errno = EINVAL;
         return -1;

--- a/src/timer.c
+++ b/src/timer.c
@@ -39,14 +39,9 @@
  * @{
  */
 
+
 /** @brief Internal linked list of timers */
-static timer_link_t *TI_timers = 0;
-
-/** @brief Higher-part of 64-bit tick counter */
-volatile uint32_t ticks64_high;
-
-/** @brief Time at which interrupts were disabled */
-extern volatile uint32_t interrupt_disabled_tick;
+static timer_link_t *TI_timers = NULL;
 
 /** @brief Timer callback expects a context parameter */
 #define TF_CONTEXT     0x20
@@ -202,18 +197,6 @@ static void timer_poll(void)
 }
 
 /**
- * @brief Timer callback overflow function
- *
- * This function is the callback of the internal overflow timer, which
- * is configured by timer_init() and is used to create a 64-bit timer
- * accessed by timer_ticks().
- */
-static void timer_overflow_callback(int ovfl)
-{
-	ticks64_high++;
-}
-
-/**
  * @brief Initialize the timer subsystem
  *
  * This function will reset the COP0 ticks counter to 0. Even if you
@@ -226,27 +209,9 @@ static void timer_overflow_callback(int ovfl)
 void timer_init(void)
 {
 	assertf(!TI_timers, "timer module already initialized");
-	/* Create first timer for overflows: expires when counter is 0 and
-	 * has a period of 2**32. */
-	timer_link_t *timer = malloc(sizeof(timer_link_t));
-	if (timer)
-	{
-		timer->left = 0;
-		timer->set = 0;
-		timer->flags = TF_CONTINUOUS | TF_OVERFLOW;
-		timer->callback = timer_overflow_callback;
-		timer->ctx = NULL;
-		timer->next = NULL;
-
-		TI_timers = timer;
-	}
-
-	/* Reset the count and compare registers. Avoid to accidentally trigger
-	   an interrupt by setting count to 1 and compare to 0. Also enable
-	   timer interrupts in COP0. */
+	// Reset the compare register and enable timer interrupts in COP0.
+	// Do not write the COUNT register to avoid interfering with get_ticks().
 	disable_interrupts();
-	ticks64_high = 0;
-	C0_WRITE_COUNT(1);
 	C0_WRITE_COMPARE(0);
 	set_TI_interrupt(1);
 	register_TI_handler(timer_poll);
@@ -556,40 +521,7 @@ void timer_close(void)
  */
 long long timer_ticks(void)
 {
-	uint32_t low, high;
-	assertf(TI_timers, "timer module not initialized");
-
-	/* Check whether interrupts are enabled or not. We need a different strategy
-	 * to account for race conditions. */
-	if (C0_STATUS() & C0_STATUS_IE) {
-		/* Read the hardware counter twice, and fetch the high part counter
-		 * in between. In the unlikely case that the counter overflows exactly
-		 * during the sequence, it means that there's a race condition and
-		 * we can't really know whether high and low are coherent -- but in
-		 * that case, we just repeat the sequence again to avoid the ambiguity. */
-		uint32_t pre;
-		do {
-			pre = TICKS_READ();
-			MEMORY_BARRIER();
-			high = ticks64_high;
-			MEMORY_BARRIER();
-			low = TICKS_READ();
-		} while ((int32_t)pre < 0 && (int32_t)low >= 0);
-
-	} else {
-		/* Interrupts are currently disabled. If they've been disabled for more
-		 * than 2**32 ticks, it's game over because we can't know how many times
-		 * the counter has overflown.
-		 * So assuming they were disabled for not too long, check whether there
-		 * was a counter overflow between now and when they were disabled. 
-		 * If there was, increment high. */
-		low = TICKS_READ();
-		high = ticks64_high;
-		if (interrupt_disabled_tick > low)
-			high++;
-	}
-
-	return ((uint64_t)high << 32) + low;
+	return get_ticks();
 }
 
 /** @} */

--- a/tests/test_ticks.c
+++ b/tests/test_ticks.c
@@ -80,6 +80,7 @@ void test_ticks(TestContext *ctx) {
 	uint32_t ticks_1;
 
 	uint32_t continue_ticks = TICKS_READ();
+	DEFER(C0_WRITE_COUNT(continue_ticks));
 
 	disable_interrupts();
 
@@ -121,6 +122,7 @@ void test_ticks(TestContext *ctx) {
 
 	// Prepare for next test
 	register_VI_handler(frame_callback);
+	DEFER(unregister_VI_handler(frame_callback));
 	enable_interrupts();
 
 	ASSERT(ticks_0 == 0 && ticks_1 == (!sys_bbplayer() ? 45812 : 30542), "not reading correct register or function not inlined. Received %lu and %lu", ticks_0, ticks_1);
@@ -135,8 +137,4 @@ void test_ticks(TestContext *ctx) {
 	// iQue, so just skip this part.
 	if (!sys_bbplayer())
 		test_ticks_func(ctx, wait_ms, "wait_ms", test_ticks_ms_cases, sizeof(test_ticks_ms_cases) / sizeof(test_ticks_ms_cases[0]));
-
-	// Cleanup
-	unregister_VI_handler(frame_callback);
-	C0_WRITE_COUNT(continue_ticks);
 }


### PR DESCRIPTION
Flow of smallish changes, see individual commits.

The biggest change is that `get_ticks()` now directly returns a 64-bit counter (no initialization or interrupts are necessary), so we can remove the previous machinery we had in `timer_ticks()` (which is now an alias of `get_ticks()`). This also happens to fix compatibility with Ares which doesn't implement correct timing of timer overflow interrupt when the JIT is enabled, which can cause games to hang or misbehave after 90 seconds.

We now also enable `-ffast-math` by default, and use warnings (rather than errors) for unused variables / functions.