### PR TITLE
Add rdpq_load_block_linear

### DIFF
--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -1270,6 +1270,30 @@ inline void rdpq_set_texture_image_raw(uint8_t index, uint32_t offset, tex_forma
 }
 
 /**
+ * @brief Load a block of memory to TMEM with a single contiguous memory transfer.
+ *
+ * Loads data from RDRAM to TMEM but takes in byte offsets and sizes unlike #rdpq_load_block.
+ *
+ * @param[in] offset    Destination TMEM offset
+ * @param[in] buffer    Pointer to data in RDRAM to load
+ * @param[in] size      Number of bytes to load (max: 4096)
+ *
+ * @see #rdpq_load_block
+ * @see #rdpq_load_block_fx
+ */
+inline void rdpq_load_block_linear(int32_t offset, void *buffer, uint16_t size)
+{
+    assertf((offset & 7) == 0, "invalid TMEM offset %ld: must be 8-byte aligned", offset);
+    assertf((PhysicalAddr(buffer) & 7) == 0, "invalid buffer: %p, must be 8-byte aligned", buffer);
+    assertf((size & 7) == 0, "invalid size %d: must be a multiple of 8", size);
+    assertf(size <= 4096, "invalid size %d: must fit TMEM", size);
+    rdpq_set_texture_image_raw(0, PhysicalAddr(buffer), FMT_RGBA16, 8, size / 8);
+    rdpq_set_tile(RDPQ_TILE_INTERNAL, FMT_RGBA16, offset, 0, NULL);
+    uint32_t num_texels = size / 2;
+    rdpq_load_block(RDPQ_TILE_INTERNAL, 0, 0, num_texels, 16);
+}
+
+/**
  * @brief Store an address into the rdpq lookup table
  * 
  * This function is for advanced usages, it is not normally required to call it.

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -1182,6 +1182,7 @@ extern inline void rdpq_load_tlut_raw(rdpq_tile_t tile, int first_color, int num
 extern inline void rdpq_set_tile_size_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t s1, uint16_t t1);
 extern inline void rdpq_load_block(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t num_texels, uint16_t tmem_pitch);
 extern inline void rdpq_load_block_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t num_texels, uint16_t dxt);
+extern inline void rdpq_load_block_linear(int32_t offset, void *buffer, uint16_t size);
 extern inline void rdpq_load_tile_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t s1, uint16_t t1);
 extern inline void rdpq_set_combiner_raw(uint64_t cc);
 extern inline void rdpq_set_other_modes_raw(uint64_t mode);


### PR DESCRIPTION
Commit message: Current rdpq functions are cumbersome to use for specific TMEM manipulations. This commit adds a new helper function rdpq_load_block_linear that operates directly on bytes instead of texels.