### PR TITLE
console: Close console's display in console_close

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -165,6 +165,8 @@ void console_close()
     /* Unregister ourselves from newlib */
     stdio_t console_calls = { 0, __console_write, 0 };
     unhook_stdio_calls( &console_calls );
+    // Close the display that the console module initialized for itself.
+    display_close();
 }
 
 void console_clear()


### PR DESCRIPTION
`console_close` doesn't currently close the console's display which can often lead people to staying in the 640x240 mode without being aware of it.