### PR TITLE
Add script to build + install GDB in the toolchain

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -7,10 +7,12 @@ on:
   push:
     paths:
       - 'tools/build-toolchain.sh'
+      - 'tools/build-gdb.sh'
   pull_request:
     paths:
       - 'tools/build-toolchain.sh'
-  
+      - 'tools/build-gdb.sh'
+
 jobs:
   Build-Toolchain:
     # targets the oldest ubuntu image available to create valid packages for as many versions possible.
@@ -22,6 +24,7 @@ jobs:
       gmp-version: ${{ steps.gcc-version-generator.outputs.GMP_VERSION }}
       mpc-version: ${{ steps.gcc-version-generator.outputs.MPC_VERSION }}
       mpfr-version: ${{ steps.gcc-version-generator.outputs.MPFR_VERSION }}
+      gdb-version: ${{ steps.gcc-version-generator.outputs.GDB_VERSION }}
       make-version: ${{ steps.gcc-version-generator.outputs.MAKE_VERSION }}
     strategy:
       fail-fast: false
@@ -33,7 +36,8 @@ jobs:
     runs-on: ${{ matrix.host-os }}
 
     env:
-      Build_Directory: libdragon
+      Install_Directory: libdragon
+      Build_Directory: scratch
 
     steps:
       - name: Install native system build dependencies
@@ -89,6 +93,7 @@ jobs:
           echo "BINUTILS_VERSION=$(grep -Po 'BINUTILS_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
           echo "GCC_VERSION=$(grep -Po 'GCC_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
           echo "NEWLIB_VERSION=$(grep -Po 'NEWLIB_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
+          echo "GDB_VERSION=$(grep -Po 'GDB_V=\K[^"]*' ./tools/build-gdb.sh)" >> $GITHUB_OUTPUT
 
           echo "GMP_VERSION=$(grep -Po 'GMP_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
           echo "MPC_VERSION=$(grep -Po 'MPC_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
@@ -100,11 +105,14 @@ jobs:
       - name: Build N64 MIPS GCC toolchain for ${{ matrix.target-platform }}
         run: |
           # required for newlib (as not the default?!)
-          export PATH="$PATH:${{ runner.temp }}/${{ env.Build_Directory }}"
+          export PATH="$PATH:${{ runner.temp }}/${{ env.Install_Directory }}"
+          export BUILD_PATH=${{ runner.temp }}/${{ env.Build_Directory }}
+          export N64_INST=${{ runner.temp }}/${{ env.Install_Directory }}
+          export N64_HOST=${{ matrix.host }}
           cd ./tools/
