### PR TITLE
[trunk] exception: provide mnemonic names for GPRs in reg_block_t | rdpq_rect: improve rdpq_fill_rectangle docs

### DIFF
--- a/include/exception.h
+++ b/include/exception.h
@@ -67,7 +67,15 @@ typedef enum {
 typedef struct __attribute__((packed))
 {
     /** @brief General purpose registers 1-32 */
-    uint64_t gpr[32];
+    union {
+        uint64_t gpr[32];
+        struct {
+            uint64_t zr, at, v0, v1, a0, a1, a2, a3;
+            uint64_t t0, t1, t2, t3, t4, t5, t6, t7;
+            uint64_t s0, s1, s2, s3, s4, s5, s6, s7;
+            uint64_t t8, t9, k0, k1, gp, sp, fp, ra;
+        };
+    };
     /** @brief HI */
     uint64_t hi;
     /** @brief LO */

--- a/include/rdpq_rect.h
+++ b/include/rdpq_rect.h
@@ -200,20 +200,16 @@ inline void __rdpq_texture_rectangle_flip_raw_fx(rdpq_tile_t tile, uint16_t x0, 
  * @brief Draw a filled rectangle (RDP command: FILL_RECTANGLE)
  * 
  * This command is used to render a rectangle filled with a solid color.
- * The color must have been configured via #rdpq_set_fill_color, and the
- * render mode should be set to FILL via #rdpq_set_mode_fill.
  * 
  * The rectangle must be defined using exclusive bottom-right bounds, so for
  * instance `rdpq_fill_rectangle(10,10,30,30)` will draw a square of exactly
  * 20x20 pixels.
  * 
- * Fractional values can be used, and will create a semi-transparent edge. For
- * instance, `rdpq_fill_rectangle(9.75, 9.75, 30.25, 30.25)` will create a 22x22 pixel
- * square, with the most external pixel rows and columns having a alpha of 25%.
- * This obviously makes more sense in RGBA32 mode where there is enough alpha
- * bitdepth to appreciate the result. Make sure to configure the blender via
- * #rdpq_mode_blender (part of the mode API) or via the lower-level #rdpq_set_other_modes_raw,
- * to decide the blending formula.
+ * Depending on the render mode, the way to configure the color differs:
+ * 
+ * * In fill mode, the color is normally configured directly via #rdpq_set_mode_fill,
+ *   and can be changed with #rdpq_set_fill_color. Notice that fill mode does not
+ *   support blending.
  * 
  * @code{.c}
  *      // Fill the screen with red color.
@@ -221,6 +217,24 @@ inline void __rdpq_texture_rectangle_flip_raw_fx(rdpq_tile_t tile, uint16_t x0, 
  *      rdpq_fill_rectangle(0, 0, 320, 240);
  * @endcode
  * 
+ * * In standard mode (#rdpq_set_mode_standard), the color must be configured
+ *   using the combiner, so normally by calling #rdpq_mode_combiner with
+ *   #RDPQ_COMBINER_FLAT, and setting the color via #rdpq_set_prim_color.
+ *   To draw a blended rectangle, activate the blender via #rdpq_mode_blender,
+ *   normally with #RDPQ_BLENDER_MULTIPLY.
+ * 
+ * @code{.c}
+ *      // Set the render mode to standard, with blending enabled
+ *      rdpq_set_mode_standard();
+ *      rdpq_mode_combiner(RDPQ_COMBINER_FLAT);
+ *      rdpq_mode_blender(RDPQ_BLENDER_MULTIPLY);
+ * 
+ *      // Set color to black, and alpha to 25% (64 out of 255)
+ *      rdpq_set_prim_color(RGBA32(0, 0, 0, 64));
+ * 
+ *      // Draw the rectangle
+ *      rdpq_fill_rectangle(10, 10, 30, 30);
+ * @endcode
  * 
  * @param[x0]   x0      Top-left X coordinate of the rectangle (integer or float)
  * @param[y0]   y0      Top-left Y coordinate of the rectangle (integer or float)


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - exception: provide mnemonic names for GPRs in reg_block_t (c10bf39b)
 - rdpq_rect: improve rdpq_fill_rectangle docs (40b36fa4)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)