### PR TITLE
Don't garbage collect `keep.{text,data,rodata}.*` sections

### DIFF
--- a/n64.ld
+++ b/n64.ld
@@ -36,6 +36,7 @@ SECTIONS {
         __text_start = .;
         *(.text)
         *(.text.*)
+        KEEP(*(keep.text.*))
         *(.init)
         *(.fini)
         *(.gnu.linkonce.t.*)
@@ -55,6 +56,7 @@ SECTIONS {
         *(.rdata)
         *(.rodata)
         *(.rodata.*)
+        KEEP(*(keep.rodata.*))
         *(.gnu.linkonce.r.*)
         . = ALIGN(8);
     } > mem
@@ -101,6 +103,7 @@ SECTIONS {
         __data_start = .;
         *(.data)
         *(.data.*)
+        KEEP(*(keep.data.*))
         *(.gnu.linkonce.d.*)
         . = ALIGN(8);
     } > mem


### PR DESCRIPTION
This allows manually preventing specific sections (that is, specific symbols, since `-ffunction-sections -fdata-sections` means one section per symbol) from being garbage collected by the linker ld in the case they are not referenced.

----------

For example:
```c
#include <libdragon.h>

char string[] = "hey";

int main()
{
    return 0;
}
```

The `-fdata-sections` flag passed to gcc makes the `string` symbol be put into its own `.rodata.string` section. Then on linking since that symbol is unreferenced the section is dropped.

This PR changes the linker script n64.ld such that sections named like `keep.{text,data,rodata}.*` are always linked in regardless of garbage collection.
This allows using the gcc section attribute to put a symbol in a so-named section that would be kept:
```c
__attribute__((section("keep.rodata.string")))
char string[] = "hey";
```
The section suffix ("string" here) doesn't matter but I'd recommend using the symbol name like `-fdata-sections` does for simplicity, consistency and ~~avoiding name collisions~~ (EDIT: section names don't collide. that's the point of the linker after all... should we just not have suffixes at all?).

I also made this possible with text and data. Not that it matters where a symbol ends up, afaik having put this string in `keep.text.string` and having it ending up in the rom elf's .text section would work just fine. (likewise with putting text in .data/.rodata) Still it seems preferable to put things where they're expected.

I did not add this for .bss because that looks like a footgun, for example picture doing `__attribute__((section("keep.bss.mydata"))) int mydata;`, and later adding an initializer to `mydata` but not changing the section from `keep.bss` to `keep.data`: then the C source makes it look like the variable has that initial value, but it will be linked in the NOLOAD bss section which is 0-initialized regardless.
Note that (afaik) linking a "bss" uninitialized data symbol into a LOAD section such as .data (`__attribute__((section("keep.data.mydata"))) int mydata;`) will just work, the linker will store 0s in the data section for those bytes.

----------

Other alternatives:

- `LDFLAGS += --require-defined=string` in the Makefile but it would be better/easier to control this from the .c where the symbol is
- just reference the symbol, but this requires hacks/workarounds for performing noops with the symbols without those noops being optimized out