### PR TITLE
Allow pifiles to be writable in the DOM2 area

### DIFF
--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -95,7 +95,9 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 		if ((buf->wpos << bps) & 1) {
 			buf->wpos--; len++;
 		}
-		buf->wv_read(buf->wv_ctx, buf, buf->wpos, ROUNDUP8_BPS(len, bps), seeking);
+		if (buf->wv_read) {
+			buf->wv_read(buf->wv_ctx, buf, buf->wpos, ROUNDUP8_BPS(len, bps), seeking);
+		}
 		buf->wnext = buf->wpos + buf->widx;
 	} else {
 		// Record first sample that we still need to keep in the sample
@@ -116,12 +118,14 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 		if (reuse < *wlen) {
 			tracef("samplebuffer_get: read missing: reuse=%x wpos=%x wlen=%x\n", reuse, wpos, *wlen);
 			assertf(wpos+reuse == buf->wnext, "wpos:%x reuse:%x buf->wnext:%x", wpos, reuse, buf->wnext);
-			buf->wv_read(buf->wv_ctx, buf, wpos+reuse, ROUNDUP8_BPS(*wlen-reuse, bps), false);
+			if (buf->wv_read) {
+				buf->wv_read(buf->wv_ctx, buf, wpos+reuse, ROUNDUP8_BPS(*wlen-reuse, bps), false);
+			}
 			buf->wnext = buf->wpos + buf->widx;
 		}
 	}
 
-	assertf(wpos >= buf->wpos && wpos < buf->wpos+buf->widx, 
+	assertf((wpos >= buf->wpos && wpos < buf->wpos+buf->widx) || (buf->wv_read == NULL), 
 		"samplebuffer_get: logic error\n"
 		"wpos:%x buf->wpos:%x buf->widx:%x", wpos, buf->wpos, buf->widx);
 


### PR DESCRIPTION
This change adds code to be able to open DOM2 space as a regular file handle.