### PR TITLE
display: revert VI_V_CURRENT_VBLANK value to 2

### DIFF
--- a/src/vi.h
+++ b/src/vi.h
@@ -113,7 +113,7 @@ typedef struct vi_config_s{
 
 /** Under VI_V_CURRENT  */
 /** @brief VI_V_CURRENT Register: default value for vblank begin line. */
-#define VI_V_CURRENT_VBLANK                 0
+#define VI_V_CURRENT_VBLANK                 2
 
 /** Under VI_V_INTR    */
 /** @brief VI_V_INTR Register: set value for vertical interrupt. */


### PR DESCRIPTION
Reverts `VI_V_CURRENT_VBLANK` value from 0 to 2 due to bug in the VI. Vblank interrupt is not triggered on every field (odd and even) when serrate bit is set and `V_INTR` register is set to zero. Instead, interrupt is only triggered on one field, essentially halving the interrupt frequency.