### PR TITLE
[trunk] sprite: assert if a compressed sprite is loaded via old-style file reading

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -3,6 +3,7 @@
 #include "debug.h"
 #include "surface.h"
 #include "sprite_internal.h"
+#include "asset_internal.h"
 #include "asset.h"
 #include "utils.h"
 #include "rdpq_tex.h"
@@ -32,6 +33,12 @@ sprite_ext_t *__sprite_ext(sprite_t *sprite)
 
 bool __sprite_upgrade(sprite_t *sprite)
 {
+    // Check if the sprite header begins with ASSET_MAGIC, which indicates a 
+    // compressed sprite loaded with old-style file reading. In this case, we
+    // can emit an assertion.
+    assertf(memcmp(sprite, ASSET_MAGIC, 3) != 0, 
+        "Sprite is compressed: use sprite_load() instead of reading the file manually");
+
     // Previously, the "format" field of the sprite structure (now renamed "flags")
     // was unused and always contained 0. Sprites could only be RGBA16 and RGBA32 anyway,
     // so only a bitdepth field could be used to understand the format.


### PR DESCRIPTION
# Backport

This will backport the following commits from `trunk` to `trunk`:
 - sprite: assert if a compressed sprite is loaded via old-style file reading (c1a13d9b)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)