### PR TITLE
gl: Fix Wunused-value in gl_ensure_no_begin_end

### DIFF
--- a/src/GL/gl_internal.h
+++ b/src/GL/gl_internal.h
@@ -56,7 +56,6 @@
 #define gl_ensure_no_begin_end() ({ \
     if (state->begin_end_active) { \
         gl_set_error(GL_INVALID_OPERATION, "%s is not allowed between glBegin/glEnd", __func__); \
-        false; \
     } \
     true; \
 })


### PR DESCRIPTION
Prepares libdragon for possible C23 adoption in the future.