### PR TITLE
add override for manual profile-slot placement

### DIFF
--- a/include/rsp_queue.inc
+++ b/include/rsp_queue.inc
@@ -140,7 +140,7 @@ _RSPQ_SAVED_STATE_START:
 ########################################################
 .macro RSPQ_EndSavedState
     .align 3
-#if RSPQ_PROFILE
+#if RSPQ_PROFILE && !RSPQ_PROFILE_MANUAL_SLOT
 _RSPQ_OVL_PROFILESLOT:
     # Profiling data for this overlay
     .long 0, 0


### PR DESCRIPTION
By defining `RSPQ_PROFILE_MANUAL_SLOT 1` in a ucode, the profiling variable will no be set automatically.
Instead `_RSPQ_OVL_PROFILESLOT: .long 0, 0` can be placed manually to better manage DMEM.
This can be important for alignment as well as continuous memory for state and bss 