### PR TITLE
[trunk] display: fix display_get_fps on iQue

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -418,5 +418,5 @@ uint32_t display_get_num_buffers(void)
 float display_get_fps(void)
 {
     if (!frame_times_duration) return 0;
-    return (float)(FPS_WINDOW * TICKS_PER_SECOND) / frame_times_duration;
+    return (float)FPS_WINDOW * TICKS_PER_SECOND / frame_times_duration;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - display: fix display_get_fps on iQue (d1153c2a)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)