### PR TITLE
wav64 improvements

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -482,6 +482,20 @@ void mixer_remove_event(MixerEvent cb, void *ctx);
 typedef void (*WaveformRead)(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking);
 
 /**
+ * @brief Waveform callback function invoked by the mixer whenever the playback
+ *        is stopped.
+ * 
+ * The callback function is invoked whenever a waveform playback stops, which is
+ * one of the following reasons:
+ * 
+ *  * The waveform reaches its end, and it does not contain any loop.
+ *  * Another waveform was started in the same channel via #mixer_ch_play,
+ *    causing the current waveform to stop.
+ *  * #mixer_ch_stop was explicitly called to stop playback of the waveform.
+ */
+typedef void (*WaveformStop)(void *ctx);
+
+/**
  * @brief A waveform that can be played back through the mixer.
  * 
  * waveform_t represents a waveform that can be played back by the mixer.
@@ -547,8 +561,21 @@ typedef struct waveform_s {
      */
 	WaveformRead read;
 
-	/** @brief Opaque pointer provided as context to the read function. */
+     /**
+      * @brief Waveform stop function
+      * 
+      * This optional function is invoked by the mixer when the waveform
+      * playback is stopped.
+      */
+     WaveformStop wv_stop;
+
+	/** @brief Opaque pointer provided as context to the read and stop functions. */
 	void *ctx;
+
+     ///@cond
+     ///  Mixer private state. Do not touch, initialize to zero
+     uint32_t __uuid;
+     ///@endcond
 } waveform_t;
 
 /** @brief Maximum number of samples in a waveform */

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -14,6 +14,10 @@
 extern "C" {
 #endif
 
+/// @cond
+typedef struct waveform_s waveform_t;
+/// @endcond
+
 /** 
  * Tagged pointer to an array of samples. It contains both the void*
  * sample pointer, and byte-per-sample information (encoded as shift value).
@@ -120,6 +124,11 @@ typedef struct samplebuffer_s {
     int wnext;
 
     /**
+     * Waveform being played back on this sample buffer.
+     */
+    waveform_t *wave;
+
+    /**
      * wv_read is invoked by samplebuffer_get whenever more samples are
      * requested by the mixer. See #WaveformRead for more information.
      */
@@ -179,11 +188,12 @@ void samplebuffer_set_bps(samplebuffer_t *buf, int bps);
  * information.
  * 
  * @param[in]       buf     Sample buffer
- * @param[in]       read    Waveform reading function, that produces samples.
- * @param[in]       ctx     Opaque context that will be passed to the read
+ * @param[in]       wave    Waveform to connect to the sample buffer
+ * @param[in]       read    Waveform read function
+ * @param[in]       ctx     Opaque context that will be passed to the read/stop
  *                          function.
  */
-void samplebuffer_set_waveform(samplebuffer_t *buf, WaveformRead read, void *ctx);
+void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read, void *ctx);
 
 /**
  * @brief Get a pointer to specific set of samples in the buffer (zero-copy).

--- a/include/wav64.h
+++ b/include/wav64.h
@@ -85,6 +85,7 @@ typedef struct wav64_s {
  */ 
 void wav64_open(wav64_t *wav, const char *fn);
 
