### PR TITLE
joybus: fix race condition in SI interrupt that causes a crash at start

### DIFF
--- a/src/joybus.c
+++ b/src/joybus.c
@@ -131,6 +131,11 @@ void __joybus_init(void)
     msgs_ridx = 0;
     joybus_state = JOYBUS_STATE_IDLE;
 
+    // Wait for any pending SI write. This can happen mainly because of the
+    // write made by entrypoint.S to complete the PIF boot. If the write is still
+    // pending, it would trigger a SI interrupt later and cause a crash.
+    while (SI_regs->status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) {}
+
     // Acknowledge any pending SI interrupt
     SI_regs->status = 0;
 


### PR DESCRIPTION
entrypoint.S writes 0x8 to PIF-RAM to complete the PIF boot process (and avoid the PIF freezing the console after ~5 seconds). Like all writes to PIF-RAM, it takes a while to get through and when it's done, an interrupt is generated. If the interrupt triggers after the __joybus_init() constructor is run, the interrupt handler would get confused and assert it.

This commit fixes it by waiting for any pending SI transfers before enabling SI interrupts.

Notice that the same problem was fixed in preview by the new IPL3, which terminates the PIF boot correctly, including not leaving any pending interrupt when the application is booted.