### PR TITLE
build: Add missing extern inlines

### DIFF
--- a/src/joybus.c
+++ b/src/joybus.c
@@ -275,3 +275,5 @@ void joybus_exec( const void * input, void * output )
         }
     }
 }
+
+extern inline void joybus_exec_cmd(int port, size_t send_len, size_t recv_len, const void *send_data, void *recv_data);

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -1192,3 +1192,4 @@ extern inline void rdpq_set_texture_image_raw(uint8_t index, uint32_t offset, te
 extern inline void rdpq_set_lookup_address(uint8_t index, void* rdram_addr);
 extern inline void rdpq_set_tile(rdpq_tile_t tile, tex_format_t format, int32_t tmem_addr, uint16_t tmem_pitch, const rdpq_tileparms_t *parms);
 extern inline void rdpq_call_deferred(void (*func)(void *), void *arg);
+extern inline void rdpq_set_yuv_parms(uint16_t k0, uint16_t k1, uint16_t k2, uint16_t k3, uint16_t k4, uint16_t k5);

--- a/src/vi.c
+++ b/src/vi.c
@@ -741,4 +741,5 @@ void vi_init(void)
 }
 
 extern inline int vi_get_scanline(int *field);
+extern inline void vi_write(volatile uint32_t *reg, uint32_t value);
 extern inline uint32_t vi_read(volatile uint32_t *reg);


### PR DESCRIPTION
I was inspired by #669 and I went over current `preview` and added extern inlines that were missing. `build.sh` can now build libdragon and all examples with `-Os` without compile-time or link-time errors.