### PR TITLE
Restore execution mode to kernel in interrupt handler

### DIFF
--- a/src/inthandler.S
+++ b/src/inthandler.S
@@ -80,8 +80,9 @@ inthandler:
 	# we can now turn off EXL. This allows a reentrant exception to save its
 	# own full context for operating. At the same time, it is better to keep
 	# interrupts disabled so that we don't risk triggering recursive interrupts,
-	# so disable IE as well.
-	and k1, ~(SR_IE | SR_EXL)
+	# so disable IE as well. If the triggering code was running in a non-kernel
+	# mode, we also need to re-enter kernel mode.
+	and k1, ~(SR_IE | SR_EXL | SR_KSU)
 	mtc0 k1, C0_SR
 
 	# WARNING: after clearing the EXL bit, it is now possible to trigger

--- a/src/regs.S
+++ b/src/regs.S
@@ -99,6 +99,7 @@
 #define SR_SX		0x00000040	/* Supervisor extended addressing enabled */
 #define SR_UX		0x00000020	/* User extended addressing enabled */
 
+#define SR_KSU      0x00000018  /* CPU execution mode */
 #define SR_ERL      0x00000004  /* Error level */
 #define SR_EXL      0x00000002  /* Exception level */
 #define SR_IE       0x00000001  /* Interrupts enabled */


### PR DESCRIPTION
Consider when an exception is thrown from user mode:
![image](https://github.com/user-attachments/assets/d0924d61-fbc6-4109-9100-0f6c75929544)

The exception handler will save all registers, then mask out EXL and IE, then write the masked value back to $Status. Because the code was running in user mode, this will dump us back to user mode in the middle of the exception handler in KSEG0, which will throw a TLB exception immediately.
![image](https://github.com/user-attachments/assets/4effd3cf-e88f-4f4c-8c5e-22725a6b0fbc)

This PR is a simple change to mask out KSU as well. I validated that it works with my custom exception handler, and even puts me back into my original user mode code with KSU set properly.
