### PR TITLE
GL: Allocate state at runtime

### DIFF
--- a/src/GL/array.c
+++ b/src/GL/array.c
@@ -2,7 +2,7 @@
 #include "debug.h"
 #include <malloc.h>
 
-extern gl_state_t state;
+extern gl_state_t *state;
 
 typedef struct {
     GLboolean et, ec, en;
@@ -127,8 +127,8 @@ void gl_array_object_init(gl_array_object_t *obj)
 
 void gl_array_init()
 {
-    gl_array_object_init(&state.default_array_object);
-    state.array_object = &state.default_array_object;
+    gl_array_object_init(&state->default_array_object);
+    state->array_object = &state->default_array_object;
 }
 
 void gl_set_array(gl_array_type_t array_type, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer)
@@ -145,18 +145,18 @@ void gl_set_array(gl_array_type_t array_type, GLint size, GLenum type, GLsizei s
     // ARRAY_BUFFER buffer object, and the pointer is not NULL[fn].
     //     [fn: This error makes it impossible to create a vertex array
     //           object containing client array pointers.]
-    if (state.array_object != &state.default_array_object && state.array_buffer == NULL && pointer != NULL) {
+    if (state->array_object != &state->default_array_object && state->array_buffer == NULL && pointer != NULL) {
         gl_set_error(GL_INVALID_OPERATION, "Vertex array objects can only be used in conjunction with vertex buffer objects");
         return;
     }
 
-    gl_array_t *array = &state.array_object->arrays[array_type];
+    gl_array_t *array = &state->array_object->arrays[array_type];
 
     array->size = size;
     array->type = type;
     array->stride = stride;
     array->pointer = pointer;
-    array->binding = state.array_buffer;
+    array->binding = state->array_buffer;
 
     gl_update_array(array, array_type);
 }
@@ -294,7 +294,7 @@ void glMatrixIndexPointerARB(GLint size, GLenum type, GLsizei stride, const GLvo
 
 void gl_set_array_enabled(gl_array_type_t array_type, bool enabled)
 {
-    gl_array_t *array = &state.array_object->arrays[array_type];
+    gl_array_t *array = &state->array_object->arrays[array_type];
     array->enabled = enabled;
 }
 
@@ -421,7 +421,7 @@ void glDeleteVertexArrays(GLsizei n, const GLuint *arrays)
             continue;
         }
 
-        if (obj == state.array_object) {
+        if (obj == state->array_object) {
             glBindVertexArray(0);
         }
 
@@ -438,10 +438,10 @@ void glBindVertexArray(GLuint array)
     gl_array_object_t *obj = (gl_array_object_t*)array;
 
     if (obj == NULL) {
-        obj = &state.default_array_object;
+        obj = &state->default_array_object;
     }
 
-    state.array_object = obj;
+    state->array_object = obj;
 }
 
 GLboolean glIsVertexArray(GLuint array)

--- a/src/GL/buffer.c
+++ b/src/GL/buffer.c
@@ -3,7 +3,7 @@
 #include <malloc.h>
 #include <string.h>
 
-extern gl_state_t state;
+extern gl_state_t *state;
 
 
 GLboolean glIsBufferARB(GLuint buffer)
@@ -24,10 +24,10 @@ void glBindBufferARB(GLenum target, GLuint buffer)
 
     switch (target) {
     case GL_ARRAY_BUFFER_ARB:
-        state.array_buffer = obj;
+        state->array_buffer = obj;
         break;
     case GL_ELEMENT_ARRAY_BUFFER_ARB:
-        state.element_array_buffer = obj;
+        state->element_array_buffer = obj;
         break;
     default:
         gl_set_error(GL_INVALID_ENUM, "%#04lx is not a valid buffer target", target);
@@ -56,8 +56,8 @@ void glDeleteBuffersARB(GLsizei n, const GLuint *buffers)
             continue;
         }
         
-        gl_unbind_buffer(obj, &state.array_buffer);
-        gl_unbind_buffer(obj, &state.element_array_buffer);
+        gl_unbind_buffer(obj, &state->array_buffer);
+        gl_unbind_buffer(obj, &state->element_array_buffer);
 
         for (uint32_t a = 0; a < ATTRIB_COUNT; a++)
         {
@@ -68,7 +68,7 @@ void glDeleteBuffersARB(GLsizei n, const GLuint *buffers)
             // A buffer object that is deleted while attached to a non-current VAO
             // is treated just like a buffer object bound to another context (or to
             // a current VAO in another context).
-            gl_unbind_buffer(obj, &state.array_object->arrays[a].binding);
+            gl_unbind_buffer(obj, &state->array_object->arrays[a].binding);
         }
 
         // TODO: keep alive until no longer in use
@@ -99,10 +99,10 @@ bool gl_get_buffer_object(GLenum target, gl_buffer_object_t **obj)
 {
     switch (target) {
     case GL_ARRAY_BUFFER_ARB:
-        *obj = state.array_buffer;
+        *obj = state->array_buffer;
         break;
     case GL_ELEMENT_ARRAY_BUFFER_ARB:
-        *obj = state.element_array_buffer;
+        *obj = state->element_array_buffer;
         break;
     default:
         gl_set_error(GL_INVALID_ENUM, "%#04lx is not a valid buffer target", target);

--- a/src/GL/gl_internal.h
+++ b/src/GL/gl_internal.h
@@ -49,19 +49,19 @@
 })
 
 #define gl_set_error(error, message, ...)  ({ \
-    state.current_error = error; \
+    state->current_error = error; \
     assertf(error == GL_NO_ERROR, "%s: " message, #error, ##__VA_ARGS__); \
 })
 
 #define gl_ensure_no_begin_end() ({ \
-    if (state.begin_end_active) { \
+    if (state->begin_end_active) { \
         gl_set_error(GL_INVALID_OPERATION, "%s is not allowed between glBegin/glEnd", __func__); \
         false; \
     } \
     true; \
 })
 
