### PR TITLE
fmath: Change sinf_approx coefficients

### DIFF
--- a/src/math/fmath.c
+++ b/src/math/fmath.c
@@ -25,17 +25,13 @@ static float sinf_approx(float x, int approx) {
     s = x * x;
     // Execute only a portion of the series, depending on the approximation level.
     // This generate the most efficient code among similar approaches.
-    if (LIKELY(--approx < 0)) p +=   1.32729383e-10f, p *= s;
-    if (LIKELY(--approx < 0)) p += - 2.33177868e-8f,  p *= s;
-    if (LIKELY(--approx < 0)) p +=   2.52223435e-6f,  p *= s;
-    if (LIKELY(--approx < 0)) p += - 1.73503853e-4f,  p *= s;
-    if (LIKELY(--approx < 0)) p +=   6.62087463e-3f,  p *= s;
-    if (LIKELY(--approx < 0)) p += - 1.01321176e-1f;
+    if (LIKELY(--approx < 0)) p +=   1.3291330536e-10f, p *= s;
+    if (LIKELY(--approx < 0)) p += - 2.3317808128e-8f,  p *= s;
+    if (LIKELY(--approx < 0)) p +=   2.5222900603e-6f,  p *= s;
+    if (LIKELY(--approx < 0)) p += - 1.7350520647e-4f,  p *= s;
+    if (LIKELY(--approx < 0)) p +=   6.6208802163e-3f,  p *= s;
+    if (LIKELY(--approx < 0)) p += - 1.0132116824e-1f;
     x = x * ((x - pi_hi) - pi_lo) * ((x + pi_hi) + pi_lo) * p;
-    // FIXME: workaround for a bug in our sinf approximation. We found at least
-    // one input (0xbfc915a2 => -1.570973) that produces an out of bounds result
-    // -1.000000119209289551 (0xbf800001).
-    x = CLAMP(x, -1.0f, 1.0f);
     return x;
 }
 


### PR DESCRIPTION
Based on discussion in Discord (https://discord.com/channels/205520502922543113/1326227607733276684), we have identified that the existing sinf approximation can sometimes return values beyond +-1. Using https://github.com/thekovic/fm_math_sinf_bruteforcer I have managed to bruteforce a new set of approximation coefficients that always produces inbounds results while maintaining acceptable accuracy.

New coefficients stats:
```
coef 0: -0.10132116824388504028 [0xbdcf8179] (-1110474375)
coef 1: 0.00662088021636009216 [0x3bd8f3f8] (1004073976)
coef 2: -0.00017350520647596568 [0xb935eef3] (-1187647757)
coef 3: 0.00000252229006036941 [0x3629449d] (908674205)
coef 4: -0.00000002331780812881 [0xb2c84c67] (-1295496089)
coef 5: 0.00000000013291330536 [0x2f1223c5] (789717957)
RMSD: 0.00052741984092337759
maximum measured error: 0.00000029802322387695
maximum measured error (int): 5
```