### PR TITLE
Implement ioctl

### DIFF
--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -66,6 +66,12 @@
 #define MAX_DIRECTORY_DEPTH 100
 
 /**
+ * @brief Base ROM Address Request ioctl Command Code
+ */
+#define IODFS_GET_ROM_BASE _IO('D', 0)
+
+
+/**
  * @name DragonFS Return values
  * @{
  */

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -77,5 +77,6 @@
 #include "skc.h"
 #include "nand.h"
 #include "bbfs.h"
+#include "system.h"
 
 #endif

--- a/include/system.h
+++ b/include/system.h
@@ -362,7 +362,7 @@ int unhook_time_call( time_t (*time_fn)( void ) );
 /**
  * @brief Perform IO Control Request
  *
- * @param[in] file
+ * @param[in] fd
  *            File handle
  * @param[in] cmd
  *            Request ioctl command code 

--- a/include/system.h
+++ b/include/system.h
@@ -43,6 +43,20 @@
 /** @brief Number of open handles that can be maintained at one time */
 #define MAX_OPEN_HANDLES    4096
 
+/** 
+ * @brief Generate an IOCTL Command Code
+ *
+ * @param[in] type
+ *            A 16-bit number, often a character literal, specific to a subsystem
+ *            or driver
+ *
+ * @param[in] nr
+ *            A 16-bit number identifying the specific command, unique for a given
+ *            value of 'type'
+ * @return An IOCTL Command Code
+ */
+#define _IO(type, nr) (((type) & 0xFFFF) << 16)|((nr) & 0xFFFF)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -203,6 +217,19 @@ typedef struct
      * @return 0 on success or a negative value on failure (errno must be set)
      */
     int (*mkdir)( char *path, mode_t mode );
+    /**
+     * @brief Perform IO Control Request
+     *
+     * @param[in] file
+     *            File handle
+     * @param[in] cmd
+     *            Request ioctl command code 
+     * @param[in] argp
+     *            Pointer to a request-specific data structure
+     *
+     * @return Zero on success, or a negative value on error.
+     */
+    int (*ioctl)(void *file, unsigned long cmd, void *argp);
 } filesystem_t;
 
 /**
@@ -331,6 +358,20 @@ int hook_time_call( time_t (*time_fn)( void ) );
  * @return 0 if successful or a negative value on failure.
  */
 int unhook_time_call( time_t (*time_fn)( void ) );
+
+/**
+ * @brief Perform IO Control Request
+ *
+ * @param[in] file
+ *            File handle
+ * @param[in] cmd
+ *            Request ioctl command code 
+ * @param[in] argp
+ *            Pointer to a request-specific data structure
+ *
+ * @return Zero on success, or a negative value on error.
+ */
+int ioctl(int fd, unsigned long cmd, void *argp);
 
 #ifdef __cplusplus
 }

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -1175,6 +1175,23 @@ static int __findnext( dir_t *dir )
     return 0;
 }
 
+static int __ioctl(void *file, unsigned long cmd, void *argp)
+{
+    switch(cmd) {
+        case IODFS_GET_ROM_BASE:
+        {
+            uint32_t *rom_addr = argp;
+            dfs_open_file_t *openfile = HANDLE_TO_OPENFILE(file);
+            *rom_addr = openfile->cart_start_loc;
+        }
+            return 0;
+            
+        default:
+            errno = ENOTTY;
+            return -1;
+    }
+}
+
 /**
  * @brief Structure used for hooking DragonFS into newlib
  *
@@ -1189,6 +1206,7 @@ static filesystem_t dragon_fs = {
     .close = __close,
     .findfirst = __findfirst,
     .findnext = __findnext,
+    .ioctl = __ioctl
 };
 
 /**

--- a/src/system.c
+++ b/src/system.c
@@ -1189,6 +1189,24 @@ int wait( int *status )
     return -1;
 }
 
+int ioctl(int fd, unsigned long cmd, void *argp)
+{
+    filesystem_t *fs = __get_fs_pointer_by_handle(fd);
+    void **handle_ptr = __get_fs_handle(fd);
+    if(fs == 0 || handle_ptr == 0)
+    {
+        errno = EBADF;
+        return -1;
+    }
+    if(fs->ioctl == 0 )
+    {
+        /* Filesystem doesn't support ioctl */
+        errno = ENOTTY;
+        return -1;
+    }
+    return fs->ioctl(*handle_ptr, cmd, argp);
+}
+
 /**
  * @brief Write data to a file
  *

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -88,3 +88,13 @@ void test_dfs_rom_addr(TestContext *ctx) {
 
 	ASSERT_EQUAL_MEM(buf1, buf2, 128, "DMA ROM access is different");
 }
+
+void test_dfs_ioctl(TestContext *ctx) {
+    FILE *file = fopen("rom:/counter.dat", "rb");
+    ASSERT(file, "counter.dat not found");
+    DEFER(fclose(file));
+    uint32_t rom_addr = 0;
+    int ret = ioctl(fileno(file), IODFS_GET_ROM_BASE, &rom_addr);
+    ASSERT(ret >= 0, "DFS ioctl failed");
+    ASSERT(rom_addr == dfs_rom_addr("counter.dat"), "IODFS_GET_ROM_BASE ioctl not working");
+}

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -250,6 +250,7 @@ static const struct Testsuite
 	TEST_FUNC(test_irq_reentrancy,           230, TEST_FLAGS_RESET_COUNT),
 	TEST_FUNC(test_dfs_read,                 948, TEST_FLAGS_IO),
 	TEST_FUNC(test_dfs_rom_addr,              25, TEST_FLAGS_IO),
+	TEST_FUNC(test_dfs_ioctl,                  0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_eepromfs,                   0, TEST_FLAGS_IO),
 	TEST_FUNC(test_cache_invalidate,        1763, TEST_FLAGS_NONE),
 	TEST_FUNC(test_debug_sdfs,                 0, TEST_FLAGS_NO_BENCHMARK),


### PR DESCRIPTION
Includes implementation of IODFS_GET_ROM_BASE ioctl to get base ROM address of DFS file.