### PR TITLE
Change prefix handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: libdragon
 V = 1  # force verbose (at least until we have converted all sub-Makefiles)
 SOURCE_DIR = src
 BUILD_DIR = build
-FILE_PREFIX=libdragon
 include n64.mk
 INSTALLDIR = $(N64_INST)
 
@@ -11,6 +10,11 @@ INSTALLDIR = $(N64_INST)
 # (e.g. /opt/libdragon/mips64-elf/include), set in n64.mk
 # When building libdragon, override it to use the source include files instead (./include)
 N64_INCLUDEDIR = $(CURDIR)/include
+
+# N64_BACKTRACE_FILE_PREFIX is exposed from n64.mk, so we can use it to set the
+# prefix for libdragon. It is still possible to override this when running make
+# for libdragon specifically via a make override.
+N64_BACKTRACE_FILE_PREFIX=libdragon
 
 LIBDRAGON_CFLAGS = -I$(CURDIR)/src
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: libdragon
 V = 1  # force verbose (at least until we have converted all sub-Makefiles)
 SOURCE_DIR = src
 BUILD_DIR = build
+FILE_PREFIX=libdragon
 include n64.mk
 INSTALLDIR = $(N64_INST)
 
@@ -11,7 +12,7 @@ INSTALLDIR = $(N64_INST)
 # When building libdragon, override it to use the source include files instead (./include)
 N64_INCLUDEDIR = $(CURDIR)/include
 
-LIBDRAGON_CFLAGS = -I$(CURDIR)/src -ffile-prefix-map=$(CURDIR)=libdragon
+LIBDRAGON_CFLAGS = -I$(CURDIR)/src
 
 # Activate N64 toolchain for libdragon build
 libdragon: CC=$(N64_CC)

--- a/n64.mk
+++ b/n64.mk
@@ -1,6 +1,5 @@
 BUILD_DIR ?= .
 SOURCE_DIR ?= .
-FILE_PREFIX ?=
 DSO_COMPRESS_LEVEL ?= 1
 
 N64_ROM_TITLE = "Made with libdragon" # Override this with the name of your game or project
@@ -13,6 +12,14 @@ N64_ROM_CONTROLLER1 = # Sets the type of Controller 1 in the Advanced Homebrew H
 N64_ROM_CONTROLLER2 = # Sets the type of Controller 2 in the Advanced Homebrew Header. This could influence emulator behaviour such as Ares'
 N64_ROM_CONTROLLER3 = # Sets the type of Controller 3 in the Advanced Homebrew Header. This could influence emulator behaviour such as Ares'
 N64_ROM_CONTROLLER4 = # Sets the type of Controller 4 in the Advanced Homebrew Header. This could influence emulator behaviour such as Ares'
+
+# Override this to use a different file prefix for the debug symbols. This is
+# useful when building multiple projects in the same directory and you can set
+# this to the project name to differentiate between similar paths. Example:
+# .PHONY: tiny3d
+# tiny3d:
+# 	$(MAKE) -C $(T3D_INST) N64_BACKTRACE_FILE_PREFIX=tiny3d
+N64_BACKTRACE_FILE_PREFIX=
 
 # Override this to use a toolchain installed separately from libdragon
 N64_GCCPREFIX ?= $(N64_INST)
@@ -50,7 +57,7 @@ N64_DSOMSYM = $(N64_BINDIR)/n64dso-msym
 
 N64_C_AND_CXX_FLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR) -include ktls.h
 N64_C_AND_CXX_FLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
-N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=$(FILE_PREFIX)
+N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=$(N64_BACKTRACE_FILE_PREFIX)
 N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
 N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_C_AND_CXX_FLAGS += -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-parameter -Wno-error=unused-but-set-parameter -Wno-error=unused-label -Wno-error=unused-local-typedefs -Wno-error=unused-const-variable

--- a/n64.mk
+++ b/n64.mk
@@ -1,5 +1,6 @@
 BUILD_DIR ?= .
 SOURCE_DIR ?= .
+FILE_PREFIX ?=
 DSO_COMPRESS_LEVEL ?= 1
 
 N64_ROM_TITLE = "Made with libdragon" # Override this with the name of your game or project
@@ -49,7 +50,7 @@ N64_DSOMSYM = $(N64_BINDIR)/n64dso-msym
 
 N64_C_AND_CXX_FLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR) -include ktls.h
 N64_C_AND_CXX_FLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
-N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=
+N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=$(FILE_PREFIX)
 N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
 N64_C_AND_CXX_FLAGS += -DN64 -O2 -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 N64_C_AND_CXX_FLAGS += -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-parameter -Wno-error=unused-but-set-parameter -Wno-error=unused-label -Wno-error=unused-local-typedefs -Wno-error=unused-const-variable


### PR DESCRIPTION
The build system is stripping the file prefix to clean it and make it readable. OTOH that was preventing changing it, which is useful when you have multi-sub-projects built by n64.mk, such as tiny3d. The debug symbols then are all relative paths like `/src/*` and it is not possible to properly map them to different sub projects for debugging. This change allows overriding the prefix so that it is possible to do this:

```Makefile
.PHONY: tiny3d
tiny3d:
	$(MAKE) -C $(T3D_INST) FILE_PREFIX=tiny3d
```

Then, all files become prefixed by `tiny3d/` allowing mapping to the workspace source files.