-#define gl_assert_no_display_list() assertf(state.current_list == 0, "%s cannot be recorded into a display list", __func__)
+#define gl_assert_no_display_list() assertf(state->current_list == 0, "%s cannot be recorded into a display list", __func__)
 
 typedef int16_t int16u_t __attribute__((aligned(1)));
 typedef uint16_t uint16u_t __attribute__((aligned(1)));
@@ -641,7 +641,7 @@ inline uint32_t gl_type_to_index(GLenum type)
     }
 }
 
-#define next_prim_id() (state.prim_id++)
+#define next_prim_id() (state->prim_id++)
 
 inline const void *gl_get_attrib_element(const gl_array_t *src, uint32_t index)
 {

--- a/src/GL/pixelrect.c
+++ b/src/GL/pixelrect.c
@@ -1,17 +1,17 @@
 #include "gl_internal.h"
 #include <debug.h>
 
-extern gl_state_t state;
+extern gl_state_t *state;
 
 bool gl_calc_transfer_is_noop()
 {
-    if (state.map_color || state.unpack_swap_bytes) {
+    if (state->map_color || state->unpack_swap_bytes) {
         return false;
     }
 
     for (uint32_t i = 0; i < 4; i++)
     {
-        if (state.transfer_bias[i] != 0.0f || state.transfer_scale[i] != 1.0f) {
+        if (state->transfer_bias[i] != 0.0f || state->transfer_scale[i] != 1.0f) {
             return false;
         }
     }
@@ -21,21 +21,21 @@ bool gl_calc_transfer_is_noop()
 
 void gl_update_transfer_state()
 {
-    state.transfer_is_noop = gl_calc_transfer_is_noop();
+    state->transfer_is_noop = gl_calc_transfer_is_noop();
 }
 
 void gl_pixel_init()
 {
-    state.unpack_alignment = 4;
-    state.transfer_scale[0] = 1;
-    state.transfer_scale[1] = 1;
-    state.transfer_scale[2] = 1;
-    state.transfer_scale[3] = 1;
+    state->unpack_alignment = 4;
+    state->transfer_scale[0] = 1;
+    state->transfer_scale[1] = 1;
+    state->transfer_scale[2] = 1;
+    state->transfer_scale[3] = 1;
 
-    state.pixel_maps[0].size = 1;
-    state.pixel_maps[1].size = 1;
-    state.pixel_maps[2].size = 1;
-    state.pixel_maps[3].size = 1;
+    state->pixel_maps[0].size = 1;
+    state->pixel_maps[1].size = 1;
+    state->pixel_maps[2].size = 1;
+    state->pixel_maps[3].size = 1;
 
     gl_update_transfer_state();
 }
@@ -46,39 +46,39 @@ void glPixelStorei(GLenum pname, GLint param)
     
     switch (pname) {
     case GL_UNPACK_SWAP_BYTES:
-        state.unpack_swap_bytes = param != 0;
+        state->unpack_swap_bytes = param != 0;
         gl_update_transfer_state();
         break;
     case GL_UNPACK_LSB_FIRST:
-        state.unpack_lsb_first = param != 0;
+        state->unpack_lsb_first = param != 0;
         break;
     case GL_UNPACK_ROW_LENGTH:
         if (param < 0) {
             gl_set_error(GL_INVALID_VALUE, "GL_UNPACK_ROW_LENGTH must not be negative");
             return;
         }
-        state.unpack_row_length = param;
+        state->unpack_row_length = param;
         break;
     case GL_UNPACK_SKIP_ROWS:
         if (param < 0) {
             gl_set_error(GL_INVALID_VALUE, "GL_UNPACK_SKIP_ROWS must not be negative");
             return;
         }
-        state.unpack_skip_rows = param;
+        state->unpack_skip_rows = param;
         break;
     case GL_UNPACK_SKIP_PIXELS:
         if (param < 0) {
             gl_set_error(GL_INVALID_VALUE, "GL_UNPACK_SKIP_PIXELS must not be negative");
             return;
         }
-        state.unpack_skip_pixels = param;
+        state->unpack_skip_pixels = param;
         break;
     case GL_UNPACK_ALIGNMENT:
         if (param != 1 && param != 2 && param != 4 && param != 8) {
             gl_set_error(GL_INVALID_VALUE, "GL_UNPACK_ALIGNMENT must be 1, 2, 4 or 8");
             return;
         }
-        state.unpack_alignment = param;
+        state->unpack_alignment = param;
         break;
     case GL_PACK_SWAP_BYTES:
     case GL_PACK_LSB_FIRST:
@@ -99,11 +99,11 @@ void glPixelStoref(GLenum pname, GLfloat param)
     
     switch (pname) {
     case GL_UNPACK_SWAP_BYTES:
-        state.unpack_swap_bytes = param != 0.0f;
+        state->unpack_swap_bytes = param != 0.0f;
         gl_update_transfer_state();
         break;
     case GL_UNPACK_LSB_FIRST:
-        state.unpack_lsb_first = param != 0.0f;
+        state->unpack_lsb_first = param != 0.0f;
         break;
     default:
         glPixelStorei(pname, param);
@@ -117,7 +117,7 @@ void glPixelTransferi(GLenum pname, GLint value)
     
     switch (pname) {
     case GL_MAP_COLOR:
-        state.map_color = value != 0;
+        state->map_color = value != 0;
         gl_update_transfer_state();
         break;
     default:
@@ -132,31 +132,31 @@ void glPixelTransferf(GLenum pname, GLfloat value)
     
     switch (pname) {
     case GL_MAP_COLOR:
-        state.map_color = value != 0.0f;
+        state->map_color = value != 0.0f;
         break;
     case GL_RED_SCALE:
-        state.transfer_scale[0] = value;
+        state->transfer_scale[0] = value;
         break;
     case GL_GREEN_SCALE:
-        state.transfer_scale[1] = value;
+        state->transfer_scale[1] = value;
         break;
     case GL_BLUE_SCALE:
-        state.transfer_scale[2] = value;
+        state->transfer_scale[2] = value;
         break;
     case GL_ALPHA_SCALE:
-        state.transfer_scale[3] = value;
+        state->transfer_scale[3] = value;
         break;
     case GL_RED_BIAS:
-        state.transfer_bias[0] = value;
+        state->transfer_bias[0] = value;
         break;
     case GL_GREEN_BIAS:
-        state.transfer_bias[1] = value;
+        state->transfer_bias[1] = value;
         break;
     case GL_BLUE_BIAS:
-        state.transfer_bias[2] = value;
+        state->transfer_bias[2] = value;
         break;
     case GL_ALPHA_BIAS:
-        state.transfer_bias[3] = value;
+        state->transfer_bias[3] = value;
         break;
     case GL_DEPTH_SCALE:
     case GL_DEPTH_BIAS:
@@ -176,13 +176,13 @@ gl_pixel_map_t * gl_get_pixel_map(GLenum map)
 {
     switch (map) {
     case GL_PIXEL_MAP_R_TO_R:
-        return &state.pixel_maps[0];
+        return &state->pixel_maps[0];
     case GL_PIXEL_MAP_G_TO_G:
-        return &state.pixel_maps[1];
+        return &state->pixel_maps[1];
     case GL_PIXEL_MAP_B_TO_B:
-        return &state.pixel_maps[2];
+        return &state->pixel_maps[2];
     case GL_PIXEL_MAP_A_TO_A:
-        return &state.pixel_maps[3];
+        return &state->pixel_maps[3];
     case GL_PIXEL_MAP_I_TO_I:
     case GL_PIXEL_MAP_S_TO_S:
     case GL_PIXEL_MAP_I_TO_R:

--- a/src/GL/query.c
+++ b/src/GL/query.c
@@ -2,7 +2,7 @@
 #include "gl_constants.h"
 #include "rspq_constants.h"
 
-extern gl_state_t state;
+extern gl_state_t *state;
 
 typedef enum {
     QUERY_BOOLEAN,
@@ -138,109 +138,109 @@ static bool gl_query_get_value_source(GLenum value, const void **src, uint32_t *
         SET_RESULT(&max_palette_matrices, 1, &from_i32);
         break;
     case GL_VERTEX_HALF_FIXED_PRECISION_N64:
-        SET_RESULT(&state.vertex_halfx_precision.precision, 1, &from_u32);
+        SET_RESULT(&state->vertex_halfx_precision.precision, 1, &from_u32);
         break;
     case GL_TEXTURE_COORD_HALF_FIXED_PRECISION_N64:
-        SET_RESULT(&state.texcoord_halfx_precision.precision, 1, &from_u32);
+        SET_RESULT(&state->texcoord_halfx_precision.precision, 1, &from_u32);
         break;
     case GL_VERTEX_ARRAY:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_VERTEX].enabled, 1, &from_bool);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_VERTEX].enabled, 1, &from_bool);
         break;
     case GL_VERTEX_ARRAY_SIZE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_VERTEX].size, 1, &from_i32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_VERTEX].size, 1, &from_i32);
         break;
     case GL_VERTEX_ARRAY_STRIDE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_VERTEX].stride, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_VERTEX].stride, 1, &from_u32);
         break;
     case GL_VERTEX_ARRAY_TYPE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_VERTEX].type, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_VERTEX].type, 1, &from_u32);
         break;
     case GL_VERTEX_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_VERTEX].binding, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_VERTEX].binding, 1, &from_u32);
         break;
     case GL_NORMAL_ARRAY:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_NORMAL].enabled, 1, &from_bool);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_NORMAL].enabled, 1, &from_bool);
         break;
     case GL_NORMAL_ARRAY_STRIDE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_NORMAL].stride, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_NORMAL].stride, 1, &from_u32);
         break;
     case GL_NORMAL_ARRAY_TYPE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_NORMAL].type, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_NORMAL].type, 1, &from_u32);
         break;
     case GL_NORMAL_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_NORMAL].binding, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_NORMAL].binding, 1, &from_u32);
         break;
     case GL_COLOR_ARRAY:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_COLOR].enabled, 1, &from_bool);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_COLOR].enabled, 1, &from_bool);
         break;
     case GL_COLOR_ARRAY_SIZE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_COLOR].size, 1, &from_i32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_COLOR].size, 1, &from_i32);
         break;
     case GL_COLOR_ARRAY_STRIDE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_COLOR].stride, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_COLOR].stride, 1, &from_u32);
         break;
     case GL_COLOR_ARRAY_TYPE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_COLOR].type, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_COLOR].type, 1, &from_u32);
         break;
     case GL_COLOR_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_COLOR].binding, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_COLOR].binding, 1, &from_u32);
         break;
     case GL_TEXTURE_COORD_ARRAY:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_TEXCOORD].enabled, 1, &from_bool);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_TEXCOORD].enabled, 1, &from_bool);
         break;
     case GL_TEXTURE_COORD_ARRAY_SIZE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_TEXCOORD].size, 1, &from_i32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_TEXCOORD].size, 1, &from_i32);
         break;
     case GL_TEXTURE_COORD_ARRAY_STRIDE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_TEXCOORD].stride, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_TEXCOORD].stride, 1, &from_u32);
         break;
     case GL_TEXTURE_COORD_ARRAY_TYPE:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_TEXCOORD].type, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_TEXCOORD].type, 1, &from_u32);
         break;
     case GL_TEXTURE_COORD_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_TEXCOORD].binding, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_TEXCOORD].binding, 1, &from_u32);
         break;
     case GL_MATRIX_INDEX_ARRAY_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_MTX_INDEX].enabled, 1, &from_bool);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_MTX_INDEX].enabled, 1, &from_bool);
         break;
     case GL_MATRIX_INDEX_ARRAY_SIZE_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_MTX_INDEX].size, 1, &from_i32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_MTX_INDEX].size, 1, &from_i32);
         break;
     case GL_MATRIX_INDEX_ARRAY_STRIDE_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_MTX_INDEX].stride, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_MTX_INDEX].stride, 1, &from_u32);
         break;
     case GL_MATRIX_INDEX_ARRAY_TYPE_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_MTX_INDEX].type, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_MTX_INDEX].type, 1, &from_u32);
         break;
     case GL_MATRIX_INDEX_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.array_object->arrays[ATTRIB_MTX_INDEX].binding, 1, &from_u32);
