### PR TITLE
Implement support for async Joypad accessory reads and writes

### DIFF
--- a/src/joypad.c
+++ b/src/joypad.c
@@ -92,17 +92,11 @@ static joypad_device_cold_t joypad_devices_cold[JOYPAD_PORT_COUNT] = {0};
  */
 static void joypad_device_changed(joypad_port_t port, joybus_identifier_t identifier)
 {
-    timer_link_t *timer = joypad_accessories_hot[port].transfer_pak_wait_timer;
-    if (timer) { stop_timer(timer); }
-
     joypad_identifiers_hot[port] = identifier;
     joypad_origins_hot[port] = JOYPAD_GCN_ORIGIN_INIT;
     memset((void *)&joypad_devices_cold[port], 0, sizeof(joypad_devices_cold[port]));
     memset((void *)&joypad_devices_hot[port], 0, sizeof(joypad_devices_hot[port]));
-    memset((void *)&joypad_accessories_hot[port], 0, sizeof(joypad_accessories_hot[port]));
-
-    // Restore the timer pointer on the cleared accessory
-    joypad_accessories_hot[port].transfer_pak_wait_timer = timer;
+    joypad_accessory_reset(port);
 }
 
 /**

--- a/src/joypad_accessory.c
+++ b/src/joypad_accessory.c
@@ -518,6 +518,187 @@ void joypad_rumble_pak_toggle_async(joypad_port_t port, bool active)
     );
 }
 
+static void joypad_accessory_read_callback(uint64_t *out_dwords, void *ctx)
+{
+    const uint8_t *out_bytes = (void *)out_dwords;
+    joypad_port_t port = (joypad_port_t)ctx;
+    volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
+    volatile joypad_accessory_io_t *io = &accessory->io;
+    joypad_accessory_state_t state = accessory->state;
+    if (state != JOYPAD_ACCESSORY_STATE_READ)
+    {
+         // TODO Call callback with error code
+        if (io->callback)
+        {
+            io->callback(-1, io->ctx);
+        }
+        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
+        return; // Unexpected accessory state!
+    }
+
+    const joybus_cmd_n64_accessory_read_port_t *cmd =
+        (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
+    joybus_callback_t retry_callback = joypad_accessory_read_callback;
+    if (joypad_accessory_check_read_crc_error(port, cmd, retry_callback, ctx))
+    {
+        // TODO Call callback with error code
+        if (io->callback)
+        {
+            io->callback(-1, io->ctx);
+        }
+        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
+        return; // Accessory communication error!
+    }
+
+    memcpy(io->cursor, cmd->recv.data, JOYBUS_ACCESSORY_DATA_SIZE);
+    io->cursor += JOYBUS_ACCESSORY_DATA_SIZE;
+    if (io->cursor < io->end)
+    {
+        // Read the next block of data
+        accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+        accessory->retries = 0;
+        uint16_t next_addr = cmd->send.addr_checksum & JOYBUS_ACCESSORY_ADDR_MASK_OFFSET;
+        next_addr += JOYBUS_ACCESSORY_DATA_SIZE;
+        joybus_accessory_read_async(
+            port, next_addr,
+            joypad_accessory_read_callback, ctx
+        );
+    }
+    else
+    {
+        // Read operation is complete
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        if (io->callback)
+        {
+            io->callback(0, io->ctx);
+        }
+        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
+    }
+}
+
+void joypad_accessory_read_async(
+    joypad_port_t port,
+    uint16_t start_addr,
+    void *dst,
+    size_t len,
+    joypad_accessory_io_callback_t callback,
+    void *ctx
+)
+{
+    ASSERT_JOYPAD_PORT_VALID(port);
+    assert(len % JOYBUS_ACCESSORY_DATA_SIZE == 0);
+    volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
+    if (accessory->state != JOYPAD_ACCESSORY_STATE_IDLE)
+    {
+        callback(-1, ctx);
+        return; // Accessory is busy with another operation
+    }
+    accessory->io = (joypad_accessory_io_t){
+        .start = dst,
+        .end = dst + len,
+        .cursor = dst,
+        .callback = callback,
+        .ctx = ctx,
+    };
+
+    accessory->state = JOYPAD_ACCESSORY_STATE_READ;
+    accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+    accessory->retries = 0;
+    joybus_accessory_read_async(
+        port, start_addr,
+        joypad_accessory_read_callback, (void *)port
+    );
+}
+
+static void joypad_accessory_write_callback(uint64_t *out_dwords, void *ctx)
+{
+    const uint8_t *out_bytes = (void *)out_dwords;
+    joypad_port_t port = (joypad_port_t)ctx;
+    volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
+    volatile joypad_accessory_io_t *io = &accessory->io;
+    joypad_accessory_state_t state = accessory->state;
+    if (state != JOYPAD_ACCESSORY_STATE_WRITE)
+    {
+        if (io->callback)
+        {
+            io->callback(-1, io->ctx);
+        }
+        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
+        return; // Unexpected accessory state!
+    }
+
+    const joybus_cmd_n64_accessory_write_port_t *cmd =
+        (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
+    joybus_callback_t retry_callback = joypad_accessory_write_callback;
+    if (joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    {
+        if (io->callback)
+        {
+            io->callback(-1, io->ctx);
+        }
+        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
+        return; // Accessory communication error!
+    }
+
+    uint8_t *cursor = io->cursor += JOYBUS_ACCESSORY_DATA_SIZE;
+    if (cursor < io->end)
+    {
+        // Read the next block of data
+        accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+        accessory->retries = 0;
+        uint16_t next_addr = cmd->send.addr_checksum & JOYBUS_ACCESSORY_ADDR_MASK_OFFSET;
+        next_addr += JOYBUS_ACCESSORY_DATA_SIZE;
+        joybus_accessory_write_async(
+            port, next_addr, cursor,
+            joypad_accessory_write_callback, ctx
+        );
+    }
+    else
+    {
+        // Read operation is complete
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        if (io->callback)
+        {
+            io->callback(0, io->ctx);
+        }
+        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
+    }
+}
+
+void joypad_accessory_write_async(
+    joypad_port_t port,
+    uint16_t start_addr,
+    void *src,
+    size_t len,
+    joypad_accessory_io_callback_t callback,
+    void *ctx
+)
+{
+    ASSERT_JOYPAD_PORT_VALID(port);
+    assert(len % JOYBUS_ACCESSORY_DATA_SIZE == 0);
+    volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
+    if (accessory->state != JOYPAD_ACCESSORY_STATE_IDLE)
+    {
+        callback(-1, ctx);
+        return; // Accessory is busy with another operation
+    }
+    accessory->io = (joypad_accessory_io_t){
+        .start = src,
+        .end = src + len,
+        .cursor = src,
+        .callback = callback,
+        .ctx = ctx,
+    };
+
+    accessory->state = JOYPAD_ACCESSORY_STATE_WRITE;
+    accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+    accessory->retries = 0;
+    joybus_accessory_write_async(
+        port, start_addr, src,
+        joypad_accessory_write_callback, (void *)port
+    );
+}
+
 /**
  * @brief Callback for the accessory read commands used by #joypad_transfer_pak_enable_async.
  * 

--- a/src/joypad_accessory.c
+++ b/src/joypad_accessory.c
@@ -112,7 +112,7 @@ static bool joypad_accessory_check_read_crc_error(
  * @retval true The accessory write command failed
  * @retval false The accessory write command succeeded
  */
