### PR TITLE
[trunk] audio: fix exact DAC rates | rdpq: fix nested blocks that contain RDP static buffers

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -18,11 +18,11 @@
  * @{
  */
 /** @brief NTSC DAC rate */
-#define AI_NTSC_DACRATE 48681812
+#define AI_NTSC_DACRATE 48681818
 /** @brief PAL DAC rate */
 #define AI_PAL_DACRATE  49656530
 /** @brief MPAL DAC rate */
-#define AI_MPAL_DACRATE 48628316
+#define AI_MPAL_DACRATE 48628322
 /** @} */
 
 /**

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -737,15 +737,15 @@ rdpq_block_t* __rdpq_block_end()
     return ret;
 }
 
-/** @brief Run a block (called by #rspq_block_run). */
+/** @brief Notify that a rspq block was run (called by #rspq_block_run). */
 void __rdpq_block_run(rdpq_block_t *block)
 {
-    // We are about to run a block that contains rdpq commands.
-    // During creation, we tracked some state for the block 
-    // and saved it into the block structure; set it as current,
-    // because from now on we can assume the block would and the
-    // state of the engine must match the state at the end of the block.
     if (block) {
+        // We have run a block that contains rdpq commands.
+        // During creation, we tracked some state for the block 
+        // and saved it into the block structure; set it as current,
+        // because from now on we can assume the block would and the
+        // state of the engine must match the state at the end of the block.
         rdpq_tracking_t prev = rdpq_tracking;
         rdpq_tracking = block->tracking;
 
@@ -756,6 +756,15 @@ void __rdpq_block_run(rdpq_block_t *block)
             rdpq_tracking.cycle_type_known = prev.cycle_type_known;
         if (rdpq_tracking.cycle_type_frozen == 0)
             rdpq_tracking.cycle_type_frozen = prev.cycle_type_frozen;
+
+        // The called block has switched static buffer. Adjust our state to set
+        // our buffer as pending; if a new RDP command is issued, we will switch
+        // back to it.
+        struct rdpq_block_state_s *st = &rdpq_block_state;
+        st->pending_wptr = st->wptr;
+        st->pending_wend = st->wend;
+        st->wptr = NULL;
+        st->wend = NULL;
     } else {
         // Initialize tracking state for unknown state
         rdpq_tracking = (rdpq_tracking_t){

--- a/src/rspq/rspq.c
+++ b/src/rspq/rspq.c
@@ -1193,9 +1193,6 @@ void rspq_block_run(rspq_block_t *block)
     // mode, but it might be an acceptable limitation.
     assertf(rspq_ctx != &highpri, "block run is not supported in highpri mode");
 
-    // Notify rdpq engine we are about to run a block
-    __rdpq_block_run(block->rdp_block);
-
     // Write the CALL op. The second argument is the nesting level
     // which is used as stack slot in the RSP to save the current
     // pointer position.
@@ -1209,6 +1206,9 @@ void rspq_block_run(rspq_block_t *block)
         assertf(rspq_block->nesting_level < RSPQ_MAX_BLOCK_NESTING_LEVEL,
             "reached maximum number of nested block runs");
     }
+
+    // Notify rdpq engine we have run a block
+    __rdpq_block_run(block->rdp_block);
 }
 
 void rspq_block_run_rsp(int nesting_level)

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -287,6 +287,7 @@ static const struct Testsuite
 	TEST_FUNC(test_rdpq_block_coalescing,      0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_block_contiguous,      0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_block_dynamic,         0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_rdpq_block_nested,          0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_change_other_modes,    0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_fixup_setfillcolor,    0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_fixup_setscissor,      0, TEST_FLAGS_NO_BENCHMARK),


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - audio: fix exact DAC rates (11b58b04)
 - rdpq: fix nested blocks that contain RDP static buffers (cb0e13e2)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)