### PR TITLE
[trunk] asset: add missing function declaration (breaks builds with GCC 14)

### DIFF
--- a/include/asset.h
+++ b/include/asset.h
@@ -75,8 +75,10 @@
 extern "C" {
 #endif
 
-/// @private
+/// @cond
 extern void __asset_init_compression_lvl2(void);
+extern void __asset_init_compression_lvl3(void);
+/// @endcond
 
 /**
  * @brief Enable a non-default compression level


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - asset: add missing function declaration (breaks builds with GCC 14) (bb21b6a4)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)