### PR TITLE
videoplayer example bug - Update videoplayer.c

### DIFF
--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -77,7 +77,7 @@ int main(void)
 
 	// Open the audio track and start playing it in channel 0.
 	wav64_t audio_track;
-	wav64_open(&audio_track, "movie.wav64");
+	wav64_open(&audio_track, "rom:/movie.wav64");
 	mixer_ch_play(0, &audio_track.wave);
 
 	int nframes = 0;


### PR DESCRIPTION
Add `rom:/` prefix to properly locate the ROM wav64 asset.

Currently, running the ROM compiled from the example's Makefile will yield a CPU Assertion:
```
ASSERTION FAILED: fd >= 0
file "src/asset.c", line 83, function: must_open
File not found: movie.wav64
Did you forget the filesystem prefix? (e.g. "rom:/")
```

![videoplayer 2024-11-06 14-06-43](https://github.com/user-attachments/assets/2753771d-7dd0-409d-acf8-4bb5935de490)

This fixes the issue for me. Hopefully this is correct! 🤞