### PR TITLE
[trunk] graphics: improve color_from_packed16 to do correctly 8bpp upscaling | rdpq_tex: fix buggy test and make rdpq_tex_upload_tlut work correctly

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -86,7 +86,10 @@ inline uint32_t color_to_packed32(color_t c) {
 }
 /** @brief Create a #color_t from the 16-bit packed format used by a #FMT_RGBA16 surface (RGBA 5551) */
 inline color_t color_from_packed16(uint16_t c) {
-    return (color_t){ .r=(uint8_t)(((c>>11)&0x1F)<<3), .g=(uint8_t)(((c>>6)&0x1F)<<3), .b=(uint8_t)(((c>>1)&0x1F)<<3), .a=(uint8_t)((c&0x1) ? 0xFF : 0) };
+    int r = (c >> 11) & 0x1F;
+    int g = (c >> 6) & 0x1F;
+    int b = (c >> 1) & 0x1F;
+    return (color_t){ .r=(uint8_t)((r << 3) | (r >> 2)), .g=(uint8_t)((g << 3) | (g >> 2)), .b=(uint8_t)((b << 3) | (b >> 2)), .a=(uint8_t)((c&0x1) ? 0xFF : 0) };
 }
 
 /** @brief Create a #color_t from the 32-bit packed format used by a #FMT_RGBA32 surface (RGBA 8888) */

--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -584,7 +584,7 @@ inline void rdpq_load_tile_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16
  * 
  * @see #rdpq_tex_upload_tlut
  */
-inline void rdpq_load_tlut_raw(rdpq_tile_t tile, uint8_t color_idx, uint8_t num_colors)
+inline void rdpq_load_tlut_raw(rdpq_tile_t tile, int color_idx, int num_colors)
 {
     extern void __rdpq_write8_syncchangeuse(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t);
     __rdpq_write8_syncchangeuse(RDPQ_CMD_LOAD_TLUT, 

--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -190,8 +190,8 @@ int rdpq_tex_upload_sub(rdpq_tile_t tile, const surface_t *tex, const rdpq_texpa
  * for 256 colors in total, which allows for one palette for a CI8 texture, or up
  * to 16 palettes for CI4 textures.
  * 
- * @param tlut          Pointer to the color entries to load 
- * @param color_idx     First color entry in TMEM that will be written to (0-255)
+ * @param tlut          Pointer to the first color entry to load (must be 8-byte aligned) 
+ * @param color_idx     Index of the first color entry in TMEM (0-255)
  * @param num_colors    Number of color entries to load (1-256)
  */
 void rdpq_tex_upload_tlut(uint16_t *tlut, int color_idx, int num_colors);

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -1133,7 +1133,7 @@ extern inline void rdpq_set_prim_lod_frac(uint8_t value);
 extern inline void rdpq_set_prim_register_raw(color_t color, uint8_t minlod, uint8_t primlod);
 extern inline void rdpq_set_env_color(color_t color);
 extern inline void rdpq_set_prim_depth_raw(uint16_t primitive_z, int16_t primitive_delta_z);
-extern inline void rdpq_load_tlut_raw(rdpq_tile_t tile, uint8_t lowidx, uint8_t highidx);
+extern inline void rdpq_load_tlut_raw(rdpq_tile_t tile, int first_color, int num_colors);
 extern inline void rdpq_set_tile_size_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t s1, uint16_t t1);
 extern inline void rdpq_load_block(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t num_texels, uint16_t tmem_pitch);
 extern inline void rdpq_load_block_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t num_texels, uint16_t dxt);

--- a/src/rdpq/rdpq_tex.c
+++ b/src/rdpq/rdpq_tex.c
@@ -671,9 +671,13 @@ void rdpq_tex_blit(const surface_t *surf, float x0, float y0, const rdpq_blitpar
 
 void rdpq_tex_upload_tlut(uint16_t *tlut, int color_idx, int num_colors)
 {
+    // TODO: this is a conservative limit. It should be possible to workaround
+    // this limit by playing with the tlut pointer passed to SET_TEX_IMAGE and
+    // then adjust the first_color offset in rdpq_load_tlut_raw.
+    assertf((PhysicalAddr(tlut) & 7) == 0, "TLUT pointer must be 8-byte aligned");
     rdpq_set_texture_image_raw(0, PhysicalAddr(tlut), FMT_RGBA16, 256, 1);
     rdpq_set_tile(RDPQ_TILE_INTERNAL, FMT_I4, TMEM_PALETTE_ADDR + color_idx*4*2, 256, NULL);
-    rdpq_load_tlut_raw(RDPQ_TILE_INTERNAL, color_idx, num_colors);
+    rdpq_load_tlut_raw(RDPQ_TILE_INTERNAL, 0, num_colors);
 }
 
 void rdpq_tex_multi_begin(void)

--- a/tests/test_rdpq_tex.c
+++ b/tests/test_rdpq_tex.c
@@ -437,6 +437,13 @@ void test_rdpq_tex_upload_tlut(TestContext *ctx)
     rspq_wait();
     ASSERT_SURFACE(&fb, { return color_from_packed32(0xE0); });
 
+    color_t expected_fb[256];
+    for (int i=0; i<256; i++) {
+        uint16_t c16 = color_to_packed16(palette_debug_color(i));
+        expected_fb[i] = color_from_packed16(c16);
+        expected_fb[i].a = 0xE0; // full coverage value
+    }
+
     for (int first_color=8; first_color<16; first_color++) {
         for (int i=1; i<9; i++) {
             surface_clear(&fb, 0xFF);
@@ -444,7 +451,7 @@ void test_rdpq_tex_upload_tlut(TestContext *ctx)
 
             memset(tlut, 0, 256*2);
             for (int j=0;j<i;j++)
-                tlut[first_color+j] = color_to_packed16(palette_debug_color(first_color+j));
+                tlut[j] = color_to_packed16(palette_debug_color(first_color+j));
             
             rdpq_tex_upload_tlut(tlut, first_color, i);
             rdpq_tex_blit(&tex, 0, 0, NULL);
@@ -453,7 +460,7 @@ void test_rdpq_tex_upload_tlut(TestContext *ctx)
             ASSERT_SURFACE(&fb, { 
                 int pos = y*16+x;
                 if (pos >= first_color && pos < first_color+i)
-                    return surface_debug_expected_color(&fb, x, y);
+                    return expected_fb[pos];
                 else
                     return color_from_packed32(0xE0); 
             });


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - graphics: improve color_from_packed16 to do correctly 8bpp upscaling (11c90c66)
 - rdpq_tex: fix buggy test and make rdpq_tex_upload_tlut work correctly (91937145)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)