### PR TITLE
[trunk] rdpq: fix rdpq_tex_upload_tlut to support any index range

### DIFF
--- a/src/rdpq/rdpq_tex.c
+++ b/src/rdpq/rdpq_tex.c
@@ -671,9 +671,9 @@ void rdpq_tex_blit(const surface_t *surf, float x0, float y0, const rdpq_blitpar
 
 void rdpq_tex_upload_tlut(uint16_t *tlut, int color_idx, int num_colors)
 {
-    rdpq_set_texture_image_raw(0, PhysicalAddr(tlut), FMT_RGBA16, num_colors, 1);
-    rdpq_set_tile(RDPQ_TILE_INTERNAL, FMT_I4, TMEM_PALETTE_ADDR + color_idx*2*4, num_colors, NULL);
-    rdpq_load_tlut_raw(RDPQ_TILE_INTERNAL, 0, num_colors);
+    rdpq_set_texture_image_raw(0, PhysicalAddr(tlut), FMT_RGBA16, 256, 1);
+    rdpq_set_tile(RDPQ_TILE_INTERNAL, FMT_I4, TMEM_PALETTE_ADDR + color_idx*4*2, 256, NULL);
+    rdpq_load_tlut_raw(RDPQ_TILE_INTERNAL, color_idx, num_colors);
 }
 
 void rdpq_tex_multi_begin(void)

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -318,6 +318,7 @@ static const struct Testsuite
 	TEST_FUNC(test_rdpq_tex_upload_multi,      0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_tex_blit_normal,       0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_tex_multi_i4,          0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_rdpq_tex_upload_tlut,       0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_sprite_upload,         0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_sprite_lod,            0, TEST_FLAGS_NO_BENCHMARK),
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - rdpq: fix rdpq_tex_upload_tlut to support any index range (d60b6df7)
 
Fixes #621 

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)