### PR TITLE
[trunk] subprocess: fix some warnings | graphics.h: fix C++ compilation | tools: fix some compilation warnings, upgrade C++ version, fix clean | tools: build static executables on Windows

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -35,7 +35,9 @@ typedef struct __attribute__((packed))
     uint8_t a;
 } color_t;
 
+#ifndef __cplusplus
 _Static_assert(sizeof(color_t) == 4, "invalid sizeof for color_t");
+#endif
 
 /** @brief Create a #color_t from the R,G,B,A components in the RGBA16 range (that is: RGB in 0-31, A in 0-1) */
 #define RGBA16(rx,gx,bx,ax) ({ \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,6 +3,12 @@ INSTALLDIR ?= $(N64_INST)
 CFLAGS   += -std=gnu11 -O2 -Wall -Werror -Wno-unused-result -Wno-error=unknown-pragmas -Wno-sign-compare -I../include -MMD
 CXXFLAGS += -std=gnu++17 -O2 -Wall -Werror -Wno-unused-result -Wno-error=unknown-pragmas -Wno-sign-compare -Wno-c++11-narrowing -Wno-narrowing -Wno-error=conversion-null -MMD
 
+ifeq ($(OS),Windows_NT)
+	CFLAGS += -static
+	CXXFLAGS += -static
+  	LDFLAGS += -static
+endif
+
 all:
 
 %.o: %.c

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,8 +1,7 @@
 hN64_GCCPREFIX ?= $(N64_INST)
 INSTALLDIR ?= $(N64_INST)
-CFLAGS   += -std=gnu11 -O2 -Wall -Werror -Wno-unused-result -Wno-error=unknown-pragmas -Wno-error=sign-compare -I../include -MMD
-CXXFLAGS += -std=c++11 -O2 -Wall -Werror -Wno-unused-result -Wno-error=unknown-pragmas -Wno-error=sign-compare -MMD
-LDFLAGS   = 
+CFLAGS   += -std=gnu11 -O2 -Wall -Werror -Wno-unused-result -Wno-error=unknown-pragmas -Wno-sign-compare -I../include -MMD
+CXXFLAGS += -std=gnu++17 -O2 -Wall -Werror -Wno-unused-result -Wno-error=unknown-pragmas -Wno-sign-compare -Wno-c++11-narrowing -Wno-narrowing -Wno-error=conversion-null -MMD
 
 all:
 
@@ -17,6 +16,8 @@ all:
 	rm -f $@
 	$(AR) rcs $@ $^
 
+# Avoid many warnings for vendored code that we don't intend to ever modify
+common/shrinkler_compress.o: 	   CFLAGS += -Wno-all -Wno-error
 common-clean:
 	rm -f common/*.o common/*.a common/*.d
 common/assetcomp.a: common/assetcomp.o common/lz4_compress.o \
@@ -54,7 +55,7 @@ $(1)-install: $(1)
 	mkdir -p $(INSTALLDIR)/bin
 	install -m 0755 $$($(1)_BIN) $(INSTALLDIR)/bin
 $(1)-clean:
-	rm -f $$($(1)_BIN) $$($(1)_DIR)/*.o $$($(1)_DIR)/*.d
+	rm -f $$($(1)_BIN) $$($(1)_DIR)/**/*.o $$($(1)_DIR)/**/*.d
 -include $$(wildcard $$($(1)_DIR)/*.d)
 endef
 
@@ -62,6 +63,7 @@ $(foreach tool,$(TOOLS),$(eval $(call TOOL_template,$(tool))))
 all: $(TOOLS)
 install: $(foreach tool,$(TOOLS),$(tool)-install)
 clean: $(foreach tool,$(TOOLS),$(tool)-clean) common-clean
+	rm -f ${n64tool_OBJS} ${n64sym_OBJS} ${ed64romconfig_OBJS} 
 .PHONY: all install clean
 
 ifneq ($(V),1)

--- a/tools/common/subprocess.h
+++ b/tools/common/subprocess.h
@@ -259,7 +259,9 @@ typedef struct _OVERLAPPED *LPOVERLAPPED;
 #pragma clang diagnostic pop
 #endif
 
+#if defined(_MSC_VER)
 #pragma warning(push, 1)
+#endif
 struct subprocess_subprocess_information_s {
   void *hProcess;
   void *hThread;
@@ -308,7 +310,9 @@ struct subprocess_overlapped_s {
   void *hEvent;
 };
 
+#if defined(_MSC_VER)
 #pragma warning(pop)
+#endif
 
 __declspec(dllimport) unsigned long __stdcall GetLastError(void);
 __declspec(dllimport) int __stdcall SetHandleInformation(void *, unsigned long,
@@ -416,7 +420,7 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
   static subprocess_tls long index = 0;
   const long unique = index++;
 
-#if _MSC_VER < 1900
+#if defined(_MSC_VER) &&  _MSC_VER < 1900
 #pragma warning(push, 1)
 #pragma warning(disable : 4996)
   _snprintf(name, sizeof(name) - 1,
@@ -431,14 +435,14 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
 
   *rd =
       CreateNamedPipeA(name, pipeAccessInbound | fileFlagOverlapped,
-                       pipeTypeByte | pipeWait, 1, 4096, 4096, SUBPROCESS_NULL,
+                       pipeTypeByte | pipeWait, 1, 4096, 4096, 0,
                        SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr));
 
   if (invalidHandleValue == *rd) {
     return -1;
   }
 
-  *wr = CreateFileA(name, genericWrite, SUBPROCESS_NULL,
+  *wr = CreateFileA(name, genericWrite, 0,
                     SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
                     openExisting, fileAttributeNormal, SUBPROCESS_NULL);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - subprocess: fix some warnings (4f5eaa74)
 - graphics.h: fix C++ compilation (448adefd)
 - tools: fix some compilation warnings, upgrade C++ version, fix clean (1d7f39af)
 - tools: build static executables on Windows (17108c7d)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)