### PR TITLE
Stop rumble motors upon exception or reset

### DIFF
--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -95,7 +95,11 @@ int main(void)
     {
         console_clear();
 
-        printf("LibDragon Joypad Subsystem Test\n\n");
+        printf("\n");
+        printf("LibDragon Joypad Subsystem Test\n");
+        printf("Hold A to test rumble motors.\n");
+        printf("Press B to trigger an exception.\n");
+        printf("\n");
 
         joypad_poll();
 
@@ -117,6 +121,11 @@ int main(void)
                 {
                     joypad_set_rumble_active(port, false);
                 }
+            }
+
+            if (inputs.btn.b)
+            {
+                debugf((char *)0x1);
             }
 
             printf("Port %d ", port + 1);

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -580,8 +580,6 @@ static void inspector(exception_t* ex, enum Mode mode) {
         *MI_MASK = MI_WMASK_CLR_DP | MI_WMASK_CLR_AI | MI_WMASK_CLR_VI;
     }
 
-    joypad_emergency_rumble_stop();
-
 	display_close();
 	display_init(RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
 

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -580,6 +580,8 @@ static void inspector(exception_t* ex, enum Mode mode) {
         *MI_MASK = MI_WMASK_CLR_DP | MI_WMASK_CLR_AI | MI_WMASK_CLR_VI;
     }
 
+    joypad_emergency_rumble_stop();
+
 	display_close();
 	display_init(RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
 

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -722,6 +722,7 @@ void joypad_emergency_rumble_stop(void)
     JOYPAD_PORT_FOREACH (port)
     {
         identify_cmd = (void *)&identify_block[i + JOYBUS_COMMAND_METADATA_SIZE];
+        i += JOYBUS_COMMAND_METADATA_SIZE + sizeof(*identify_cmd);
         identifier = identify_cmd->recv.identifier;
         if( identifier == JOYBUS_IDENTIFIER_N64_CONTROLLER )
         {
@@ -761,7 +762,6 @@ void joypad_emergency_rumble_stop(void)
             // Stop the GameCube controller rumble motor
             joybus_exec_cmd_struct(port, gcn_motor_cmd);
         }
-        i += JOYBUS_COMMAND_METADATA_SIZE + sizeof(*identify_cmd);
     }
 }
 

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -721,8 +721,11 @@ void joypad_emergency_rumble_stop(void)
 
     JOYPAD_PORT_FOREACH (port)
     {
+        // Find the identify command for this port in the joybus block
         identify_cmd = (void *)&identify_block[i + JOYBUS_COMMAND_METADATA_SIZE];
+        // Skip to the next command for the next loop iteration
         i += JOYBUS_COMMAND_METADATA_SIZE + sizeof(*identify_cmd);
+        // Determine how to handle the controller based on its identifier
         identifier = identify_cmd->recv.identifier;
         if( identifier == JOYBUS_IDENTIFIER_N64_CONTROLLER )
         {

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -613,6 +613,38 @@ static void joypad_vi_interrupt_callback(void)
 }
 
 /**
+ * @brief Callback for NMI/Reset interrupt to stop rumble motors.
+ */
+static void joypad_reset_interrupt_callback(void)
+{
+    // BBPlayer does not support rumble
+    if( sys_bbplayer() ) return;
+
+    uint8_t n64_motor_data[JOYBUS_ACCESSORY_DATA_SIZE] = {0};
+    const joybus_cmd_gcn_controller_read_port_t gcn_motor_cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_GCN_CONTROLLER_READ,
+        .mode = 3,
+        .rumble = false,
+    } };
+
+    JOYPAD_PORT_FOREACH (port)
+    {
+        if( !joypad_get_rumble_supported(port) ) continue;
+        switch( joypad_get_style(port) )
+        {
+            case JOYPAD_STYLE_N64:
+                joybus_accessory_write(port, JOYBUS_ACCESSORY_ADDR_RUMBLE_MOTOR, n64_motor_data);
+                break;
+            case JOYPAD_STYLE_GCN:
+                joybus_exec_cmd_struct(port, gcn_motor_cmd);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+/**
  * @brief Re-identify and reset all Joypads and wait for completion.
  */
 static void joypad_reset(void)
@@ -665,6 +697,74 @@ joypad_inputs_t joypad_read_n64_inputs(joypad_port_t port)
     }
 }
 
+void joypad_emergency_rumble_stop(void)
+{
+    // BBPlayer does not support rumble
+    if( sys_bbplayer() ) return;
+
+    uint8_t identify_block[JOYBUS_BLOCK_SIZE];
+    uint8_t write_data[JOYBUS_ACCESSORY_DATA_SIZE];
+    uint8_t read_data[JOYBUS_ACCESSORY_DATA_SIZE];
+    const joybus_cmd_identify_port_t *identify_cmd;
+    joybus_identifier_t identifier;
+    size_t i = 0;
+
+    const joybus_cmd_gcn_controller_read_port_t gcn_motor_cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_GCN_CONTROLLER_READ,
+        .mode = 3,
+        .rumble = false,
+    } };
+
+    // Identify all connected controllers
+    joybus_input_identify(identify_block, false);
+    joybus_exec(identify_block, identify_block);
+
+    JOYPAD_PORT_FOREACH (port)
+    {
+        identify_cmd = (void *)&identify_block[i + JOYBUS_COMMAND_METADATA_SIZE];
+        identifier = identify_cmd->recv.identifier;
+        if( identifier == JOYBUS_IDENTIFIER_N64_CONTROLLER )
+        {
+            uint8_t accessory_status = identify_cmd->recv.status & JOYBUS_IDENTIFY_STATUS_ACCESSORY_MASK;
+            // Check if an accessory is present
+            if( accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT ||
+                accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED )
+            {
+                continue;
+            }
+            // Probe the accessory to see if it is a Rumble Pak
+            memset(write_data, JOYBUS_ACCESSORY_PROBE_RUMBLE_PAK, JOYBUS_ACCESSORY_DATA_SIZE);
+            if( joybus_accessory_write(port, JOYBUS_ACCESSORY_ADDR_PROBE, write_data) != JOYBUS_ACCESSORY_IO_STATUS_OK )
+            {
+                continue;
+            }
+            // Read back the probe value to confirm the accessory type
+            if( joybus_accessory_read(port, JOYBUS_ACCESSORY_ADDR_PROBE, read_data) != JOYBUS_ACCESSORY_IO_STATUS_OK )
+            {
+                continue;
+            }
+            // Confirm that the accessory is a Rumble Pak
+            if( memcmp(read_data, write_data, JOYBUS_ACCESSORY_DATA_SIZE) != 0 )
+            {
+                continue;
+            }
+            // Stop the Rumble Pak motor
+            memset(write_data, 0x00, JOYBUS_ACCESSORY_DATA_SIZE);
+            joybus_accessory_write(port, JOYBUS_ACCESSORY_ADDR_RUMBLE_MOTOR, write_data);
+        }
+        else if (
+            (identifier & JOYBUS_IDENTIFIER_MASK_PLATFORM) == JOYBUS_IDENTIFIER_PLATFORM_GCN &&
+            (identifier & JOYBUS_IDENTIFIER_MASK_GCN_CONTROLLER) &&
+            !(identifier & JOYBUS_IDENTIFIER_MASK_GCN_NORUMBLE)
+        )
+        {
+            // Stop the GameCube controller rumble motor
+            joybus_exec_cmd_struct(port, gcn_motor_cmd);
+        }
+        i += JOYBUS_COMMAND_METADATA_SIZE + sizeof(*identify_cmd);
+    }
+}
+
 void joypad_init(void)
 {
     // Just increment the refcount if already initialized
@@ -685,6 +785,8 @@ void joypad_init(void)
 
     // Update the Joypads on VI interrupt
     register_VI_handler(joypad_vi_interrupt_callback);
+    // Stop rumble on console reset
+    register_RESET_handler(joypad_reset_interrupt_callback);
 }
 
 void joypad_close(void)
