### PR TITLE
fix: rsp_ucode_t init order

### DIFF
--- a/include/rsp.h
+++ b/include/rsp.h
@@ -348,8 +348,8 @@ typedef struct {
     extern uint8_t ucode_name ## _data_end[0]; \
     rsp_ucode_t ucode_name = (rsp_ucode_t){ \
         .code = ucode_name ## _text_start, \
-        .data = ucode_name ## _data_start, \
         .code_end = ucode_name ## _text_end, \
+        .data = ucode_name ## _data_start, \
         .data_end = ucode_name ## _data_end, \
         .name = #ucode_name, .start_pc = 0, \
         .crash_handler = 0, .assert_handler = 0, \


### PR DESCRIPTION
Using `DEFINE_RSP_UCODE` in C++ leads to errors since it wants to have the init order the same as in the struct:
`error: designator order for field 'rsp_ucode_t::code_end' does not match declaration order in 'rsp_ucode_t'`