### PR TITLE
display: Add basic VI borders to `resolution_t`

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -57,17 +57,30 @@ typedef enum {
 /**
  * @brief Video Interface borders structure
  *
- * This structure defines how thick (in dots) should the borders around a framebuffer be.
- * The dots always assume VI scale (that is 640x480 NTSC or 640x576 PAL)
- * and the framebuffer will be scaled to fit under them.
- * For example, when displaying on CRT TVs, one can add borders around a framebuffer so
- * that the whole image can be seen on the screen. 
+ * This structure defines how thick (in dots) should the borders around
+ * a framebuffer be.
  * 
- * If no borders are applied, the output will use the entire NTSC/PAL region space
- * for showing a framebuffer, useful for emulators, upscalers, and LCD TVs.
+ * The dots refer to the VI virtual display output (640x480, on both NTSC, PAL,
+ * and M-PAL), and thus reduce the actual display output, and even potentially
+ * modify the aspect ratio. The framebuffer will be scaled to fit under them.
+ * 
+ * For example, when displaying on CRT TVs, one can add borders around a
+ * framebuffer so that the whole image can be seen on the screen. 
+ * 
+ * If no borders are applied, the output will use the entire virtual dsplay
+ * output (640x480) for showing a framebuffer. This is useful for emulators,
+ * upscalers, and LCD TVs.
+ * 
+ * Notice that borders can also be *negative*: this obtains the effect of
+ * actually enlarging the output, growing from 640x480. Doing so will very
+ * likely create problems with most TV grabbers and upscalers, but it might
+ * work correctly on most CRTs (though the added pixels will surely be
+ * part of the overscan so not really visible). Horizontally, the maximum display
+ * output will probably be ~700-ish on CRTs, after which the sync will be lost.
+ * Vertically, any negative number will likely create immediate syncing problems,
  */
-typedef struct vi_borders_s{
-    uint16_t left, right, up, down;
+typedef struct vi_borders_s {
+    int16_t left, right, up, down;
 } vi_borders_t;
 
 /**
@@ -75,11 +88,55 @@ typedef struct vi_borders_s{
  *
  * You can either use one of the pre-defined constants
  * (such as #RESOLUTION_320x240) or define a custom resolution.
+ * 
+ * By default, the VI will be configured to resample the specified framebuffer
+ * picture into a virtual 640x480 display output with 4:3 aspect ratio (on both
+ * PAL, NTSC and MPAL). In reality, TVs didn't have that vertical resolution
+ * so the actual output depends on whether you request interlaced display or not:
+ * 
+ *  * In case of non interlaced display, the actual resolution is 640x240, but
+ *    since dots will be configured to be twice as big vertically, the aspect
+ *    ratio will be 4:3 as-if the image was 640x480 (with duplicated scanlines)
+ *  * In case of interlaced display, you do get to display 480 scanlines, by
+ *    alternating two slightly-shifted 640x240 pictures.
+ * 
+ * As an example, if you specify a resolution like 512x320, with interlacing
+ * turned off, what happens is that the image gets scaled into 640x240, so
+ * horizontally some pixels will be duplicated to enlarge the resolution to 640,
+ * but vertically some scanlines will be dropped. The output display aspect ratio
+ * will still be 4:3, which is not the source aspect ratio of the framebuffer
+ * (512 / 320 = 1.6666 = 16:10), so the image will appear squished, unless
+ * obviously this was accounted for while drawing to the framebuffer.
+ * 
+ * While resampling the framebuffer into the display output, the VI can use either
+ * bilinear filtering or simple nearest sampling (duplicating or dropping pixels).
+ * See #filter_options_t for more information on configuring
+ * the VI image filters.
+ * 
+ * The 640x480 virtual display output can be fully viewed on emulators and on
+ * modern screens (via grabbers, converters, etc.). When displaying on old
+ * CRTs though, part of the display will be hidden because of the overscan.
+ * To account for that, it is possible to reduce the 640x480 display output
+ * by adding black borders. For instance, if you specify 12 dots of borders
+ * on all the four edges, you will get a 616x456 display output, plus
+ * the requested 12 dots of borders on all sides; the actual display output
+ * will thus be smaller, and possibly get fully out of overscan. The value
+ * #VI_BORDERS_CRT is a good default you can use for overscan compensation on
+ * most CRT TVs.
+ * 
+ * Notice that adding borders also affect the aspect ratio of the display output;
+ * for instance, in the above example, the 616x456 display output is not
+ * exactly 4:3 anymore, but more like 4.05:3. By carefully calculating borders,
+ * thus, it is possible to obtain specific display outputs with custom aspect
+ * ratios (eg: 16:9).
+ * 
+ * To help calculating the borders by taking both potential goals into account
+ * (overscan compensation and aspect ratio changes), you can use #vi_calc_borders.
  */
 typedef struct {
-    /** @brief Screen width (must be between 2 and 800) */
+    /** @brief Framebuffer width (must be between 2 and 800) */
     int32_t width;
-    /** @brief Screen height (must be between 1 and 720) */
+    /** @brief Framebuffer height (must be between 1 and 720) */
     int32_t height;
     /** @brief Interlace mode */
     interlace_mode_t interlaced;
@@ -95,47 +152,112 @@ typedef struct {
      */
     bool pal60;
     /**
-     * @brief 
+     * @brief Borders to add to the picture
      * 
-     * This setting will enable additional borders around your display to cover
-     * the overscan margin of some CRT TVs to help ensure your entire frame is
-     * visible on the screen.
+     * This setting will reduce the display output by adidng additional borders
+     * around your display; this can be useful to cover the overscan margin of
+     * some CRT TVs to help ensure your entire frame is visible on the screen,
+     * and optionally to modify the display aspect ratio.
      * 
-     * Screen resolution is not affected by it. Due to the way VI scaling works,
+     * Framebuffer resolution is not affected by this. Due to the way VI scaling works,
      * it is advisable to not use the #FILTERS_DISABLED option for your display
      * if borders are enabled because no bilinear resampling means VI is likely
      * to output unevenly thick columns of pixels or skip some scanlines.
+     * 
+     * You can use #VI_BORDERS_NONE (default) to disable borders, or
+     * #VI_BORDERS_CRT to enable a safe overscan compensation for most TVs.
+     * 
+     * To do more advanced tweaking, including generating a display output
+     * with a specific aspect ratio, use #vi_calc_borders.
      */
-    vi_borders_t vi_borders;
+    vi_borders_t borders;
 } resolution_t;
 
 ///@cond
 #define const static const /* fool doxygen to document these static members */
 ///@endcond
+
 /**
- * @brief
- * No VI borders defined. Useful when outputing for emulators, upscalers, or LCD TVs.
+ * @brief Request no borders from VI.
+ * 
+ * No VI borders will be defined, so the virtual display output will be
+ * 640x480, 4:3. Useful when outputing for emulators, upscalers, or LCD TVs.
  */
 const vi_borders_t VI_BORDERS_NONE = {0, 0, 0, 0};
+
 /**
- * @brief
+ * @brief Request CRT overscan compensation
+ * 
  * VI border preset that leaves a 5% margin on each side. Useful when outputing
  * for CRT TVs in order to account for possible overscan to ensure the frame is
  * visible on the screen.
+ * 
+ * The display output will still be exactly 4:3.
  */
 const vi_borders_t VI_BORDERS_CRT = {32, 32, 24, 24};
-/** @brief 256x240 mode */
-const resolution_t RESOLUTION_256x240 = {.width = 256, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
-/** @brief 320x240 mode */
-const resolution_t RESOLUTION_320x240 = {.width = 320, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
-/** @brief 512x240 mode, high-res progressive */
-const resolution_t RESOLUTION_512x240 = {.width = 512, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
-/** @brief 640x240 mode, high-res progressive */
-const resolution_t RESOLUTION_640x240 = {.width = 640, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
-/** @brief 512x480 mode, interlaced */
-const resolution_t RESOLUTION_512x480 = {.width = 512, .height = 480, .interlaced = INTERLACE_HALF, .vi_borders = VI_BORDERS_NONE};
-/** @brief 640x480 mode, interlaced */
-const resolution_t RESOLUTION_640x480 = {.width = 640, .height = 480, .interlaced = INTERLACE_HALF, .vi_borders = VI_BORDERS_NONE};
+
+/** Good default for a safe CRT overscan margin (5%) */
+#define DEFAULT_CRT_MARGIN      0.05f
+
+/**
+ * @brief Calculate correct VI borders for a target aspect ratio.
+ * 
+ * This function calculates the appropriate VI borders to obtain the specified
+ * aspect ratio, and optionally adding a margin to make the picture CRT-safe.
+ * 
+ * The margin is expressed as a percentage relative to the virtual VI display
+ * output (640x480). A good default for this margin for most CRTs is
+ * #DEFAULT_CRT_MARGIN (5%).
+ * 
+ * For instance, to create a 16:9 resolution, you can do:
+ * 
+ * \code{.c}
+ *      vi_borders_t borders = vi_calc_borders(16./9, false);
+ * \endcode
+ * 
+ * @param aspect_ratio      Target aspect ratio
+ * @param overscan_margin   Margin to add to compensate for TV overscan. Use 0
+ *                          to use full picture (eg: for emulators), and something
+ *                          like #DEFAULT_CRT_MARGIN to get a good CRT default.
+ * 
+ * @return vi_borders_t The requested border settings
+ */
+static inline vi_borders_t vi_calc_borders(float aspect_ratio, float overscan_margin)
+{
+    vi_borders_t b;
+    b.left = b.right = 640 * overscan_margin;
+    b.up = b.down = 480 * overscan_margin;
+
+    int width = 640 - b.left - b.right;
+    int height = 480 - b.up - b.down;
+
+    if (aspect_ratio > 4/3.f) {
+        int vborders = (int)(height - width / aspect_ratio + 0.5f);
+        b.up += vborders / 2;
+        b.down += vborders / 2;
+    } else {
+        int hborders = (int)(width - height * aspect_ratio + 0.5f);
+        b.left += hborders / 2;
+        b.right += hborders / 2;
+    }
+
+    return b;
+}
+
+
+/** @brief 256x240 mode, stretched to 4:3, no borders */
+const resolution_t RESOLUTION_256x240 = {.width = 256, .height = 240, .interlaced = INTERLACE_OFF, .borders = VI_BORDERS_NONE};
+/** @brief 320x240 mode, no borders */
+const resolution_t RESOLUTION_320x240 = {.width = 320, .height = 240, .interlaced = INTERLACE_OFF, .borders = VI_BORDERS_NONE};
+/** @brief 512x240 mode, stretched to 4:3, no borders */
+const resolution_t RESOLUTION_512x240 = {.width = 512, .height = 240, .interlaced = INTERLACE_OFF, .borders = VI_BORDERS_NONE};
+/** @brief 640x240 mode, stretched to 4:3, no borders */
+const resolution_t RESOLUTION_640x240 = {.width = 640, .height = 240, .interlaced = INTERLACE_OFF, .borders = VI_BORDERS_NONE};
+/** @brief 512x480 mode, interlaced, stretched to 4:3, no borders */
+const resolution_t RESOLUTION_512x480 = {.width = 512, .height = 480, .interlaced = INTERLACE_HALF, .borders = VI_BORDERS_NONE};
+/** @brief 640x480 mode, interlaced, no borders */
+const resolution_t RESOLUTION_640x480 = {.width = 640, .height = 480, .interlaced = INTERLACE_HALF, .borders = VI_BORDERS_NONE};
+
 #undef const
 
 /** @brief Valid bit depths */

--- a/include/display.h
+++ b/include/display.h
@@ -55,6 +55,22 @@ typedef enum {
 } interlace_mode_t;
 
 /**
+ * @brief Video Interface borders structure
+ *
+ * This structure defines how thick (in dots) should the borders around a framebuffer be.
+ * The dots always assume VI scale (that is 640x480 NTSC or 640x576 PAL)
+ * and the framebuffer will be scaled to fit under them.
+ * For example, when displaying on CRT TVs, one can add borders around a framebuffer so
+ * that the whole image can be seen on the screen. 
+ * 
+ * If no borders are applied, the output will use the entire NSTC/PAL region space
+ * for showing a framebuffer, useful for emulators, upscalers, and LCD TVs.
+ */
+typedef struct vi_borders_s{
+    uint16_t left, right, up, down;
+} vi_borders_t;
+
+/**
  * @brief Video resolution structure
  *
  * You can either use one of the pre-defined constants
@@ -78,23 +94,47 @@ typedef struct {
      * Setting this variable to true on NTSC/MPAL will have no effect.
      */
     bool pal60;
+    /**
+     * @brief 
+     * 
+     * This setting will enable additional borders around your display to cover
+     * the overscan margin of some CRT TVs to help ensure your entire frame is
+     * visible on the screen.
+     * 
+     * Screen resolution is not affected by it. Due to the way VI scaling works,
+     * it is advisable to not use the #FILTERS_DISABLED for your display if borders
+     * are enabled.
+     */
+    vi_borders_t vi_borders;
 } resolution_t;
 
 ///@cond
 #define const static const /* fool doxygen to document these static members */
 ///@endcond
+/**
+ * @brief
+ * No VI borders defined. Useful when outputing for emulators, upscalers, or LCD TVs.
+ */
+const vi_borders_t VI_BORDERS_NONE = {0, 0, 0, 0};
+/**
+ * @brief
+ * VI border preset that leaves a 5% margin on each side. Useful when outputing
+ * for CRT TVs in order to account for possible overscan to ensure the frame is
+ * visible on the screen.
+ */
+const vi_borders_t VI_BORDERS_CRT = {32, 32, 24, 24};
 /** @brief 256x240 mode */
-const resolution_t RESOLUTION_256x240 = {256, 240, INTERLACE_OFF};
+const resolution_t RESOLUTION_256x240 = {.width = 256, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
 /** @brief 320x240 mode */
-const resolution_t RESOLUTION_320x240 = {320, 240, INTERLACE_OFF};
+const resolution_t RESOLUTION_320x240 = {.width = 320, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
 /** @brief 512x240 mode, high-res progressive */
-const resolution_t RESOLUTION_512x240 = {512, 240, INTERLACE_OFF};
+const resolution_t RESOLUTION_512x240 = {.width = 512, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
 /** @brief 640x240 mode, high-res progressive */
-const resolution_t RESOLUTION_640x240 = {640, 240, INTERLACE_OFF};
+const resolution_t RESOLUTION_640x240 = {.width = 640, .height = 240, .interlaced = INTERLACE_OFF, .vi_borders = VI_BORDERS_NONE};
 /** @brief 512x480 mode, interlaced */
-const resolution_t RESOLUTION_512x480 = {512, 480, INTERLACE_HALF};
+const resolution_t RESOLUTION_512x480 = {.width = 512, .height = 480, .interlaced = INTERLACE_HALF, .vi_borders = VI_BORDERS_NONE};
 /** @brief 640x480 mode, interlaced */
-const resolution_t RESOLUTION_640x480 = {640, 480, INTERLACE_HALF};
+const resolution_t RESOLUTION_640x480 = {.width = 640, .height = 480, .interlaced = INTERLACE_HALF, .vi_borders = VI_BORDERS_NONE};
 #undef const
 
 /** @brief Valid bit depths */

--- a/include/display.h
+++ b/include/display.h
@@ -57,52 +57,13 @@ typedef enum {
 /**
  * @brief Video resolution structure
  *
- * You can either use one of the pre-defined constants
- * (such as #RESOLUTION_320x240) or define a custom resolution.
+ * This structure allows to configure the video resolution, which includes both
+ * the framebuffer size and some parameters of how the framebuffer is displayed
+ * on the screen (aspect ratio, TV overscan margins, etc.).
  * 
- * By default, the VI will be configured to resample the specified framebuffer
- * picture into a virtual 640x480 display output with 4:3 aspect ratio (on both
- * PAL, NTSC and MPAL). In reality, TVs didn't have that vertical resolution
- * so the actual output depends on whether you request interlaced display or not:
- * 
- *  * In case of non interlaced display, the actual resolution is 640x240, but
- *    since dots will be configured to be twice as big vertically, the aspect
- *    ratio will be 4:3 as-if the image was 640x480 (with duplicated scanlines)
- *  * In case of interlaced display, you do get to display 480 scanlines, by
- *    alternating two slightly-shifted 640x240 pictures.
- * 
- * As an example, if you specify a resolution like 512x320, with interlacing
- * turned off, what happens is that the image gets scaled into 640x240, so
- * horizontally some pixels will be duplicated to enlarge the resolution to 640,
- * but vertically some scanlines will be dropped. The output display aspect ratio
- * will still be 4:3, which is not the source aspect ratio of the framebuffer
- * (512 / 320 = 1.6666 = 16:10), so the image will appear squished, unless
- * obviously this was accounted for while drawing to the framebuffer.
- * 
- * While resampling the framebuffer into the display output, the VI can use either
- * bilinear filtering or simple nearest sampling (duplicating or dropping pixels).
- * See #filter_options_t for more information on configuring
- * the VI image filters.
- * 
- * The 640x480 virtual display output can be fully viewed on emulators and on
- * modern screens (via grabbers, converters, etc.). When displaying on old
- * CRTs though, part of the display will be hidden because of the overscan.
- * To account for that, it is possible to reduce the 640x480 display output
- * by adding black borders. For instance, if you specify 12 dots of borders
- * on all the four edges, you will get a 616x456 display output, plus
- * the requested 12 dots of borders on all sides; the actual display output
- * will thus be smaller, and possibly get fully out of overscan. The value
- * #VI_BORDERS_CRT is a good default you can use for overscan compensation on
- * most CRT TVs.
- * 
- * Notice that adding borders also affect the aspect ratio of the display output;
- * for instance, in the above example, the 616x456 display output is not
- * exactly 4:3 anymore, but more like 4.05:3. By carefully calculating borders,
- * thus, it is possible to obtain specific display outputs with custom aspect
- * ratios (eg: 16:9).
- * 
- * To help calculating the borders by taking both potential goals into account
- * (overscan compensation and aspect ratio changes), you can use #vi_calc_borders.
+ * Most users should just use one of the pre-defined constants (such as 
+ * #RESOLUTION_320x240), but it is possible to configure custom resolutions
+ * by manually filling fields in this structure.
  */
 typedef struct {
     /** @brief Framebuffer width (must be between 2 and 800) */
@@ -111,17 +72,6 @@ typedef struct {
     int32_t height;
     /** @brief Interlace mode */
     interlace_mode_t interlaced;
-    /** 
-     * @brief Use PAL60 mode if on PAL
-     * 
-     * PAL60 is a PAL video setting with NTSC-like vertical timing, that allows
-     * to refresh 60 frames per second instead of the usual 50. This is compatible
-     * with most PAL CRTs, but sometimes it creates issues with some modern
-     * converters / upscalers. 
-     * 
-     * Setting this variable to true on NTSC/MPAL will have no effect.
-     */
-    bool pal60;
     /** 
      * @brief Configure the desired aspect ratio of the output display picture.
      * 
@@ -153,6 +103,17 @@ typedef struct {
      * use for this field
      */
     float overscan_margin;
+    /** 
+     * @brief Use PAL60 mode if on PAL
+     * 
+     * PAL60 is a PAL video setting with NTSC-like vertical timing, that allows
+     * to refresh 60 frames per second instead of the usual 50. This is compatible
+     * with most PAL CRTs, but sometimes it creates issues with some modern
+     * converters / upscalers. 
+     * 
+     * Setting this variable to true on NTSC/MPAL will have no effect.
+     */
+    bool pal60;
 } resolution_t;
 
 ///@cond

--- a/include/display.h
+++ b/include/display.h
@@ -63,7 +63,7 @@ typedef enum {
  * For example, when displaying on CRT TVs, one can add borders around a framebuffer so
  * that the whole image can be seen on the screen. 
  * 
- * If no borders are applied, the output will use the entire NSTC/PAL region space
+ * If no borders are applied, the output will use the entire NTSC/PAL region space
  * for showing a framebuffer, useful for emulators, upscalers, and LCD TVs.
  */
 typedef struct vi_borders_s{
@@ -102,8 +102,9 @@ typedef struct {
      * visible on the screen.
      * 
      * Screen resolution is not affected by it. Due to the way VI scaling works,
-     * it is advisable to not use the #FILTERS_DISABLED for your display if borders
-     * are enabled.
+     * it is advisable to not use the #FILTERS_DISABLED option for your display
+     * if borders are enabled because no bilinear resampling means VI is likely
+     * to output unevenly thick columns of pixels or skip some scanlines.
      */
     vi_borders_t vi_borders;
 } resolution_t;

--- a/src/display.c
+++ b/src/display.c
@@ -417,7 +417,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     vi_write_safe(VI_X_SCALE, VI_X_SCALE_SET(__width, 640 - __borders.left - __borders.right));
     vi_write_safe(VI_V_VIDEO, *VI_V_VIDEO + VI_V_VIDEO_SET(__borders.up, 0) - VI_V_VIDEO_SET(0, __borders.down)); 
     const uint32_t base_height = (__tv_type == TV_PAL) ? 288 : 240;
-    vi_write_safe(VI_Y_SCALE, VI_Y_SCALE_SET(__height, base_height - __borders.up));
+    vi_write_safe(VI_Y_SCALE, VI_Y_SCALE_SET(__height, base_height - ((__borders.up + __borders.down) / 2)));
 
     /* Configure other VI registers */
     vi_write_safe(VI_ORIGIN, PhysicalAddr(__safe_buffer[0]));

--- a/src/display.c
+++ b/src/display.c
@@ -368,7 +368,9 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     __height = res.height;
     __bitdepth = ( bit == DEPTH_16_BPP ) ? 2 : 4;
     __interlace_mode = res.interlaced;
-    __borders = res.borders;
+
+    float aspect_ratio = res.aspect_ratio ? res.aspect_ratio : 4.0f / 3.0f;
+    __borders = vi_calc_borders(__tv_type, aspect_ratio, res.overscan_margin);
 
     surfaces = malloc(sizeof(surface_t) * __buffers);
 

--- a/src/display.c
+++ b/src/display.c
@@ -368,7 +368,7 @@ void display_init( resolution_t res, bitdepth_t bit, uint32_t num_buffers, gamma
     __height = res.height;
     __bitdepth = ( bit == DEPTH_16_BPP ) ? 2 : 4;
     __interlace_mode = res.interlaced;
-    __borders = res.vi_borders;
+    __borders = res.borders;
 
     surfaces = malloc(sizeof(surface_t) * __buffers);
 

--- a/src/vi.h
+++ b/src/vi.h
@@ -194,15 +194,11 @@ typedef struct vi_config_s{
 
 /**  Under VI_X_SCALE   */
 /** @brief VI_X_SCALE Register: set 1/horizontal scale up factor (value is converted to 2.10 format) */
-#define VI_X_SCALE_SET(value)               (( 1024*(value) + 320 ) / 640)
+#define VI_X_SCALE_SET(from, to)            ((1024 * (from) + (to) / 2 ) / (to))
 
 /**  Under VI_Y_SCALE   */
 /** @brief VI_Y_SCALE Register: set 1/vertical scale up factor (value is converted to 2.10 format) */
-#define VI_Y_SCALE_SET_240_LINES(value)               (( 1024*(value) + 120 ) / 240)
-
-/**  Under VI_Y_SCALE   */
-/** @brief VI_Y_SCALE Register: set 1/vertical scale up factor (value is converted to 2.10 format) */
-#define VI_Y_SCALE_SET_288_LINES(value)               (( 1024*(value) + 144 ) / 288)
+#define VI_Y_SCALE_SET(from, to)            ((1024 * (from) + (to) / 2 ) / (to))
 
 /** @brief VI period for showing one NTSC and MPAL picture in ms. */
 #define VI_PERIOD_NTSC_MPAL                 ((float)1000/60)
@@ -227,8 +223,8 @@ static const vi_config_t vi_ntsc_p = {.regs = {
     VI_H_VIDEO_SET(108, 748),
     VI_V_VIDEO_SET(35, 515),
     VI_V_BURST_SET(14, 516),
-    VI_X_SCALE_SET(0),
-    VI_Y_SCALE_SET_240_LINES(0),
+    VI_X_SCALE_SET(0, 640),
+    VI_Y_SCALE_SET(0, 240),
 }};
 static const vi_config_t vi_pal_p =  {.regs = {
     0,
@@ -243,8 +239,8 @@ static const vi_config_t vi_pal_p =  {.regs = {
     VI_H_VIDEO_SET(128, 768),
     VI_V_VIDEO_SET(45, 621),
     VI_V_BURST_SET(9, 619),
-    VI_X_SCALE_SET(0),
-    VI_Y_SCALE_SET_288_LINES(0),
+    VI_X_SCALE_SET(0, 640),
+    VI_Y_SCALE_SET(0, 288),
 }};
 static const vi_config_t vi_mpal_p = {.regs = {
     0,
@@ -259,8 +255,8 @@ static const vi_config_t vi_mpal_p = {.regs = {
     VI_H_VIDEO_SET(108, 748),
     VI_V_VIDEO_SET(37, 511),
     VI_V_BURST_SET(14, 516),
-    VI_X_SCALE_SET(0),
-    VI_Y_SCALE_SET_240_LINES(0)
+    VI_X_SCALE_SET(0, 640),
+    VI_Y_SCALE_SET(0, 240)
 }};
 static const vi_config_t vi_ntsc_i = {.regs = {
     0,
@@ -275,8 +271,8 @@ static const vi_config_t vi_ntsc_i = {.regs = {
     VI_H_VIDEO_SET(108, 748),
     VI_V_VIDEO_SET(35, 515),
     VI_V_BURST_SET(14, 516),
-    VI_X_SCALE_SET(0),
-    VI_Y_SCALE_SET_240_LINES(0)
+    VI_X_SCALE_SET(0, 640),
+    VI_Y_SCALE_SET(0, 240)
 }};
 static const vi_config_t vi_pal_i = {.regs = {
     0,
@@ -291,8 +287,8 @@ static const vi_config_t vi_pal_i = {.regs = {
     VI_H_VIDEO_SET(128, 768),
     VI_V_VIDEO_SET(45, 621),
     VI_V_BURST_SET(9, 619),
-    VI_X_SCALE_SET(0),
-    VI_Y_SCALE_SET_288_LINES(0)
+    VI_X_SCALE_SET(0, 640),
+    VI_Y_SCALE_SET(0, 288)
 }};
 static const vi_config_t vi_mpal_i = {.regs = {
     0,
@@ -307,8 +303,8 @@ static const vi_config_t vi_mpal_i = {.regs = {
     VI_H_VIDEO_SET(108, 748),
     VI_V_VIDEO_SET(35, 509),
     VI_V_BURST_SET(11, 514),
-    VI_X_SCALE_SET(0),
-    VI_Y_SCALE_SET_240_LINES(0)
+    VI_X_SCALE_SET(0, 640),
+    VI_Y_SCALE_SET(0, 240)
 }};
 /** @} */
 


### PR DESCRIPTION
Border sizes are fully configurable. Sensible pre-configured option for handling overscan on CRT TVs is provided.