### PR TITLE
[trunk] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 
 ## Welcome to libdragon
 
+> [!TIP]
+> Coming back here after a while? Check the [ChangeLog](https://github.com/DragonMinded/libdragon/wiki/Stable-branch--Changelog) of our stable branch, or the [Preview branch](https://github.com/DragonMinded/libdragon/wiki/Preview-branch)
+
 Libdragon is an open-source SDK for Nintendo 64. It aims for a complete N64
 programming experience while providing programmers with modern approach to
 programming and debugging. These are the main features:
@@ -18,42 +21,86 @@ programming and debugging. These are the main features:
 * The GCC toolchain is 64 bit capable to be able to use the full R4300 capabilities
   (commercial games and libultra are based on a 32-bit ABI and is not possible
   to use 64-bit registers and opcodes with it)
-* Can be developed with newer-generation emulators (ares, cen64, Dillonb's n64,
-  simple64) or development cartridges (64drive, EverDrive64, SummerCart64).
-* Support both vanilla N64 and iQue Player (Chinese variant). The support is
-  experimental and done fully at runtime, so it is possible to run ROMs built
-  with libdragon on iQue without modifying the source code.
-* In-ROM filesystem implementation for assets. Assets can be loaded with
-  `fopen("rom://asset.dat")` without having to do complex things to link them in.
-* Efficient interrupt-based timer library (also features a monotone 64-bit
-  timer to avoid dealing with 32-bit overflows)
-* Graphics: easy-to-use API for 2D games, accelerated with RDP
+* Can be developed with newer-generation emulators (Ares) and development cartridges
+  (64drive, EverDrive64, SummerCart64).
+* Support both vanilla N64 and iQue Player (Chinese variant). It is possible
+  to run ROMs built with libdragon on iQue without modifying the source code.
+* 2D accelerated graphics:
+   * Comprehensive RDP library called [rdpq](https://github.com/DragonMinded/libdragon/wiki/Rdpq)
+     that offers both low-level access and very high-level blitting functions.
+   * Support for drawing sprites of arbitrary sizes and arbitrary pixel formats.
+     Rdpq takes care of handling TMEM limits transparently and efficiently.
+   * Support for sprite zooming and rotation. Rotated sprites are transparently
+     drawn via triangles instead of rectangles.
+   * Support for all RDP pixel formats, including palettized ones.
+   * Very simple render mode configuration, that allows for full RDP graphic effects
+     including custom color combiner and blender.
+   * Comprehensive [mksprite](https://github.com/DragonMinded/libdragon/wiki/Mksprite)
+     tool, that converts from PNG format, includes optional state-of-the-art color
+     quantizer and dithering.
+   * Transparent compression of graphics for minimal ROM size
+* Audio:
+   * Advanced RSP-accelerated mixer library, supporting up to 32 channels and
+     streaming samples from ROM during playback for very low memory usage.
+   * Supports WAV files for sound effects
+   * Supports streaming of uncompressed or VADPCM-compressed WAV files for music.
+   * Supports playing of XM modules (FastTracker, MilkyTracker, OpenMPT). Can
+     playback a 10-channel XM with < 3% CPU and < 10% RSP.
+   * Supports playing of YM modules (Arkos Tracker 2)  
+* Filesystems:
+  * In-ROM filesystem implementation for assets. Assets can be loaded with
+    `fopen("rom://asset.dat")` without having to do complex things to link them in.
+  * SD card access (`fopen("sd://asset.dat")`) on all available flashcarts.
+* [Compression](https://github.com/DragonMinded/libdragon/wiki/Compression):
+   * Asset library for fast, transparent compression support for data files,
+     including your custom ones.
+   * Automatically integrated in conversion tools for graphics.
+   * Three different compression algorithms with increasing compression ratio
+     (and decreasing decompression speed). Currently based on LZ4, Aplib, Shrinkler.
+     Compression ratios competitive with gzip and xz, at higher decompression speeds.
+   * Optimized decompression routines in MIPS assembly that run in parallel
+     with DMA for maximum speed.
+   * Support for streaming decompression based on the `fopen()` interface.
+* Debugging: 
+   * Clear error screens with symbolized stack traces in case of crashes
+   * Codebase is filled with assertions, so that you get a nice error screen
+     instead of a console lockup.
+   * Printf-debugging via `debugf()` which are redirected to your PC console
+     in emulators and to USB via compatible tools (UNFLoader, g64drive).
 * Support for standard N64 controllers and memory paks.
 * Support for saving to flashes and EEPROMs (including a mini EEPROM
   filesystem to simplify serialization of structures).
-* Audio: advanced RSP-accelerated library, supporting up to 32 channels and
-  streaming samples from ROM during playback for very low memory usage.
-  Supports WAV files for sound effects and the XM (FastTracker, MilkyTracker,
-  OpenMPT), and YM (Arkos Tracker 2) module formats for background music. 
-  Can playback a 10-channel XM with < 3% CPU and < 10% RSP.
-* Debugging aids: console (printf goes to screen) exception screen, many
-  asserts (so that you get a nice error screen instead of a console lockup),
-  `fprintf(stderr)` calls are redirected to your PC console in emulators
-  and to USB via compatible tools (UNFLoader, g64drive).
-* Support to read/write to SD cards in development kits (64drive, EverDrive64, SummerCart64),
-  simply with `fopen("sd://sdata.dat")`
-* Simple and powerful Makefile-based build system for your ROMs and assets
-  (n64.mk)
 
 The [preview branch](https://github.com/DragonMinded/libdragon/wiki/Preview-branch) features
 many more features:
 
- * a new comprehensive RDP engine
- * a full OpenGL 1.1 port for 3D graphics programming, with a custom, efficient RSP ucode
-   with full T&L support.
- * a MPEG1 RSP-accelerated movie player
- * support for showing source-level stack traces in case of crashes or assertions, including
-   source file name and line number.
+ * 3D graphics
+   * Allow for easily plugging in 3D graphics pipelines, that can
+     potentially even coexist in the same scene.
+   * Included in libdragon: full [OpenGL 1.1 port](https://github.com/DragonMinded/libdragon/wiki/OpenGL-on-N64), together with custom
+     N64 extensions for using RDP-specific features.
+   * Third-party: [Tiny3D](https://github.com/HailToDodongo/tiny3d), a high-performance native
+     3D pipeline.
+   * Both OpenGL and Tiny3D import model files from Blender via the GLTF format,
+     and feature also an animation system with skinning support.
+ * a [MPEG1 RSP-accelerated movie player](https://github.com/DragonMinded/libdragon/wiki/MPEG1-Player), for high-quality FMVs.
+   * Expected performance for FMV: 320x240 movie at 800 Kbit/s at 20 fps
+   * Very simple to use also for render-to-texture scenarios, where
+     a movie is played back as part of a 3D scene or as background in
+     a 2D game.
+ * Improved boot using open-source IPL3 bootcode, which boots ROMs up to 5x
+   faster and allows for compressed game code (using libdragon compression library).
+ * Dynamic library support (DSO, sometimes called "overlays") for dynamically
+   loading and unloading part of game code and data. This is implemented using
+   the standard `dlopen()` / `dlsym()`.
+ * Support for [Opus audio compression](https://github.com/DragonMinded/libdragon/wiki/Opus-decompression) for ultra-compressed music streaming.
+   * Same state-of-the-art audio algorithm that is currently mainstream on PCs.
+   * Compression ratios around 15:1 for audio files. Around 3-5 minutes of mono
+     audio per Megabyte of ROM, depending on quality.
+   * RSP-accelerated for realtime playback. 18-20% of CPU usage for mono streams,
+     which makes it feasible for menus or not resource-intensive games.
+   * Well suited also for speech at very high compression ratio, would allow for
+     a fully talkie game.
 
 and much more. These features will eventually land to trunk, but you can start playing
 with them even today. Go the [preview branch doc](https://github.com/DragonMinded/libdragon/wiki/Preview-branch) for more information.
@@ -68,14 +115,18 @@ Make sure to read the [full installation instructions](https://github.com/Dragon
 
 ### Using emulators
 
-libdragon requires a modern N64 emulator (the first generation of emulators
-are basically HLE-only and can only play the old commercial games). Suggested
-emulators for homebrew developemnt are: [ares](https://ares-emu.net),
-[cen64](https://github.com/n64dev/cen64), [dgb-n64](https://github.com/Dillonb/n64),
-[simple64](https://simple64.github.io).
+libdragon targets real N64 hardware and uses many advanced corners
+of the hardware not used by old commercial games, and thus requires
+a modern N64 emulator which focuses on full hardware emulation.
 
-On all the above emulators, you are also able to see in console anything printed
-via `fprintf(stderr)`, see the debug library for more information.
+At the moment, the only emulator that accurately emulates the hardware
+(and does not just focus on playing old classics) is [Ares](https://github.com/ares-emulator/ares). Ares requires a modern PC with a discrete
+GPU with Vulkan support.
+
+You can develop 99% of your game using libdragon and the Ares emulator,
+and be confident that the game will correctly run on hardware as well.
+Make sure to turn on the "Homebrew mode" in Ares to enable developer
+specific checks during emulation that will simplify the debugging experience.
 
 ### Using a development cartridge on a real N64
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - Update README (fca26a4b)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)