### PR TITLE
Ensure toolchain downloads are complete before unpacking

### DIFF
--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -46,12 +46,16 @@ command_exists () {
 
 # Download the file URL using wget or curl (depending on which is installed)
 download () {
-    if   command_exists wget ; then (cd "$DOWNLOAD_PATH" && wget -c  "$1")
-    elif command_exists curl ; then (cd "$DOWNLOAD_PATH" && curl -LO "$1")
+    local url="$1"
+    local file="$DOWNLOAD_PATH/$(basename "$url")"
+    local tmpfile="$file.part"
+    if   command_exists wget ; then wget --continue --output-document "$tmpfile" "$url"
+    elif command_exists curl ; then curl --location --output "$tmpfile" "$url"
     else
         echo "Install wget or curl to download toolchain sources" 1>&2
         return 1
     fi
+    mv "$tmpfile" "$file"
 }
 
 # Dependency downloads and unpack

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -59,12 +59,16 @@ command_exists () {
 
 # Download the file URL using wget or curl (depending on which is installed)
 download () {
-    if   command_exists wget ; then (cd "$DOWNLOAD_PATH" && wget -c  "$1")
-    elif command_exists curl ; then (cd "$DOWNLOAD_PATH" && curl -LO "$1")
+    local url="$1"
+    local file="$DOWNLOAD_PATH/$(basename "$url")"
+    local tmpfile="$file.part"
+    if   command_exists wget ; then wget --continue --output-document "$tmpfile" "$url"
+    elif command_exists curl ; then curl --location --output "$tmpfile" "$url"
     else
         echo "Install wget or curl to download toolchain sources" 1>&2
         return 1
     fi
+    mv "$tmpfile" "$file"
 }
 
 # Compilation on macOS via homebrew
@@ -220,7 +224,7 @@ pushd gcc_compile_target
     --with-newlib \
     --disable-win32-registry \
     --disable-nls \
-    --disable-werror 
+    --disable-werror
 make all-gcc -j "$JOBS"
 make install-gcc || sudo make install-gcc || su -c "make install-gcc"
 make all-target-libgcc -j "$JOBS"


### PR DESCRIPTION
This resolves an issue where the build script gets stuck if re-run after being interrupted during a download.

[Related discussion in N64brew Discord](https://discord.com/channels/205520502922543113/974342113850445874/1340705420817338431)