### PR TITLE
Fix Windows-Tool CI build

### DIFF
--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -13,7 +13,7 @@ jobs:
           { sys: mingw32, arch: i686,   build: tools}
         ]
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v2.22.0
         with:
           msystem: ${{matrix.sys}}
           install: >-


### PR DESCRIPTION
This is a temporary fix for building windows tools until we can work out why. It was unfortunate that the latest release coinsided with changes to `align` functions which confused matters.

The msys2 releases are here: https://github.com/msys2/setup-msys2/releases