### PR TITLE
n64.mk: Bump default C standard to C17

### DIFF
--- a/n64.mk
+++ b/n64.mk
@@ -49,7 +49,7 @@ N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map=
 N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
 N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_C_AND_CXX_FLAGS += -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-parameter -Wno-error=unused-but-set-parameter -Wno-error=unused-label -Wno-error=unused-local-typedefs -Wno-error=unused-const-variable
-N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu99
+N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu17
 N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu++17
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)


### PR DESCRIPTION
C17 standard has been implemented since GCC 8.1. Libdragon has used a toolchain that supports C17 since 2019 (https://github.com/DragonMinded/libdragon/commit/a318fc8bbc6546359c2be610a5e4a88e3e118746#diff-4cdfece525412cfc651464566e6bc1e6a8c333a3d67831a751e8c78f3a82ab69) when it adopted GCC 9.1 (from GCC 6.2). 5 years seems like a long enough window for users to adopt a new toolchain so this PR bumps the default C standard in n64.mk.

Also worth considering is the timeline for C++20 adoption. C++20 support is basically finalized as of GCC 11 which libdragon adopted in 2021 (https://github.com/DragonMinded/libdragon/commit/799b60e9a997658f911d5a3d5de4675e22da006d#diff-ab08cd81e36c363dc23244d73671f6a3b023e85cb22a4e9763f14b5ec3d318ea).