### PR TITLE
[trunk] asset.c: speed up ~50 us asset_fopen by avoid FILE* for internal files | exception: improve dumping of bus errors | debug: avoid initializing isviewer on iQue as it triggers a crash

### DIFF
--- a/src/asset_internal.h
+++ b/src/asset_internal.h
@@ -57,7 +57,7 @@ typedef struct {
     int state_size;     ///< Basic size of the decompression state (without ringbuffer)
 
     /** @brief Initialize the decompression state */
-    void (*decompress_init)(void *state, FILE *fp, int winsize);
+    void (*decompress_init)(void *state, int fd, int winsize);
 
     /** @brief Partially read a decompressed file from a state */
     ssize_t (*decompress_read)(void *state, void *buf, size_t len);
@@ -66,7 +66,7 @@ typedef struct {
     void (*decompress_reset)(void *state);
 
     /** @brief Decompress a full file in one go */
-    void* (*decompress_full)(const char *fn, FILE *fp, size_t cmp_size, size_t len);
+    void* (*decompress_full)(const char *fn, int fd, size_t cmp_size, size_t len);
 
     /** @brief Decompress a full file in-place */
     int (*decompress_full_inplace)(const uint8_t *in, size_t cmp_size, uint8_t *out, size_t len);

--- a/src/compress/aplib_dec_internal.h
+++ b/src/compress/aplib_dec_internal.h
@@ -12,14 +12,14 @@
 
 #define DECOMPRESS_APLIB_STATE_SIZE       348
 
-void decompress_aplib_init(void *state, FILE *fp, int winsize);
+void decompress_aplib_init(void *state, int fd, int winsize);
 ssize_t decompress_aplib_read(void *state, void *buf, size_t len);
 void decompress_aplib_reset(void *state);
 
 #if DECOMPRESS_APLIB_FULL_USE_ASM
 int decompress_aplib_full_inplace(const uint8_t* in, size_t cmp_size, uint8_t *out, size_t size);
 #else
-void* decompress_aplib_full(const char *fn, FILE *fp, size_t cmp_size, size_t size);
+void* decompress_aplib_full(const char *fn, int fd, size_t cmp_size, size_t size);
 #endif
 
 #endif

--- a/src/compress/lz4_dec_internal.h
+++ b/src/compress/lz4_dec_internal.h
@@ -59,7 +59,7 @@ int decompress_lz4_full_inplace(const uint8_t *src, size_t src_size, uint8_t *ds
 
 #define DECOMPRESS_LZ4_STATE_SIZE  176
 
-void decompress_lz4_init(void *state, FILE *fp, int winsize);
+void decompress_lz4_init(void *state, int fd, int winsize);
 ssize_t decompress_lz4_read(void *state, void *buf, size_t len);
 void decompress_lz4_reset(void *state);
 void* decompress_lz4_full(const char *fn, FILE *fp, size_t cmp_size, size_t size);

--- a/src/compress/shrinkler_dec.c
+++ b/src/compress/shrinkler_dec.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #ifdef N64
 #include "debug.h"
 #else
@@ -179,10 +180,10 @@ int shr_unpack(uint8_t *dst, uint8_t *src)
     return dst - dst_start;
 }
 
-void* decompress_shrinkler_full(const char *fn, FILE *fp, size_t cmp_size, size_t size)
+void* decompress_shrinkler_full(const char *fn, int fd, size_t cmp_size, size_t size)
 {
     void *in = malloc(cmp_size);
-    fread(in, 1, cmp_size, fp);
+    read(fd, in, cmp_size);
 
     void *out = malloc(size);
     if (!out) return 0;

--- a/src/compress/shrinkler_dec_internal.h
+++ b/src/compress/shrinkler_dec_internal.h
@@ -13,7 +13,7 @@
 #if DECOMPRESS_SHRINKLER_FULL_USE_ASM
 int decompress_shrinkler_full_inplace(const uint8_t* in, size_t cmp_size, uint8_t *out, size_t size);
 #else
-void* decompress_shrinkler_full(const char *fn, FILE *fp, size_t cmp_size, size_t size);
+void* decompress_shrinkler_full(const char *fn, int fd, size_t cmp_size, size_t size);
 #endif
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -91,6 +91,11 @@ void __debug_backtrace(FILE *out, bool skip_exception);
 
 static bool isviewer_init(void)
 {
+	// No ISViewer on iQue Player (and touching PI addresses outside ROM
+	// trigger a bus error, so better avoid it)
+	if (sys_bbplayer())
+		return false;
+
 	// To check whether an ISViewer is present (probably emulated),
 	// write some data to the buffer address. If we can read it
 	// back, it means that there's some memory there and we can
@@ -487,8 +492,8 @@ static bool sd_initialize_once(void) {
 		if (!sys_bbplayer())
 			ok = cart_init() >= 0;
 		else
-			/* 64drive autodetection makes iQue player crash; disable SD
-			   support altogether for now. */
+			/* Don't call cart_init() on iQue, as touching PI addresses outside ROM
+			   triggers a bus error. */
 			ok = false;
 	}
 	return ok;
@@ -504,8 +509,8 @@ static bool usb_initialize_once(void) {
 		if (!sys_bbplayer())
 			ok = usb_initialize();
 		else
-			/* 64drive autodetection makes iQue player crash; disable USB
-			   support altogether for now. */
+			/* Don't call usb_initialize() on iQue, as touching PI addresses outside ROM
+			   triggers a bus error. */
 			ok = false;
 	}
 	return ok;


### PR DESCRIPTION
# Backport

This will backport the following commits from `trunk` to `trunk`:
 - asset.c: speed up ~50 us asset_fopen by avoid FILE* for internal files (b273d3c2)
 - exception: improve dumping of bus errors (5cdac856)
 - debug: avoid initializing isviewer on iQue as it triggers a crash (b929d466)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)