### PR TITLE
Updating root .gitignore file and example .gitignore files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ tools/n64sym
 tools/**/*.exe
 website/ref/
 
-## Generated assets
-tests/filesystem/*.sprite
-
 ## OSX junk
 .DS_Store
 .Trashes

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ tools/**/*.exe
 website/ref/
 
 ## Generated assets
-examples/fontdemo/filesystem/*.font64
 tests/filesystem/*.sprite
 
 ## OSX junk

--- a/examples/fontdemo/.gitignore
+++ b/examples/fontdemo/.gitignore
@@ -1,0 +1,1 @@
+filesystem/

--- a/examples/vifx/.gitignore
+++ b/examples/vifx/.gitignore
@@ -1,0 +1,1 @@
+filesystem/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 filesystem/*.dso
 filesystem/*.dso.sym
+filesystem/*.sprite


### PR DESCRIPTION
This pattern has already been established in the `customfont` and `gldemo` examples, among others. Correct me if I'm naively overlooking something. The **_vifx_** example/demo was causing some goofy git file tracking on the `examples/vifx/filesystem/philips.rgba32.sprite` file that was created.