### PR TITLE
[trunk] xm64: fix memory leak of instrument names

### DIFF
--- a/include/xm64.h
+++ b/include/xm64.h
@@ -60,7 +60,7 @@ typedef struct waveform_s waveform_t;
 typedef struct xm64player_s {
 	xm_context_t *ctx;        ///< libxm context
 	waveform_t *waves;        ///< array of all waveforms (one per XM "sample")
-	int nwaves;               ///< number of wavers (XM "samples")
+	int nwaves;               ///< number of waves (XM "samples")
 	FILE *fh;                 ///< open handle of XM64 file
 	int first_ch;             ///< first channel used in the mixer
 	bool playing;             ///< playing flag

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -131,12 +131,11 @@ void xm64player_open(xm64player_t *player, const char *fn) {
 
 	// Count samples
 	int ninst = xm_get_number_of_instruments(player->ctx);
-	int nwaves = 0;
 	for (int i=0;i<ninst;i++)
-		nwaves += xm_get_number_of_samples(player->ctx, i+1);
+		player->nwaves += xm_get_number_of_samples(player->ctx, i+1);
 
 	// Allocate waveforms (one per XM64's "samples" aka waveforms)
-	player->waves = malloc(sizeof(waveform_t) * nwaves);
+	player->waves = malloc(sizeof(waveform_t) * player->nwaves);
 	assert(player->waves);
 	int nw = 0;
 	for (int i=0;i<ninst;i++) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - xm64: fix memory leak of instrument names (d2495605)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)