### PR TITLE
README: Update API reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ to check the relevant header files yourself to check what is changed.
 
 ## Resources
 
- * [API reference](https://dragonminded.github.io/libdragon/ref/modules.html)
+ * [API reference](https://dragonminded.github.io/libdragon/ref/topics.html)
  * [Examples](https://github.com/DragonMinded/libdragon/tree/trunk/examples)
  * [Wiki](https://github.com/DragonMinded/libdragon/wiki) (contains tutorials
    and troubleshooting guides)


### PR DESCRIPTION
Doxygen 1.10 renamed the "Modules" page to "Topics", which requires an update of the API reference link.