### PR TITLE
Fix accessory detection for linear paging controller paks

### DIFF
--- a/src/joypad_accessory.c
+++ b/src/joypad_accessory.c
@@ -291,15 +291,34 @@ static void joypad_accessory_detect_read_callback(uint64_t *out_dwords, void *ct
     {
         return; // Accessory communication error!
     }
-    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_LABEL_READ)
+    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_BACKUP)
+    {
+        memcpy((void *)accessory->cpak_label_backup, cmd->recv.data, sizeof(cmd->recv.data));
+        // Step 2C: Overwrite the Controller Pak "label" area
+        for (size_t i = 0; i < sizeof(write_data); ++i) write_data[i] = i;
+        accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_WRITE;
+        accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+        accessory->retries = 0;
+        joybus_accessory_write_async(
+            port, JOYBUS_ACCESSORY_ADDR_LABEL, write_data,
+            joypad_accessory_detect_write_callback, ctx
+        );
+    }
+    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_READ)
     {
         // Compare the expected label with what was actually read back
         for (size_t i = 0; i < sizeof(write_data); ++i) write_data[i] = i;
         if (memcmp(cmd->recv.data, write_data, sizeof(write_data)) == 0)
         {
-            // Success: Label write persisted; this appears to be a Controller Pak
-            accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-            accessory->type = JOYPAD_ACCESSORY_TYPE_CONTROLLER_PAK;
+            // Step 2E: Restore the Controller Pak "label" area
+            memcpy(write_data, (void *)accessory->cpak_label_backup, sizeof(write_data));
+            accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_RESTORE;
+            accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+            accessory->retries = 0;
+            joybus_accessory_write_async(
+                port, JOYBUS_ACCESSORY_ADDR_LABEL, write_data,
+                joypad_accessory_detect_write_callback, ctx
+            );
         }
         else
         {
@@ -418,27 +437,43 @@ static void joypad_accessory_detect_write_callback(uint64_t *out_dwords, void *c
     {
         // Transfer Pak has been turned off; reset Transfer Pak status
         accessory->transfer_pak_status.raw = 0x00;
-        // Step 2A: Overwrite "label" area to detect Controller Pak
-        uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE];
-        for (size_t i = 0; i < sizeof(data); ++i) data[i] = i;
-        accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_LABEL_WRITE;
+        // Step 2A: Set Controller Pak "linear paging bank" to 0
+        uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE] = {0};
+        accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_CPAK_BANK_WRITE;
         accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
         accessory->retries = 0;
         joybus_accessory_write_async(
-            port, JOYBUS_ACCESSORY_ADDR_LABEL, data,
+            port, JOYPAD_CONTROLLER_PAK_BANK_SWITCH_ADDRESS, data,
             joypad_accessory_detect_write_callback, ctx
         );
     }
-    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_LABEL_WRITE)
+    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_CPAK_BANK_WRITE)
     {
-        // Step 2B: Read back the "label" area to detect Controller Pak
-        accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_LABEL_READ;
+        // Step 2B: Backup the Controller Pak "label" area
+        accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_BACKUP;
         accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
         accessory->retries = 0;
         joybus_accessory_read_async(
             port, JOYBUS_ACCESSORY_ADDR_LABEL,
             joypad_accessory_detect_read_callback, ctx
         );
+    }
+    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_WRITE)
+    {
+        // Step 2D: Read back the "label" area to detect Controller Pak
+        accessory->state = JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_READ;
+        accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+        accessory->retries = 0;
+        joybus_accessory_read_async(
+            port, JOYBUS_ACCESSORY_ADDR_LABEL,
+            joypad_accessory_detect_read_callback, ctx
+        );
+    }
+    else if (state == JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_RESTORE)
+    {
+        // Success: Controller Pak detected
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        accessory->type = JOYPAD_ACCESSORY_TYPE_CONTROLLER_PAK;
     }
     else if (state == JOYPAD_ACCESSORY_STATE_DETECT_RUMBLE_PROBE_WRITE)
     {

--- a/src/joypad_accessory.h
+++ b/src/joypad_accessory.h
@@ -33,8 +33,11 @@ typedef enum
     JOYPAD_ACCESSORY_STATE_IDLE = 0,
     // Accessory detection routine states
     JOYPAD_ACCESSORY_STATE_DETECT_INIT,
-    JOYPAD_ACCESSORY_STATE_DETECT_LABEL_WRITE,
-    JOYPAD_ACCESSORY_STATE_DETECT_LABEL_READ,
+    JOYPAD_ACCESSORY_STATE_DETECT_CPAK_BANK_WRITE,
+    JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_BACKUP,
+    JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_WRITE,
+    JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_READ,
+    JOYPAD_ACCESSORY_STATE_DETECT_CPAK_LABEL_RESTORE,
     JOYPAD_ACCESSORY_STATE_DETECT_RUMBLE_PROBE_WRITE,
     JOYPAD_ACCESSORY_STATE_DETECT_RUMBLE_PROBE_READ,
     JOYPAD_ACCESSORY_STATE_DETECT_TRANSFER_PROBE_ON,
@@ -138,6 +141,7 @@ typedef struct joypad_accessory_s
     joypad_accessory_state_t state;
     joypad_accessory_error_t error;
     unsigned retries;
+    uint8_t cpak_label_backup[JOYBUS_ACCESSORY_DATA_SIZE];
     joypad_accessory_io_t io;
     timer_link_t *transfer_pak_wait_timer;
     joybus_transfer_pak_status_t transfer_pak_status;
@@ -155,8 +159,11 @@ void joypad_accessory_reset(joypad_port_t port);
  * @brief Detect which accessory is inserted in an N64 controller.
  *
  * * Step 1: Ensure Transfer Pak is turned off
- * * Step 2A: Overwrite "label" area to detect Controller Pak
- * * Step 2B: Read back the "label" area to detect Controller Pak
+ * * Step 2A: Set Controller Pak "linear paging bank" to 0
+ * * Step 2B: Backup the Controller Pak "label" area
+ * * Step 2C: Overwrite the Controller Pak "label" area
+ * * Step 2D: Read back the "label" area to detect Controller Pak
+ * * Step 2E: Restore the Controller Pak "label" area
  * * Step 3A: Write probe value to detect Rumble Pak
  * * Step 3B: Read probe value to detect Rumble Pak
  * * Step 4A: Write probe value to detect Transfer Pak


### PR DESCRIPTION
"Linear Paging System" Controller Paks use the accessory probe address to switch banks, which was causing accessory detection to write into unsafe areas containing save data (!!). To prevent this, the detection routine now switches to "Bank 0" before accessing the label area.

Standard Controller Paks do not support bank switching and will safely ignore bank switch writes.

Additionally, we now backup and restore the label area so that the label write test does not clobber any data on the Controller Pak.