### PR TITLE
[trunk] xm: fix a potential bug with a wrong usage of memcpy in pattern decompression | mksprite: remove one usage of plain sprintf | n64tool: avoid writing random memory into DFS file

### DIFF
--- a/src/audio/libxm/context.c
+++ b/src/audio/libxm/context.c
@@ -402,7 +402,7 @@ int xm_context_decompress_pattern(uint8_t *in, int sz, xm_pattern_slot_t *pat) {
 		int runs = zeros & 7; if (runs == 7) runs += varint_get(&in);
 		zeros >>= 3;
 		memset(out, 0, zeros); out += zeros;
-		memcpy(out, in, runs); out += runs; in += runs;
+		memmove(out, in, runs); out += runs; in += runs;
 		assert((out<=in) == direction);  // check for overruns during in-place decompression
 	}
 	return out - (uint8_t*)pat;

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -1136,7 +1136,7 @@ void spritemaker_write_pngs(spritemaker_t *spr) {
     for (int i=0; i<MAX_IMAGES; i++) {
         if (spr->images[i].image == NULL)
             continue;
-        char lodext[16]; sprintf(lodext, ".%d.png", i);
+        char lodext[16]; snprintf(lodext, sizeof(lodext), ".%d.png", i);
         char debugfn[2048];
         strcpy(debugfn, spr->outfn);
         strcpy(strrchr(debugfn, '.'), lodext);

--- a/tools/n64tool.c
+++ b/tools/n64tool.c
@@ -718,7 +718,7 @@ int main(int argc, char *argv[])
 		toc.entry_size = SWAPLONG(toc.entry_size);
 
 		fseek(write_file, toc_offset, SEEK_SET);
-		fwrite(&toc, 1, TOC_SIZE, write_file);
+		fwrite(&toc, 1, sizeof(toc), write_file);
 	}
 
 	/* Sync and close the output file */


### PR DESCRIPTION
# Backport

This will backport the following commits from `preview` to `trunk`:
 - xm: fix a potential bug with a wrong usage of memcpy in pattern decompression (06a22bd5)
 - mksprite: remove one usage of plain sprintf (7eb470cd)
 - n64tool: avoid writing random memory into DFS file (9779fbe1)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)