### PR TITLE
[trunk] wav64: remove leftover debug print

### DIFF
--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -312,8 +312,6 @@ void wav64_open(wav64_t *wav, const char *fn) {
 	}
 
 	dfs_close(fh);
-	debugf("wav64 %s: %d-bit %.1fHz %dch %d samples (loop: %d)\n",
-		fn, wav->wave.bits, wav->wave.frequency, wav->wave.channels, wav->wave.len, wav->wave.loop_len);
 }
 
 void wav64_play(wav64_t *wav, int ch)


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - wav64: remove leftover debug print (e5b93a68)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)