+        SET_RESULT(&state->array_object->arrays[ATTRIB_MTX_INDEX].binding, 1, &from_u32);
         break;
     case GL_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.array_buffer, 1, &from_u32);
+        SET_RESULT(&state->array_buffer, 1, &from_u32);
         break;
     case GL_ELEMENT_ARRAY_BUFFER_BINDING_ARB:
-        SET_RESULT(&state.element_array_buffer, 1, &from_u32);
+        SET_RESULT(&state->element_array_buffer, 1, &from_u32);
         break;
     case GL_VERTEX_ARRAY_BINDING:
-        SET_RESULT(&state.array_object, 1, &from_u32);
+        SET_RESULT(&state->array_object, 1, &from_u32);
         break;
     case GL_UNPACK_ALIGNMENT:
-        SET_RESULT(&state.unpack_alignment, 1, &from_i32);
+        SET_RESULT(&state->unpack_alignment, 1, &from_i32);
         break;
     case GL_UNPACK_LSB_FIRST:
-        SET_RESULT(&state.unpack_lsb_first, 1, &from_bool);
+        SET_RESULT(&state->unpack_lsb_first, 1, &from_bool);
         break;
     case GL_UNPACK_ROW_LENGTH:
-        SET_RESULT(&state.unpack_row_length, 1, &from_i32);
+        SET_RESULT(&state->unpack_row_length, 1, &from_i32);
         break;
     case GL_UNPACK_SKIP_PIXELS:
