### PR TITLE
Add support for category code to n64tool

### DIFF
--- a/n64.mk
+++ b/n64.mk
@@ -5,6 +5,7 @@ SOURCE_DIR ?= .
 N64_MKDFS_ROOT ?= filesystem
 
 N64_ROM_TITLE = "Made with libdragon" # Override this with the name of your game or project
+N64_ROM_CATEGORY = # Set an N64 Media Category code in the ROM header (N, D, C, E, Z)
 N64_ROM_SAVETYPE = # Supported savetypes: none eeprom4k eeprom16 sram256k sram768k sram1m flashram
 N64_ROM_RTC = # Set to true to enable the Joybus Real-Time Clock
 N64_ROM_REGIONFREE = # Set to true to allow booting on any console region
@@ -74,6 +75,7 @@ N64_DSOLDFLAGS = --emit-relocs --unresolved-symbols=ignore-all --nmagic -T$(N64_
 
 N64_TOOLFLAGS = --title $(N64_ROM_TITLE)
 N64_TOOLFLAGS += $(if $(N64_ROM_HEADER),--header $(N64_ROM_HEADER))
+N64_TOOLFLAGS += $(if $(N64_ROM_CATEGORY),--category $(N64_ROM_CATEGORY))
 N64_TOOLFLAGS += $(if $(N64_ROM_REGION),--region $(N64_ROM_REGION))
 N64_ED64ROMCONFIGFLAGS =  $(if $(N64_ROM_SAVETYPE),--savetype $(N64_ROM_SAVETYPE))
 N64_ED64ROMCONFIGFLAGS += $(if $(N64_ROM_RTC),--rtc) 


### PR DESCRIPTION
Prerequisite for testing 64DD functionality

Adds `-C`/`--category` flag to n64tool to set N64 Media Category Code
Adds `N64_ROM_CATEGORY` variable to n64.mk

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/e7c5dca4-9126-452a-9828-9646f54faaba" />
