### PR TITLE
Add "meta" section to ucodes

### DIFF
--- a/include/rsp.h
+++ b/include/rsp.h
@@ -281,6 +281,8 @@ typedef struct {
     void    *code_end;     ///< Pointer past the end of the code segment
     uint8_t *data;         ///< Pointer to the data segment
     void    *data_end;     ///< Pointer past the end of the data segment
+    uint8_t *meta;         ///< Pointer to the meta segment
+    void    *meta_end;     ///< Pointer past the end of the meta segment
 
     const char *name;      ///< Name of the ucode
     uint32_t start_pc;     ///< Initial RSP PC
@@ -344,13 +346,17 @@ typedef struct {
 #define DEFINE_RSP_UCODE(ucode_name, ...) \
     extern uint8_t ucode_name ## _text_start[]; \
     extern uint8_t ucode_name ## _data_start[]; \
+    extern uint8_t ucode_name ## _meta_start[]; \
     extern uint8_t ucode_name ## _text_end[0]; \
     extern uint8_t ucode_name ## _data_end[0]; \
+    extern uint8_t ucode_name ## _meta_end[0]; \
     rsp_ucode_t ucode_name = (rsp_ucode_t){ \
         .code = ucode_name ## _text_start, \
         .code_end = ucode_name ## _text_end, \
         .data = ucode_name ## _data_start, \
         .data_end = ucode_name ## _data_end, \
+        .meta = ucode_name ## _meta_start, \
+        .meta_end = ucode_name ## _meta_end, \
         .name = #ucode_name, .start_pc = 0, \
         .crash_handler = 0, .assert_handler = 0, \
         __VA_ARGS__ \

--- a/rsp.ld
+++ b/rsp.ld
@@ -63,5 +63,10 @@ SECTIONS
         } 
     } > ram_data AT > rom_dmem
 
+    .meta : {
+        KEEP(*(.meta))
+        *(.meta.*)
+    }
+
     /DISCARD/ : { *(.MIPS.abiflags) }
 }


### PR DESCRIPTION
By putting output into the .meta section, ucodes can now store arbitrary metadata about themselves in a blob that is separate to text and data.

If a ucode does not define a .meta section, the meta blob will be a single zero byte by default.