-static bool joypad_accessory_write_crc_error_check(
+static bool joypad_accessory_check_write_crc_error(
     joypad_port_t port,
     const joybus_cmd_n64_accessory_write_port_t *cmd,
     joybus_callback_t retry_callback,
@@ -175,6 +175,35 @@ static bool joypad_accessory_write_crc_error_check(
             accessory->error = JOYPAD_ACCESSORY_ERROR_UNKNOWN;
             return true;
         }
+    }
+}
+
+void joypad_accessory_reset(joypad_port_t port)
+{
+    ASSERT_JOYPAD_PORT_VALID(port);
+    volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
+    joypad_accessory_state_t state = accessory->state;
+    timer_link_t *tpak_wait_timer = accessory->transfer_pak_wait_timer;
+    joypad_accessory_io_callback_t io_callback = accessory->io.callback;
+    void *io_callback_ctx = accessory->io.ctx;
+
+    // Stop the Transfer Pak wait timer if it is running
+    if (tpak_wait_timer) { stop_timer(tpak_wait_timer); }
+
+    // Clear the accessory state
+    memset((void *)accessory, 0, sizeof(*accessory));
+
+    // Restore Transfer Pak wait timer pointer so that it can be re-used
+    accessory->transfer_pak_wait_timer = tpak_wait_timer;
+
+    // Resolve async accessory read/write callback
+    if( (
+        state == JOYPAD_ACCESSORY_STATE_READ ||
+        state == JOYPAD_ACCESSORY_STATE_WRITE
+        ) && io_callback != NULL
+    )
+    {
+        io_callback( JOYPAD_ACCESSORY_ERROR_ABSENT, io_callback_ctx );
     }
 }
 
