### PR TITLE
Fix priority constructor order

### DIFF
--- a/dso.ld
+++ b/dso.ld
@@ -28,8 +28,8 @@ SECTIONS {
     /* Write constructors and destructors which each must be 4-byte aligned */
     .ctors ALIGN(4) : {
         LONG(0); /* Add terminator to CTOR list */
-        KEEP(*(SORT(.ctors.*)))
         KEEP(*(.ctors))
+        KEEP(*(SORT(.ctors.*)))
         __CTOR_LIST__ = .-4; /* Define symbol for CTOR list */
     }
     

--- a/n64.ld
+++ b/n64.ld
@@ -80,7 +80,7 @@ SECTIONS {
         if you don't provide the --wrap option. */
         KEEP(*(EXCLUDE_FILE (*crtend.o) .ctors))
         KEEP(*(SORT(.ctors.*)))
-        KEEP(*(.ctors))
+        KEEP(*crtend.o(.ctors))
          /* Similarly we should have a;
 
         LONG(0)

--- a/n64.ld
+++ b/n64.ld
@@ -78,6 +78,8 @@ SECTIONS {
         __wrap___do_global_ctors and enables it via the --wrap linker option.
         When linking with ld, we should use __do_global_ctors, which is the default
         if you don't provide the --wrap option. */
+        KEEP(*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP(*(SORT(.ctors.*)))
         KEEP(*(.ctors))
          /* Similarly we should have a;
 

--- a/tests/test_constructors.c
+++ b/tests/test_constructors.c
@@ -1,6 +1,19 @@
 extern unsigned int __global_cpp_constructor_test_value;
 
 unsigned int __global_constructor_test_value;
+unsigned int __global_constructor_test_value_old;
+unsigned int __global_constructor_test_prio;
+
+__attribute__((constructor(123))) void __global_constructor_test_prio1(void)
+{
+    __global_constructor_test_prio = 0xC0C70123;
+}
+
+__attribute__((constructor(125))) void __global_constructor_test_prio2(void)
+{
+    __global_constructor_test_value_old = __global_constructor_test_value;
+    __global_constructor_test_prio = 0xE0C70125;
+}
 
 __attribute__((constructor)) void __global_constructor_test()
 {
@@ -10,4 +23,5 @@ __attribute__((constructor)) void __global_constructor_test()
 void test_constructors(TestContext *ctx) {
 	ASSERT(__global_constructor_test_value == 0xC0C70125, "Global constructors did not get executed!");
 	ASSERT(__global_cpp_constructor_test_value == 0xD0C70125, "Global C++ constructors did not get executed!");
+    ASSERT(__global_constructor_test_prio == 0xE0C70125 && __global_constructor_test_value_old == 0, "Global constructors with priority don't work correctly!");
 }


### PR DESCRIPTION
Constructors with priority now execute before other constructors.