### PR TITLE
[trunk] xm64: avoid use-after-free bug when calling stop before close

### DIFF
--- a/include/xm64.h
+++ b/include/xm64.h
@@ -60,6 +60,7 @@ typedef struct xm64player_s {
 	FILE *fh;                 ///< open handle of XM64 file
 	int first_ch;             ///< first channel used in the mixer
 	bool playing;             ///< playing flag
+	bool stop_requested;      ///< user requested stop playing
 	bool looping;             ///< true if the XM is configured to loop
 	struct {
 		int patidx, row, tick;

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -27,10 +27,11 @@ static int tick(void *arg) {
 	}
 
 	// If we're requested to stop playback, do it.
-	if (!xmp->playing || (!xmp->looping && ctx->loop_count > 0)) {
+	if (xmp->stop_requested || (!xmp->looping && ctx->loop_count > 0)) {
 		for (int i=0;i<ctx->module.num_channels;i++)
 			mixer_ch_stop(xmp->first_ch+i);
 		xmp->playing = false;
+		xmp->stop_requested = false;
 		// Do not reschedule again
 		return 0;
 	}
@@ -197,7 +198,7 @@ void xm64player_play(xm64player_t *player, int first_ch) {
 
 void xm64player_stop(xm64player_t *player) {
 	// Let the mixer callback stop playing
-	player->playing = false;
+	player->stop_requested = true;
 }
 
 void xm64player_tell(xm64player_t *player, int *patidx, int *row, float *secs) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - xm64: avoid use-after-free bug when calling stop before close (208f4ead)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)