### PR TITLE
Fix linker error when using Os optimization

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -225,7 +225,7 @@ extern "C" {
 #endif
 
 /** @brief Return true if we are running on a iQue player */
-inline bool sys_bbplayer(void) {
+static inline bool sys_bbplayer(void) {
     extern int __boot_consoletype;
     return __boot_consoletype != 0;
 }

--- a/src/vi.h
+++ b/src/vi.h
@@ -209,7 +209,7 @@ static const vi_config_t vi_config_presets[2][3] = {
  * @param[in] value
  *            Value to be written to the register
  */
-inline void vi_write_safe(volatile uint32_t *reg, uint32_t value){
+static inline void vi_write_safe(volatile uint32_t *reg, uint32_t value){
     assert(reg); /* This should never happen */
     *reg = value;
     MEMORY_BARRIER();
@@ -221,7 +221,7 @@ inline void vi_write_safe(volatile uint32_t *reg, uint32_t value){
  * @param[in] config
  *            A pointer to a set of register values to be written
  */
-inline void vi_write_config(const vi_config_t* config)
+static inline void vi_write_config(const vi_config_t* config)
 {
     /* This should never happen */
     assert(config);


### PR DESCRIPTION
I noticed this bug when compiling libdragon with my own build scripts, which used `-Os` instead of `-O2`.

This generated a final linking error of

```
C:/Users/Max/.platformio/packages/toolchain-gccmips64/bin/../lib/gcc/mips64-elf/14.2.0/../../../../mips64-elf/bin/ld.exe: .pio\build\n64\FrameworkLibdragon\display.o: in function `display_init':
(.text.display_init+0x360): undefined reference to `vi_write_config'
```
I then noticed that `vi_write_safe()` and `vi_write_config()` were the only two functions that were `inline` instead of `static inline`.

After adding the `static`, the linker error went away.

Edit: Corrected a similiar error in `include/n64sys.h`.