### PR TITLE
toolchain: Update GCC to 14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Libdragon is an open-source SDK for Nintendo 64. It aims for a complete N64
 programming experience while providing programmers with modern approach to
 programming and debugging. These are the main features:
 
-* Based on modern GCC (13) and Newlib, for a full C11 programming experience.
+* Based on modern GCC (version 14) and Newlib, for a full C11 programming experience.
   A Docker container is available to quickly set up the programming environment.
 * The GCC toolchain is 64 bit capable to be able to use the full R4300 capabilities
   (commercial games and libultra are based on a 32-bit ABI and is not possible

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -36,7 +36,7 @@ GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
 BINUTILS_V=2.42
-GCC_V=13.2.0
+GCC_V=14.1.0
 NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0 
 MPC_V=1.3.1 
@@ -224,7 +224,7 @@ popd
 # Compile newlib for target.
 mkdir -p newlib_compile_target
 pushd newlib_compile_target
-CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2" ../"newlib-$NEWLIB_V"/configure \
+CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" ../"newlib-$NEWLIB_V"/configure \
     --prefix="$CROSS_PREFIX" \
     --target="$N64_TARGET" \
     --with-cpu=mips64vr4300 \
@@ -290,7 +290,7 @@ else
     # Compile newlib for target.
     mkdir -p newlib_compile
     pushd newlib_compile
-    CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2" ../"newlib-$NEWLIB_V"/configure \
+    CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" ../"newlib-$NEWLIB_V"/configure \
         --prefix="$INSTALL_PATH" \
         --target="$N64_TARGET" \
         --with-cpu=mips64vr4300 \


### PR DESCRIPTION
Add -fpermissive to newlib CFLAGS since current upstream does not otherwise work with the stricter GCC 14 defaults.