### PR TITLE
Add function for getting the size of a DFS file without calling `dfs_open`

### DIFF
--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -268,7 +268,7 @@ uint32_t dfs_rom_addr(const char *path);
  * @brief Return the size of a file (in ROM data)
  * 
  * Returns the size of a file without opening it. Can be used in conjunction
- * with dfs_rom_addr to get the size of a file without calling dfs_open.
+ * with dfs_rom_addr to perform DMA without without calling dfs_open.
  *
  * @param[in] path
  *            Name of the file

--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -273,12 +273,12 @@ uint32_t dfs_rom_addr(const char *path);
  * @param[in] path
  *            Name of the file
  *
- * @return The size of a file in ROM, or 0 if the file was not found.
+ * @return The size of a file in ROM, or -1 if the file was not found.
  * 
  * @see #dfs_rom_addr
  * 
  */
-uint32_t dfs_rom_size(const char *path);
+int dfs_rom_size(const char *path);
 
 /**
  * @brief Convert DFS error code into an error string

--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -265,6 +265,22 @@ int dfs_size(uint32_t handle);
 uint32_t dfs_rom_addr(const char *path);
 
 /**
+ * @brief Return the size of a file (in ROM data)
+ * 
+ * Returns the size of a file without opening it. Can be used in conjunction
+ * with dfs_rom_addr to get the size of a file without calling dfs_open.
+ *
+ * @param[in] path
+ *            Name of the file
+ *
+ * @return The size of a file in ROM, or 0 if the file was not found.
+ * 
+ * @see #dfs_rom_addr
+ * 
+ */
+uint32_t dfs_rom_size(const char *path);
+
+/**
  * @brief Convert DFS error code into an error string
  */
 const char *dfs_strerror(int error);

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -1042,24 +1042,45 @@ uint32_t dfs_rom_addr(const char *path)
         /* Return the starting location in ROM */
         return get_start_location(&t_node);
     }
-    
 }
 
 int dfs_rom_size(const char *path)
 {
-    //Skip initial slash
-    if(path[0] == '/') {
+    /* Skip initial slash */
+    if(path[0] == '/')
+    {
         path++;
     }
-    dfs_lookup_file_t *entry = lookup_file(path);
-    
-    if(!entry)
-    {
-        //File not found
-        return -1;
-    }
 
-    return (int)(entry->data_len);
+    if(can_use_hash(path)) {
+        dfs_lookup_file_t *entry = lookup_file(path);
+        if(!entry)
+        {
+            /* File not found */
+            return -1;
+        }
+
+        return (int)(entry->data_len);
+    }
+    else
+    {
+        /* Try to find file */
+        directory_entry_t *dirent;
+        int ret = recurse_path(path, WALK_OPEN, &dirent, TYPE_FILE);
+
+        if(ret != DFS_ESUCCESS)
+        {
+            /* File not found, or other error */
+            return -1;
+        }
+
+        /* We now have the pointer to the file entry */
+        directory_entry_t t_node;
+        grab_sector(dirent, &t_node);
+
+        /* Return the starting location in ROM */
+        return (int)(get_size(&t_node));
+    }
 }
 
 int dfs_eof(uint32_t handle)

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -979,10 +979,11 @@ uint32_t dfs_rom_addr(const char *path)
     return base_ptr+entry->data_ofs;
 }
 
-uint32_t dfs_rom_size(const char *path)
+int dfs_rom_size(const char *path)
 {
     //Skip initial slash
-    if(path[0] == '/') {
+    if(path[0] == '/')
+    {
         path++;
     }
     dfs_lookup_file_t *entry = lookup_file(path);
@@ -990,9 +991,10 @@ uint32_t dfs_rom_size(const char *path)
     if(!entry)
     {
         //File not found
-        return 0;
+        return -1;
     }
-    return base_ptr+entry->data_len;
+
+    return (int)(entry->data_len);
 }
 
 int dfs_eof(uint32_t handle)

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -982,8 +982,7 @@ uint32_t dfs_rom_addr(const char *path)
 int dfs_rom_size(const char *path)
 {
     //Skip initial slash
-    if(path[0] == '/')
-    {
+    if(path[0] == '/') {
         path++;
     }
     dfs_lookup_file_t *entry = lookup_file(path);

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -979,6 +979,22 @@ uint32_t dfs_rom_addr(const char *path)
     return base_ptr+entry->data_ofs;
 }
 
+uint32_t dfs_rom_size(const char *path)
+{
+    //Skip initial slash
+    if(path[0] == '/') {
+        path++;
+    }
+    dfs_lookup_file_t *entry = lookup_file(path);
+    
+    if(!entry)
+    {
+        //File not found
+        return 0;
+    }
+    return base_ptr+entry->data_len;
+}
+
 int dfs_eof(uint32_t handle)
 {
     dfs_open_file_t *file = HANDLE_TO_OPENFILE(handle);

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -95,7 +95,7 @@ void test_dfs_rom_size(TestContext *ctx) {
 	DEFER(dfs_close(fh));
 
 	int dfs_file_size = dfs_size(fh);
-	assert(dfs_file_size >= 0, "Unable to get size of counter.dat");
+	ASSERT(dfs_file_size >= 0, "Unable to get size of counter.dat");
 
 	int rom_file_size = dfs_rom_size("counter.dat");
 	ASSERT_EQUAL_SIGNED(dfs_file_size, rom_file_size, "dfs_rom_size returns a different size from dfs_file_size");

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -89,6 +89,18 @@ void test_dfs_rom_addr(TestContext *ctx) {
 	ASSERT_EQUAL_MEM(buf1, buf2, 128, "DMA ROM access is different");
 }
 
+void test_dfs_rom_size(TestContext *ctx) {
+	int fh = dfs_open("counter.dat");
+	ASSERT(fh >= 0, "counter.dat not found");
+	DEFER(dfs_close(fh));
+
+	int dfs_file_size = dfs_size(fh);
+	assert(dfs_file_size >= 0, "Unable to get size of counter.dat");
+
+	int rom_file_size = dfs_rom_size("counter.dat");
+	ASSERT_EQUAL_SIGNED(dfs_file_size, rom_file_size, "dfs_rom_size returns a different size from dfs_file_size");
+}
+
 void test_dfs_ioctl(TestContext *ctx) {
     FILE *file = fopen("rom:/counter.dat", "rb");
     ASSERT(file, "counter.dat not found");

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -258,6 +258,7 @@ static const struct Testsuite
 	TEST_FUNC(test_kernel_thread_local,        5, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dfs_read,                 948, TEST_FLAGS_IO),
 	TEST_FUNC(test_dfs_rom_addr,              25, TEST_FLAGS_IO),
+	TEST_FUNC(test_dfs_rom_size,              25, TEST_FLAGS_IO),
 	TEST_FUNC(test_dfs_ioctl,                  0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_eepromfs,                   0, TEST_FLAGS_IO),
 	TEST_FUNC(test_cache_invalidate,        1763, TEST_FLAGS_NONE),


### PR DESCRIPTION
## About
This change implements `dfs_rom_size`, which returns the size of a file without calling `dfs_open`.

## Rationale
This can be used in conjunction with `dfs_rom_addr` and `dma_read` to get ROM data without needing to open a file handle. This can be useful in scenarios where a programmer might want to avoid invoking `malloc` (eg: after a level has been loaded).