### PR TITLE
docs: Set group for RDPQ modules to rdpq

### DIFF
--- a/include/rdpq_attach.h
+++ b/include/rdpq_attach.h
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_attach.h
  * @brief RDP Command queue: surface attachment API
- * @ingroup rdp
+ * @ingroup rdpq
  * 
  * This module implements a higher level API for attaching surfaces to the RDP.
  * 

--- a/include/rdpq_debug.h
+++ b/include/rdpq_debug.h
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_debug.h
  * @brief RDP Command queue: debugging helpers
- * @ingroup rdp
+ * @ingroup rdpq
  */
 
 #ifndef LIBDRAGON_RDPQ_DEBUG_H

--- a/include/rdpq_macros.h
+++ b/include/rdpq_macros.h
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_macros.h
  * @brief RDP command macros
- * @ingroup rdp
+ * @ingroup rdpq
  * 
  * This file contains macros that can be used to assembly some complex RDP commands:
  * the blender and the color combiner configurations.

--- a/include/rdpq_mode.h
+++ b/include/rdpq_mode.h
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_mode.h
  * @brief RDP Command queue: mode setting
- * @ingroup rdp
+ * @ingroup rdpq
  * 
  * The mode API is a high level API to simplify mode setting with RDP. Configuring
  * render modes is possibly the most complex task with RDP programming, as the RDP

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq.c
  * @brief RDP Command queue
- * @ingroup rdp
+ * @ingroup rdpq
  *
  * # RDP Queue: implementation details
  * 

--- a/src/rdpq/rdpq_attach.c
+++ b/src/rdpq/rdpq_attach.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_attach.c
  * @brief RDP Command queue: surface attachment API
- * @ingroup rdp
+ * @ingroup rdpq
  */
 
 #include "rdpq.h"

--- a/src/rdpq/rdpq_debug.c
+++ b/src/rdpq/rdpq_debug.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_debug.c
  * @brief RDP Command queue: debugging helpers
- * @ingroup rdp
+ * @ingroup rdpq
  */
 #include "rdpq_debug.h"
 #include "rdpq_debug_internal.h"

--- a/src/rdpq/rdpq_internal.h
+++ b/src/rdpq/rdpq_internal.h
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_internal.h
  * @brief RDP Command queue: internal functions
- * @ingroup rdp
+ * @ingroup rdpq
  */
 
 #ifndef __LIBDRAGON_RDPQ_INTERNAL_H

--- a/src/rdpq/rdpq_mode.c
+++ b/src/rdpq/rdpq_mode.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_mode.c
  * @brief RDP Command queue: mode setting
- * @ingroup rdp
+ * @ingroup rdpq
  */
 
 #include "rdpq_mode.h"

--- a/src/rdpq/rdpq_rect.c
+++ b/src/rdpq/rdpq_rect.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq.h
  * @brief RDP Command queue
- * @ingroup rdp
+ * @ingroup rdpq
  * 
  */
 

--- a/src/rdpq/rdpq_sprite.c
+++ b/src/rdpq/rdpq_sprite.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_sprite.c
  * @brief RDP Command queue: high-level sprite loading and blitting
- * @ingroup rdp
+ * @ingroup rdpq
  */
 
 #include "rspq.h"

--- a/src/rdpq/rdpq_tex.c
+++ b/src/rdpq/rdpq_tex.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_tex.c
  * @brief RDP Command queue: texture loading
- * @ingroup rdp
+ * @ingroup rdpq
  */
 
 ///@cond

--- a/src/rdpq/rdpq_tri.c
+++ b/src/rdpq/rdpq_tri.c
@@ -1,7 +1,7 @@
 /**
  * @file rdpq_tri.c
  * @brief RDP Command queue: triangle drawing routine
- * @ingroup rdp
+ * @ingroup rdpq
  * 
  * This file contains the implementation of a single function: #rdpq_triangle.
  * 


### PR DESCRIPTION
Sets group of RDPQ modules to `rdpq` so they don't show up in the generated API reference under the old RDP module.