-          N64_INST=${{ runner.temp }}/${{ env.Build_Directory }} N64_HOST=${{ matrix.host }} MAKE_V=${{ matrix.makefile-version }} ./build-toolchain.sh
-
-          echo Remove un-necessary content
+          MAKE_V=${{ matrix.makefile-version }} ./build-toolchain.sh
+          ./build-gdb.sh
+          echo "Removing un-necessary content"
           rm -rf ${N64_INST}/share/locale/*
         continue-on-error: true
 
@@ -152,8 +160,8 @@ jobs:
             $Package_Name-env.sh=/etc/profile.d/$Package_Name-env.sh
         continue-on-error: true
         env:
-          Package_Source_Directory: ${{ runner.temp }}/${{ env.Build_Directory }}/
-          Package_Installation_Directory: /opt/${{ env.Build_Directory }}
+          Package_Source_Directory: ${{ runner.temp }}/${{ env.Install_Directory }}/
+          Package_Installation_Directory: /opt/${{ env.Install_Directory }}
           Package_Name: gcc-toolchain-mips64
           Package_Version: ${{ steps.gcc-version-generator.outputs.GCC_VERSION }}
           Package_Revision: ${{ github.run_id }}
@@ -169,7 +177,7 @@ jobs:
         with:
           name: gcc-toolchain-mips64-${{ matrix.target-platform }}
           path: |
-            ${{ runner.temp }}/${{ env.Build_Directory }}
+            ${{ runner.temp }}/${{ env.Install_Directory }}
         continue-on-error: true
 
       - name: Publish Linux-x86_64 Build Artifacts
@@ -219,6 +227,7 @@ jobs:
           CHANGELOG_TEXT+="  * GCC:      V${{ needs.build-toolchain.outputs.gcc-version }}</br>"
           CHANGELOG_TEXT+="  * Newlib:   V${{ needs.build-toolchain.outputs.newlib-version }}</br>"
           CHANGELOG_TEXT+="  * BinUtils: V${{ needs.build-toolchain.outputs.binutils-version }}</br>"
+          CHANGELOG_TEXT+="  * GDB:      V${{ needs.build-toolchain.outputs.gdb-version }}</br>"
           CHANGELOG_TEXT+='</br>'
           CHANGELOG_TEXT+="With dependencies:</br>"
           CHANGELOG_TEXT+="  * GMP:      V${{ needs.build-toolchain.outputs.gmp-version }}</br>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,66 @@
 # syntax=docker/dockerfile:1
 # V0 - Use this comment to force a re-build without changing the contents
 
+ARG BASE_IMAGE=ubuntu:22.04
+
 # Stage 1 - Build the toolchain
-FROM ubuntu:22.04
+FROM ${BASE_IMAGE} AS builder
 
 # Setup paths for the libdragon toolchain
 ARG N64_INST=/n64_toolchain
+ARG BUILD_PATH=/tmp/n64_toolchain
 ENV N64_INST=${N64_INST}
+ENV BUILD_PATH=${BUILD_PATH}
 
-# install dependencies
-RUN apt-get update
-RUN apt-get install -yq \
-    wget \
-    bzip2 \
-    gcc \
-    g++ \
-    make \
-    file \
-    libmpfr-dev \
-    libmpc-dev \
-    zlib1g-dev \
-    texinfo \
-    git
+# Install system dependencies
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt update \
+    && apt upgrade -y \
+    && apt install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        file \
+        g++ \
+        gcc \
+        git \
+        libmpc-dev \
+        libmpfr-dev \
+        make \
+        texinfo \
+        wget \
+        zlib1g-dev \
+    && apt autoremove -yq
 
 # Build toolchain
-COPY ./tools/build-toolchain.sh /tmp/tools/build-toolchain.sh
-WORKDIR /tmp/tools
-RUN ./build-toolchain.sh
-
-# Remove locale strings which are not so important in our use case
-RUN rm -rf ${N64_INST}/share/locale/*
-
+RUN --mount=type=bind,source=./tools,target=/tools \
+    --mount=type=cache,target=${BUILD_PATH} \
+    /tools/build-toolchain.sh && \
+    /tools/build-gdb.sh && \
+    rm -rf ${N64_INST}/share/locale/*
 
 # Stage 2 - Prepare minimal image
-FROM ubuntu:22.04
+FROM ${BASE_IMAGE} AS runner
 
 # Setup paths for the libdragon toolchain
 ARG N64_INST=/n64_toolchain
 ENV N64_INST=${N64_INST}
 ENV PATH="${N64_INST}/bin:$PATH"
 
-# Install toolchain (built in Stage 1)
-COPY --from=0 ${N64_INST} ${N64_INST}
-
-# install dependencies & perform cleanup
-RUN apt-get update \
-    && apt-get install -yq \
-    gcc \
-    g++ \
-    make \
-    git \
-    xxd \
-    && apt-get clean \
+# Install system dependencies
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt update \
+    && apt upgrade -y \
+    && apt install -y --no-install-recommends \
+        g++ \
+        gcc \
+        git \
+        make \
+        xxd \
     && apt autoremove -yq
+
+# Copy over built toolchain from previous stage
+COPY --from=builder ${N64_INST} ${N64_INST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         zlib1g-dev \
     && apt autoremove -yq
 
-# Build toolchain
-RUN --mount=type=bind,source=./tools,target=/tools \
-    /tools/build-toolchain.sh && \
+# Copy the build scripts into the container
+COPY ./tools/build-toolchain.sh ./tools/build-gdb.sh /tools/
+
+# Run the build scripts and cleanup unnecessary files
+RUN /tools/build-toolchain.sh && \
     /tools/build-gdb.sh && \
     rm -rf ${N64_INST}/share/locale/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 
 # Build toolchain
 RUN --mount=type=bind,source=./tools,target=/tools \
-    --mount=type=cache,target=${BUILD_PATH} \
     /tools/build-toolchain.sh && \
     /tools/build-gdb.sh && \
     rm -rf ${N64_INST}/share/locale/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,17 @@ FROM ${BASE_IMAGE} AS builder
 
 # Setup paths for the libdragon toolchain
 ARG N64_INST=/n64_toolchain
-ARG BUILD_PATH=/tmp/n64_toolchain
+ARG BUILD_PATH=/tmp/build
+ARG DOWNLOAD_PATH=/tmp/download
 ENV N64_INST=${N64_INST}
 ENV BUILD_PATH=${BUILD_PATH}
+ENV DOWNLOAD_PATH=${DOWNLOAD_PATH}
 
 # Install system dependencies
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \
     && apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \
@@ -37,7 +40,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 COPY ./tools/build-toolchain.sh ./tools/build-gdb.sh /tools/
 
 # Run the build scripts and cleanup unnecessary files
-RUN /tools/build-toolchain.sh && \
+RUN --mount=target=${DOWNLOAD_PATH},type=cache,sharing=locked \
+    /tools/build-toolchain.sh && \
     /tools/build-gdb.sh && \
     rm -rf ${N64_INST}/share/locale/*
 
@@ -53,6 +57,7 @@ ENV PATH="${N64_INST}/bin:$PATH"
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \
     && apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \

--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -1,0 +1,105 @@
+#! /bin/bash
+# N64 MIPS GDB toolchain build/install script for Unix distributions
+# (c) DragonMinded and libDragon Contributors.
+# See the root folder for license information.
+
+# Bash strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+# Check that N64_INST is defined
+if [ -z "${N64_INST-}" ]; then
+    echo "N64_INST environment variable is not defined."
+    echo "Please define N64_INST and point it to the requested installation directory"
+    exit 1
+fi
+
+# Dependency source libs (Versions)
+GDB_V=${GDB_V:-"16.2"}
+
+# Defines the build system variables to allow cross compilation.
+N64_HOST=${N64_HOST:-""}
+N64_TARGET=${N64_TARGET:-mips64-elf}
+
+# Set N64_INST before calling the script to change the default installation directory path
+INSTALL_PATH="${N64_INST}"
+# Path where the toolchain will be built.
+BUILD_PATH="${BUILD_PATH:-toolchain}"
+
+# Determine how many parallel Make jobs to run based on CPU count
+JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN)}"
+JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
+
+# GDB configure arguments to use system GMP/MPC/MFPF
+GDB_CONFIGURE_ARGS=()
+
+# Check if a command-line tool is available: status 0 means "yes"; status 1 means "no"
+command_exists () {
+    (command -v "$1" >/dev/null 2>&1)
+    return $?
+}
+
+# Download the file URL using wget or curl (depending on which is installed)
+download () {
+    if   command_exists wget ; then wget -c  "$1"
+    elif command_exists curl ; then curl -LO "$1"
+    else
+        echo "Install wget or curl to download toolchain sources" 1>&2
+        return 1
+    fi
+}
+
+# Create build path and enter it
+mkdir -p "$BUILD_PATH"
+cd "$BUILD_PATH"
+
+# Dependency downloads and unpack
+test -f "gdb-$GDB_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gdb/gdb-$GDB_V.tar.gz"
+test -d "gdb-$GDB_V"                  || tar -xzf "gdb-$GDB_V.tar.gz"
+
+# Resolve dependencies on macOS via homebrew
+if [[ $OSTYPE == 'darwin'* ]]; then
+    # Tell GDB configure to use Homebrew's GMP, MPFR, MPC, and Zlib.
+    # These should have already been installed by build-toolchain.sh
+    GDB_CONFIGURE_ARGS=(
+        "--with-gmp=$(brew --prefix)"
+        "--with-mpfr=$(brew --prefix)"
+        "--with-mpc=$(brew --prefix)"
+        "--with-zlib=$(brew --prefix)"
+    )
+else
+    # Configure GDB arguments for non-macOS platforms
+    GDB_CONFIGURE_ARGS+=("--with-system-zlib")
+fi
+
+# Add host to GDG configure arguments if defined
+if [[ -n "${N64_HOST}" ]]; then
+    GDB_CONFIGURE_ARGS+=("--host=${N64_HOST}")
+fi
+
+# Add target to GDB configure arguments if defined
+if [[ -n "${N64_TARGET}" ]]; then
+    GDB_CONFIGURE_ARGS+=("--target=${N64_TARGET}")
+fi
+
+# Compile GDB
+pushd "gdb-$GDB_V"
+./configure "${GDB_CONFIGURE_ARGS[@]}" \
+    --prefix="$INSTALL_PATH" \
+    --disable-docs \
+    --disable-gdbserver \
+    --disable-binutils \
+    --disable-gas \
+    --disable-sim \
+    --disable-gprof \
+    --disable-inprocess-agent
+make all -j "$JOBS"
+make install-strip || sudo make install-strip || su -c "make install-strip"
+popd
+
+# Final message
+echo
+echo "***********************************************"
+echo "GDB correctly built and installed to LibDragon toolchain"
+echo "Installation directory: \"${N64_INST}\""
+echo "Build directory: \"${BUILD_PATH}\" (can be removed now)"

--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -15,7 +15,7 @@ if [ -z "${N64_INST-}" ]; then
 fi
 
 # Dependency source libs (Versions)
-GDB_V=${GDB_V:-"16.2"}
+GDB_V=16.2
 
 # Defines the build system variables to allow cross compilation.
 N64_HOST=${N64_HOST:-""}

--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -25,6 +25,7 @@ N64_TARGET=${N64_TARGET:-mips64-elf}
 INSTALL_PATH="${N64_INST}"
 # Path where the toolchain will be built.
 BUILD_PATH="${BUILD_PATH:-toolchain}"
+DOWNLOAD_PATH="${DOWNLOAD_PATH:-$BUILD_PATH}"
 
 # Determine how many parallel Make jobs to run based on CPU count
 JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN)}"
@@ -32,6 +33,10 @@ JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
 
 # GDB configure arguments to use system GMP/MPC/MFPF
 GDB_CONFIGURE_ARGS=()
+
+# Resolve absolute paths for build and download directories
+BUILD_PATH=$(cd "$BUILD_PATH" && pwd)
+DOWNLOAD_PATH=$(cd "$DOWNLOAD_PATH" && pwd)
 
 # Check if a command-line tool is available: status 0 means "yes"; status 1 means "no"
 command_exists () {
@@ -41,21 +46,17 @@ command_exists () {
 
 # Download the file URL using wget or curl (depending on which is installed)
 download () {
-    if   command_exists wget ; then wget -c  "$1"
-    elif command_exists curl ; then curl -LO "$1"
+    if   command_exists wget ; then (cd "$DOWNLOAD_PATH" && wget -c  "$1")
+    elif command_exists curl ; then (cd "$DOWNLOAD_PATH" && curl -LO "$1")
     else
         echo "Install wget or curl to download toolchain sources" 1>&2
         return 1
     fi
 }
 
-# Create build path and enter it
-mkdir -p "$BUILD_PATH"
-cd "$BUILD_PATH"
-
 # Dependency downloads and unpack
-test -f "gdb-$GDB_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gdb/gdb-$GDB_V.tar.gz"
-test -d "gdb-$GDB_V"                  || tar -xzf "gdb-$GDB_V.tar.gz"
+test -f "$DOWNLOAD_PATH/gdb-$GDB_V.tar.gz" || download "https://ftp.gnu.org/gnu/gdb/gdb-$GDB_V.tar.gz"
+test -d "$BUILD_PATH/gdb-$GDB_V"           || tar -xzf "$DOWNLOAD_PATH/gdb-$GDB_V.tar.gz" -C "$BUILD_PATH"
 
 # Resolve dependencies on macOS via homebrew
 if [[ $OSTYPE == 'darwin'* ]]; then
@@ -83,7 +84,7 @@ if [[ -n "${N64_TARGET}" ]]; then
 fi
 
 # Compile GDB
-pushd "gdb-$GDB_V"
+pushd "$BUILD_PATH/gdb-$GDB_V"
 ./configure "${GDB_CONFIGURE_ARGS[@]}" \
     --prefix="$INSTALL_PATH" \
     --disable-docs \

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -16,6 +16,7 @@ fi
 
 # Path where the toolchain will be built.
 BUILD_PATH="${BUILD_PATH:-toolchain}"
+DOWNLOAD_PATH="${DOWNLOAD_PATH:-$BUILD_PATH}"
 
 # Defines the build system variables to allow cross compilation.
 N64_BUILD=${N64_BUILD:-""}
@@ -38,10 +39,17 @@ GCC_CONFIGURE_ARGS=()
 BINUTILS_V=2.43.1
 GCC_V=14.2.0
 NEWLIB_V=4.4.0.20231231
-GMP_V=6.3.0 
-MPC_V=1.3.1 
+GMP_V=6.3.0
+MPC_V=1.3.1
 MPFR_V=4.2.1
 MAKE_V=${MAKE_V:-""}
+
+# Create build and download directories
+mkdir -p "$BUILD_PATH" "$DOWNLOAD_PATH"
+
+# Resolve absolute paths for build and download directories
+BUILD_PATH=$(cd "$BUILD_PATH" && pwd)
+DOWNLOAD_PATH=$(cd "$DOWNLOAD_PATH" && pwd)
 
 # Check if a command-line tool is available: status 0 means "yes"; status 1 means "no"
 command_exists () {
@@ -51,8 +59,8 @@ command_exists () {
 
 # Download the file URL using wget or curl (depending on which is installed)
 download () {
-    if   command_exists wget ; then wget -c  "$1"
-    elif command_exists curl ; then curl -LO "$1"
+    if   command_exists wget ; then (cd "$DOWNLOAD_PATH" && wget -c  "$1")
+    elif command_exists curl ; then (cd "$DOWNLOAD_PATH" && curl -LO "$1")
     else
         echo "Install wget or curl to download toolchain sources" 1>&2
         return 1
@@ -93,48 +101,47 @@ else
     # Configure GCC arguments for non-macOS platforms
     GCC_CONFIGURE_ARGS+=("--with-system-zlib")
 fi
-# Create build path and enter it
-mkdir -p "$BUILD_PATH"
-cd "$BUILD_PATH"
 
 # Dependency downloads and unpack
-test -f "binutils-$BINUTILS_V.tar.gz" || download "https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz"
-test -d "binutils-$BINUTILS_V"        || tar -xzf "binutils-$BINUTILS_V.tar.gz"
+test -f "$DOWNLOAD_PATH/binutils-$BINUTILS_V.tar.gz" || download "https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz"
+test -d "$BUILD_PATH/binutils-$BINUTILS_V"           || tar -xzf "$DOWNLOAD_PATH/binutils-$BINUTILS_V.tar.gz" -C "$BUILD_PATH"
 
-test -f "gcc-$GCC_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
-test -d "gcc-$GCC_V"                  || tar -xzf "gcc-$GCC_V.tar.gz"
+test -f "$DOWNLOAD_PATH/gcc-$GCC_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
+test -d "$BUILD_PATH/gcc-$GCC_V"                     || tar -xzf "$DOWNLOAD_PATH/gcc-$GCC_V.tar.gz" -C "$BUILD_PATH"
 
-test -f "newlib-$NEWLIB_V.tar.gz"     || download "https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz"
-test -d "newlib-$NEWLIB_V"            || tar -xzf "newlib-$NEWLIB_V.tar.gz"
+test -f "$DOWNLOAD_PATH/newlib-$NEWLIB_V.tar.gz"     || download "https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz"
+test -d "$BUILD_PATH/newlib-$NEWLIB_V"               || tar -xzf "$DOWNLOAD_PATH/newlib-$NEWLIB_V.tar.gz" -C "$BUILD_PATH"
 
 if [ "$GMP_V" != "" ]; then
-    test -f "gmp-$GMP_V.tar.bz2"           || download "https://ftp.gnu.org/gnu/gmp/gmp-$GMP_V.tar.bz2"
-    test -d "gmp-$GMP_V"                  || tar -xf "gmp-$GMP_V.tar.bz2" # note: no .gz download file currently available
-    pushd "gcc-$GCC_V"
+    test -f "$DOWNLOAD_PATH/gmp-$GMP_V.tar.bz2"      || download "https://ftp.gnu.org/gnu/gmp/gmp-$GMP_V.tar.bz2"
+    test -d "$BUILD_PATH/gmp-$GMP_V"                 || tar -xf "$DOWNLOAD_PATH/gmp-$GMP_V.tar.bz2" -C "$BUILD_PATH" # note: no .gz download file currently available
+    pushd "$BUILD_PATH/gcc-$GCC_V"
     ln -sf ../"gmp-$GMP_V" "gmp"
     popd
 fi
 
 if [ "$MPC_V" != "" ]; then
-    test -f "mpc-$MPC_V.tar.gz"           || download "https://ftp.gnu.org/gnu/mpc/mpc-$MPC_V.tar.gz"
-    test -d "mpc-$MPC_V"                  || tar -xzf "mpc-$MPC_V.tar.gz"
-    pushd "gcc-$GCC_V"
+    test -f "$DOWNLOAD_PATH/mpc-$MPC_V.tar.gz"       || download "https://ftp.gnu.org/gnu/mpc/mpc-$MPC_V.tar.gz"
+    test -d "$BUILD_PATH/mpc-$MPC_V"                 || tar -xzf "$DOWNLOAD_PATH/mpc-$MPC_V.tar.gz" -C "$BUILD_PATH"
+    pushd "$BUILD_PATH/gcc-$GCC_V"
     ln -sf ../"mpc-$MPC_V" "mpc"
     popd
 fi
 
 if [ "$MPFR_V" != "" ]; then
-    test -f "mpfr-$MPFR_V.tar.gz"         || download "https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFR_V.tar.gz"
-    test -d "mpfr-$MPFR_V"                || tar -xzf "mpfr-$MPFR_V.tar.gz"
-    pushd "gcc-$GCC_V"
+    test -f "$DOWNLOAD_PATH/mpfr-$MPFR_V.tar.gz"     || download "https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFR_V.tar.gz"
+    test -d "$BUILD_PATH/mpfr-$MPFR_V"               || tar -xzf "$DOWNLOAD_PATH/mpfr-$MPFR_V.tar.gz" -C "$BUILD_PATH"
+    pushd "$BUILD_PATH/gcc-$GCC_V"
     ln -sf ../"mpfr-$MPFR_V" "mpfr"
     popd
 fi
 
 if [ "$MAKE_V" != "" ]; then
-    test -f "make-$MAKE_V.tar.gz"       || download "https://ftp.gnu.org/gnu/make/make-$MAKE_V.tar.gz"
-    test -d "make-$MAKE_V"              || tar -xzf "make-$MAKE_V.tar.gz"
+    test -f "$DOWNLOAD_PATH/make-$MAKE_V.tar.gz"     || download "https://ftp.gnu.org/gnu/make/make-$MAKE_V.tar.gz"
+    test -d "$BUILD_PATH/make-$MAKE_V"               || tar -xzf "$DOWNLOAD_PATH/make-$MAKE_V.tar.gz" -C "$BUILD_PATH"
 fi
+
+cd "$BUILD_PATH"
 
 # Deduce build triplet using config.guess (if not specified)
 # This is by the definition the current system so it should be OK.

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -41,7 +41,6 @@ NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0 
 MPC_V=1.3.1 
 MPFR_V=4.2.1
-GDB_V=${GDB_V:-""}
 MAKE_V=${MAKE_V:-""}
 
 # Check if a command-line tool is available: status 0 means "yes"; status 1 means "no"
@@ -130,11 +129,6 @@ if [ "$MPFR_V" != "" ]; then
     pushd "gcc-$GCC_V"
     ln -sf ../"mpfr-$MPFR_V" "mpfr"
     popd
-fi
-
-if [ "$GDB_V" != "" ]; then
-    test -f "gdb-$GDB_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gdb/gdb-$GDB_V.tar.gz"
-    test -d "gdb-$GDB_V"                  || tar -xzf "gdb-$GDB_V.tar.gz"
 fi
 
 if [ "$MAKE_V" != "" ]; then
@@ -315,26 +309,6 @@ else
     popd
 fi
 
-if [ "$GDB_V" != "" ]; then
-    # Compile GDB
-    pushd "gdb-$GDB_V"
-    ./configure "${GCC_CONFIGURE_ARGS[@]}" \
-        --prefix="$INSTALL_PATH" \
-        --target="$N64_TARGET" \
-        --build="$N64_BUILD" \
-        --host="$N64_HOST" \
-        --disable-docs \
-        --disable-gdbserver \
-        --disable-binutils \
-        --disable-gas \
-        --disable-sim \
-        --disable-gprof \
-        --disable-inprocess-agent
-    make all -j "$JOBS"
-    make install-strip || sudo make install-strip || su -c "make install-strip"
-    popd
-fi
-
 if [ "$MAKE_V" != "" ]; then
     pushd "make-$MAKE_V"
     ./configure \
@@ -355,3 +329,4 @@ echo "***********************************************"
 echo "Libdragon toolchain correctly built and installed"
 echo "Installation directory: \"${N64_INST}\""
 echo "Build directory: \"${BUILD_PATH}\" (can be removed now)"
+echo "If you would like to install GDB in your toolchain, run build-gdb.sh"

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -41,6 +41,7 @@ NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0 
 MPC_V=1.3.1 
 MPFR_V=4.2.1
+GDB_V=${GDB_V:-""}
 MAKE_V=${MAKE_V:-""}
 
 # Check if a command-line tool is available: status 0 means "yes"; status 1 means "no"
@@ -129,6 +130,11 @@ if [ "$MPFR_V" != "" ]; then
     pushd "gcc-$GCC_V"
     ln -sf ../"mpfr-$MPFR_V" "mpfr"
     popd
+fi
+
+if [ "$GDB_V" != "" ]; then
+    test -f "gdb-$GDB_V.tar.gz"           || download "https://ftp.gnu.org/gnu/gdb/gdb-$GDB_V.tar.gz"
+    test -d "gdb-$GDB_V"                  || tar -xzf "gdb-$GDB_V.tar.gz"
 fi
 
 if [ "$MAKE_V" != "" ]; then
@@ -304,6 +310,26 @@ else
     # Finish compiling GCC
     mkdir -p gcc_compile
     pushd gcc_compile
+    make all -j "$JOBS"
+    make install-strip || sudo make install-strip || su -c "make install-strip"
+    popd
+fi
+
+if [ "$GDB_V" != "" ]; then
+    # Compile GDB
+    pushd "gdb-$GDB_V"
+    ./configure "${GCC_CONFIGURE_ARGS[@]}" \
+        --prefix="$INSTALL_PATH" \
+        --target="$N64_TARGET" \
+        --build="$N64_BUILD" \
+        --host="$N64_HOST" \
+        --disable-docs \
+        --disable-gdbserver \
+        --disable-binutils \
+        --disable-gas \
+        --disable-sim \
+        --disable-gprof \
+        --disable-inprocess-agent
     make all -j "$JOBS"
     make install-strip || sudo make install-strip || su -c "make install-strip"
     popd


### PR DESCRIPTION
Inspired by https://github.com/DragonMinded/libdragon/issues/668

`build-gdb.sh` is now an optional follow-up script to `build_toolchain.sh`. Accepts the same environment variables.