### PR TITLE
Explicitly install ca-certificates in Dockerfile runner stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     && apt update \
     && apt upgrade -y \
     && apt install -y --no-install-recommends \
+        ca-certificates \
         g++ \
         gcc \
         git \


### PR DESCRIPTION
Should resolve reported issue with using `ghcr.io/dragonminded/libdragon:latest` Docker image in GitHub Action workflows.

![image](https://github.com/user-attachments/assets/a43efab0-ace8-4c11-b466-b82a0ce47b0a)

Related Discord discussion: https://discord.com/channels/205520502922543113/974342113850445874/1365246910000136215