+/** @brief WAV64 streaming mode */
 typedef enum {
 	/** 
 	 * @brief Full streaming
@@ -108,6 +109,7 @@ typedef enum {
 
 } wav64_streaming_mode_t;
 
+/** @brief WAV64 loading parameters (to be passed to #wav64_load) */
 typedef struct {
 	/** 
 	 * @brief Maximum number of simultaneous playbacks 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -489,17 +489,7 @@ void mixer_ch_stop(int ch) {
 	// waveform, we will realize that by the uuid, and reuse the same
 	// samplebuffer contents.
 	c->wave = NULL;
-}
-
-void __mixer_wave_stopall(waveform_t *wave)
-{
-	for (int i=0; i<Mixer.num_channels; i++)
-	{
-		// Check if this channel is playing back the waveform.
-		mixer_channel_t *c = &Mixer.channels[i];
-		if (c->wave == wave)
-			mixer_ch_stop(i);
-	}
+	c->ctx = NULL;
 }
 
 bool mixer_ch_playing(int ch) {

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -6,7 +6,4 @@
 /** @brief RSPQ overlay ID assigned to the mixer ucode */
 extern uint32_t __mixer_overlay_id;
 
-/** Check if a certain waveform is currently playing on some channel */
-void __mixer_wave_stopall(waveform_t *wave);
-
 #endif

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -176,6 +176,7 @@
 	RSPQ_BeginOverlayHeader
 		RSPQ_DefineCommand command_exec, 16				# 0x0
 		RSPQ_DefineCommand VADPCM_Decompress, 16		# 0x1
+		RSPQ_DefineCommand VADPCM_SetState, 16			# 0x2
 	RSPQ_EndOverlayHeader
 
 ############################################################################
@@ -1494,3 +1495,68 @@ VADPM_OutputDma:
 
 	.endfunc
 
+	#undef v_out_l
+	#undef v_out_r
+	#undef v_sample_0
+	#undef v_sample_1
+	#undef v_sample_2
+	#undef v_sample_3
+	#undef v_mix_l
+	#undef v_mix_r
+	#undef vscale
+	#undef vstatef
+	#undef pred0
+	#undef pred1
+	#undef pred1a
+	#undef pred1b
+	#undef pred1c
+	#undef pred1d
+	#undef pred1e
+	#undef pred1f
+	#undef pred1g
+	#undef pred1h
+	#undef vres0
+	#undef vres1
+	#undef vstate0
+	#undef vstate1
+	#undef vstate2
+	#undef vstate3
+	#undef v____
+	#undef scaling
+	#undef predictor
+	#undef nframes
+	#undef dmem_state
+	#undef dmem_codebook
+	#undef dmem_output
+	#undef dmem_input
+	#undef buffer_in_size
+	#undef buffer_out_size
+	#undef stereo_toggle
+	#undef rdram_input
+	#undef rdram_output
+
+
+	########################################
+	# VADPCM_SetState
+	#
+	# Args:
+	#   a0: pointer to RDRAM state (destination)
+	#   a1: pointer to RDRAM buffer with source state
+    #       or 0 if state must be cleared
+	########################################
+
+	.func VADPCM_SetState
+VADPCM_SetState:
+	li s4, %lo(VADPCM_STATE)
+	sqv vzero, 0x00,s4
+	sqv vzero, 0x10,s4
+	beqz a1, VADPCM_SetState_Write
+	 li t0, DMA_SIZE(16*2, 1)
+	jal DMAIn
+	 move s0, a1
+
+VADPCM_SetState_Write:
+	move s0, a0
+	jal_and_j DMAOut, RSPQ_Loop
+
+	.endfunc

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -176,7 +176,7 @@
 	RSPQ_BeginOverlayHeader
 		RSPQ_DefineCommand command_exec, 16				# 0x0
 		RSPQ_DefineCommand VADPCM_Decompress, 16		# 0x1
-		RSPQ_DefineCommand VADPCM_SetState, 16			# 0x2
+		RSPQ_DefineCommand VADPCM_SetState, 8			# 0x2
 	RSPQ_EndOverlayHeader
 
 ############################################################################

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -49,7 +49,8 @@ void samplebuffer_set_bps(samplebuffer_t *buf, int bits_per_sample) {
 	buf->size = nbytes >> bps;
 }
 
-void samplebuffer_set_waveform(samplebuffer_t *buf, WaveformRead read, void *ctx) {
+void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read, void *ctx) {
+	buf->wave = wave;
 	buf->wv_read = read;
 	buf->wv_ctx = ctx;
 }

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -108,7 +108,8 @@ static int wav64_none_get_bitrate(wav64_t *wav) {
 
 wav64_t* internal_open(wav64_t *wav, const char *file_name, wav64_loadparms_t *parms)
 {
-	if (!parms) parms = &(wav64_loadparms_t){0};
+	wav64_loadparms_t default_parms = {0};
+	if (!parms) parms = &default_parms;
 
 	// For backwards compatibility with old versions of this file, we support
 	// an unprefixed file name as a dfs file. This is deprecated and not documented
@@ -204,7 +205,6 @@ wav64_t* wav64_load(const char *file_name, wav64_loadparms_t *parms)
 
 
 void __wav64_channel_stopped(wav64_t *wav, int chidx) {
-	debugf("wav64: channel %d stopped for %s\n", chidx, wav->wave.name);
 	assert(chidx >= 0 && chidx < wav->st->nsimul);
 	assert(wav->st->mixer_channels[chidx] >= 0);
 	wav->st->mixer_channels[chidx] = -1;

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -119,7 +119,7 @@ static int wav64_none_get_bitrate(wav64_t *wav) {
 	return wav->wave.frequency * wav->wave.channels * wav->wave.bits;
 }
 
-wav64_t* internal_open(wav64_t *wav, const char *file_name, wav64_loadparms_t *parms)
+static wav64_t* internal_open(wav64_t *wav, const char *file_name, wav64_loadparms_t *parms)
 {
 	wav64_loadparms_t default_parms = {0};
 	if (!parms) parms = &default_parms;

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -265,7 +265,7 @@ void wav64_play(wav64_t *wav, int ch)
 {
 	if (wav->st->nsimul == 0) {
 		// Infinite simultaneous playbacks, no need to track anything
-		mixer_ch_play_ctx(ch, &wav->wave, NULL);
+		mixer_ch_play(ch, &wav->wave);
 		return;
 	}
 
@@ -291,8 +291,8 @@ void wav64_play(wav64_t *wav, int ch)
 		assert(wav->st->mixer_channels[chidx] < 0);
 	}
 
-	wav->st->mixer_channels[chidx] = ch;
 	mixer_ch_play_ctx(ch, &wav->wave, (void*)chidx);
+	wav->st->mixer_channels[chidx] = ch;
 }
 
 void wav64_set_loop(wav64_t *wav, bool loop) {

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -22,23 +22,17 @@ typedef struct __attribute__((packed)) {
 	int32_t freq;           ///< Default playback frequency
 	int32_t len;            ///< Length of the file (in samples)
 	int32_t loop_len;       ///< Length of the loop since file end (or 0 if no loop)
-	int32_t start_offset;   ///< Offset of the first sample in the file
-} wav64_header_t;
-
-_Static_assert(sizeof(wav64_header_t) == 24, "invalid wav64_header size");
-
-typedef struct __attribute__((packed)) {
-	char id[4];             ///< ID of the file (WAV64_ID)
-	int8_t version;         ///< Version of the file (WAV64_FILE_VERSION)
-	int8_t format;          ///< Format of the file (WAV64_FORMAT_RAW)
 	uint32_t start_offset;  ///< Offset of the first sample in the file
 	uint32_t state_size;    ///< Size of per-mixer-channel state to allocate at runtime
-} wav64_file_header_t;
+} wav64_header_t;
+
+_Static_assert(sizeof(wav64_header_t) == 28, "invalid wav64_header size");
 
 typedef struct wav64_state_s {
 	int format;			     // Internal format of the file
 	void *ext;               // Pointer to extended header data (format-dependent)
 	void *states;            // Pointer to per-mixer-channel state data (format-dependent)
+	void *samples;           // Pointer to the preloaded samples (if streaming is disabled)
 	int current_fd;			 // File descriptor for the wav64 file
 	int base_offset;		 // Start of Wav64 data (as offset from start of the file)
 	int nsimul;				 // Number of maximum simultaneous playbacks

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -28,16 +28,17 @@ typedef struct __attribute__((packed)) {
 
 _Static_assert(sizeof(wav64_header_t) == 28, "invalid wav64_header size");
 
+/** @brief WAV64 state */
 typedef struct wav64_state_s {
-	int format;			     // Internal format of the file
-	void *ext;               // Pointer to extended header data (format-dependent)
-	void *states;            // Pointer to per-mixer-channel state data (format-dependent)
-	void *samples;           // Pointer to the preloaded samples (if streaming is disabled)
-	int current_fd;			 // File descriptor for the wav64 file
-	int base_offset;		 // Start of Wav64 data (as offset from start of the file)
-	int nsimul;				 // Number of maximum simultaneous playbacks
-	uint8_t flags;           // Misc flags
-	int8_t mixer_channels[]; // Mixer channels in which the waveform is reproduced
+	int format;			     ///< Internal format of the file
+	void *ext;               ///< Pointer to extended header data (format-dependent)
+	void *states;            ///< Pointer to per-mixer-channel state data (format-dependent)
+	void *samples;           ///< Pointer to the preloaded samples (if streaming is disabled)
+	int current_fd;			 ///< File descriptor for the wav64 file
+	int base_offset;		 ///< Start of Wav64 data (as offset from start of the file)
+	int nsimul;				 ///< Number of maximum simultaneous playbacks
+	uint8_t flags;           ///< Misc flags
+	int8_t mixer_channels[]; ///< Mixer channels in which the waveform is reproduced
 } wav64_state_t;
 
 /** @brief WAV64 pluggable compression algorithm */

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -2,11 +2,12 @@
 #define __LIBDRAGON_WAV64_INTERNAL_H
 
 #define WAV64_ID            "WV64"
-#define WAV64_FILE_VERSION  2
 #define WAV64_FORMAT_RAW    0
 #define WAV64_FORMAT_VADPCM 1
 #define WAV64_FORMAT_OPUS   3
 #define WAV64_NUM_FORMATS   4
+
+#define WAV64_FLAG_WARN_SIMULTANEITY	 (1 << 0)
 
 typedef struct wav64_s wav64_t;
 typedef struct samplebuffer_s samplebuffer_t;
@@ -26,26 +27,31 @@ typedef struct __attribute__((packed)) {
 
 _Static_assert(sizeof(wav64_header_t) == 24, "invalid wav64_header size");
 
-/** @brief A vector of audio samples */
-typedef struct __attribute__((aligned(8))) {
-	int16_t v[8];						///< Samples
-} wav64_vadpcm_vector_t;
+typedef struct __attribute__((packed)) {
+	char id[4];             ///< ID of the file (WAV64_ID)
+	int8_t version;         ///< Version of the file (WAV64_FILE_VERSION)
+	int8_t format;          ///< Format of the file (WAV64_FORMAT_RAW)
+	uint32_t start_offset;  ///< Offset of the first sample in the file
+	uint32_t state_size;    ///< Size of per-mixer-channel state to allocate at runtime
+} wav64_file_header_t;
 
-/** @brief Extended header for a WAV64 file with VADPCM compression. */
-typedef struct __attribute__((packed, aligned(8))) {
-	int8_t npredictors;					///< Number of predictors
-	int8_t order;						///< Order of the predictors
-	uint16_t padding;					///< padding
-	uint32_t padding1;					///< padding1
-	wav64_vadpcm_vector_t loop_state[2];///< State at the loop point
-	wav64_vadpcm_vector_t state[2];		///< Current decompression state
-	wav64_vadpcm_vector_t codebook[];	///< Codebook of the predictors
-} wav64_header_vadpcm_t;
+typedef struct wav64_state_s {
+	int format;			     // Internal format of the file
+	void *ext;               // Pointer to extended header data (format-dependent)
+	void *states;            // Pointer to per-mixer-channel state data (format-dependent)
+	int current_fd;			 // File descriptor for the wav64 file
+	int base_offset;		 // Start of Wav64 data (as offset from start of the file)
+	int nsimul;				 // Number of maximum simultaneous playbacks
+	uint8_t flags;           // Misc flags
+	int8_t mixer_channels[]; // Mixer channels in which the waveform is reproduced
+} wav64_state_t;
 
 /** @brief WAV64 pluggable compression algorithm */
 typedef struct {
+	/** @brief Default number of simultaneous playbacks */
+	int default_simul;
 	/** @brief Init function: parses extra header information for the specific codec */
-	void (*init)(wav64_t *wav);
+	void (*init)(wav64_t *wav, int state_size);
 	/** @brief Close function: deallocates memory for codec-specific data */
 	void (*close)(wav64_t *wav);
 	/** @brief Return the compressed bitrate, mainly used for statistics */
@@ -66,4 +72,13 @@ void raw_waveform_read(samplebuffer_t *sbuf, int fd, int wpos, int wlen, int bps
  * Note: Tempory function should be removed when XM64 moves to using FILE*.
  */  
 void raw_waveform_read_address(samplebuffer_t *sbuf, int rom_addr, int wpos, int wlen, int bps);
+
+/** 
+ * @brief Inform wav64 that a certain channel has finished playback.
+ * 
+ * This is meant to be called by waveform's stop callbacks, so that the
+ * generic code can track the number of simultaneous playbacks.
+ */
+void __wav64_channel_stopped(wav64_t *wav, int chidx);
+
 #endif

--- a/src/audio/wav64_opus.c
+++ b/src/audio/wav64_opus.c
@@ -50,23 +50,18 @@ typedef struct {
     uint32_t frame_size;            ///< Size of an audioframe in samples
     uint32_t max_cmp_frame_size;    ///< Maximum compressed frame size in bytes
     uint32_t bitrate_bps;           ///< Bitrate in bits per second
+    OpusCustomMode *mode;           ///< Opus custom mode for this file
 } wav64_opus_header_ext;
 
-/// @brief Wav64 Opus state
-typedef struct {
-    wav64_opus_header_ext xhead;    ///< Opus header extension
-    OpusCustomMode *mode;           ///< Opus custom mode for this file
-    OpusCustomDecoder *dec;         ///< Opus decoder for this file
-} wav64_opus_state;
-
 static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
-	wav64_t *wav = (wav64_t*)ctx;
-	wav64_opus_state *st = (wav64_opus_state*)wav->ext;
-
+	wav64_t *wav = (wav64_t*)sbuf->wave;
+	wav64_opus_header_ext *ext = wav->st->ext;
+    OpusCustomDecoder *dec = (OpusCustomDecoder*)wav->st->states;
+    
 	if (seeking) {
 		if (wpos == 0) {
-			lseek(wav->current_fd, wav->base_offset, SEEK_SET);
-			opus_custom_decoder_ctl(st->dec, OPUS_RESET_STATE);
+			lseek(wav->st->current_fd, wav->st->base_offset, SEEK_SET);
+			opus_custom_decoder_ctl(dec, OPUS_RESET_STATE);
 		} else {
 			assertf(0, "seeking not support in wav64 with opus compression");
 		}
@@ -74,21 +69,21 @@ static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wl
 
     // Allocate stack buffer for reading compressed data. Align it to cacheline
     // to avoid any false sharing.
-    uint8_t alignas(16) buf[st->xhead.max_cmp_frame_size + 1];
-    int nframes = DIVIDE_CEIL(wlen, st->xhead.frame_size);
+    uint8_t alignas(16) buf[ext->max_cmp_frame_size + 1];
+    int nframes = DIVIDE_CEIL(wlen, ext->frame_size);
 
     // Make space for the decoded samples. Call samplebuffer_append once as we
     // use RSP in background, and each call to the function might trigger a
     // memmove of internal samples.
-    int16_t *out = samplebuffer_append(sbuf, st->xhead.frame_size*nframes);
+    int16_t *out = samplebuffer_append(sbuf, ext->frame_size*nframes);
 
     for (int i=0; i<nframes; i++) {
         assert(wpos < wav->wave.len);
 
         // Read frame size
         uint16_t nb = 0;
-        read(wav->current_fd, &nb, 2);
-        assertf(nb <= st->xhead.max_cmp_frame_size, "opus frame size too large: %08X (%ld)", nb, st->xhead.max_cmp_frame_size);
+        read(wav->st->current_fd, &nb, 2);
+        assertf(nb <= ext->max_cmp_frame_size, "opus frame size too large: %08X (%ld)", nb, ext->max_cmp_frame_size);
 
         unsigned long aligned_frame_size = nb; 
         if (aligned_frame_size & 1) {
@@ -97,17 +92,17 @@ static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wl
 
         // Read frame
         data_cache_hit_writeback_invalidate(buf, aligned_frame_size);
-        int size = read(wav->current_fd, buf, aligned_frame_size);
+        int size = read(wav->st->current_fd, buf, aligned_frame_size);
         assertf(size == aligned_frame_size, "opus read past end: %d", size);
 
         // Decode frame
-        int err = opus_custom_decode(st->dec, buf, nb, out, st->xhead.frame_size);
+        int err = opus_custom_decode(dec, buf, nb, out, ext->frame_size);
         assertf(err > 0, "opus decode error: %s", opus_strerror(err));
-        assertf(err == st->xhead.frame_size, "opus wrong frame size: %d (exp: %lx)", err, st->xhead.frame_size);
+        assertf(err == ext->frame_size, "opus wrong frame size: %d (exp: %lx)", err, ext->frame_size);
 
-        out += st->xhead.frame_size * wav->wave.channels;
-        wpos += st->xhead.frame_size;
-        wlen -= st->xhead.frame_size;
+        out += ext->frame_size * wav->wave.channels;
+        wpos += ext->frame_size;
+        wlen -= ext->frame_size;
     }
 
     if (wav->wave.loop_len && wpos >= wav->wave.len) {
@@ -116,39 +111,42 @@ static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wl
     }
 }
 
-void wav64_opus_init(wav64_t *wav) {
-    wav64_opus_header_ext xhead;
-    read(wav->current_fd, &xhead, sizeof(xhead));
+static void waveform_opus_stop(void *ctx, samplebuffer_t *sbuf) {
+	wav64_t *wav = (wav64_t*)sbuf->wave;
 
+    // Inform wav64 that the channel has stopped
+    int chidx = (int)ctx;
+    assert(chidx >= 0 && chidx <= wav->st->nsimul);
+    __wav64_channel_stopped(wav, chidx);
+}
+
+void wav64_opus_init(wav64_t *wav, int state_size) {
     rsp_opus_init();
+    wav64_opus_header_ext *ext = wav->st->ext;
 
     int err = OPUS_OK;
-    OpusCustomMode *custom_mode = opus_custom_mode_create(wav->wave.frequency, xhead.frame_size, &err);
+    ext->mode = opus_custom_mode_create(wav->wave.frequency, ext->frame_size, &err);
     assertf(err == OPUS_OK, "%i", err);
-    OpusCustomDecoder *dec = opus_custom_decoder_create(custom_mode, wav->wave.channels, &err);
+
+    assertf(state_size >= opus_custom_decoder_get_size(ext->mode, wav->wave.channels), "wav64: opus state_size=%d calc_size=%d\n", state_size, opus_custom_decoder_get_size(ext->mode, wav->wave.channels));
+    debugf("wav64: opus state_size=%d calc_size=%d\n", state_size, opus_custom_decoder_get_size(ext->mode, wav->wave.channels));
+
+    OpusCustomDecoder *dec = (OpusCustomDecoder*)wav->st->states;
+    assert(wav->st->nsimul == 1); 
+    opus_custom_decoder_init(dec, ext->mode, wav->wave.channels);
     assert(err == OPUS_OK);
 
-    // FIXME: try to avoid one allocation by allocating the decoder in the same malloc
-    wav64_opus_state *state = malloc(sizeof(wav64_opus_state));
-    state->mode = custom_mode;
-    state->dec = dec;
-    state->xhead = xhead;
- 
-    wav->ext = state;
     wav->wave.read = waveform_opus_read;
-    wav->wave.ctx = wav;
+    wav->wave.stop = waveform_opus_stop;
+    wav->wave.ctx = 0;
 }
 
 void wav64_opus_close(wav64_t *wav) {
- 	wav64_opus_state *st = (wav64_opus_state*)wav->ext;
-
-    opus_custom_decoder_destroy(st->dec);
-    opus_custom_mode_destroy(st->mode);
-    free(st);
-    wav->ext = NULL;
+    wav64_opus_header_ext *ext = wav->st->ext;
+    opus_custom_mode_destroy(ext->mode);
 }
 
 int wav64_opus_get_bitrate(wav64_t *wav) {
-    wav64_opus_state *st = (wav64_opus_state*)wav->ext;
-    return st->xhead.bitrate_bps;
+    wav64_opus_header_ext *ext = wav->st->ext;
+    return ext->bitrate_bps;
 }

--- a/src/audio/wav64_opus_internal.h
+++ b/src/audio/wav64_opus_internal.h
@@ -12,7 +12,7 @@
 #include "wav64.h"
 
 /** @brief Initialize opus decompression on a wav64 file */
-void wav64_opus_init(wav64_t *wav);
+void wav64_opus_init(wav64_t *wav, int state_size);
 
 /** @brief Shut down opus decompression on a wav64 file */
 void wav64_opus_close(wav64_t *wav);

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -179,7 +179,7 @@ static void huffv_decompress(int nframe, wav64_t *wav, wav64_state_vadpcm_t *vst
             uint8_t code1 = tbl->codes[(buffer >> (buffer_bits - 8)) & 0xFF];
             int len1 = code1 & 0xF;
             int val1 = code1 >> 4;
-            assert(len1 != 0);
+            assert(len1 <= 8);
             buffer_bits -= len1;
             bitpos += len1;
             if (j == 0) tbl++;
@@ -187,7 +187,7 @@ static void huffv_decompress(int nframe, wav64_t *wav, wav64_state_vadpcm_t *vst
             uint8_t code2 = tbl->codes[(buffer >> (buffer_bits - 8)) & 0xFF];
             int len2 = code2 & 0xF;
             int val2 = code2 >> 4;
-            assert(len2 != 0);
+            assert(len2 <= 8);
             buffer_bits -= len2;
             bitpos += len2;
             if (j == 0) tbl++;
@@ -350,7 +350,7 @@ static void wav64_vadpcm_init_huffman(wav64_t *wav) {
     for (int i = 0; i < 3; i++) {
         for (int j=0; j<16; j++) {
             int len = ctx[i].lengths[j/2] >> (4*(~j&1)) & 0xf;
-            if (len == 0) continue;
+            if (len == 0xF) continue;
             assert(len <= 8);
             assert((ctx[i].values[j] >> len) == 0);
 

--- a/src/audio/wav64_vadpcm_internal.h
+++ b/src/audio/wav64_vadpcm_internal.h
@@ -1,27 +1,41 @@
 #ifndef LIBDRAGON_AUDIO_VADPCM_INTERNAL_H
 #define LIBDRAGON_AUDIO_VADPCM_INTERNAL_H
 
+#define VADPCM_FLAG_HUFFMAN      (1 << 0)	///< Huffman-encoded VADPCM
+
 /** @brief A vector of audio samples */
 typedef struct __attribute__((aligned(8))) {
 	int16_t v[8];						///< Samples
 } wav64_vadpcm_vector_t;
 
+/** @brief Huffamn decoding context */
+typedef struct {
+	uint8_t lengths[8];					///< Length of each symbol (4-bit)
+	uint8_t values[16];					///< Code used for each symbol
+} wav64_vadpcm_huffctx_t;
+
+/** @brief Huffman decoding tables */
+typedef struct {
+	uint8_t codes[256];				    ///< Symbol+length found in the prefix of each byte
+} wav64_vadpcm_hufftable_t;
+
 /** @brief Extended header for a WAV64 file with VADPCM compression. */
 typedef struct __attribute__((packed, aligned(8))) {
 	int8_t npredictors;					///< Number of predictors
 	int8_t order;						///< Order of the predictors
-	uint16_t padding;					///< padding
-	uint32_t padding1;					///< padding1
+	uint8_t flags;						///< VADPCM flags
+	uint8_t padding;					///< padding
+	wav64_vadpcm_hufftable_t *huff_tbl; ///< Huffman tables (computed at load time)
 	wav64_vadpcm_vector_t loop_state[2];///< State at the loop point
+	wav64_vadpcm_huffctx_t huff_ctx[3]; ///< Huffman contexts
 	wav64_vadpcm_vector_t codebook[];	///< Codebook of the predictors
 } wav64_header_vadpcm_t;
 
 /** @brief WAV64 VADPCM decoding state (for a single mixer channel) */
-typedef struct {
+typedef struct __attribute__((aligned(16))) {
 	wav64_vadpcm_vector_t state[2];		///< Current decompression state
 	int bitpos;							///< Current bit position in the input buffer
 } wav64_state_vadpcm_t;
-
 
 void wav64_vadpcm_init(wav64_t *wav, int state_size);
 void wav64_vadpcm_close(wav64_t *wav);

--- a/src/audio/wav64_vadpcm_internal.h
+++ b/src/audio/wav64_vadpcm_internal.h
@@ -1,7 +1,27 @@
 #ifndef LIBDRAGON_AUDIO_VADPCM_INTERNAL_H
 #define LIBDRAGON_AUDIO_VADPCM_INTERNAL_H
 
-void wav64_vadpcm_init(wav64_t *wav);
+/** @brief A vector of audio samples */
+typedef struct __attribute__((aligned(8))) {
+	int16_t v[8];						///< Samples
+} wav64_vadpcm_vector_t;
+
+/** @brief Extended header for a WAV64 file with VADPCM compression. */
+typedef struct __attribute__((packed, aligned(8))) {
+	int8_t npredictors;					///< Number of predictors
+	int8_t order;						///< Order of the predictors
+	uint16_t padding;					///< padding
+	uint32_t padding1;					///< padding1
+	wav64_vadpcm_vector_t loop_state[2];///< State at the loop point
+	wav64_vadpcm_vector_t codebook[];	///< Codebook of the predictors
+} wav64_header_vadpcm_t;
+
+typedef struct {
+	wav64_vadpcm_vector_t state[2];		///< Current decompression state
+} wav64_state_vadpcm_t;
+
+
+void wav64_vadpcm_init(wav64_t *wav, int state_size);
 void wav64_vadpcm_close(wav64_t *wav);
 int wav64_vadpcm_get_bitrate(wav64_t *wav);
 

--- a/src/audio/wav64_vadpcm_internal.h
+++ b/src/audio/wav64_vadpcm_internal.h
@@ -10,7 +10,7 @@ typedef struct __attribute__((aligned(8))) {
 
 /** @brief Huffamn decoding context */
 typedef struct {
-	uint8_t lengths[8];					///< Length of each symbol (4-bit)
+	uint8_t lengths[8];					///< Length of each symbol (4-bit - 0xF means unused)
 	uint8_t values[16];					///< Code used for each symbol
 } wav64_vadpcm_huffctx_t;
 

--- a/src/audio/wav64_vadpcm_internal.h
+++ b/src/audio/wav64_vadpcm_internal.h
@@ -16,8 +16,10 @@ typedef struct __attribute__((packed, aligned(8))) {
 	wav64_vadpcm_vector_t codebook[];	///< Codebook of the predictors
 } wav64_header_vadpcm_t;
 
+/** @brief WAV64 VADPCM decoding state (for a single mixer channel) */
 typedef struct {
 	wav64_vadpcm_vector_t state[2];		///< Current decompression state
+	int bitpos;							///< Current bit position in the input buffer
 } wav64_state_vadpcm_t;
 
 

--- a/tools/audioconv64/conv_wav64.c
+++ b/tools/audioconv64/conv_wav64.c
@@ -265,21 +265,13 @@ int wav_convert(const char *infn, const char *outfn) {
 	fwrite(id, 1, 4, out);
 	w8(out, 3); 				 			// version
 	w8(out, flag_wav_compress);  			// format
+	w8(out, wav.channels);					// channels
+	w8(out, nbits);							// bits
+	w32(out, wav.sampleRate);				// frequency
+	w32(out, cnt);							// len
+	w32(out, loop_len);						// loop_len
 	w32_placeholderf(out, "samples");		// offset where samples begin
 	w32_placeholderf(out, "state_size");    // size of per-mixer-channel state to allocate at runtime
-
-	// Serialize a waveform_t
-	w32_placeholderf(out, "name");
-	w8(out, nbits);
-	w8(out, wav.channels);
-	w16(out, 0); 							// padding
-	wf32(out, wav.sampleRate);
-	w32(out, cnt);
-	w32(out, loop_len);
-	w32(out, 0);                            // WaveformRead
-	w32(out, 0);                            // WaveformStop
-	w32(out, 0);							// Context
-	w32(out, 0);							// Mixer UUID
 
 	switch (flag_wav_compress) {
 	case 0: { // no compression

--- a/tools/audioconv64/conv_wav64.c
+++ b/tools/audioconv64/conv_wav64.c
@@ -40,29 +40,30 @@ bool flag_wav_mono = false;
 const int OPUS_SAMPLE_RATE = 48000;
 
 typedef struct {
-	int16_t *samples;
-	int channels;
+	int16_t *samples;			// Samples (always 16-bit signed)
+	int cnt;					// Number of audio frames
+	int channels;				// Number of channels
 	int bitsPerSample;
 	int sampleRate;
 	bool looping;
 	int loopOffset;
 } wav_data_t;
 
-static size_t read_wav(const char *infn, wav_data_t *out)
+static bool read_wav(const char *infn, wav_data_t *out)
 {
 	drwav wav;
 	if (!drwav_init_file_with_metadata(&wav, infn, 0, NULL)) {
 		fprintf(stderr, "ERROR: %s: not a valid WAV/RIFF/AIFF file\n", infn);
-		return 0;
+		return false;
 	}
 
 	// Decode the samples as 16bit little-endian. This will decode everything including
 	// compressed formats so that we're able to read any kind of WAV file, though
 	// it will end up as an uncompressed file.
 	int16_t* samples = malloc(wav.totalPCMFrameCount * wav.channels * sizeof(int16_t));
-	size_t cnt = drwav_read_pcm_frames_s16le(&wav, wav.totalPCMFrameCount, samples);
-	if (cnt != wav.totalPCMFrameCount) {
-		fprintf(stderr, "WARNING: %s: %d frames found, but only %zu decoded\n", infn, (int)wav.totalPCMFrameCount, cnt);
+	out->cnt = drwav_read_pcm_frames_s16le(&wav, wav.totalPCMFrameCount, samples);
+	if (out->cnt != wav.totalPCMFrameCount) {
+		fprintf(stderr, "WARNING: %s: %d frames found, but only %d decoded\n", infn, (int)wav.totalPCMFrameCount, out->cnt);
 	}
 
 	out->samples = samples;
@@ -76,8 +77,8 @@ static size_t read_wav(const char *infn, wav_data_t *out)
 			drwav_smpl* smpl = &wav.pMetadata[i].data.smpl;
 			if (smpl->sampleLoopCount > 0) {
 				if (flag_verbose)
-					fprintf(stderr, "  found %d loop points [start=%d end=%d cnt=%zu]\n", smpl->sampleLoopCount,
-						smpl->pLoops[0].firstSampleByteOffset, smpl->pLoops[0].lastSampleByteOffset, cnt);
+					fprintf(stderr, "  found %d loop points [start=%d end=%d cnt=%d]\n", smpl->sampleLoopCount,
+						smpl->pLoops[0].firstSampleByteOffset, smpl->pLoops[0].lastSampleByteOffset, out->cnt);
 
 				// If we have multiple loops, we just take the first one.
 				drwav_smpl_loop* loop = &smpl->pLoops[0];
@@ -89,15 +90,15 @@ static size_t read_wav(const char *infn, wav_data_t *out)
 				// See also https://github.com/mackron/dr_libs/issues/267
 				out->looping = true;
 				out->loopOffset = loop->firstSampleByteOffset;
-				if (cnt > loop->lastSampleByteOffset+1)
-					cnt = loop->lastSampleByteOffset+1;
+				if (out->cnt > loop->lastSampleByteOffset+1)
+					out->cnt = loop->lastSampleByteOffset+1;
 				break;
 			}
 		}
 	}
 
 	drwav_uninit(&wav);
-	return cnt;
+	return true;
 }
 
 static size_t read_mp3(const char *infn, wav_data_t *out)
@@ -105,14 +106,14 @@ static size_t read_mp3(const char *infn, wav_data_t *out)
 	drmp3 mp3;
 	if (!drmp3_init_file(&mp3, infn, NULL)) {
 		fprintf(stderr, "ERROR: %s: not a valid MP3 file\n", infn);
-		return 0;
+		return false;
 	}
 
 	uint64_t nframes = drmp3_get_pcm_frame_count(&mp3);
 	int16_t* samples = malloc(nframes * mp3.channels * sizeof(int16_t));
-	size_t cnt = drmp3_read_pcm_frames_s16(&mp3, nframes, samples);
-	if (cnt != nframes) {
-		fprintf(stderr, "WARNING: %s: %d frames found, but only %zu decoded\n", infn, (int)nframes, cnt);
+	out->cnt = drmp3_read_pcm_frames_s16(&mp3, nframes, samples);
+	if (out->cnt != nframes) {
+		fprintf(stderr, "WARNING: %s: %d frames found, but only %d decoded\n", infn, (int)nframes, out->cnt);
 	}
 
 	out->samples = samples;
@@ -120,171 +121,34 @@ static size_t read_mp3(const char *infn, wav_data_t *out)
 	out->bitsPerSample = 16;
 	out->sampleRate = mp3.sampleRate;
 	drmp3_uninit(&mp3);
-	return cnt;
+	return true;
 }
 
-int wav_convert(const char *infn, const char *outfn) {
-	if (flag_verbose) {
-		const char *compr[4] = { "raw", "vadpcm", "raw", "opus" };
-		fprintf(stderr, "Converting: %s => %s (%s)\n", infn, outfn, compr[flag_wav_compress]);
-	}
-
+bool wav64_write(const char *infn, const char *outfn, FILE *out, wav_data_t* wav, size_t loop_len, int nbits, int format)
+{
 	bool failed = false;
-	wav_data_t wav = {0}; size_t cnt;
-
-	// Read the input file
-	if (strcasestr(infn, ".mp3"))
-		cnt = read_mp3(infn, &wav);
-	else
-		cnt = read_wav(infn, &wav);
-	if (cnt == 0) {
-		return 1;
-	}
-
-	if (flag_verbose)
-		fprintf(stderr, "  input: %d bits, %d Hz, %d channels\n", wav.bitsPerSample, wav.sampleRate, wav.channels);
-
-	// Apply command line flags if not provided by WAV itself
-	if (flag_wav_looping_offset > 0 && wav.loopOffset == 0)
-		wav.loopOffset = flag_wav_looping_offset;
-	if (flag_wav_looping && !wav.looping)
-		wav.looping = true;
-
-	// Check if the user requested conversion to mono
-	if (flag_wav_mono && wav.channels == 2) {
-		if (flag_verbose)
-			fprintf(stderr, "  converting to mono\n");
-
-		// Allocate a new buffer for the mono samples
-		int16_t *mono_samples = malloc(cnt * sizeof(int16_t));
-
-		// Convert to mono
-		int16_t *sptr = wav.samples;
-		int16_t *dptr = mono_samples;
-		for (int i=0;i<cnt;i++) {
-			int32_t v = *sptr + *(sptr+1);
-			v /= 2;
-			*dptr = v;
-			sptr += 2;
-			dptr++;
-		}
-
-		// Replace the samples buffer with the mono one
-		free(wav.samples);
-		wav.samples = mono_samples;
-		wav.channels = 1;
-	}
-
-	int wavOriginalSampleRate = wav.sampleRate;
-
-	// When compressing with opus, we need to resample to 32 Khz. Whatever value
-	// was selected by the user, we force it to 32 Khz.
-	if (flag_wav_compress == 3) {
-		if (flag_verbose)
-			fprintf(stderr, "  opus only supports %d kHz, forcing resample\n", OPUS_SAMPLE_RATE/1000);
-
-		// If the user asked to resample to a certain sample rate, keep that in
-		// mind for later when we will calculate th opus output bitrate.
-		// Basically --wav-resample becomes a way to tune the bitrate,
-		// but resampling is always done to OPUS_SAMPLE_RATE.
-		if (flag_wav_resample)
-			wavOriginalSampleRate = flag_wav_resample;
-		flag_wav_resample = OPUS_SAMPLE_RATE;
-	}
-
-	// Do sample rate conversion if requested
-	if (flag_wav_resample && wav.sampleRate != flag_wav_resample) {
-		if (flag_verbose)
-			fprintf(stderr, "  resampling to %d Hz\n", flag_wav_resample);
-
-		// Convert input samples to float
-		float *fsamples_in = malloc(cnt * wav.channels * sizeof(float));
-		src_short_to_float_array(wav.samples, fsamples_in, cnt * wav.channels);
-
-		// Allocate output buffer, estimating the size based on the ratio.
-		// We add some margin because we are not sure of rounding errors.
-		int newcnt = cnt * flag_wav_resample / wav.sampleRate + 16;
-		float *fsamples_out = malloc(newcnt * wav.channels * sizeof(float));
-
-		// Do the conversion
-		SRC_DATA data = {
-			.data_in = fsamples_in,
-			.input_frames = cnt,
-			.data_out = fsamples_out,
-			.output_frames = newcnt,
-			.src_ratio = (double)flag_wav_resample / wav.sampleRate,
-		};
-		int err = src_simple(&data, SRC_SINC_BEST_QUALITY, wav.channels);
-		if (err != 0) {
-			fprintf(stderr, "ERROR: %s: resampling failed: %s\n", infn, src_strerror(err));
-			free(fsamples_in);
-			free(fsamples_out);
-			free(wav.samples);
-			return 1;
-		}
-
-		// Extract the number of samples generated, and convert back to 16-bit
-		cnt = data.output_frames_gen;
-		wav.samples = realloc(wav.samples, cnt * wav.channels * sizeof(int16_t));
-		src_float_to_short_array(fsamples_out, wav.samples, cnt * wav.channels);
-
-		free(fsamples_in);
-		free(fsamples_out);
-
-		// Update wav.sampleRate as it will be used later
-		wav.sampleRate = flag_wav_resample;
-
-		// Update also the loop offset to the new sample rate
-		wav.loopOffset = wav.loopOffset * flag_wav_resample / wav.sampleRate;
-	}
-
-	// Keep 8 bits file if original is 8 bit, otherwise expand to 16 bit.
-	// Compressed waveforms always expand to 16 (both vadpcm and opus only supports 16 bits)
-	int nbits = wav.bitsPerSample == 8 ? 8 : 16;
-	if (flag_wav_compress != 0)
-		nbits = 16;
-
-	int loop_len = wav.looping ? cnt - wav.loopOffset : 0;
-	if (loop_len < 0) {
-		fprintf(stderr, "WARNING: %s: invalid looping offset: %d (size: %zu)\n", infn, wav.loopOffset, cnt);
-		loop_len = 0;
-	}
-	if (loop_len&1 && nbits==8) {
-		// Odd loop lengths are not supported for 8-bit waveforms because they would
-		// change the 2-byte phase between ROM and RDRAM addresses during loop unrolling.
-		// We shorten the loop by 1 sample which shouldn't matter.
-		fprintf(stderr, "WARNING: %s: invalid looping size: %d\n", infn, loop_len);
-		loop_len -= 1;
-	}
-
-	FILE *out = fopen(outfn, "wb");
-	if (!out) {
-		fprintf(stderr, "ERROR: %s: cannot create file\n", outfn);
-		free(wav.samples);
-		return 1;
-	}
 
 	char id[4] = "WV64";
 	fwrite(id, 1, 4, out);
 	w8(out, 3); 				 			// version
-	w8(out, flag_wav_compress);  			// format
-	w8(out, wav.channels);					// channels
+	w8(out, format);  						// format
+	w8(out, wav->channels);					// channels
 	w8(out, nbits);							// bits
-	w32(out, wav.sampleRate);				// frequency
-	w32(out, cnt);							// len
+	w32(out, wav->sampleRate);				// frequency
+	w32(out, wav->cnt);						// len
 	w32(out, loop_len);						// loop_len
 	w32_placeholderf(out, "samples");		// offset where samples begin
 	w32_placeholderf(out, "state_size");    // size of per-mixer-channel state to allocate at runtime
 
-	switch (flag_wav_compress) {
+	switch (format) {
 	case 0: { // no compression
 		// Uncompressed waveforms need to no state (0 bytes).
 		placeholder_set_offset(out, 0, "state_size");
 
 		// Start of the samples data
 		placeholder_set(out, "samples");
-		int16_t *sptr = wav.samples;
-		for (int i=0;i<cnt*wav.channels;i++) {
+		int16_t *sptr = wav->samples;
+		for (int i=0;i<wav->cnt*wav->channels;i++) {
 			// Byteswap *sptr
 			int16_t v = *sptr;
 			v = ((v & 0xFF00) >> 8) | ((v & 0x00FF) << 8);
@@ -309,52 +173,52 @@ int wav_convert(const char *infn, const char *outfn) {
 		// In addition to that, our RSP decompressor at the moment only supports
 		// multiples of 32 (for DMA alignment issues), so pad it to that.
 		const int VADPCM_ALIGN = kVADPCMFrameSampleCount*2;
-		if (cnt % VADPCM_ALIGN) {
-			int newcnt = (cnt + VADPCM_ALIGN - 1) / VADPCM_ALIGN * VADPCM_ALIGN;
-			wav.samples = realloc(wav.samples, newcnt * wav.channels * sizeof(int16_t));
-			memset(wav.samples + cnt, 0, (newcnt - cnt) * wav.channels * sizeof(int16_t));
-			cnt = newcnt;
+		if (wav->cnt % VADPCM_ALIGN) {
+			int newcnt = (wav->cnt + VADPCM_ALIGN - 1) / VADPCM_ALIGN * VADPCM_ALIGN;
+			wav->samples = realloc(wav->samples, newcnt * wav->channels * sizeof(int16_t));
+			memset(wav->samples + wav->cnt, 0, (newcnt - wav->cnt) * wav->channels * sizeof(int16_t));
+			wav->cnt = newcnt;
 		}
 
 		enum { kPREDICTORS = 4 };
 
-		assert(cnt % kVADPCMFrameSampleCount == 0);
-		int nframes = cnt / kVADPCMFrameSampleCount;
+		assert(wav->cnt % kVADPCMFrameSampleCount == 0);
+		int nframes = wav->cnt / kVADPCMFrameSampleCount;
 		void *scratch = malloc(vadpcm_encode_scratch_size(nframes));
-		struct vadpcm_vector *codebook = alloca(kPREDICTORS * kVADPCMEncodeOrder * wav.channels * sizeof(struct vadpcm_vector));
+		struct vadpcm_vector *codebook = alloca(kPREDICTORS * kVADPCMEncodeOrder * wav->channels * sizeof(struct vadpcm_vector));
 		struct vadpcm_params parms = { .predictor_count = kPREDICTORS };
-		void *dest = malloc(nframes * kVADPCMFrameByteSize * wav.channels);
+		void *dest = malloc(nframes * kVADPCMFrameByteSize * wav->channels);
 		
 		if (flag_verbose)
 			fprintf(stderr, "  compressing into VADPCM format (%d frames)\n", nframes);
 
-		int16_t *schan = malloc(cnt * sizeof(int16_t));
-		for (int i=0; i<wav.channels; i++) {
+		int16_t *schan = malloc(wav->cnt * sizeof(int16_t));
+		for (int i=0; i<wav->channels; i++) {
 			uint8_t *destchan = malloc(nframes * kVADPCMFrameByteSize);
-			for (int j=0; j<cnt; j++)
-				schan[j] = wav.samples[i + j*wav.channels];
+			for (int j=0; j<wav->cnt; j++)
+				schan[j] = wav->samples[i + j*wav->channels];
 			vadpcm_error err = vadpcm_encode(&parms, codebook + kPREDICTORS * kVADPCMEncodeOrder * i, nframes, destchan, schan, scratch);
 			if (err != 0) {
 				fprintf(stderr, "VADPCM encoding error: %s\n", vadpcm_error_name(err));
 				return 1;
 			}
 			for (int j=0; j<nframes; j++)
-				memcpy(dest + (i + wav.channels * j) * kVADPCMFrameByteSize, destchan + j * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
+				memcpy(dest + (i + wav->channels * j) * kVADPCMFrameByteSize, destchan + j * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
 			free(destchan);
 		}
 		free(scratch);
 
-		const int maxcompbuflen = nframes * kVADPCMFrameByteSize * wav.channels;
+		const int maxcompbuflen = nframes * kVADPCMFrameByteSize * wav->channels;
 		uint8_t *compbuf = malloc(maxcompbuflen);
 		uint8_t *ctxbuf = calloc(HUFF_CONTEXT_LEN, 1);
 		int compbuflen = 0;
 		if (huffman) 
-			compbuflen = huffv_compress(dest, nframes * kVADPCMFrameByteSize * wav.channels, compbuf, maxcompbuflen, ctxbuf, HUFF_CONTEXT_LEN);
+			compbuflen = huffv_compress(dest, nframes * kVADPCMFrameByteSize * wav->channels, compbuf, maxcompbuflen, ctxbuf, HUFF_CONTEXT_LEN);
 
 		if (flag_verbose)
 			fprintf(stderr, "  huffman compressed %d bytes into %d bytes (ratio: %.1f)\n", 
-				nframes * kVADPCMFrameByteSize * wav.channels, compbuflen,
-				100.0f * compbuflen / (nframes * kVADPCMFrameByteSize * wav.channels));
+				nframes * kVADPCMFrameByteSize * wav->channels, compbuflen,
+				100.0f * compbuflen / (nframes * kVADPCMFrameByteSize * wav->channels));
 
 		uint8_t flags = 0;
 		if (huffman) flags |= (1<<0);
@@ -368,7 +232,7 @@ int wav_convert(const char *infn, const char *outfn) {
 		fwrite(&state, 1, sizeof(struct vadpcm_vector), out);   // TBC: loop_state[0]
 		fwrite(&state, 1, sizeof(struct vadpcm_vector), out);   // TBC: loop_state[1]
 		fwrite(ctxbuf, 1, HUFF_CONTEXT_LEN, out);				// Huffman context
-		for (int i=0; i<kPREDICTORS * kVADPCMEncodeOrder * wav.channels; i++)    // codebook
+		for (int i=0; i<kPREDICTORS * kVADPCMEncodeOrder * wav->channels; i++)    // codebook
 			for (int j=0; j<8; j++)
 				w16(out, codebook[i].v[j]);
 
@@ -377,26 +241,26 @@ int wav_convert(const char *infn, const char *outfn) {
 		if (huffman)
 			fwrite(compbuf, 1, compbuflen, out);
 		else
-			fwrite(dest, 1, nframes * kVADPCMFrameByteSize * wav.channels, out);
+			fwrite(dest, 1, nframes * kVADPCMFrameByteSize * wav->channels, out);
 
 		if (flag_debug) {
 			char* wav2fn = changeext(outfn, ".vadpcm.wav");
 			if (flag_verbose)
 				fprintf(stderr, "  writing uncompressed file %s\n", wav2fn);
 			
-			int16_t *out_samples = malloc(cnt * wav.channels * sizeof(int16_t));
-			int16_t *out_channel = malloc(cnt * sizeof(int16_t));
-			for (int i=0;i<wav.channels;i++) {		
+			int16_t *out_samples = malloc(wav->cnt * wav->channels * sizeof(int16_t));
+			int16_t *out_channel = malloc(wav->cnt * sizeof(int16_t));
+			for (int i=0;i<wav->channels;i++) {		
 				uint8_t *in_channel = malloc(nframes * kVADPCMFrameByteSize);
 				for (int j=0;j<nframes;j++)
-					memcpy(in_channel + j * kVADPCMFrameByteSize, dest + (i + wav.channels * j) * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
+					memcpy(in_channel + j * kVADPCMFrameByteSize, dest + (i + wav->channels * j) * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
 
 				memset(&state, 0, sizeof(state));
 				vadpcm_decode(kPREDICTORS, kVADPCMEncodeOrder,
 					codebook + kPREDICTORS * kVADPCMEncodeOrder * i,
 					&state, nframes, out_channel, in_channel);
-				for (int j=0;j<cnt;j++)
-					out_samples[i + j*wav.channels] = out_channel[j];
+				for (int j=0;j<wav->cnt;j++)
+					out_samples[i + j*wav->channels] = out_channel[j];
 				free(in_channel);
 			}
 			free(out_channel);
@@ -404,8 +268,8 @@ int wav_convert(const char *infn, const char *outfn) {
 			drwav_data_format fmt = {
 				.container = drwav_container_riff,
 				.format = DR_WAVE_FORMAT_PCM,
-				.channels = wav.channels,
-				.sampleRate = wav.sampleRate,
+				.channels = wav->channels,
+				.sampleRate = wav->sampleRate,
 				.bitsPerSample = 16,
 			};
 			drwav wav2;
@@ -413,7 +277,7 @@ int wav_convert(const char *infn, const char *outfn) {
 				fprintf(stderr, "ERROR: %s: cannot create WAV file\n", outfn);
 				failed = true;
 			} else {
-				drwav_write_pcm_frames(&wav2, cnt, out_samples);
+				drwav_write_pcm_frames(&wav2, wav->cnt, out_samples);
 				drwav_uninit(&wav2);
 			}
 		}
@@ -429,18 +293,18 @@ int wav_convert(const char *infn, const char *outfn) {
 		// 48 Khz => 960 samples
 		// 32 Khz => 640 samples
 		const int FRAMES_PER_SECOND = 50;
-		int frame_size = wav.sampleRate / FRAMES_PER_SECOND;
+		int frame_size = wav->sampleRate / FRAMES_PER_SECOND;
 		int err = OPUS_OK;
 
 		OpusCustomMode *custom_mode = opus_custom_mode_create(
-			wav.sampleRate, frame_size, &err);
+			wav->sampleRate, frame_size, &err);
 		if (err != OPUS_OK) {
 			fprintf(stderr, "ERROR: %s: cannot create opus custom mode: %s\n", infn, opus_strerror(err));
 			failed = true; goto end;
 		}
 
 		OpusCustomEncoder *enc = opus_custom_encoder_create(
-				custom_mode, wav.channels, &err);
+				custom_mode, wav->channels, &err);
 		if (err != OPUS_OK) {
 			opus_custom_mode_destroy(custom_mode);
 			fprintf(stderr, "ERROR: %s: cannot create opus encoder: %s\n", infn, opus_strerror(err));
@@ -449,7 +313,7 @@ int wav_convert(const char *infn, const char *outfn) {
 
 		// Automatic bitrate calculation for "good quality". This is the same
 		// algorithm libopus selects when setting OPUS_AUTO bitrate.
-		int bitrate_bps = 60*FRAMES_PER_SECOND + wavOriginalSampleRate * wav.channels;
+		int bitrate_bps = 60*FRAMES_PER_SECOND + flag_wav_resample * wav->channels;
 		if (flag_verbose)
 			fprintf(stderr, "  opus bitrate: %d bps\n", bitrate_bps);
 
@@ -464,7 +328,7 @@ int wav_convert(const char *infn, const char *outfn) {
 		// so it could be larger than on the N64, but it's a good approximation.
 		// Add 16 because OpusDecoder has a 16-byte internal alingment, so we add
 		// some margin. The value is asserted at runtime anyway.
-		placeholder_set_offset(out, 16+opus_custom_decoder_get_size(custom_mode, wav.channels), "state_size");
+		placeholder_set_offset(out, 16+opus_custom_decoder_get_size(custom_mode, wav->channels), "state_size");
 
 		// Configure opus encoder. We use VBR as it provides the best
 		// compression/quality balance and we don't have specific constraints
@@ -481,15 +345,15 @@ int wav_convert(const char *infn, const char *outfn) {
 		opus_custom_encoder_ctl(enc, OPUS_SET_LSB_DEPTH(16));
 
 		// Pad input samples with zeros, rounding to frame size
-		int newcnt = (cnt + frame_size - 1) / frame_size * frame_size;
-		wav.samples = realloc(wav.samples, newcnt * wav.channels * sizeof(int16_t));
-		memset(wav.samples + cnt, 0, (newcnt - cnt) * wav.channels * sizeof(int16_t));
+		int newcnt = (wav->cnt + frame_size - 1) / frame_size * frame_size;
+		wav->samples = realloc(wav->samples, newcnt * wav->channels * sizeof(int16_t));
+		memset(wav->samples + wav->cnt, 0, (newcnt - wav->cnt) * wav->channels * sizeof(int16_t));
 		
 		int max_nb = 0;
 		int out_max_size = bitrate_bps/8; // overestimation
 		uint8_t *out_buffer = malloc(out_max_size);
 		for (int i=0; i<newcnt; i+=frame_size) {
-			int nb = opus_custom_encode(enc, wav.samples + i*wav.channels, frame_size, out_buffer, out_max_size);
+			int nb = opus_custom_encode(enc, wav->samples + i*wav->channels, frame_size, out_buffer, out_max_size);
 			if (nb < 0) {
 				fprintf(stderr, "ERROR: %s: opus encoding failed: %s\n", infn, opus_strerror(nb));
 				failed = true;
@@ -516,9 +380,15 @@ int wav_convert(const char *infn, const char *outfn) {
 				fprintf(stderr, "  writing uncompressed file %s\n", wav2fn);
 
 			out = fopen(outfn, "rb");
-			fseek(out, 36, SEEK_SET);
+			fseek(out, 20, SEEK_SET);
+			int start_offset = 0;
+			start_offset |= fgetc(out) << 24;
+			start_offset |= fgetc(out) << 16;
+			start_offset |= fgetc(out) << 8;
+			start_offset |= fgetc(out);
+			fseek(out, start_offset, SEEK_SET);
 			OpusCustomDecoder *dec = opus_custom_decoder_create(
-					custom_mode, wav.channels, &err);
+					custom_mode, wav->channels, &err);
 			if (err != OPUS_OK) {
 				opus_custom_mode_destroy(custom_mode);
 				fprintf(stderr, "ERROR: %s: cannot create opus decoder: %s\n", infn, opus_strerror(err));
@@ -527,7 +397,7 @@ int wav_convert(const char *infn, const char *outfn) {
 			}
 
 			// Decode the whole file to check for errors
-			int16_t *out_samples = malloc(newcnt * wav.channels * sizeof(int16_t));
+			int16_t *out_samples = malloc(newcnt * wav->channels * sizeof(int16_t));
 			int outcnt = 0;
 			for (int i=0; i<newcnt; i+=frame_size) {
 				int nb = fgetc(out) << 8;
@@ -542,7 +412,7 @@ int wav_convert(const char *infn, const char *outfn) {
 				fread(in_samples, 1, nb, out);
 				if (nb & 1) fgetc(out); // align to 2-byte boundary
 
-				int ret = opus_custom_decode(dec, in_samples, nb, out_samples + outcnt*wav.channels, frame_size);
+				int ret = opus_custom_decode(dec, in_samples, nb, out_samples + outcnt*wav->channels, frame_size);
 				if (ret < 0) {
 					fprintf(stderr, "ERROR: %s: opus decoding failed: %s\n", infn, opus_strerror(ret));
 					failed = true;
@@ -556,8 +426,8 @@ int wav_convert(const char *infn, const char *outfn) {
 				drwav_data_format fmt = {
 					.container = drwav_container_riff,
 					.format = DR_WAVE_FORMAT_PCM,
-					.channels = wav.channels,
-					.sampleRate = wav.sampleRate,
+					.channels = wav->channels,
+					.sampleRate = wav->sampleRate,
 					.bitsPerSample = 16,
 				};
 				drwav wav2;
@@ -578,6 +448,154 @@ int wav_convert(const char *infn, const char *outfn) {
 	}
 
 end:
+	return !failed;
+}
+
+
+
+int wav_convert(const char *infn, const char *outfn) {
+	if (flag_verbose) {
+		const char *compr[4] = { "raw", "vadpcm", "raw", "opus" };
+		fprintf(stderr, "Converting: %s => %s (%s)\n", infn, outfn, compr[flag_wav_compress]);
+	}
+
+	bool failed = false;
+	wav_data_t wav = {0};
+
+	// Read the input file
+	bool loaded;
+	if (strcasestr(infn, ".mp3"))
+		loaded = read_mp3(infn, &wav);
+	else
+		loaded = read_wav(infn, &wav);
+	if (!loaded) {
+		return 1;
+	}
+
+	if (flag_verbose)
+		fprintf(stderr, "  input: %d bits, %d Hz, %d channels\n", wav.bitsPerSample, wav.sampleRate, wav.channels);
+
+	// Apply command line flags if not provided by WAV itself
+	if (flag_wav_looping_offset > 0 && wav.loopOffset == 0)
+		wav.loopOffset = flag_wav_looping_offset;
+	if (flag_wav_looping && !wav.looping)
+		wav.looping = true;
+
+	// Check if the user requested conversion to mono
+	if (flag_wav_mono && wav.channels == 2) {
+		if (flag_verbose)
+			fprintf(stderr, "  converting to mono\n");
+
+		// Allocate a new buffer for the mono samples
+		int16_t *mono_samples = malloc(wav.cnt * sizeof(int16_t));
+
+		// Convert to mono
+		int16_t *sptr = wav.samples;
+		int16_t *dptr = mono_samples;
+		for (int i=0;i<wav.cnt;i++) {
+			int32_t v = *sptr + *(sptr+1);
+			v /= 2;
+			*dptr = v;
+			sptr += 2;
+			dptr++;
+		}
+
+		// Replace the samples buffer with the mono one
+		free(wav.samples);
+		wav.samples = mono_samples;
+		wav.channels = 1;
+	}
+
+	int wavResampleTo = flag_wav_resample;
+
+	// When compressing with opus, we need to resample to 32 Khz. Whatever value
+	// was selected by the user, we force it to 32 Khz.
+	if (flag_wav_compress == 3) {
+		if (flag_verbose)
+			fprintf(stderr, "  opus only supports %d kHz, forcing resample\n", OPUS_SAMPLE_RATE/1000);
+
+		// For Opus, input files must always be 48 Khz (OPUS_SAMPLE_RATE).
+		// We will check the real flag_wav_resample later as a way to tune the
+		// bitrate.
+		wavResampleTo = OPUS_SAMPLE_RATE;
+		if (!flag_wav_resample)
+			flag_wav_resample = wav.sampleRate;
+	}
+
+	// Do sample rate conversion if requested
+	if (wavResampleTo && wav.sampleRate != wavResampleTo) {
+		if (flag_verbose)
+			fprintf(stderr, "  resampling to %d Hz\n", wavResampleTo);
+
+		// Convert input samples to float
+		float *fsamples_in = malloc(wav.cnt * wav.channels * sizeof(float));
+		src_short_to_float_array(wav.samples, fsamples_in, wav.cnt * wav.channels);
+
+		// Allocate output buffer, estimating the size based on the ratio.
+		// We add some margin because we are not sure of rounding errors.
+		int newcnt = wav.cnt * wavResampleTo / wav.sampleRate + 16;
+		float *fsamples_out = malloc(newcnt * wav.channels * sizeof(float));
+
+		// Do the conversion
+		SRC_DATA data = {
+			.data_in = fsamples_in,
+			.input_frames = wav.cnt,
+			.data_out = fsamples_out,
+			.output_frames = newcnt,
+			.src_ratio = (double)wavResampleTo / wav.sampleRate,
+		};
+		int err = src_simple(&data, SRC_SINC_BEST_QUALITY, wav.channels);
+		if (err != 0) {
+			fprintf(stderr, "ERROR: %s: resampling failed: %s\n", infn, src_strerror(err));
+			free(fsamples_in);
+			free(fsamples_out);
+			free(wav.samples);
+			return 1;
+		}
+
+		// Extract the number of samples generated, and convert back to 16-bit
+		wav.cnt = data.output_frames_gen;
+		wav.samples = realloc(wav.samples, wav.cnt * wav.channels * sizeof(int16_t));
+		src_float_to_short_array(fsamples_out, wav.samples, wav.cnt * wav.channels);
+
+		free(fsamples_in);
+		free(fsamples_out);
+
+		// Update wav.sampleRate as it will be used later
+		wav.sampleRate = wavResampleTo;
+
+		// Update also the loop offset to the new sample rate
+		wav.loopOffset = wav.loopOffset * wavResampleTo / wav.sampleRate;
+	}
+
+	// Keep 8 bits file if original is 8 bit, otherwise expand to 16 bit.
+	// Compressed waveforms always expand to 16 (both vadpcm and opus only supports 16 bits)
+	int nbits = wav.bitsPerSample == 8 ? 8 : 16;
+	if (flag_wav_compress != 0)
+		nbits = 16;
+
+	int loop_len = wav.looping ? wav.cnt - wav.loopOffset : 0;
+	if (loop_len < 0) {
+		fprintf(stderr, "WARNING: %s: invalid looping offset: %d (size: %d)\n", infn, wav.loopOffset, wav.cnt);
+		loop_len = 0;
+	}
+	if (loop_len&1 && nbits==8) {
+		// Odd loop lengths are not supported for 8-bit waveforms because they would
+		// change the 2-byte phase between ROM and RDRAM addresses during loop unrolling.
+		// We shorten the loop by 1 sample which shouldn't matter.
+		fprintf(stderr, "WARNING: %s: invalid looping size: %d\n", infn, loop_len);
+		loop_len -= 1;
+	}
+
+	FILE *out = fopen(outfn, "wb");
+	if (!out) {
+		fprintf(stderr, "ERROR: %s: cannot create file\n", outfn);
+		free(wav.samples);
+		return 1;
+	}
+
+	failed = !wav64_write(infn, outfn, out, &wav, loop_len, nbits, flag_wav_compress);
+
 	fclose(out);
 	free(wav.samples);
 	if (failed) {

--- a/tools/audioconv64/huff_vadpcm.c
+++ b/tools/audioconv64/huff_vadpcm.c
@@ -1,0 +1,192 @@
+#include <stdio.h>
+#include <assert.h>
+#include <stdint.h>
+
+#define HUFF_TABLE_SIZE     16
+#define HUFF_CONTEXTS       3
+#define HUFF_CONTEXT_LEN    (HUFF_CONTEXTS * 24)
+
+// Huffman tree node
+typedef struct HuffNode {
+    int symbol;
+    int frequency;
+    struct HuffNode *left, *right;
+} HuffNode;
+
+typedef struct {
+    int value;
+    int length;
+} HuffCode;
+
+typedef struct {
+    int freq[HUFF_CONTEXTS][HUFF_TABLE_SIZE];
+} HuffFreq;
+
+typedef struct {
+    HuffNode *root;
+    HuffCode codes[HUFF_TABLE_SIZE];
+} HuffCtx;
+
+int compare_freq(const void *a, const void *b) {
+    HuffNode *node_a = *(HuffNode**)a;
+    HuffNode *node_b = *(HuffNode**)b;
+    return node_a->frequency - node_b->frequency;
+}
+
+HuffNode* build_huffman_tree(int frequencies[], int size) {
+    HuffNode* heap[16];
+    int hsize = 0;
+    for (int i = 0; i < size; i++) {
+        if (frequencies[i] == 0) {
+            continue;
+        }
+        heap[hsize] = (HuffNode*)malloc(sizeof(HuffNode));
+        heap[hsize]->symbol = i;
+        heap[hsize]->frequency = frequencies[i];
+        heap[hsize]->left = heap[hsize]->right = NULL;
+        hsize++;
+    }
+    qsort(heap, hsize, sizeof(HuffNode*), compare_freq);
+
+    while (hsize > 1) {
+        HuffNode* left = heap[0];
+        HuffNode* right = heap[1];
+        HuffNode* parent = (HuffNode*)malloc(sizeof(HuffNode));
+        parent->symbol = -1;
+        parent->frequency = left->frequency + right->frequency;
+        parent->left = left;
+        parent->right = right;
+        memmove(&heap[0], &heap[2], (hsize - 2) * sizeof(HuffNode*));
+        heap[hsize - 2] = parent;
+        hsize--;
+        qsort(heap, hsize, sizeof(HuffNode*), compare_freq);
+    }
+    return heap[0];
+}
+
+void free_huffman_tree(HuffNode* root) {
+    if (root->left) free_huffman_tree(root->left);
+    if (root->right) free_huffman_tree(root->right);
+    free(root);
+}
+
+void generate_huffman_codes(HuffNode* root, int code, int length, HuffCode codes[]) {
+    if (root->symbol != -1) {
+        codes[root->symbol].value = code;
+        codes[root->symbol].length = length;
+    } else {
+        generate_huffman_codes(root->left, (code << 1) | 0, length + 1, codes);
+        generate_huffman_codes(root->right, (code << 1) | 1, length + 1, codes);
+    }
+}
+
+void calculate_frequencies(uint8_t *input_data, int data_len, HuffFreq *freq) {
+    assert(data_len % 9 == 0);
+
+    memset(freq, 0, sizeof(HuffFreq));
+    while (data_len > 0) {
+        for (int i = 0; i < 18; i+=2) {
+            int sym0 = input_data[i/2] >> 4;
+            int sym1 = input_data[i/2] & 15;
+            int c0 = (i+0 < 2) ? i+0 : 2;
+            int c1 = (i+1 < 2) ? i+1 : 2;
+            freq->freq[c0][sym0]++;
+            freq->freq[c1][sym1]++;
+        }
+        input_data += 9;
+        data_len -= 9;
+    }
+
+    // Now normalize the frequencies so that they sum to 1
+    for (int i = 0; i < HUFF_CONTEXTS; i++) {
+        int sum = 0;
+        for (int j = 0; j < HUFF_TABLE_SIZE; j++) {
+            sum += freq->freq[i][j];
+        }
+        if (sum == 0) {
+            continue;
+        }
+        for (int j = 0; j < HUFF_TABLE_SIZE; j++) {
+            int nfreq = (freq->freq[i][j] * 255 + sum - 1) / sum;
+            if (nfreq == 0) assert(freq->freq[i][j] == 0);
+            freq->freq[i][j] = nfreq;
+        }
+    }
+}
+
+int huffv_compress(uint8_t *input_data, int data_len, uint8_t *output, int output_len, uint8_t *outctx, int outctxlen) {
+    HuffFreq freq;
+    calculate_frequencies(input_data, data_len, &freq);
+
+    HuffCtx ctx[HUFF_CONTEXTS] = {0};
+    for (int i = 0; i < HUFF_CONTEXTS; i++) {
+        ctx[i].root = build_huffman_tree(freq.freq[i], HUFF_TABLE_SIZE);
+        generate_huffman_codes(ctx[i].root, 0, 0, ctx[i].codes);
+    }
+
+    int written = 0;
+
+    // Serialize the compression contexts
+    for (int i = 0; i < HUFF_CONTEXTS; i++) {
+        // Write lengths as 4-bit
+        for (int j=0; j<16; j+=2) {
+            int l = 0;
+            assert(ctx[i].codes[j+0].length < 16);
+            assert(ctx[i].codes[j+1].length < 16);
+            l |= ctx[i].codes[j+0].length << 4;
+            l |= ctx[i].codes[j+1].length;
+            assert(outctxlen-- > 0);
+            *outctx++ = l;
+        }
+
+        // Write values as 8 bits
+        for (int j=0; j<16; j++) {
+            assert(ctx[i].codes[j].value < 256);
+            assert(outctxlen-- > 0);
+            *outctx++ = ctx[i].codes[j].value;
+        }
+    }
+    assert(outctxlen == 0);
+
+    uint32_t buffer = 0;
+    int bit_pos = 0;
+
+    assert(data_len % 9 == 0);
+    while (data_len > 0) {
+        for (int i = 0; i < 18; i += 2) {
+            int sym0 = input_data[i/2] >> 4;
+            int sym1 = input_data[i/2] & 15;
+            int c0 = (i+0 < 2) ? i+0 : 2;
+            int c1 = (i+1 < 2) ? i+1 : 2;
+
+            assert(ctx[c0].codes[sym0].length > 0);
+            assert(ctx[c1].codes[sym1].length > 0);
+
+            buffer = (buffer << ctx[c0].codes[sym0].length) | ctx[c0].codes[sym0].value;
+            bit_pos += ctx[c0].codes[sym0].length;
+            buffer = (buffer << ctx[c1].codes[sym1].length) | ctx[c1].codes[sym1].value;
+            bit_pos += ctx[c1].codes[sym1].length;
+
+            while (bit_pos >= 8) {
+                assert(written < output_len);
+                output[written++] = buffer >> (bit_pos - 8);
+                bit_pos -= 8;
+            }
+        }
+
+        input_data += 9;
+        data_len -= 9;
+    }
+
+    if (bit_pos > 0) {
+        assert(written < output_len);
+        assert(bit_pos < 8);
+        output[written++] = buffer << (8 - bit_pos);
+    }
+
+    for (int i=0; i<HUFF_CONTEXTS; i++) {
+        free_huffman_tree(ctx[i].root);
+    }
+
+    return written;
+}


### PR DESCRIPTION
This PR includes a mix of wav64 improvements, coming through insightful discussions had with people joining the recent n64brew game jam:

 * Add new `wav64_load` API that also allocates the `wav64_t` structure and return the new object. This is more in line with all loading APIs in libdragon and allows to for better encapsulation of internal details of wav64 implementation. `wav64_open` is still available, but we can deprecate it in the future.
 * Allow wav64 to playback the same waveform on multiple simultaneous channels (that is, you can now call `wav64_play()` multiple times on the same object). This is a feature that was originally available in the first iteration of wav64 because of its stateless approach (uncompressed audio streaming using direct DMA to ROM). It got lost as more features were added (mainly, compression and streaming on arbitrary filesystems). Now it is properly designed and available for all wav64s. The default number of simultaneous playbacks depends on the compression level (eg: 4 for VADPCM), but it can be tuned when calling `wav64_load`.
 * Allow to preload and uncompress the whole wav64 in RDRAM. You can enable this via new loading option in `wav64_load`. It might be useful mainly for small sound effects: if you can spare the RAM, you can avoid the overhead of streaming and decompressing them from ROM at each playback.
 * Improved VADPCM by adding an additional Huffman layer on top. This is tuned to be extremely fast at runtime, and can still provide an average ~10% reduction.
