### PR TITLE
Update GH action for building multi platform images [WIP]

### DIFF
--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -53,7 +53,6 @@ jobs:
                 steps.vars.outputs.default_remote
             }}
           head: ${{ github.sha }}
-          
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build and push image
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           # Only push image if this is a push event. Otherwise it will fail because
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
@@ -99,7 +99,7 @@ jobs:
       # cached, it should not take long to build.
       - name: Load image for libdragon build
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           # Do not push the image yet, we also want to make sure libdragon builds
           # with the fresh image.
@@ -134,8 +134,9 @@ jobs:
       # build with this freshly built image.
       - name: Push latest image
         if: ${{ steps.path_diff.outputs.changed == 1 && github.ref == steps.vars.outputs.default_ref }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ steps.vars.outputs.repository_name }}:latest
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -15,8 +15,7 @@ jobs:
       matrix:
         include: [
           #{ host-os: ubuntu-latest },
-          #{ host-os: macos-15 }
-          { host-os: ubuntu-24.04-arm }
+          { host-os: ubuntu-24.04-arm },
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -54,16 +53,6 @@ jobs:
                 steps.vars.outputs.default_remote
             }}
           head: ${{ github.sha }}
-
-
-      - name: Install docker for macos
-        if: ${{ matrix.host-os == 'macos-15' }}
-        run: |
-          brew install --cask docker
-          # sudo ln -s ~/Library/Containers/com.docker.docker/Data/docker.raw.sock /var/run/docker.sock
-          # DOCKER_HOST=unix:///var/run/docker.sock docker ps # test that it works using linked socket file
-          docker --version
-        continue-on-error: false
           
 
       # Build the toolchain if toolchain files changed w.r.t target and we can

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include: [
           #{ host-os: ubuntu-latest },
-          { host-os: macos-14 }
+          { host-os: macos-15 }
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -121,6 +121,7 @@ jobs:
           ./build.sh
 
       - name: "Upload built ROMs to artifacts"
+        if: ${{ matrix.host-os == 'ubuntu-latest' }} # don't upload duplicate artifacts from other builds.
         uses: actions/upload-artifact@v4
         with:
           name: roms

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include: [
           { host-os: ubuntu-latest },
-          { host-os: ubuntu-24.04-arm },
+          { host-os: ubuntu-22.04-arm },
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include: [
-          #{ host-os: ubuntu-latest },
+          { host-os: ubuntu-latest },
           { host-os: ubuntu-24.04-arm },
         ]
     runs-on: ${{ matrix.host-os }}
@@ -57,7 +57,7 @@ jobs:
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
-#        if: ${{ steps.path_diff.outputs.changed == 1 }}
+        if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v3
         continue-on-error: false
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT" # FIXME: macos cannot handle lowercase conversion
-          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
-          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
+          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
+          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Compare files
         uses: ./.github/actions/path-diff

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         include: [
           #{ host-os: ubuntu-latest },
-          { host-os: macos-15 }
+          #{ host-os: macos-15 }
+          { host-os: ubuntu-24.04-arm }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -56,7 +57,7 @@ jobs:
 
 
       - name: Install docker for macos
-        if: ${{ matrix.host-os == 'macos-14' }}
+        if: ${{ matrix.host-os == 'macos-15' }}
         run: |
           brew install --cask docker
           # sudo ln -s ~/Library/Containers/com.docker.docker/Data/docker.raw.sock /var/run/docker.sock

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -67,7 +67,7 @@ jobs:
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
-        if: ${{ steps.path_diff.outputs.changed == 1 }} && ${{ matrix.host-os != 'macos-14' }}
+        if: (${{ steps.path_diff.outputs.changed == 1 }} && ${{ matrix.host-os != 'macos-14' }})
         uses: docker/setup-buildx-action@v3
 
       - name: Docker meta

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -47,10 +47,10 @@ jobs:
             }}
           head: ${{ github.sha }}
 
-      # Setup QEMU so docker image can be built across platforms.
-      - name: Set up QEMU
-        if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/setup-qemu-action@v3
+      # # Setup QEMU so docker image can be built across platforms.
+      # - name: Set up QEMU
+      #   if: ${{ steps.path_diff.outputs.changed == 1 }}
+      #   uses: docker/setup-qemu-action@v3
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -91,7 +91,8 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
-          platform: ${{ matrix.platform }}
+          context: .
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install docker for macos
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
-          brew cask install docker
+          brew install docker --cask
         continue-on-error: true
           
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -54,6 +54,14 @@ jobs:
             }}
           head: ${{ github.sha }}
 
