### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and push image
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           # Only push image if this is a push event. Otherwise it will fail because
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
@@ -91,7 +91,7 @@ jobs:
       # cached, it should not take long to build.
       - name: Load image for libdragon build
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           # Do not push the image yet, we also want to make sure libdragon builds
           # with the fresh image.
@@ -125,7 +125,7 @@ jobs:
       # build with this freshly built image.
       - name: Push latest image
         if: ${{ steps.path_diff.outputs.changed == 1 && github.ref == steps.vars.outputs.default_ref }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: ghcr.io/${{ steps.vars.outputs.repository_name }}:latest

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -51,14 +51,14 @@ jobs:
         continue-on-error: true
 
       - name: Install x-compile system build dependencies
-        if: ${{ matrix.target-platform == 'Windows-x86_64' }}
+        if: ${{ matrix.target-os == 'Windows' }}
         run: |
           sudo apt-get install -y mingw-w64
           # If there are other dependencies, we should add them here and make sure the documentation is updated!
 
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby
       - name: Set up Ruby
-        if: ${{ matrix.target-platform != 'Windows-x86_64' }}
+        if: ${{ matrix.target-os != 'Windows' }}
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -66,7 +66,7 @@ jobs:
         continue-on-error: true
 
       - name: Install Package Creator
-        if: ${{ matrix.target-platform != 'Windows-x86_64' }}
+        if: ${{ matrix.target-os != 'Windows' }}
         run: |
           echo installing jordansissel/fpm ruby package
           gem install fpm
@@ -103,7 +103,7 @@ jobs:
           echo "MAKE_VERSION=4.4" >> $GITHUB_OUTPUT
         continue-on-error: false
 
-      - name: Build N64 MIPS GCC toolchain for ${{ matrix.target-platform }}
+      - name: Build N64 MIPS GCC toolchain for ${{ matrix.target-os }}-${{ matrix.target-platform }}
         run: |
           # required for newlib (as not the default?!)
           export PATH="$PATH:${{ runner.temp }}/${{ env.Install_Directory }}"
@@ -120,7 +120,7 @@ jobs:
       # https://fpm.readthedocs.io/en/v1.15.0/getting-started.html
       # TODO: add --deb-changelog with versions (like we do in release)
       - name: Generate toolchain packages for Linux based OS
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-os == 'Linux' }}
         run: |
           echo Generate environment var file
           echo 'export N64_INST=${{ env.Package_Installation_Directory }}' > "$Package_Name-env.sh"
@@ -166,26 +166,26 @@ jobs:
           Package_Name: gcc-toolchain-mips64
           Package_Version: ${{ steps.gcc-version-generator.outputs.GCC_VERSION }}
           Package_Revision: ${{ github.run_id }}
-          Package_Architecture: x86_64
+          Package_Architecture: ${{ matrix.target-platform }}
           Package_License: GPL
           Package_Description: MIPS GCC toolchain for the N64
           Package_Url: https://n64brew.com
           Package_Maintainer: N64 Brew Community
 
       - name: Publish Windows-x86_64 Build Artifact
-        if: ${{ matrix.target-platform == 'Windows-x86_64' }}
+        if: ${{ matrix.target-os == 'Windows' }}
         uses: actions/upload-artifact@v4
         with:
-          name: gcc-toolchain-mips64-${{ matrix.target-platform }}
+          name: gcc-toolchain-mips64-${{ matrix.target-os }}-${{ matrix.target-platform }}
           path: |
             ${{ runner.temp }}/${{ env.Install_Directory }}
         continue-on-error: true
 
-      - name: Publish Linux-x86_64 Build Artifacts
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+      - name: Publish ${{ matrix.target-os }}-${{ matrix.target-platform }} Build Artifacts
+        if: ${{ matrix.target-os == 'Linux' }}
         uses: actions/upload-artifact@v4
         with:
