### PR TITLE
Remove libdragon.h from internal files

### DIFF
--- a/include/xm64.h
+++ b/include/xm64.h
@@ -36,6 +36,10 @@
 #ifndef __LIBDRAGON_AUDIO_XM64_H
 #define __LIBDRAGON_AUDIO_XM64_H
 
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/audio/opus/celt.c
+++ b/src/audio/opus/celt.c
@@ -27,10 +27,6 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifdef N64
-#include <libdragon.h>
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/audio/opus/celt_decoder.c
+++ b/src/audio/opus/celt_decoder.c
@@ -28,7 +28,8 @@
 */
 
 #ifdef N64
-#include <libdragon.h>
+#include <n64sys.h>
+#include <rspq.h>
 #else
 #define debugf(...)
 #endif

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -4,12 +4,19 @@
  * @ingroup mixer
  */
 
-#include <libdragon.h>
+#include "xm64.h"
+#include "mixer.h"
+#include "audio.h"
+#include <assert.h>
+#include "debug.h"
+#include "interrupt.h"
+#include "dragonfs.h"
 #include "wav64internal.h"
 #include "asset_internal.h"
 #include "libxm/xm.h"
 #include "libxm/xm_internal.h"
 #include <stdbool.h>
+#include <stdio.h>
 
 static void wave_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	xm_sample_t *samp = (xm_sample_t*)ctx;

--- a/src/console.c
+++ b/src/console.c
@@ -6,13 +6,16 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <malloc.h>
 #include <string.h>
 #include <stdarg.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include "system.h"
-#include "libdragon.h"
+#include "cop0.h"
+#include "console.h"
+#include "graphics.h"
 
 /* Prototypes */
 static void __console_render(void);

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -8,7 +8,12 @@
 #include <stdint.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include "libdragon.h"
+#include <malloc.h>
+#include <stdalign.h>
+#include "dragonfs.h"
+#include "n64sys.h"
+#include "dma.h"
+#include "debug.h"
 #include "system.h"
 #include "dfsinternal.h"
 #include "rompak_internal.h"

--- a/src/eepromfs.c
+++ b/src/eepromfs.c
@@ -6,9 +6,10 @@
 #include <string.h>
 #include <stdint.h>
 #include <malloc.h>
-#include "libdragon.h"
 #include "system.h"
 #include "utils.h"
+#include "eeprom.h"
+#include "eepromfs.h"
 
 /**
  * @brief EEPROM Filesystem file descriptor.

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -4,9 +4,12 @@
  * @ingroup interrupt
  */
 #include <malloc.h>
-#include "libdragon.h"
+#include "mi.h"
 #include "regsinternal.h"
 #include "kernel/kernel_internal.h"
+#include "n64sys.h"
+#include "interrupt.h"
+#include "debug.h"
 
 /** @brief Bit to set to clear the PI interrupt */
 #define PI_CLEAR_INTERRUPT 0x02

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,8 +1,10 @@
-#include <libdragon.h>
 #include "kernel.h"
 #include "kernel_internal.h"
 #include "backtrace_internal.h"
 #include "timer.h"
+#include "debug.h"
+#include "interrupt.h"
+#include "backtrace.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <memory.h>

--- a/src/mempak.c
+++ b/src/mempak.c
@@ -4,9 +4,10 @@
  * @ingroup controllerpak
  */
 #include <string.h>
-#include "libdragon.h"
 #include "regsinternal.h"
 #include <unistd.h>
+#include "joybus_accessory.h"
+#include "mempak.h"
 
 /**
  * @name Inode values

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -6,8 +6,12 @@
 
 #include <string.h>
 #include <time.h>
-#include "libdragon.h"
+#include <stdbool.h>
 #include "system.h"
+#include "n64sys.h"
+#include "joybus.h"
+#include "timer.h"
+#include "rtc.h"
 
 /**
  * @brief Joybus real-time clock identifier.

--- a/src/usb.c
+++ b/src/usb.c
@@ -10,7 +10,9 @@ https://github.com/buu342/N64-UNFLoader
 #ifndef LIBDRAGON
     #include <ultra64.h>
 #else
-    #include <libdragon.h>
+    #include <stdint.h>
+    #include <n64sys.h>
+    #include <dma.h>
 #endif
 #include <string.h>
 


### PR DESCRIPTION
Specific header files will now be included instead. This helps with the development of libdragon because it will reduce the number of recompiled source files whenever header files are edited.