@@ -694,7 +796,8 @@ void joypad_close(void)
 
     // Stop updating the Joypads on VI interrupt
     unregister_VI_handler(joypad_vi_interrupt_callback);
-    
+    unregister_RESET_handler(joypad_reset_interrupt_callback);
+
     // Decrement the timer subsystem refcount (possibly closing it)
     timer_close();
 }

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -490,6 +490,9 @@ static void joypad_identify_callback(uint64_t *out_dwords, void *ctx)
  */
 static void joypad_identify_async(bool reset)
 {
+    // Async operations are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
+
     // Bail if this operation is already in-progress
     if (joypad_identify_pending) { return; }
     joypad_identify_pending = true;
@@ -527,6 +530,9 @@ static void joypad_read_callback(uint64_t *out_dwords, void *ctx)
  */
 static void joypad_read_async(void)
 {
+    // Async operations are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
+
     // Bail if this operation is already in-progress
     if (joypad_read_pending) { return; }
     joypad_read_pending = true;
@@ -620,7 +626,12 @@ static void joypad_reset_interrupt_callback(void)
     // BBPlayer does not support rumble
     if( sys_bbplayer() ) return;
 
-    uint8_t n64_motor_data[JOYBUS_ACCESSORY_DATA_SIZE] = {0};
+    const joybus_cmd_n64_accessory_write_port_t n64_motor_cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_N64_ACCESSORY_WRITE,
+        .addr_checksum = joybus_accessory_calculate_addr_checksum(JOYBUS_ACCESSORY_ADDR_RUMBLE_MOTOR),
+        .data = { 0 },
+    } };
+
     const joybus_cmd_gcn_controller_read_port_t gcn_motor_cmd = { .send = {
         .command = JOYBUS_COMMAND_ID_GCN_CONTROLLER_READ,
         .mode = 3,
@@ -633,7 +644,7 @@ static void joypad_reset_interrupt_callback(void)
         switch( joypad_get_style(port) )
         {
             case JOYPAD_STYLE_N64:
-                joybus_accessory_write(port, JOYBUS_ACCESSORY_ADDR_RUMBLE_MOTOR, n64_motor_data);
+                joybus_exec_cmd_struct(port, n64_motor_cmd);
                 break;
             case JOYPAD_STYLE_GCN:
                 joybus_exec_cmd_struct(port, gcn_motor_cmd);
@@ -650,6 +661,9 @@ static void joypad_reset_interrupt_callback(void)
 static void joypad_reset(void)
 {
     ASSERT_JOYPAD_INITIALIZED();
+    // Async operations are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
+
     // Wait for pending identify/reset operation to resolve
     while (joypad_identify_pending) { /* Spinlock */ }
     // Enqueue this identify/reset operation
@@ -666,6 +680,9 @@ static void joypad_reset(void)
 static void joypad_read(void)
 {
     ASSERT_JOYPAD_INITIALIZED();
+    // Async operations are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
+
     joypad_read_async();
     while (joypad_read_pending) { /* Spinlock */ }
     joypad_poll();
@@ -808,6 +825,8 @@ void joypad_close(void)
 void joypad_poll(void)
 {
     ASSERT_JOYPAD_INITIALIZED();
+    // Controller inputs are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
 
     uint8_t output[JOYBUS_BLOCK_SIZE];
     joypad_gcn_origin_t origins[JOYPAD_PORT_COUNT];
@@ -975,6 +994,10 @@ void joypad_set_rumble_active(joypad_port_t port, bool active)
 {
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
+
+    // Rumble motor operations are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
+
     disable_interrupts();
     volatile joypad_device_hot_t *device = &joypad_devices_hot[port];
     joypad_rumble_method_t rumble_method = device->rumble_method;

--- a/src/joypad_accessory.c
+++ b/src/joypad_accessory.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "debug.h"
+#include "interrupt.h"
 #include "kernel/kernel_internal.h"
 #include "kirq.h"
 #include "joypad_internal.h"
@@ -241,7 +242,15 @@ static void joypad_transfer_pak_wait_timer_callback(int ovfl, void *ctx)
     joypad_port_t port = (joypad_port_t)ctx;
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     joypad_accessory_state_t state = accessory->state;
-    if (state == JOYPAD_ACCESSORY_STATE_TRANSFER_ENABLE_PROBE_WAIT)
+
+    // Cancel accessory detection during reset
+    if( exception_reset_time() > 0 )
+    {
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        accessory->type = JOYPAD_ACCESSORY_TYPE_UNKNOWN;
+        accessory->error = JOYPAD_ACCESSORY_ERROR_UNKNOWN;
+    }
+    else if (state == JOYPAD_ACCESSORY_STATE_TRANSFER_ENABLE_PROBE_WAIT)
     {
         uint8_t write_data[JOYBUS_ACCESSORY_DATA_SIZE];
         memset(write_data, JOYBUS_TRANSFER_PAK_STATUS_ACCESS, sizeof(write_data));
@@ -281,6 +290,15 @@ static void joypad_accessory_detect_read_callback(uint64_t *out_dwords, void *ct
     if (!joypad_accessory_state_is_detecting(state))
     {
         return; // Unexpected accessory state!
+    }
+
+    // Cancel accessory detection during reset
+    if( exception_reset_time() > 0 )
+    {
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        accessory->type = JOYPAD_ACCESSORY_TYPE_UNKNOWN;
+        accessory->error = JOYPAD_ACCESSORY_ERROR_UNKNOWN;
+        return;
     }
 
     uint8_t write_data[JOYBUS_ACCESSORY_DATA_SIZE];
@@ -426,6 +444,15 @@ static void joypad_accessory_detect_write_callback(uint64_t *out_dwords, void *c
         return; // Unexpected accessory state!
     }
 
+    // Cancel accessory detection during reset
+    if( exception_reset_time() > 0 )
+    {
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        accessory->type = JOYPAD_ACCESSORY_TYPE_UNKNOWN;
+        accessory->error = JOYPAD_ACCESSORY_ERROR_UNKNOWN;
+        return;
+    }
+
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_accessory_detect_write_callback;
@@ -519,6 +546,9 @@ static void joypad_accessory_detect_write_callback(uint64_t *out_dwords, void *c
 
 void joypad_accessory_detect_async(joypad_port_t port)
 {
+    // Disable accessory detection during reset
+    if( exception_reset_time() > 0 ) return;
+
     ASSERT_JOYPAD_PORT_VALID(port);
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     // Ensure Transfer Pak wait timer has been initialized
@@ -559,6 +589,13 @@ static void joypad_rumble_pak_motor_write_callback(uint64_t *out_dwords, void *c
         return; // Unexpected accessory state!
     }
 
+    // Do not attempt to retry rumble motor control commands during reset
+    if( exception_reset_time() > 0 )
+    {
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        return;
+    }
+
     const joybus_cmd_n64_accessory_write_port_t *cmd =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_callback_t retry_callback = joypad_rumble_pak_motor_write_callback;
@@ -570,6 +607,9 @@ static void joypad_rumble_pak_motor_write_callback(uint64_t *out_dwords, void *c
 
 void joypad_rumble_pak_toggle_async(joypad_port_t port, bool active)
 {
+    // Disable rumble motor control during reset
+    if( exception_reset_time() > 0 ) return;
+
     volatile joypad_device_hot_t *device = &joypad_devices_hot[port];
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
     device->rumble_active = active;
@@ -715,6 +755,13 @@ void joypad_accessory_xfer_async(
     void *ctx
 )
 {
+    // Disable accessory transfers during reset
+    if( exception_reset_time() > 0 )
+    {
+        if (callback != NULL) callback( JOYPAD_ACCESSORY_ERROR_UNKNOWN, ctx );
+        return;
+    }
+
     ASSERT_JOYPAD_PORT_VALID(port);
     volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
 
@@ -770,6 +817,9 @@ joypad_accessory_error_t joypad_accessory_xfer(
     void *dst,
     size_t len)
 {
+    // Disable accessory transfers during reset
+    if( exception_reset_time() > 0 ) return JOYPAD_ACCESSORY_ERROR_UNKNOWN;
+
     volatile bool done = false;
     volatile joypad_accessory_error_t error = JOYPAD_ACCESSORY_ERROR_NONE;
 

--- a/src/joypad_internal.h
+++ b/src/joypad_internal.h
@@ -126,6 +126,14 @@ extern volatile joypad_accessory_t  joypad_accessories_hot[JOYPAD_PORT_COUNT];
 joypad_inputs_t joypad_read_n64_inputs(joypad_port_t port);
 
 /**
+ * @brief Stop the rumble motors on all controllers synchronously.
+ *
+ * This function is intended for use in situations where interrupts may
+ * be disabled or where joypad_init may not have been called.
+ */
+void joypad_emergency_rumble_stop(void);
+
+/**
  * @brief Get the Joypad accessory state for a Joypad port.
  * 
  * @param port Joypad port number (#joypad_port_t)


### PR DESCRIPTION
Resolves https://github.com/DragonMinded/libdragon/issues/581

Introduces a new internal API called `joypad_emergency_rumble_stop` that is used by the inspector.

The NMI/Reset handler uses an optimized code-path that only sends stop commands if needed.

Unfortunately for the inspector, we cannot rely on Joypad subsystem being initialized or in a usable state, so the "emergency stop" needs to:

1. Identify all controllers
2. Determine if they support rumble
3. Disable the rumble motors

Double-unfortunately, all of that needs to happen synchronously.

I tested this with both N64 Rumble Pak and GCN rumble-compatible controllers.

Attached is a modified joypadtest ROM that allows you to trigger an exception by pressing "B":  [joypadtest.z64.zip](https://github.com/user-attachments/files/18893272/joypadtest.z64.zip)