-          name: gcc-toolchain-mips64-${{ matrix.target-platform }}
+          name: gcc-toolchain-mips64-${{ matrix.target-os }}-${{ matrix.target-platform }}
           path: |
             ./**/*.deb
             ./**/*.rpm

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -30,8 +30,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-24.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-24.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: ubuntu-24.04, target-os: Windows, target-platform: x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-24.04, target-os: Linux, target-platform: x86_64, host: '', makefile-version: '' },
+          { host-os: ubuntu-24.04-arm, target-os: Linux, target-platform: aarch64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -57,7 +58,7 @@ jobs:
 
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby
       - name: Set up Ruby
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-platform != 'Windows-x86_64' }}
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -65,7 +66,7 @@ jobs:
         continue-on-error: true
 
       - name: Install Package Creator
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-platform != 'Windows-x86_64' }}
         run: |
           echo installing jordansissel/fpm ruby package
           gem install fpm

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: ubuntu-24.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-24.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # V0 - Use this comment to force a re-build without changing the contents
 
-ARG BASE_IMAGE=ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:24.04
 
 # Stage 1 - Build the toolchain
 FROM ${BASE_IMAGE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         texinfo \
         wget \
         zlib1g-dev \
-    && apt autoremove -yq
+    && apt autoremove -yq \
+    && apt autoclean -yq
 
 # Copy the build scripts into the container
 COPY ./tools/build-toolchain.sh ./tools/build-gdb.sh /tools/
@@ -66,7 +67,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         git \
         make \
         xxd \
-    && apt autoremove -yq
+    && apt autoremove -yq \
+    && apt autoclean -yq
 
 # Copy over built toolchain from previous stage
 COPY --from=builder ${N64_INST} ${N64_INST}

--- a/src/cpak.c
+++ b/src/cpak.c
@@ -967,6 +967,7 @@ int cpak_fsck(joypad_port_t port, bool fix_errors)
         if (fix_errors) {
             debugf("fsck: generating new sector ID\n");
             int fat_size = probe_size(port);
+            debugf("fsck: size = %d\n", fat_size);
             fsid_new(&fsid, be16(fsid.bank_size_msb) & 0xFF00);
             if (fsid_write(port, &fsid) < 0) {
                 return -2;

--- a/src/system.c
+++ b/src/system.c
@@ -1644,7 +1644,11 @@ int unhook_rtc_calls( rtc_hooks_t *hooks )
     return 0;
 }
 
-/** @deprecated Use #hook_rtc_calls instead. */
+/**************************************
+ *  DEPRECATED FUNCTIONS 
+ **************************************/
+
+/** deprecated - Use #hook_rtc_calls instead. */
 int hook_time_calls( time_hooks_t *hooks )
 {
     if( hooks == NULL ) return -1;
@@ -1655,7 +1659,7 @@ int hook_time_calls( time_hooks_t *hooks )
     return 0;
 }
 
-/** @deprecated Use #unhook_rtc_calls instead. */
+/** deprecated - Use #unhook_rtc_calls instead. */
 int unhook_time_calls( time_hooks_t *hooks )
 {
     if( hooks == NULL ) return -1;
@@ -1666,19 +1670,23 @@ int unhook_time_calls( time_hooks_t *hooks )
     return 0;
 }
 
-/** @deprecated Use #hook_time_calls instead. */
+/** deprecated - Use #hook_time_calls instead. */
 int hook_time_call( time_t (*time_fn)( void ) )
 {
     time_hooks_t hooks = { time_fn, NULL };
     return hook_time_calls( &hooks );
 }
 
-/** @deprecated Use #unhook_time_calls instead. */
+/** deprecated - Use #unhook_time_calls instead. */
 int unhook_time_call( time_t (*time_fn)( void ) )
 {
     time_hooks_t hooks = { time_fn, NULL };
     return unhook_time_calls( &hooks );
 }
+
+/**************************************
+ *  END DEPRECATED FUNCTIONS 
+ **************************************/
 
 /**
  * @brief Implement _flush_cache as required by GCC for nested functions.


### PR DESCRIPTION
- Fix build warnings seen in O/P (when using N64FlashcartMenu build process)
- Update docker images to use 24.04 (LTS) - 20.04 was too old and 22.04 will be too old soon.
- Support for 20.04 has been dropped in most GH actions, so start using 24.04.
- Updated GH actions for docker build and push.
- Added toolchain package generation for arm64

REQUIRES TESTING IF POSSIBLE.
