### PR TITLE
[trunk] Make sure to use GNU extensions when building C++

### DIFF
--- a/examples/cpptest/Makefile
+++ b/examples/cpptest/Makefile
@@ -2,8 +2,6 @@ BUILD_DIR=build
 SOURCE_DIR=.
 include $(N64_INST)/include/n64.mk
 
-N64_CXXFLAGS += -std=c++14
-
 all: cpptest.z64
 
 OBJS = $(BUILD_DIR)/cpptest.o

--- a/include/pputils.h
+++ b/include/pputils.h
@@ -99,6 +99,13 @@
 #define __FEB_31(_call, x, ...) _call(x) __FEB_30(_call, __VA_ARGS__)
 #define __CALL_FOREACH_BIS(fn, ...)  __GET_33RD_ARG("ignored", ##__VA_ARGS__, __FEB_31, __FEB_30, __FEB_29, __FEB_28, __FEB_27, __FEB_26, __FEB_25, __FEB_24, __FEB_23, __FEB_22, __FEB_21, __FEB_20, __FEB_19, __FEB_18, __FEB_17, __FEB_16, __FEB_15, __FEB_14, __FEB_13, __FEB_12, __FEB_11, __FEB_10, __FEB_9, __FEB_8, __FEB_7, __FEB_6, __FEB_5, __FEB_4, __FEB_3, __FEB_2, __FEB_1, __FEB_0)(fn, ##__VA_ARGS__)
 
+// Check that GNU extensions are active and macros work correctly. Specifically
+// we require the extension that allows ##__VA_ARGS__ to elide the previous comma
+// when no variadic arguments are specified.
+#if __COUNT_VARARGS() != 0
+#error GNU extensions are required -- please specify a -std=gnuXX/gnu++XX option to the compiler
+#endif
+
 /// @endcond
 
 #endif

--- a/include/rspq.h
+++ b/include/rspq.h
@@ -391,7 +391,7 @@ void* rspq_overlay_get_state(rsp_ucode_t *overlay_ucode);
 })
 
 #define _rspq_write1(ovl_id, cmd_id, arg0, ...) ({ \
-    _Static_assert(__COUNT_VARARGS(__VA_ARGS__) < RSPQ_MAX_SHORT_COMMAND_SIZE); \
+    _Static_assert(__COUNT_VARARGS(__VA_ARGS__) <= RSPQ_MAX_SHORT_COMMAND_SIZE, "too many arguments to rspq_write, please use rspq_write_begin/arg/end instead"); \
     _rspq_write_prolog(); \
     __CALL_FOREACH(_rspq_write_arg, ##__VA_ARGS__); \
     rspq_cur_pointer[0] = ((ovl_id) + ((cmd_id)<<24)) | (arg0); \

--- a/n64.mk
+++ b/n64.mk
@@ -42,7 +42,7 @@ N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
 N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_C_AND_CXX_FLAGS += -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-parameter -Wno-error=unused-but-set-parameter -Wno-error=unused-label -Wno-error=unused-local-typedefs -Wno-error=unused-const-variable
 N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu99
-N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS)
+N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu++17
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_LDFLAGS = -g -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections --wrap __do_global_ctors


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - Make sure to use GNU extensions when building C++ (8986d642)

<!--- Backport version: 9.5.0 -->