### PR TITLE
Add RSP DMA control regs to rsp.h

### DIFF
--- a/include/rsp.h
+++ b/include/rsp.h
@@ -172,6 +172,15 @@ extern "C" {
 /** @brief Current SP program counter */
 #define SP_PC         ((volatile uint32_t*)0xA4080000)
 
+/** @brief SP DMA IMEM/DMEM address register */
+#define SP_DMA_SPADDR  ((volatile uint32_t*)0xA4040000)
+/** @brief SP DMA RDRAM address register */
+#define SP_DMA_RAMADDR ((volatile uint32_t*)0xA4040004)
+/** @brief SP DMA from RDRAM to IMEM/DMEM register */
+#define SP_DMA_RDLEN   ((volatile uint32_t*)0xA4040008)
+/** @brief SP DMA from IMEM/DMEM to RDRAM register */
+#define SP_DMA_WRLEN   ((volatile uint32_t*)0xA404000C)
+
 /** @brief SP status register */
 #define SP_STATUS     ((volatile uint32_t*)0xA4040010)
 


### PR DESCRIPTION
I am not sure about the whitespace (indentation, newlines), feel free to tell me.

I think there should be longer comments and additional macros to work with these regs, but that would be a lot to improve with the other regs too. And maybe "look at the wiki" is good enough