+
+      - name: Install docker for macos
+        if: ${{ matrix.host-os == 'macos-14' }}
+        run: |
+          brew cask install docker
+        continue-on-error: true
+          
+
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+          echo "repository_name=$GITHUB_REPOSITORY" >> $GITHUB_OUTPUT
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
           echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -59,6 +59,7 @@ jobs:
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
           brew install --cask docker
+          sleep 5s # Waits 5 seconds.
           docker ps
         continue-on-error: true
           

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -47,6 +47,11 @@ jobs:
             }}
           head: ${{ github.sha }}
 
+      # Setup QEMU so docker image can be built across platforms.
+      - name: Set up QEMU
+        if: ${{ steps.path_diff.outputs.changed == 1 }}
+        uses: docker/setup-qemu-action@v3
+
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
@@ -79,6 +84,7 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
           brew install --cask docker
-          sleep 5000
+          sleep 30
           docker ps
         continue-on-error: true
           

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -59,10 +59,8 @@ jobs:
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
           brew install --cask docker
-          sleep 10
-          systemctl start docker
-          sleep 10
-          docker ps
+          export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
+          docker --version
         continue-on-error: true
           
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -12,14 +12,18 @@ concurrency:
 jobs:
   Toolchain-Library-And-Examples:
     strategy:
+      fail-fast: false
       matrix:
-        include: [
-          { host-os: ubuntu-latest },
-          { host-os: macos-13 }
-        ]
-    runs-on: ${{ matrix.host-os }}
+        platform:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ubuntu-latest
 
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -31,9 +35,9 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT" # FIXME: macos cannot handle lowercase conversion
-          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
-          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
+          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
+          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Compare files
         uses: ./.github/actions/path-diff
@@ -54,21 +58,16 @@ jobs:
             }}
           head: ${{ github.sha }}
 
-
-      # - name: Install docker for macos
-      #   if: ${{ matrix.host-os == 'macos-14' }}
-      #   run: |
-      #     brew install --cask docker
-      #     export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
-      #     docker --version
-      #   continue-on-error: true
-          
+      # Setup QEMU so docker image can be built across platforms.
+      - name: Set up QEMU
+        if: ${{ steps.path_diff.outputs.changed == 1 }}
+        uses: docker/setup-qemu-action@v3
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
+        if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v3
-        continue-on-error: true
 
       - name: Docker meta
         if: ${{ steps.path_diff.outputs.changed == 1 }}
@@ -96,6 +95,7 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ${{ matrix.host-os }}
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -32,9 +31,9 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
-          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
-          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
+          echo "repository_name=${env.GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
+          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
 
       - name: Compare files
         uses: ./.github/actions/path-diff

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -12,8 +12,20 @@ concurrency:
 jobs:
   Toolchain-Library-And-Examples:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
-      - name: Checkout
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
+      - 
+        name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Using a full fetch so that the diff action can run.
@@ -21,14 +33,16 @@ jobs:
       # Create a lower cased version of the repo name. This is required
       # because Docker supports only lowercase names in the registry, while
       # a repo name on GitHub can have uppercase letters.
-      - name: Set variables
+      - 
+        name: Set variables
         id: vars
         run: |
           echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
           echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
-      - name: Compare files
+      - 
+        name: Compare files
         uses: ./.github/actions/path-diff
         id: path_diff
         with:
