### PR TITLE
[trunk] xm64: fix reset of mixer limits on all mixer channels

### DIFF
--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -252,7 +252,7 @@ void xm64player_close(xm64player_t *player) {
 	}
 	for (int i=0;i<player->ctx->module.num_channels;i++) {
 		mixer_ch_stop(player->first_ch+i);
-		mixer_ch_set_limits(player->first_ch, 0, 0, 0);
+		mixer_ch_set_limits(player->first_ch+i, 0, 0, 0);
 	}
 	enable_interrupts();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - xm64: fix reset of mixer limits on all mixer channels (ba28fbc4)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)