### PR TITLE
Add xxd to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,6 @@ RUN apt-get update \
     g++ \
     make \
     git \
+    xxd \
     && apt-get clean \
     && apt autoremove -yq


### PR DESCRIPTION
The `xxd` utility is used in a handful of locations in the code base.
The Dockerfile should include `xxd` as part of image creation so these utilities can be used with the Docker workflow. 👍 
* src/rdpq/mkfontbuiltin.sh
```
18:    xxd -i $OUTFN | sed "s/${OUTFN_C}/__fontdb_${font}/g" >>rdpq_font_builtin.c
```
* boot/assets/Makefile
```
5:	xxd -i font.bin >font.h
```
* boot/Makefile
```
86:	xxd -i -n default_ipl3 $< >../tools/ipl3.h
```
