### PR TITLE
make install: do mkdir include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ install: install-mk libdragon
 	install -Cv -m 0644 rsp.ld $(INSTALLDIR)/mips64-elf/lib/rsp.ld
 	install -Cv -m 0644 header $(INSTALLDIR)/mips64-elf/lib/header
 	install -Cv -m 0644 libdragonsys.a $(INSTALLDIR)/mips64-elf/lib/libdragonsys.a
+	mkdir -p $(INSTALLDIR)/mips64-elf/include
 	install -Cv -m 0644 include/n64types.h $(INSTALLDIR)/mips64-elf/include/n64types.h
 	install -Cv -m 0644 include/pputils.h $(INSTALLDIR)/mips64-elf/include/pputils.h
 	install -Cv -m 0644 include/n64sys.h $(INSTALLDIR)/mips64-elf/include/n64sys.h


### PR DESCRIPTION
otherwise install fails if the folder is missing, which is typical if installing to a brand new place (eg different from N64_GCCPREFIX)