### PR TITLE
Integrate 64DD into RTC subsystem

### DIFF
--- a/examples/rtctest/Makefile
+++ b/examples/rtctest/Makefile
@@ -7,6 +7,7 @@ include $(N64_INST)/include/n64.mk
 OBJS = $(BUILD_DIR)/rtctest.o
 
 rtctest.z64: N64_ROM_TITLE = "RTC Test"
+rtctest.z64: N64_ROM_CATEGORY = C
 rtctest.z64: N64_ROM_RTC = true
 
 $(BUILD_DIR)/rtctest.elf: $(OBJS)

--- a/examples/rtctest/constants.h
+++ b/examples/rtctest/constants.h
@@ -54,7 +54,9 @@ static const char* RTC_DATE_FORMAT  = "            YYYY-MM-DD (DoW)            "
 static const char* RTC_TIME_FORMAT  = "                HH:MM:SS                ";
 static const char* ADJUST_MESSAGE   = "      Press A to adjust date/time       ";
 static const char* CONFIRM_MESSAGE  = "        Press A to write to RTC         ";
-static const char* NOWRITE_MESSAGE  = "     RTC source is not persistent!      ";
+static const char* NOWRITE_MESSAGE  = "      RTC source is not persistent!     ";
+static const char* SRC_JOY_MESSAGE  = "    Press L to switch to Joybus RTC     ";
+static const char* SRC_DD_MESSAGE   = "     Press L to switch to 64DD RTC      ";
 
 static const char* const DAYS_OF_WEEK[7] =
     { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };

--- a/examples/rtctest/rtctest.c
+++ b/examples/rtctest/rtctest.c
@@ -79,10 +79,18 @@ int main(void)
         graphics_draw_text( disp, 0, LINE4, line4_text );
 
         /* Line 5 */
+        graphics_set_color( WHITE, BLACK );
         if( !persistent )
         {
-            graphics_set_color( WHITE, BLACK );
             graphics_draw_text( disp, 0, LINE5, NOWRITE_MESSAGE );
+        }
+        else if( rtc_get_source() == RTC_SOURCE_JOYBUS && rtc_is_source_available( RTC_SOURCE_DD ) )
+        {
+            graphics_draw_text( disp, 0, LINE5, SRC_DD_MESSAGE );
+        }
+        else if( rtc_get_source() == RTC_SOURCE_DD && rtc_is_source_available( RTC_SOURCE_JOYBUS ) )
+        {
+            graphics_draw_text( disp, 0, LINE5, SRC_JOY_MESSAGE );
         }
 
         display_show(disp);
@@ -114,8 +122,20 @@ int main(void)
 
         if( !edit_mode && pad_pressed.r )
         {
-            /* Resync the time from the hardware RTC */
-            rtc_set_source( RTC_SOURCE_JOYBUS );
+            /* Resync the time from the RTC source */
+            rtc_set_source( rtc_get_source() );
+        }
+
+        if( !edit_mode && pad_pressed.l )
+        {
+            if( rtc_get_source() == RTC_SOURCE_JOYBUS )
+            {
+                rtc_set_source( RTC_SOURCE_DD );
+            }
+            else if( rtc_get_source() == RTC_SOURCE_DD )
+            {
+                rtc_set_source( RTC_SOURCE_JOYBUS );
+            }
         }
 
         if( edit_mode )

--- a/include/dd.h
+++ b/include/dd.h
@@ -1,7 +1,9 @@
 #ifndef LIBDRAGON_DD_H
-#define LIBDRAGON_DD_H  
+#define LIBDRAGON_DD_H
 
 #include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,8 +34,12 @@ typedef enum {
 
 uint16_t dd_command(dd_cmd_t cmd);
 
+time_t dd_get_time( void );
+
+bool dd_set_time( time_t new_time );
+
 inline bool sys_dd(void) {
-    return dd_found;    
+    return dd_found;
 }
 
 #ifdef __cplusplus