@@ -379,7 +408,7 @@ static void joypad_accessory_detect_write_callback(uint64_t *out_dwords, void *c
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_accessory_detect_write_callback;
-    if (joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    if (joypad_accessory_check_write_crc_error(port, cmd, retry_callback, ctx))
     {
         return; // Accessory communication error!
     }
@@ -496,7 +525,7 @@ static void joypad_rumble_pak_motor_write_callback(uint64_t *out_dwords, void *c
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_rumble_pak_motor_write_callback;
-    if (!joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    if (!joypad_accessory_check_write_crc_error(port, cmd, retry_callback, ctx))
     {
         accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
     }
@@ -525,14 +554,15 @@ static void joypad_accessory_read_callback(uint64_t *out_dwords, void *ctx)
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     volatile joypad_accessory_io_t *io = &accessory->io;
     joypad_accessory_state_t state = accessory->state;
+    joypad_accessory_io_callback_t callback = io->callback;
+    void *callback_ctx = io->ctx;
     if (state != JOYPAD_ACCESSORY_STATE_READ)
     {
-         // TODO Call callback with error code
-        if (io->callback)
+        memset( (void *)io, 0, sizeof(*io) );
+        if (callback != NULL)
         {
-            io->callback(-1, io->ctx);
+            callback( JOYPAD_ACCESSORY_ERROR_UNKNOWN, callback_ctx );
         }
-        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
         return; // Unexpected accessory state!
     }
 
@@ -541,12 +571,11 @@ static void joypad_accessory_read_callback(uint64_t *out_dwords, void *ctx)
     joybus_callback_t retry_callback = joypad_accessory_read_callback;
     if (joypad_accessory_check_read_crc_error(port, cmd, retry_callback, ctx))
     {
-        // TODO Call callback with error code
-        if (io->callback)
+        memset( (void *)io, 0, sizeof(*io) );
+        if (callback != NULL)
         {
-            io->callback(-1, io->ctx);
+            callback( accessory->error, callback_ctx );
         }
-        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
         return; // Accessory communication error!
     }
 
@@ -567,12 +596,13 @@ static void joypad_accessory_read_callback(uint64_t *out_dwords, void *ctx)
     else
     {
         // Read operation is complete
+        memset( (void *)io, 0, sizeof(*io) );
         accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-        if (io->callback)
+        accessory->error = JOYPAD_ACCESSORY_ERROR_NONE;
+        if (callback != NULL)
         {
-            io->callback(0, io->ctx);
+            callback( accessory->error, callback_ctx );
         }
-        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
     }
 }
 
@@ -590,7 +620,7 @@ void joypad_accessory_read_async(
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     if (accessory->state != JOYPAD_ACCESSORY_STATE_IDLE)
     {
-        callback(-1, ctx);
+        callback( JOYPAD_ACCESSORY_ERROR_UNKNOWN, ctx );
         return; // Accessory is busy with another operation
     }
     accessory->io = (joypad_accessory_io_t){
@@ -617,26 +647,29 @@ static void joypad_accessory_write_callback(uint64_t *out_dwords, void *ctx)
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     volatile joypad_accessory_io_t *io = &accessory->io;
     joypad_accessory_state_t state = accessory->state;
+    joypad_accessory_io_callback_t callback = io->callback;
+    void *callback_ctx = io->ctx;
+
     if (state != JOYPAD_ACCESSORY_STATE_WRITE)
     {
-        if (io->callback)
+        memset( (void *)io, 0, sizeof(*io) );
+        if (callback != NULL)
         {
-            io->callback(-1, io->ctx);
+            callback( JOYPAD_ACCESSORY_ERROR_UNKNOWN, callback_ctx );
         }
-        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
         return; // Unexpected accessory state!
     }
 
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_accessory_write_callback;
-    if (joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    if (joypad_accessory_check_write_crc_error(port, cmd, retry_callback, ctx))
     {
-        if (io->callback)
+        memset( (void *)io, 0, sizeof(*io) );
+        if (callback != NULL)
         {
-            io->callback(-1, io->ctx);
+            callback( accessory->error, callback_ctx );
         }
-        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
         return; // Accessory communication error!
     }
 
@@ -656,12 +689,13 @@ static void joypad_accessory_write_callback(uint64_t *out_dwords, void *ctx)
     else
     {
         // Read operation is complete
+        memset( (void *)io, 0, sizeof(*io) );
         accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-        if (io->callback)
+        accessory->error = JOYPAD_ACCESSORY_ERROR_NONE;
+        if (callback != NULL)
         {
-            io->callback(0, io->ctx);
+            callback( accessory->error, callback_ctx );
         }
-        memset( (void *)io, 0, sizeof(joypad_accessory_io_t) );
     }
 }
 
@@ -679,7 +713,7 @@ void joypad_accessory_write_async(
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     if (accessory->state != JOYPAD_ACCESSORY_STATE_IDLE)
     {
-        callback(-1, ctx);
+        callback( JOYPAD_ACCESSORY_ERROR_UNKNOWN, ctx );
         return; // Accessory is busy with another operation
     }
     accessory->io = (joypad_accessory_io_t){
@@ -750,7 +784,7 @@ static void joypad_transfer_pak_enable_write_callback(uint64_t *out_dwords, void
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_transfer_pak_enable_write_callback;
-    if (joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    if (joypad_accessory_check_write_crc_error(port, cmd, retry_callback, ctx))
     {
         return; // Accessory communication error!
     }
@@ -922,7 +956,7 @@ static void joypad_transfer_pak_load_write_callback(uint64_t *out_dwords, void *
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_transfer_pak_load_write_callback;
-    if (joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    if (joypad_accessory_check_write_crc_error(port, cmd, retry_callback, ctx))
     {
         return; // Accessory communication error!
     }
@@ -1043,7 +1077,7 @@ static void joypad_transfer_pak_store_write_callback(uint64_t *out_dwords, void 
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_transfer_pak_store_write_callback;
-    if (joypad_accessory_write_crc_error_check(port, cmd, retry_callback, ctx))
+    if (joypad_accessory_check_write_crc_error(port, cmd, retry_callback, ctx))
     {
         return; // Accessory communication error!
     }

--- a/src/joypad_accessory.h
+++ b/src/joypad_accessory.h
@@ -158,6 +158,16 @@ void joypad_accessory_reset(joypad_port_t port);
  */
 void joypad_accessory_detect_async(joypad_port_t port);
 
+/**
+ * @brief Read data from a Joypad accessory asynchronously.
+ * 
+ * @param port Joypad port number (#joypad_port_t)
+ * @param start_addr Starting address in the accessory to read from.
+ * @param dst Destination buffer to read accessory data into.
+ * @param len Number of bytes to read.
+ * @param callback Callback function to call when the read operation completes.
+ * @param ctx Opaque pointer to pass to the callback function.
+ */
 void joypad_accessory_read_async(
     joypad_port_t port,
     uint16_t start_addr,
@@ -167,6 +177,16 @@ void joypad_accessory_read_async(
     void *ctx
 );
 
+/**
+ * @brief Write data to a Joypad accessory asynchronously.
+ * 
+ * @param port Joypad port number (#joypad_port_t)
+ * @param start_addr Starting address in the accessory to write to.
+ * @param src Source buffer of data to write to the accessory.
+ * @param len Number of bytes to write.
+ * @param callback Callback function to call when the write operation completes.
+ * @param ctx Opaque pointer to pass to the callback function.
+ */
 void joypad_accessory_write_async(
     joypad_port_t port,
     uint16_t start_addr,

--- a/src/joypad_accessory.h
+++ b/src/joypad_accessory.h
@@ -96,7 +96,7 @@ typedef enum
 } joypad_accessory_error_t;
 
 /** @brief Callback function signature for #joypad_accessory_read_async and #joypad_accessory_write_async */
-typedef void (*joypad_accessory_io_callback_t)(int error, void *ctx);
+typedef void (*joypad_accessory_io_callback_t)(joypad_accessory_error_t error, void *ctx);
 
 /** @brief Joypad Accessory I/O operation state */
 typedef struct
@@ -132,6 +132,13 @@ typedef struct joypad_accessory_s
     joybus_transfer_pak_status_t transfer_pak_status;
     joypad_transfer_pak_io_t transfer_pak_io;
 } joypad_accessory_t;
+
+/**
+ * @brief Reset the accessory state for a Joypad port.
+ * 
+ * @param port Joypad port number (#joypad_port_t)
+ */
+void joypad_accessory_reset(joypad_port_t port);
 
 /**
  * @brief Detect which accessory is inserted in an N64 controller.

--- a/src/joypad_accessory.h
+++ b/src/joypad_accessory.h
@@ -42,6 +42,10 @@ typedef enum
     JOYPAD_ACCESSORY_STATE_DETECT_TRANSFER_PROBE_OFF,
     JOYPAD_ACCESSORY_STATE_DETECT_SNAP_PROBE_WRITE,
     JOYPAD_ACCESSORY_STATE_DETECT_SNAP_PROBE_READ,
+    // Accessory read states
+    JOYPAD_ACCESSORY_STATE_READ,
+    // Accessory write states
+    JOYPAD_ACCESSORY_STATE_WRITE,
     // Rumble Pak motor control states
     JOYPAD_ACCESSORY_STATE_RUMBLE_WRITE,
     // Transfer Pak power control states
@@ -91,6 +95,19 @@ typedef enum
     JOYPAD_ACCESSORY_ERROR_UNKNOWN,
 } joypad_accessory_error_t;
 
+/** @brief Callback function signature for #joypad_accessory_read_async and #joypad_accessory_write_async */
+typedef void (*joypad_accessory_io_callback_t)(int error, void *ctx);
+
+/** @brief Joypad Accessory I/O operation state */
+typedef struct
+{
+    uint8_t *start;
+    uint8_t *end;
+    uint8_t *cursor;
+    joypad_accessory_io_callback_t callback;
+    void *ctx;
+} joypad_accessory_io_t;
+
 /** @brief Joypad N64 Transfer Pak I/O operation state */
 typedef struct
 {
@@ -110,6 +127,7 @@ typedef struct joypad_accessory_s
     joypad_accessory_state_t state;
     joypad_accessory_error_t error;
     unsigned retries;
+    joypad_accessory_io_t io;
     timer_link_t *transfer_pak_wait_timer;
     joybus_transfer_pak_status_t transfer_pak_status;
     joypad_transfer_pak_io_t transfer_pak_io;
@@ -132,6 +150,24 @@ typedef struct joypad_accessory_s
  * @param port Joypad port to detect the accessory on (#joypad_port_t)
  */
 void joypad_accessory_detect_async(joypad_port_t port);
+
+void joypad_accessory_read_async(
+    joypad_port_t port,
+    uint16_t start_addr,
+    void *dst,
+    size_t len,
+    joypad_accessory_io_callback_t callback,
+    void *ctx
+);
+
+void joypad_accessory_write_async(
+    joypad_port_t port,
+    uint16_t start_addr,
+    void *src,
+    size_t len,
+    joypad_accessory_io_callback_t callback,
+    void *ctx
+);
 
 /**
  * @brief Turn the Rumble Pak motor on or off for a Joypad port.

--- a/src/mempak.c
+++ b/src/mempak.c
@@ -4,9 +4,13 @@
  * @ingroup controllerpak
  */
 #include <string.h>
-#include "regsinternal.h"
 #include <unistd.h>
+#include "kernel/kernel_internal.h"
+#include "kirq.h"
+#include "regsinternal.h"
+#include "joybus.h"
 #include "joybus_accessory.h"
+#include "joypad_accessory.h"
 #include "mempak.h"
 
 /**
@@ -24,22 +28,38 @@
 #define BLOCK_VALID_LAST    0x7F
 /** @} */
 
+static void mempak_async_callback( joypad_accessory_error_t result, void *ctx )
+{
+    volatile joypad_accessory_error_t *result_ptr = (volatile joypad_accessory_error_t *)ctx;
+    *result_ptr = result;
+}
+
 int read_mempak_sector( int controller, int sector, uint8_t *sector_data )
 {
     if( sector < 0 || sector >= 128 ) { return -1; }
     if( sector_data == 0 ) { return -1; }
 
-    /* Sectors are 256 bytes, a Controller Pak reads 32 bytes at a time */
-    for( int i = 0; i < 8; i++ )
+    uint16_t start_addr = sector * MEMPAK_BLOCK_SIZE;
+    volatile joypad_accessory_error_t result = JOYPAD_ACCESSORY_ERROR_PENDING;
+    kirq_wait_t w = kirq_begin_wait_si();
+
+    joypad_accessory_read_async(
+        controller,
+        start_addr,
+        sector_data,
+        MEMPAK_BLOCK_SIZE,
+        mempak_async_callback,
+        (void *)&result
+    );
+
+    while( result == JOYPAD_ACCESSORY_ERROR_PENDING )
     {
-        if( joybus_accessory_read( controller, (sector * MEMPAK_BLOCK_SIZE) + (i * 32), sector_data + (i * 32) ) )
-        {
-            /* Failed to read a block */
-            return -2;
+        if (__kernel) {
+            kirq_wait(&w);
         }
     }
 
-    return 0;
+    return result;
 }
 
 int write_mempak_sector( int controller, int sector, uint8_t *sector_data )
@@ -47,17 +67,27 @@ int write_mempak_sector( int controller, int sector, uint8_t *sector_data )
     if( sector < 0 || sector >= 128 ) { return -1; }
     if( sector_data == 0 ) { return -1; }
 
-    /* Sectors are 256 bytes, a Controller Pak writes 32 bytes at a time */
-    for( int i = 0; i < 8; i++ )
+    uint16_t start_addr = sector * MEMPAK_BLOCK_SIZE;
+    volatile joypad_accessory_error_t result = JOYPAD_ACCESSORY_ERROR_PENDING;
+    kirq_wait_t w = kirq_begin_wait_si();
+
+    joypad_accessory_write_async(
+        controller,
+        start_addr,
+        sector_data,
+        MEMPAK_BLOCK_SIZE,
+        mempak_async_callback,
+        (void *)&result
+    );
+
+    while( result == JOYPAD_ACCESSORY_ERROR_PENDING )
     {
-        if( joybus_accessory_write( controller, (sector * MEMPAK_BLOCK_SIZE) + (i * 32), sector_data + (i * 32) ) )
-        {
-            /* Failed to read a block */
-            return -2;
+        if (__kernel) {
+            kirq_wait(&w);
         }
     }
 
-    return 0;
+    return result;
 }
 
 /**
@@ -165,7 +195,7 @@ static int __validate_toc( uint8_t *sector )
 
 /**
  * @brief Convert a Controller Pak character to UTF-8
- * 
+ *
  * The codepage used by the controller pak contains a subset of ASCII and
  * some Katakana.
  *
@@ -173,7 +203,7 @@ static int __validate_toc( uint8_t *sector )
  *            A character read from a Controller Pak entry title
  * @param[out] out
  *            Output buffer to write the bytes to (at least 3 bytes).
- * 
+ *
  * @return    The number of bytes written to the output buffer
  */
 static int __n64_to_utf8( uint8_t c, char *out )


### PR DESCRIPTION
Introduces two new internal APIs:

* `joypad_accessory_read_async`
* `joypad_accessory_write_async`

These can be used to access one or more accessory blocks in the background, and will call a callback when completed.

Example usage can be seen in `mempak.c` @rasky