### PR TITLE
Add a flag --ares-tpak to enable N64 Transfer Pak compatibility for the Ares Emulator

### DIFF
--- a/n64.mk
+++ b/n64.mk
@@ -8,6 +8,7 @@ N64_ROM_RTC = # Set to true to enable the Joybus Real-Time Clock
 N64_ROM_REGIONFREE = # Set to true to allow booting on any console region
 N64_ROM_REGION = # Set to a region code (emulators will boot on a specific console region)
 N64_ROM_ELFCOMPRESS = 1 # Set compression level of ELF file in ROM
+N64_ARES_TPAK_COMPAT = # Set to true to enable Ares Emulator Transfer Pak Compatibility.
 
 # Override this to use a toolchain installed separately from libdragon
 N64_GCCPREFIX ?= $(N64_INST)
@@ -59,6 +60,7 @@ N64_DSOLDFLAGS = --emit-relocs --unresolved-symbols=ignore-all --nmagic -T$(N64_
 N64_TOOLFLAGS = --title $(N64_ROM_TITLE)
 N64_TOOLFLAGS += $(if $(N64_ROM_HEADER),--header $(N64_ROM_HEADER))
 N64_TOOLFLAGS += $(if $(N64_ROM_REGION),--region $(N64_ROM_REGION))
+N64_TOOLFLAGS += $(if $(N64_ARES_TPAK_COMPAT),--ares-tpak)
 N64_ED64ROMCONFIGFLAGS =  $(if $(N64_ROM_SAVETYPE),--savetype $(N64_ROM_SAVETYPE))
 N64_ED64ROMCONFIGFLAGS += $(if $(N64_ROM_RTC),--rtc) 
 N64_ED64ROMCONFIGFLAGS += $(if $(N64_ROM_REGIONFREE),--regionfree)


### PR DESCRIPTION
Add a flag --ares-tpak to enable N64 Transfer Pak compatibility for the Ares Emulator. This flag is useful for debugging transfer pak functionality in Ares Emulator.

This uses the Advanced Homebrew Header controller 1 config field. When Ares Emulator reads this field in <ares-repo>/mia/nintendo-64.cpp, it will ask you to select the desired Gameboy rom to use.

Note: the gameboy SRAM sav file needs to be named <filename_of_the_rom_without_extension>.ram to be loaded as well.