--- a/include/rtc.h
+++ b/include/rtc.h
@@ -96,7 +96,7 @@ extern "C" {
  * This will also hook the RTC into the newlib gettimeofday and settimeofday
  * functions, so you will be able to use the ISO C time functions.
  *
- * This operation may take up to 50 milliseconds to complete, but does not
+ * This operation may take up to 5 milliseconds to complete, but does not
  * block the CPU while detecting and initializing the RTC hardware.
  *
  * Use #rtc_get_source to determine if a hardware RTC source was detected.
@@ -115,7 +115,7 @@ void rtc_init_async( void );
  * This will also hook the RTC into the newlib gettimeofday and settimeofday
  * functions, so you will be able to use the ISO C time functions.
  *
- * This operation may take up to 50 milliseconds to complete.
+ * This operation may take up to 5 milliseconds to complete.
  *
  * @return whether any supported hardware RTC source was initialized
  */
@@ -147,6 +147,27 @@ rtc_source_t rtc_get_source( void );
  * @return whether the new source clock was successfully selected
  */
 bool rtc_set_source( rtc_source_t source );
+
+/**
+ * @brief Determine whether a specific clock source supports persistent
+ * writing of the time.
+ *
+ * Some emulators and flash carts do not support writing to the RTC, so
+ * this function makes an attempt to detect silent write failures and will
+ * return `false` if it is unable to change the time on the RTC.
+ *
+ * This function is useful if your program wants to conditionally offer the
+ * ability to set the time based on hardware/emulator support.
+ *
+ * Unfortunately this operation may introduce a slight drift in the clock,
+ * but it is the only reliable way to determine if the RTC actually persists
+ * the time.
+ *
+ * @param source the RTC source to check
+ *
+ * @return whether RTC write persistence appears to be supported for the source
+ */
+bool rtc_is_source_persistent( rtc_source_t source );
 
 /**
  * @brief Determine whether the RTC supports persistent writing of the time.

--- a/src/dd/dd.c
+++ b/src/dd/dd.c
@@ -1,8 +1,11 @@
 #include <stdint.h>
 #include <stdbool.h>
+#include <time.h>
 #include "dd.h"
+#include "debug.h"
 #include "interrupt.h"
 #include "dma.h"
+#include "rtc_utils.h"
 
 #define DD_ASIC_STATUS_MECHA_IRQ_LINE    (1<<9)
 #define DD_ASIC_STATUS_BM_IRQ_LINE       (1<<10)
@@ -48,7 +51,7 @@ uint16_t dd_command(dd_cmd_t cmd) {
 }
 
 __attribute__((constructor))
-void dd_init(void) 
+void dd_init(void)
 {
 	uint32_t magic = 0x36344444; // "64DD"
 	dd_found = io_read(0x06000020) == magic;
@@ -59,4 +62,71 @@ void dd_init(void)
     // them to avoid stalling the CPU.
     set_CART_interrupt(1);
     register_CART_handler(dd_handler);
+}
+
+time_t dd_get_time( void )
+{
+    // NOTE: the order of these commands is important, because reading MINSEC
+    // is what actually triggers the handshake with the RTC. The other two
+    // reads just fetch cached values.
+    uint16_t ms = dd_command(DD_CMD_RTC_GET_MINSEC);
+    uint16_t dh = dd_command(DD_CMD_RTC_GET_DAYHOUR);
+    uint16_t ym = dd_command(DD_CMD_RTC_GET_YEARMONTH);
+
+    debugf("dd_get_time: raw time: %02x-%02x-%02x %02x:%02x:%02x\n",
+        ym >> 8, ym & 0xFF, dh >> 8, dh & 0xFF, ms >> 8, ms & 0xFF);
+
+    // By convention, 2-digit year is interpreted as 20YY if it's 96 or later
+    int year = bcd_decode( ym >> 8 );
+
+    struct tm rtc_time = (struct tm){
+        .tm_sec   = bcd_decode( ms & 0xFF ),
+        .tm_min   = bcd_decode( ms >> 8 ),
+        .tm_hour  = bcd_decode( dh & 0xFF ),
+        .tm_mday  = bcd_decode( dh >> 8 ),
+        .tm_mon   = bcd_decode (ym & 0xFF ) - 1,
+        .tm_year  = year + (year >= 96 ? 0 : 100),
+    };
+
+    char buff[20];
+    strftime(buff, 20, "%Y-%m-%d %H:%M:%S", &rtc_time);
+    debugf("dd_get_time: parsed time: %s\n", buff);
+
+    return mktime( &rtc_time );
+}
+
+bool dd_set_time( time_t new_time )
+{
+    struct tm * rtc_time = gmtime( &new_time );
+
+    char buff[20];
+    strftime(buff, 20, "%Y-%m-%d %H:%M:%S", rtc_time);
+    debugf("dd_set_time: parsed time: %s\n", buff);
+
+    uint8_t year = bcd_encode( rtc_time->tm_year % 100 );
+    uint8_t month = bcd_encode( rtc_time->tm_mon + 1 );
+    uint8_t day = bcd_encode( rtc_time->tm_mday );
+    uint8_t hour = bcd_encode( rtc_time->tm_hour );
+    uint8_t min = bcd_encode( rtc_time->tm_min );
+    uint8_t sec = bcd_encode( rtc_time->tm_sec );
+
+    debugf("dd_set_time raw time: %02x-%02x-%02x %02x:%02x:%02x\n",
+        year, month, day, hour, min, sec);
+
+    uint16_t ym_write = year << 8 | month;
+    uint16_t dh_write = day << 8 | hour;
+    uint16_t ms_write = min << 8 | sec;
+
+    dd_write( DD_ASIC_DATA, ym_write );
+    uint16_t ym_read = dd_command( DD_CMD_RTC_SET_YEARMONTH );
+
+    dd_write( DD_ASIC_DATA, dh_write );
+    uint16_t dh_read = dd_command( DD_CMD_RTC_SET_DAYHOUR );
+
+    dd_write( DD_ASIC_DATA, ms_write );
+    uint16_t ms_read = dd_command( DD_CMD_RTC_SET_MINSEC );
+
+    debugf("dd_set_time: result: %04x %04x %04x\n", ym_read, dh_read, ms_read);
+
+    return ym_write == ym_read && dh_write == dh_read && ms_write == ms_read;
 }


### PR DESCRIPTION
[N64brew Discord Thread](https://discord.com/channels/205520502922543113/1332811445326319646)

## Highlights

* Add functions to get and set the 64DD RTC
* Change rtctest example ROM media category to `C` (Expandable Game Pak with optional 64DD support)
* Add support for 64DD as a clock source in RTC subsystem
* Allow switching RTC source in rtctest example (if both Joybus and DD RTCs are available)

##  Outstanding items

- [ ] Investigating weird issues with clock drift
- [ ] Needs more testing

## Caveats

* 64DD is currently rather obnoxious to enable in emulators/flashcarts:
  * Ares only enables 64DD for N64 ROMs if they have category code `C` and an expansion disk is loaded
  * SC64 only enables 64DD registers if a 64DD IPL and expansion disk are provided
    * The test ROM will hang indefinitely if you try to load with just the 64DD IPL and no expansion disk
    * The test ROM will hang indefinitely on 64DD access if you detach sc64deployer
* SC64 only has one physical RTC, so things get weird when both clocks are being used
  * Still investigating the nature of this; need clarity from Korgeaux on expected behavior here

## Testing

### Ares

To test with Ares, you need to specify the US 64DD IPL in the Firmware settings and provide a "dummy" 64DD Disk:
```bash
ares rtctest.z64 dummy_disk.ndd
```

LuigiBlood has [good documentation for using 64DD with Ares on 64DD.org](https://64dd.org/tutorial_ares.html). The critical piece is that the Game Pak ROM **MUST** have a Game ID Category Code of `C` for Ares to trigger the 64DD codepath. The F-Zero Expansion Disk makes for a good "dummy" disk.

### SC64

To test with SC64, you also need to provide the US 64DD IPL and a "dummy" 64DD Disk:
```bash
sc64deployer 64dd 64DD_IPL_US.n64 dummy_disk.ndd   --rom rtctest.z64
```

Note that if you don't provide a dummy disk, SC64 will not fully emulate the 64DD and the test ROM will hang.