@@ -47,14 +61,16 @@ jobs:
             }}
           head: ${{ github.sha }}
 
-      # # Setup QEMU so docker image can be built across platforms.
-      # - name: Set up QEMU
-      #   if: ${{ steps.path_diff.outputs.changed == 1 }}
-      #   uses: docker/setup-qemu-action@v3
+      # Setup QEMU so docker image can be built across platforms.
+      - 
+        name: Set up QEMU
+        if: ${{ steps.path_diff.outputs.changed == 1 }}
+        uses: docker/setup-qemu-action@v3
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
-      - name: Set up Docker Build
+      - 
+        name: Set up Docker Build
         if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v3
 
@@ -84,7 +100,7 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include: [
           { host-os: ubuntu-latest, platform: linux/amd64 },
-          { host-os: macos-14, platform: linux/arm64 },
+          { host-os: macos-14, platform: linux/arm64 }
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Install docker for macos
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
-          brew install docker --cask
+          brew install --cask docker
+          docker ps
         continue-on-error: true
           
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${GITHUB_REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
           echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -91,7 +91,7 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
-          platforms: ${{ matrix.platform }}
+          platform: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include: [
-          { host-os: ubuntu-latest },
+          #{ host-os: ubuntu-latest },
           { host-os: macos-14 }
         ]
     runs-on: ${{ matrix.host-os }}
@@ -68,8 +68,9 @@ jobs:
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
+#        if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v3
-        continue-on-error: true
+        continue-on-error: false
 
       - name: Docker meta
         if: ${{ steps.path_diff.outputs.changed == 1 }}

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${env.GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          echo "repository_name=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT" # FIXME: macos cannot handle lowercase conversion
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
           echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
           brew install --cask docker
-          sleep 5s # Waits 5 seconds.
+          sleep 5000
           docker ps
         continue-on-error: true
           

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -14,16 +14,12 @@ jobs:
     strategy:
       matrix:
         include: [
-          { host-os: ubuntu-latest, platform: linux/amd64 },
-          { host-os: macos-14, platform: linux/arm64 }
+          { host-os: ubuntu-latest },
+          { host-os: macos-14 }
         ]
     runs-on: ${{ matrix.host-os }}
 
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,8 +87,6 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
-          context: .
-          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include: [
           { host-os: ubuntu-latest },
-          { host-os: macos-13 }
+          { host-os: macos-14 }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -55,13 +55,14 @@ jobs:
           head: ${{ github.sha }}
 
 
-      # - name: Install docker for macos
-      #   if: ${{ matrix.host-os == 'macos-14' }}
-      #   run: |
-      #     brew install --cask docker
-      #     export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
-      #     docker --version
-      #   continue-on-error: true
+      - name: Install docker for macos
+        if: ${{ matrix.host-os == 'macos-14' }}
+        run: |
+          brew install --cask docker
+          colima start --mount-type 9p
+          # export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
+          docker --version
+        continue-on-error: true
           
 
       # Build the toolchain if toolchain files changed w.r.t target and we can

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -67,7 +67,7 @@ jobs:
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
-        if: ${{ steps.path_diff.outputs.changed == 1 }}
+        if: ${{ steps.path_diff.outputs.changed == 1 }} && ${{ matrix.host-os != 'macos-14' }}
         uses: docker/setup-buildx-action@v3
 
       - name: Docker meta

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include: [
           { host-os: ubuntu-latest },
-          { host-os: macos-14 }
+          { host-os: macos-13 }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -55,13 +55,13 @@ jobs:
           head: ${{ github.sha }}
 
 
-      - name: Install docker for macos
-        if: ${{ matrix.host-os == 'macos-14' }}
-        run: |
-          brew install --cask docker
-          export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
-          docker --version
-        continue-on-error: true
+      # - name: Install docker for macos
+      #   if: ${{ matrix.host-os == 'macos-14' }}
+      #   run: |
+      #     brew install --cask docker
+      #     export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
+      #     docker --version
+      #   continue-on-error: true
           
 
       # Build the toolchain if toolchain files changed w.r.t target and we can

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -59,10 +59,10 @@ jobs:
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
           brew install --cask docker
-          colima start --mount-type 9p
-          # export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
+          # sudo ln -s ~/Library/Containers/com.docker.docker/Data/docker.raw.sock /var/run/docker.sock
+          # DOCKER_HOST=unix:///var/run/docker.sock docker ps # test that it works using linked socket file
           docker --version
-        continue-on-error: true
+        continue-on-error: false
           
 
       # Build the toolchain if toolchain files changed w.r.t target and we can

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -59,7 +59,9 @@ jobs:
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
           brew install --cask docker
-          sleep 30
+          sleep 10
+          systemctl start docker
+          sleep 10
           docker ps
         continue-on-error: true
           

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -12,18 +12,14 @@ concurrency:
 jobs:
   Toolchain-Library-And-Examples:
     strategy:
-      fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-    runs-on: ubuntu-latest
+        include: [
+          { host-os: ubuntu-latest },
+          { host-os: macos-13 }
+        ]
+    runs-on: ${{ matrix.host-os }}
 
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -35,9 +31,9 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
-          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
-          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
+          echo "repository_name=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT" # FIXME: macos cannot handle lowercase conversion
+          echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
+          echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> "$GITHUB_OUTPUT"
 
       - name: Compare files
         uses: ./.github/actions/path-diff
@@ -58,16 +54,21 @@ jobs:
             }}
           head: ${{ github.sha }}
 
-      # Setup QEMU so docker image can be built across platforms.
-      - name: Set up QEMU
-        if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/setup-qemu-action@v3
+
+      # - name: Install docker for macos
+      #   if: ${{ matrix.host-os == 'macos-14' }}
+      #   run: |
+      #     brew install --cask docker
+      #     export DOCKER_HOST=unix:///Users/$USER/Library/Containers/com.docker.docker/Data/docker.raw.sock
+      #     docker --version
+      #   continue-on-error: true
+          
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
-        if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v3
+        continue-on-error: true
 
       - name: Docker meta
         if: ${{ steps.path_diff.outputs.changed == 1 }}
@@ -95,7 +96,6 @@ jobs:
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
           # In effect, each fork will be releasing its own image to its own
           # repository, which we can use to test the toolchain changes.
-          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   Toolchain-Library-And-Examples:
     strategy:
-      fail-fast: false
       matrix:
         include: [
           { host-os: ubuntu-latest, platform: linux/amd64 },
@@ -37,7 +36,7 @@ jobs:
       - name: Set variables
         id: vars
         run: |
-          echo "repository_name=$GITHUB_REPOSITORY" >> $GITHUB_OUTPUT
+          echo "repository_name=${GITHUB_REPOSITORY}" >> $GITHUB_OUTPUT
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
           echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
@@ -59,12 +58,6 @@ jobs:
                 steps.vars.outputs.default_remote
             }}
           head: ${{ github.sha }}
-
-      # # Setup QEMU so docker image can be built across platforms.
-      # - 
-      #   name: Set up QEMU
-      #   if: ${{ steps.path_diff.outputs.changed == 1 }}
-      #   uses: docker/setup-qemu-action@v3
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -11,21 +11,22 @@ concurrency:
 
 jobs:
   Toolchain-Library-And-Examples:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include: [
+          { host-os: ubuntu-latest, platform: linux/amd64 },
+          { host-os: macos-14, platform: linux/arm64 },
+        ]
+    runs-on: ${{ matrix.host-os }}
+
     steps:
-      -
-        name: Prepare
+      - name: Prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
-      - 
-        name: Checkout
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Using a full fetch so that the diff action can run.
@@ -33,16 +34,14 @@ jobs:
       # Create a lower cased version of the repo name. This is required
       # because Docker supports only lowercase names in the registry, while
       # a repo name on GitHub can have uppercase letters.
-      - 
-        name: Set variables
+      - name: Set variables
         id: vars
         run: |
           echo "repository_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
           echo "default_remote=${{ format('refs/remotes/origin/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
-      - 
-        name: Compare files
+      - name: Compare files
         uses: ./.github/actions/path-diff
         id: path_diff
         with:
@@ -61,16 +60,15 @@ jobs:
             }}
           head: ${{ github.sha }}
 
