### PR TITLE
Fixed an error on gcc version (Ubuntu 13.2.0-23ubuntu4) 13.2.0

### DIFF
--- a/src/audio/opus/celt_encoder.c
+++ b/src/audio/opus/celt_encoder.c
@@ -1004,6 +1004,9 @@ static opus_val16 dynalloc_analysis(const opus_val16 *bandLogE, const opus_val16
       VARDECL(opus_val16, sig);
       ALLOC(mask, nbEBands, opus_val16);
       ALLOC(sig, nbEBands, opus_val16);
+
+      memset(mask, 0, nbEBands * sizeof(opus_val16));
+
       for (i=0;i<end;i++)
          mask[i] = bandLogE[i]-noise_floor[i];
       if (C==2)


### PR DESCRIPTION
I was getting an error while building the toolchain after setting up a computer on the latest version of ubuntu. I'm assuming the error is showing up now because gcc got more sophisticated error checking

I was getting this error at `src/audio/opus/celt_encoder.c:1014`
error: ‘mask’ may be used uninitialized