-        SET_RESULT(&state.unpack_skip_pixels, 1, &from_i32);
+        SET_RESULT(&state->unpack_skip_pixels, 1, &from_i32);
         break;
     case GL_UNPACK_SKIP_ROWS:
-        SET_RESULT(&state.unpack_skip_rows, 1, &from_i32);
+        SET_RESULT(&state->unpack_skip_rows, 1, &from_i32);
         break;
     case GL_UNPACK_SWAP_BYTES:
-        SET_RESULT(&state.unpack_swap_bytes, 1, &from_bool);
+        SET_RESULT(&state->unpack_swap_bytes, 1, &from_bool);
         break;
     case GL_PACK_ALIGNMENT:
     case GL_PACK_LSB_FIRST:
@@ -506,15 +506,15 @@ GLboolean glIsEnabled(GLenum value)
 {
     switch (value) {
     case GL_VERTEX_ARRAY:
-        return state.array_object->arrays[ATTRIB_VERTEX].enabled;
+        return state->array_object->arrays[ATTRIB_VERTEX].enabled;
     case GL_NORMAL_ARRAY:
-        return state.array_object->arrays[ATTRIB_NORMAL].enabled;
+        return state->array_object->arrays[ATTRIB_NORMAL].enabled;
     case GL_COLOR_ARRAY:
-        return state.array_object->arrays[ATTRIB_COLOR].enabled;
+        return state->array_object->arrays[ATTRIB_COLOR].enabled;
     case GL_TEXTURE_COORD_ARRAY:
-        return state.array_object->arrays[ATTRIB_TEXCOORD].enabled;
+        return state->array_object->arrays[ATTRIB_TEXCOORD].enabled;
     case GL_MATRIX_INDEX_ARRAY_ARB:
-        return state.array_object->arrays[ATTRIB_MTX_INDEX].enabled;
+        return state->array_object->arrays[ATTRIB_MTX_INDEX].enabled;
     case GL_ALPHA_TEST:
     case GL_AUTO_NORMAL:
     case GL_BLEND:
@@ -585,19 +585,19 @@ void glGetPointerv(GLenum pname, GLvoid **params)
 {
     switch (pname) {
     case GL_VERTEX_ARRAY_POINTER:
-        *params = (GLvoid*)state.array_object->arrays[ATTRIB_VERTEX].pointer;
+        *params = (GLvoid*)state->array_object->arrays[ATTRIB_VERTEX].pointer;
         break;
     case GL_NORMAL_ARRAY_POINTER:
-        *params = (GLvoid*)state.array_object->arrays[ATTRIB_NORMAL].pointer;
+        *params = (GLvoid*)state->array_object->arrays[ATTRIB_NORMAL].pointer;
         break;
     case GL_COLOR_ARRAY_POINTER:
-        *params = (GLvoid*)state.array_object->arrays[ATTRIB_COLOR].pointer;
+        *params = (GLvoid*)state->array_object->arrays[ATTRIB_COLOR].pointer;
         break;
     case GL_TEXTURE_COORD_ARRAY_POINTER:
-        *params = (GLvoid*)state.array_object->arrays[ATTRIB_TEXCOORD].pointer;
+        *params = (GLvoid*)state->array_object->arrays[ATTRIB_TEXCOORD].pointer;
         break;
     case GL_MATRIX_INDEX_ARRAY_POINTER_ARB:
-        *params = (GLvoid*)state.array_object->arrays[ATTRIB_MTX_INDEX].pointer;
+        *params = (GLvoid*)state->array_object->arrays[ATTRIB_MTX_INDEX].pointer;
         break;
     case GL_EDGE_FLAG_ARRAY_POINTER:
     case GL_INDEX_ARRAY_POINTER:

--- a/src/GL/rendermode.c
+++ b/src/GL/rendermode.c
@@ -12,7 +12,7 @@ _Static_assert(FLAG_BLEND << ZMODE_BLEND_FLAG_SHIFT == SOM_ZMODE_TRANSPARENT);
 _Static_assert(FLAG_TEXTURE_ACTIVE == (1 << TEXTURE_ACTIVE_SHIFT));
 _Static_assert(FLAG_TEXTURE_ACTIVE >> TEX_ACTIVE_COMBINER_SHIFT == COMBINER_FLAG_TEXTURE);
 
-extern gl_state_t state;
+extern gl_state_t *state;
 
 // All possible combinations of blend functions. Configs that cannot be supported by the RDP are set to 0.
 // NOTE: We always set fog alpha to one to support GL_ONE in both factors
@@ -71,8 +71,8 @@ static const rdpq_blender_t blend_configs[64] = {
 
 void gl_rendermode_init()
 {
-    state.fog_start = 0.0f;
-    state.fog_end = 1.0f;
+    state->fog_start = 0.0f;
+    state->fog_end = 1.0f;
 
     glEnable(GL_DITHER);
     glBlendFunc(GL_ONE, GL_ZERO);
@@ -87,14 +87,14 @@ void gl_rendermode_init()
 
 void gl_update_fog()
 {
-    float fog_diff = state.fog_end - state.fog_start;
+    float fog_diff = state->fog_end - state->fog_start;
     // start == end is undefined, so disable fog by setting the factor to 0
-    state.fog_factor = fabsf(fog_diff) < FLT_MIN ? 0.0f : 1.0f / fog_diff;
-    state.fog_offset = state.fog_start;
+    state->fog_factor = fabsf(fog_diff) < FLT_MIN ? 0.0f : 1.0f / fog_diff;
+    state->fog_offset = state->fog_start;
 
     // Convert to s15.16 and premultiply with 1.15 conversion factor
-    int32_t factor_fx = state.fog_factor * (1<<(16 + 7 + (8 - VTX_SHIFT)));
-    int16_t offset_fx = state.fog_offset * (1<<VTX_SHIFT);
+    int32_t factor_fx = state->fog_factor * (1<<(16 + 7 + (8 - VTX_SHIFT)));
+    int16_t offset_fx = state->fog_offset * (1<<VTX_SHIFT);
 
     int16_t factor_i = factor_fx >> 16;
     uint16_t factor_f = factor_fx & 0xFFFF;
@@ -106,13 +106,13 @@ void gl_update_fog()
 
 void gl_set_fog_start(GLfloat param)
 {
-    state.fog_start = param;
+    state->fog_start = param;
     gl_update_fog();
 }
 
 void gl_set_fog_end(GLfloat param)
 {
-    state.fog_end = param;
+    state->fog_end = param;
     gl_update_fog();
 }
 

--- a/src/GL/rsp_pipeline.c
+++ b/src/GL/rsp_pipeline.c
@@ -3,7 +3,7 @@
 #include "gl_internal.h"
 #include "gl_rsp_asm.h"
 
-extern gl_state_t state;
+extern gl_state_t *state;
 
 #define DEFINE_BYTE_READ_FUNC(name, src_type, convert) \
     static void name(gl_cmd_stream_t *s, const src_type *src, uint32_t count) \
@@ -46,7 +46,7 @@ DEFINE_HALF_READ_FUNC(vtx_read_i16,   int16u_t,  VTX_CONVERT_INT)
 DEFINE_HALF_READ_FUNC(vtx_read_i32,   int32u_t,  VTX_CONVERT_INT)
 DEFINE_HALF_READ_FUNC(vtx_read_f32,   floatu,    VTX_CONVERT_FLT)
 DEFINE_HALF_READ_FUNC(vtx_read_f64,   doubleu,   VTX_CONVERT_FLT)
-DEFINE_HALF_FIXED_READ_FUNC(vtx_read_x16, state.vertex_halfx_precision)
+DEFINE_HALF_FIXED_READ_FUNC(vtx_read_x16, state->vertex_halfx_precision)
 
 #define COL_CONVERT_U8(v) ((v) << 7)
 #define COL_CONVERT_I8(v) ((v) << 8)
@@ -74,7 +74,7 @@ DEFINE_HALF_READ_FUNC(tex_read_i16,  int16u_t,  TEX_CONVERT_INT)
 DEFINE_HALF_READ_FUNC(tex_read_i32,  int32u_t,  TEX_CONVERT_INT)
 DEFINE_HALF_READ_FUNC(tex_read_f32,  floatu,    TEX_CONVERT_FLT)
 DEFINE_HALF_READ_FUNC(tex_read_f64,  doubleu,   TEX_CONVERT_FLT)
-DEFINE_HALF_FIXED_READ_FUNC(tex_read_x16, state.texcoord_halfx_precision)
+DEFINE_HALF_FIXED_READ_FUNC(tex_read_x16, state->texcoord_halfx_precision)
 
 #define NRM_CONVERT_U8(v) ((v) >> 1)
 #define NRM_CONVERT_I8(v) ((v))
@@ -171,19 +171,19 @@ static uint32_t vtx_cmd_size;
 static void upload_current_attributes(const gl_array_t *arrays)
 {
     if (arrays[ATTRIB_COLOR].enabled) {
-        gl_set_current_color(state.current_attributes.color);
+        gl_set_current_color(state->current_attributes.color);
     }
 
     if (arrays[ATTRIB_TEXCOORD].enabled) {
-        gl_set_current_texcoords(state.current_attributes.texcoord);
+        gl_set_current_texcoords(state->current_attributes.texcoord);
     }
 
     if (arrays[ATTRIB_NORMAL].enabled) {
-        gl_set_current_normal(state.current_attributes.normal);
+        gl_set_current_normal(state->current_attributes.normal);
     }
 
     if (arrays[ATTRIB_MTX_INDEX].enabled) {
-        gl_set_current_mtx_index(state.current_attributes.mtx_index);
+        gl_set_current_mtx_index(state->current_attributes.mtx_index);
     }
 }
 
@@ -253,9 +253,9 @@ static void set_attrib(gl_array_type_t array_type, const void *value, GLenum typ
 
 static bool check_last_array_element(int32_t *index)
 {
-    if (state.last_array_element >= 0) {
-        *index = state.last_array_element;
-        state.last_array_element = -1;
+    if (state->last_array_element >= 0) {
+        *index = state->last_array_element;
+        state->last_array_element = -1;
         return true;
     }
 
@@ -460,7 +460,7 @@ static void gl_prepare_vtx_cmd(const gl_array_t *arrays)
 static void gl_rsp_begin()
 {
     glpipe_init();
-    state.last_array_element = -1;
+    state->last_array_element = -1;
     begin_end_type = BEGIN_END_INDETERMINATE;
 }
 
@@ -468,15 +468,15 @@ static void gl_rsp_end()
 {
     int32_t index;
     if (check_last_array_element(&index)) {
-        load_last_attributes(state.array_object->arrays, index);
+        load_last_attributes(state->array_object->arrays, index);
     }
 
-    if (state.begin_end_active) {
+    if (state->begin_end_active) {
         // TODO: Load from arrays
-        gl_set_current_color(state.current_attributes.color);
-        gl_set_current_texcoords(state.current_attributes.texcoord);
-        gl_set_current_normal(state.current_attributes.normal);
-        gl_set_current_mtx_index(state.current_attributes.mtx_index);
+        gl_set_current_color(state->current_attributes.color);
+        gl_set_current_texcoords(state->current_attributes.texcoord);
+        gl_set_current_normal(state->current_attributes.normal);
+        gl_set_current_mtx_index(state->current_attributes.mtx_index);
     }
 }
 
@@ -492,7 +492,7 @@ static void gl_rsp_vertex(const void *value, GLenum type, uint32_t size)
     uint8_t cache_index;
     if (gl_get_cache_index(next_prim_id(), &cache_index))
     {
-        require_array_element(state.array_object->arrays);
+        require_array_element(state->array_object->arrays);
 
         rsp_read_attrib_func read_func = rsp_read_funcs[ATTRIB_VERTEX][gl_type_to_index(type)];
 
@@ -528,41 +528,41 @@ static void gl_rsp_mtx_index(const void *value, GLenum type, uint32_t size)
 static void gl_rsp_array_element(uint32_t index)
 {
     if (begin_end_type != BEGIN_END_ARRAY_ELEMENT) {
-        gl_prepare_vtx_cmd(state.array_object->arrays);
+        gl_prepare_vtx_cmd(state->array_object->arrays);
         begin_end_type = BEGIN_END_ARRAY_ELEMENT;
     }
 
-    draw_vertex_from_arrays(state.array_object->arrays, index, index);
-    state.last_array_element = index;
+    draw_vertex_from_arrays(state->array_object->arrays, index, index);
+    state->last_array_element = index;
 }
 
 static void gl_rsp_draw_arrays(uint32_t first, uint32_t count)
 {
-    if (state.array_object->arrays[ATTRIB_VERTEX].enabled) {
-        gl_prepare_vtx_cmd(state.array_object->arrays);
+    if (state->array_object->arrays[ATTRIB_VERTEX].enabled) {
+        gl_prepare_vtx_cmd(state->array_object->arrays);
         for (uint32_t i = 0; i < count; i++)
         {
-            draw_vertex_from_arrays(state.array_object->arrays, next_prim_id(), first + i);
+            draw_vertex_from_arrays(state->array_object->arrays, next_prim_id(), first + i);
         }
     }
 
-    load_last_attributes(state.array_object->arrays, first + count - 1);
+    load_last_attributes(state->array_object->arrays, first + count - 1);
 }
 
 static void gl_rsp_draw_elements(uint32_t count, const void* indices, read_index_func read_index)
 {
-    gl_fill_all_attrib_defaults(state.array_object->arrays);
+    gl_fill_all_attrib_defaults(state->array_object->arrays);
 
-    if (state.array_object->arrays[ATTRIB_VERTEX].enabled) {
-        gl_prepare_vtx_cmd(state.array_object->arrays);
+    if (state->array_object->arrays[ATTRIB_VERTEX].enabled) {
+        gl_prepare_vtx_cmd(state->array_object->arrays);
         for (uint32_t i = 0; i < count; i++)
         {
             uint32_t index = read_index(indices, i);
-            draw_vertex_from_arrays(state.array_object->arrays, index, index);
+            draw_vertex_from_arrays(state->array_object->arrays, index, index);
         }
     }
 
-    load_last_attributes(state.array_object->arrays, read_index(indices, count - 1));
+    load_last_attributes(state->array_object->arrays, read_index(indices, count - 1));
 }
 
 const gl_pipeline_t gl_rsp_pipeline = (gl_pipeline_t) {


### PR DESCRIPTION
The gl_state_t struct takes up roughly 13 KiB, which was statically allocated. The state is now allocated at runtime to reduce the memory impact while GL is not initialized.