### PR TITLE
Improve toolchain CI build

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -102,7 +102,7 @@ jobs:
           # required for newlib (as not the default?!)
           export PATH="$PATH:${{ runner.temp }}/${{ env.Build_Directory }}"
           cd ./tools/
-          sudo N64_INST=${{ runner.temp }}/${{ env.Build_Directory }} N64_HOST=${{ matrix.host }} MAKE_V=${{ matrix.makefile-version }} ./build-toolchain.sh
+          N64_INST=${{ runner.temp }}/${{ env.Build_Directory }} N64_HOST=${{ matrix.host }} MAKE_V=${{ matrix.makefile-version }} ./build-toolchain.sh
 
           echo Remove un-necessary content
           rm -rf ${N64_INST}/share/locale/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN apt-get install -yq \
     libmpc-dev \
     zlib1g-dev \
     texinfo \
-    git \
-    gcc-multilib
+    git
 
 # Build toolchain
 COPY ./tools/build-toolchain.sh /tmp/tools/build-toolchain.sh

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # N64 MIPS GCC toolchain build/install script for Unix distributions
-# (c) 2012-2023 DragonMinded and libDragon Contributors.
+# (c) 2012-2024 DragonMinded and libDragon Contributors.
 # See the root folder for license information.
 
 # Bash strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/


### PR DESCRIPTION
Works towards macOS CI
* Remove un-necessary sudo when calling build-toolchain.sh
* Remove un-necessary gcc-multilib dependency