### PR TITLE
audio: Fix build errors with GCC 14

### DIFF
--- a/src/audio/libdragon.mk
+++ b/src/audio/libdragon.mk
@@ -18,3 +18,5 @@ LIBDRAGON_OBJS += \
 	$(BUILD_DIR)/audio/rsp_opus_fft_bfly4.o \
 	$(BUILD_DIR)/audio/rsp_opus_fft_bfly5.o \
 	$(BUILD_DIR)/audio/rsp_opus_fft_postrot.o
+
+$(BUILD_DIR)/audio/libopus.o: CFLAGS+=-Wno-all

--- a/src/audio/wav64_opus.c
+++ b/src/audio/wav64_opus.c
@@ -82,7 +82,7 @@ static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wl
 
     // Allocate stack buffer for reading compressed data. Align it to cacheline
     // to avoid any false sharing.
-    uint8_t buf[st->xhead.max_cmp_frame_size] alignas(16);
+    uint8_t alignas(16) buf[st->xhead.max_cmp_frame_size];
     int nframes = DIVIDE_CEIL(wlen, st->xhead.frame_size);
 
     // Make space for the decoded samples. Call samplebuffer_append once as we

--- a/tools/audioconv64/libopus.c
+++ b/tools/audioconv64/libopus.c
@@ -1,8 +1,9 @@
 
 #pragma GCC diagnostic push
 
-// Compiling libopus seems to trigger this warning that we can safely ignore.
+// Compiling libopus seems to trigger these warnings that we can safely ignore.
 #pragma GCC diagnostic ignored "-Wtautological-pointer-compare"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
 // Activate support for CELT custom modes. We are going to always use the
 // custom mode API even for standard modes (like 48 Khz), so we can safely


### PR DESCRIPTION
Disable warnings for libopus since it is third-party code.