-      # Setup QEMU so docker image can be built across platforms.
-      - 
-        name: Set up QEMU
-        if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/setup-qemu-action@v3
+      # # Setup QEMU so docker image can be built across platforms.
+      # - 
+      #   name: Set up QEMU
+      #   if: ${{ steps.path_diff.outputs.changed == 1 }}
+      #   uses: docker/setup-qemu-action@v3
 
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
-      - 
-        name: Set up Docker Build
+      - name: Set up Docker Build
         if: ${{ steps.path_diff.outputs.changed == 1 }}
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -67,8 +67,8 @@ jobs:
       # Build the toolchain if toolchain files changed w.r.t target and we can
       # use from registry o/w
       - name: Set up Docker Build
-        if: (${{ steps.path_diff.outputs.changed == 1 }} && ${{ matrix.host-os != 'macos-14' }})
         uses: docker/setup-buildx-action@v3
+        continue-on-error: true
 
       - name: Docker meta
         if: ${{ steps.path_diff.outputs.changed == 1 }}

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -29,10 +29,8 @@ jobs:
         include: [
           #{ host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
           #{ host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
-          #{ host-os: ubuntu-24.04, target-platform: Linux-arm64, host: '', makefile-version: '' },
-          #{ host-os: macos-15, target-platform: Linux-arm64, host: '', makefile-version: '' },
-          { host-os: ubuntu-24.04-arm, target-platform: macos-15, host: '', makefile-version: '' },
-          { host-os: ubuntu-24.04-arm, target-platform: Linux-arm64, host: '', makefile-version: '' }
+          { host-os: ubuntu-22.04-arm, target-platform: Linux-arm64, host: '', makefile-version: '' }
+          #{ host-os: macos-13, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -42,7 +40,7 @@ jobs:
     steps:
 
       - name: Install native linux system build dependencies
-        if: ${{ matrix.host-os != 'macos-15' }}
+        if: ${{ matrix.host-os != 'macos-13' }}
         run: |
           sudo apt-get install libmpfr-dev
           sudo apt-get install texinfo

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -30,7 +30,8 @@ jobs:
           #{ host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
           #{ host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
           #{ host-os: ubuntu-24.04, target-platform: Linux-arm64, host: '', makefile-version: '' },
-          #{ host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
+          #{ host-os: macos-15, target-platform: Linux-arm64, host: '', makefile-version: '' },
+          { host-os: ubuntu-24.04-arm, target-platform: macos-15, host: '', makefile-version: '' },
           { host-os: ubuntu-24.04-arm, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
@@ -41,7 +42,7 @@ jobs:
     steps:
 
       - name: Install native linux system build dependencies
-        if: ${{ matrix.host-os != 'macos-14' }}
+        if: ${{ matrix.host-os != 'macos-15' }}
         run: |
           sudo apt-get install libmpfr-dev
           sudo apt-get install texinfo

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          #{ host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          #{ host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
+          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
           { host-os: ubuntu-22.04-arm, target-platform: '', host: '', makefile-version: '' }, #Linux-arm64
           #{ host-os: macos-13, target-platform: '', host: '', makefile-version: '' }, # X86_64
           #{ host-os: macos-14, target-platform: '', host: '', makefile-version: '' }, # arm64

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -30,7 +30,8 @@ jobs:
           #{ host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
           #{ host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
           #{ host-os: ubuntu-24.04, target-platform: Linux-arm64, host: '', makefile-version: '' },
-          { host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
+          #{ host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
+          { host-os: ubuntu-24.04-arm, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -29,8 +29,9 @@ jobs:
         include: [
           #{ host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
           #{ host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
-          { host-os: ubuntu-22.04-arm, target-platform: Linux-arm64, host: '', makefile-version: '' }
-          #{ host-os: macos-13, target-platform: Linux-arm64, host: '', makefile-version: '' }
+          { host-os: ubuntu-22.04-arm, target-platform: '', host: '', makefile-version: '' }, #Linux-arm64
+          #{ host-os: macos-13, target-platform: '', host: '', makefile-version: '' }, # X86_64
+          #{ host-os: macos-14, target-platform: '', host: '', makefile-version: '' }, # arm64
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -39,15 +40,15 @@ jobs:
 
     steps:
 
-      - name: Install native linux system build dependencies
-        if: ${{ matrix.host-os != 'macos-13' }}
-        run: |
-          sudo apt-get install libmpfr-dev
-          sudo apt-get install texinfo
-          sudo apt-get install libmpc-dev
-          sudo apt-get install squashfs-tools
-          # If there are other dependencies, we should add them here and make sure the documentation is updated!
-        continue-on-error: true
+      # - name: Install native linux system build dependencies
+      #   if: ${{ matrix.host-os != 'macos-13' }}
+      #   run: |
+      #     sudo apt-get install libmpfr-dev
+      #     sudo apt-get install texinfo
+      #     sudo apt-get install libmpc-dev
+      #     sudo apt-get install squashfs-tools
+      #     # If there are other dependencies, we should add them here and make sure the documentation is updated!
+      #   continue-on-error: true
 
       - name: Install x-compile system build dependencies
         if: ${{ matrix.target-platform == 'Windows-x86_64' }}

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -1,4 +1,4 @@
-name: Build-Toolchain
+name: Build-Native-Toolchains
 
 # This workflow will build the libdragon N64 GCC toolchain to keep it up-to-date.
 on:

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -40,15 +40,15 @@ jobs:
 
     steps:
 
-      # - name: Install native linux system build dependencies
-      #   if: ${{ matrix.host-os != 'macos-13' }}
-      #   run: |
-      #     sudo apt-get install libmpfr-dev
-      #     sudo apt-get install texinfo
-      #     sudo apt-get install libmpc-dev
-      #     sudo apt-get install squashfs-tools
-      #     # If there are other dependencies, we should add them here and make sure the documentation is updated!
-      #   continue-on-error: true
+      - name: Install native linux system build dependencies
+        # if: ${{ matrix.host-os != 'macos-13' }} && ${{ matrix.host-os != 'macos-14' }}
+        run: |
+          sudo apt-get install libmpfr-dev
+          sudo apt-get install texinfo
+          sudo apt-get install libmpc-dev
+          sudo apt-get install squashfs-tools
+          # If there are other dependencies, we should add them here and make sure the documentation is updated!
+        continue-on-error: true
 
       - name: Install x-compile system build dependencies
         if: ${{ matrix.target-platform == 'Windows-x86_64' }}

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
 
-      - name: Install native system build dependencies
-        if: ${{ matrix.host-os == 'macos-14' }}
-        run: |
-          brew install build-essential
-          brew install texinfo
-        continue-on-error: true
+      # - name: Install native system build dependencies
+      #   if: ${{ matrix.host-os == 'macos-14' }}
+      #   run: |
+      #     brew install build-essential
+      #     brew install texinfo
+      #   continue-on-error: true
 
 
       - name: Install native system build dependencies

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -1,4 +1,4 @@
-name: Build-Toolchain-Native
+name: Build-Toolchain
 
 # This workflow will build the libdragon N64 GCC toolchain to keep it up-to-date.
 on:
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
-          { host-os: ubuntu-24.04, target-platform: Linux-arm64, host: '', makefile-version: '' },
+          #{ host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          #{ host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
+          #{ host-os: ubuntu-24.04, target-platform: Linux-arm64, host: '', makefile-version: '' },
           { host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -29,6 +29,7 @@ jobs:
         include: [
           { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
           { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -47,7 +47,7 @@ jobs:
       #   continue-on-error: true
 
 
-      - name: Install native system build dependencies
+      - name: Install native linux system build dependencies
         if: ${{ matrix.host-os != 'macos-14' }}
         run: |
           sudo apt-get install libmpfr-dev

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -42,10 +42,7 @@ jobs:
       - name: Install native system build dependencies
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
-          # sudo adduser github-ci
-          # usermod -aG sudo github-ci
-          brew install automake
-          brew install autoconf
+          brew install build-essential
           brew install texinfo
         continue-on-error: true
 

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -42,13 +42,16 @@ jobs:
       - name: Install native system build dependencies
         if: ${{ matrix.host-os == 'macos-14' }}
         run: |
-          sudo adduser github-ci
-          usermod -aG sudo github-ci
+          # sudo adduser github-ci
+          # usermod -aG sudo github-ci
+          brew install automake
+          brew install autoconf
+          brew install texinfo
         continue-on-error: true
 
 
       - name: Install native system build dependencies
-        # if: ${{ matrix.host-os != 'macos-14' }}
+        if: ${{ matrix.host-os != 'macos-14' }}
         run: |
           sudo apt-get install libmpfr-dev
           sudo apt-get install texinfo

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -5,12 +5,11 @@ on:
   # This action will take about 40-70 minutes to run!
   # It is designed to only fire if the GCC toolchain build file changes.
   push:
-  # FIXME: revert before merge. These are commented out to ensure builds happen for mac
-  #   paths:
-  #     - 'tools/build-toolchain.sh'
-  # pull_request:
-  #   paths:
-  #     - 'tools/build-toolchain.sh'
+    paths:
+      - 'tools/build-toolchain.sh'
+  pull_request:
+    paths:
+      - 'tools/build-toolchain.sh'
   
 jobs:
   Build-Toolchain:
@@ -28,8 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-#          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-#          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
+          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
+          { host-os: ubuntu-24.04, target-platform: Linux-arm64, host: '', makefile-version: '' },
           { host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
@@ -38,14 +38,6 @@ jobs:
       Build_Directory: libdragon
 
     steps:
-
-      # - name: Install native system build dependencies
-      #   if: ${{ matrix.host-os == 'macos-14' }}
-      #   run: |
-      #     brew install build-essential
-      #     brew install texinfo
-      #   continue-on-error: true
-
 
       - name: Install native linux system build dependencies
         if: ${{ matrix.host-os != 'macos-14' }}

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -1,15 +1,16 @@
-name: Build-Native
+name: Build-Toolchain-Native
 
 # This workflow will build the libdragon N64 GCC toolchain to keep it up-to-date.
 on:
   # This action will take about 40-70 minutes to run!
   # It is designed to only fire if the GCC toolchain build file changes.
   push:
-    paths:
-      - 'tools/build-toolchain.sh'
-  pull_request:
-    paths:
-      - 'tools/build-toolchain.sh'
+  # FIXME: revert before merge. These are commented out to ensure builds happen for mac
+  #   paths:
+  #     - 'tools/build-toolchain.sh'
+  # pull_request:
+  #   paths:
+  #     - 'tools/build-toolchain.sh'
   
 jobs:
   Build-Toolchain:
@@ -28,7 +29,7 @@ jobs:
       matrix:
         include: [
           { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
           { host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
@@ -37,7 +38,17 @@ jobs:
       Build_Directory: libdragon
 
     steps:
+
+      # - name: Install native system build dependencies
+      #   if: ${{ matrix.host-os == 'macos-14' }}
+      #   run: |
+      #     sudo adduser github-ci
+      #     usermod -aG sudo github-ci
+      #   continue-on-error: true
+
+
       - name: Install native system build dependencies
+        if: ${{ matrix.host-os != 'macos-14' }}
         run: |
           sudo apt-get install libmpfr-dev
           sudo apt-get install texinfo

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
+#          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+#          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' },
           { host-os: macos-14, target-platform: Linux-arm64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -39,16 +39,16 @@ jobs:
 
     steps:
 
-      # - name: Install native system build dependencies
-      #   if: ${{ matrix.host-os == 'macos-14' }}
-      #   run: |
-      #     sudo adduser github-ci
-      #     usermod -aG sudo github-ci
-      #   continue-on-error: true
+      - name: Install native system build dependencies
+        if: ${{ matrix.host-os == 'macos-14' }}
+        run: |
+          sudo adduser github-ci
+          usermod -aG sudo github-ci
+        continue-on-error: true
 
 
       - name: Install native system build dependencies
-        if: ${{ matrix.host-os != 'macos-14' }}
+        # if: ${{ matrix.host-os != 'macos-14' }}
         run: |
           sudo apt-get install libmpfr-dev
           sudo apt-get install texinfo

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -60,7 +60,7 @@ download () {
 }
 
 # Compilation on macOS via homebrew
-if [[ $OSTYPE == 'darwin'* ]]; then
+if [[ $OSTYPE == *'darwin'* ]]; then
     if ! command_exists brew; then
         echo "Compilation on macOS is supported via Homebrew (https://brew.sh)"
         echo "Please install homebrew and try again"

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -36,7 +36,7 @@ GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
 BINUTILS_V=2.42
-GCC_V=14.2.0
+GCC_V=14.1.0
 NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0 
 MPC_V=1.3.1 

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -36,7 +36,7 @@ GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
 BINUTILS_V=2.42
-GCC_V=14.1.0
+GCC_V=13.2.0
 NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0 
 MPC_V=1.3.1 
@@ -101,7 +101,7 @@ cd "$BUILD_PATH"
 test -f "binutils-$BINUTILS_V.tar.gz" || download "https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz"
 test -d "binutils-$BINUTILS_V"        || tar -xzf "binutils-$BINUTILS_V.tar.gz"
 
-test -f "gcc-$GCC_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
+test -f "gcc-$GCC_V.tar.gz"           || download "https://gcc.gnu.org/pub/gcc/snapshots/13.3.0-RC-20240514/gcc-13.3.0-RC-20240514.tar.gz" #"https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
 test -d "gcc-$GCC_V"                  || tar -xzf "gcc-$GCC_V.tar.gz"
 
 test -f "newlib-$NEWLIB_V.tar.gz"     || download "https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz"

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -36,7 +36,7 @@ GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
 BINUTILS_V=2.42
-GCC_V=13.2.0
+GCC_V=14.2.0
 NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0 
 MPC_V=1.3.1 
@@ -101,7 +101,7 @@ cd "$BUILD_PATH"
 test -f "binutils-$BINUTILS_V.tar.gz" || download "https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz"
 test -d "binutils-$BINUTILS_V"        || tar -xzf "binutils-$BINUTILS_V.tar.gz"
 
-test -f "gcc-$GCC_V.tar.gz"           || download "https://gcc.gnu.org/pub/gcc/snapshots/13.3.0-RC-20240514/gcc-13.3.0-RC-20240514.tar.gz" #"https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
+test -f "gcc-$GCC_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
 test -d "gcc-$GCC_V"                  || tar -xzf "gcc-$GCC_V.tar.gz"
 
 test -f "newlib-$NEWLIB_V.tar.gz"     || download "https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz"


### PR DESCRIPTION
In this PR, we improve the CI by adding:

Extra native toolchain builds for:
* macos13 (x86_64) [commented out] [does not create a package].
* macos14 (arm64) [commented out] [does not create a package].
* linux-arm64 images (on 22.04) [does not create a package].

Additional Multi-platform docker build support for:
* arm64  (builds on ubuntu 22.04).

Fixes #504 