### PR TITLE
[trunk] mixer: fix mixer_ch_get_pos overflow after 23 seconds

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -428,7 +428,7 @@ void mixer_ch_set_pos(int ch, float pos) {
 float mixer_ch_get_pos(int ch) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	assertf(!(c->flags & CH_FLAGS_STEREO_SUB), "mixer_ch_get_pos: cannot call on secondary stereo channel %d", ch);
-	uint32_t pos = c->pos >> (c->flags & CH_FLAGS_BPS_SHIFT);
+	uint64_t pos = c->pos >> (c->flags & CH_FLAGS_BPS_SHIFT);
 	return (float)pos / (float)(1<<MIXER_FX64_FRAC);
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - mixer: fix mixer_ch_get_pos overflow after 23 seconds (7cd57421)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)