### PR TITLE
Change examples to disable filters where appropriate

### DIFF
--- a/examples/fontgallery/fontgallery.c
+++ b/examples/fontgallery/fontgallery.c
@@ -599,7 +599,7 @@ int main()
     joypad_init();
 
     dfs_init(DFS_DEFAULT_LOCATION);
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);
     rdpq_init();
     // rdpq_debug_start();
 

--- a/examples/loadspritefromsd/loadspritefromsd.c
+++ b/examples/loadspritefromsd/loadspritefromsd.c
@@ -39,7 +39,7 @@ void load_sprite(int id) {
 
 int main(void) {
 	/* Initialize peripherals */
-	display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
+	display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_DISABLED);
 	dfs_init(DFS_DEFAULT_LOCATION);
 	joypad_init();
 

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -100,7 +100,7 @@ int main()
     debug_init_isviewer();
     debug_init_usblog();
     //Init rendering
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);
     rdpq_init();
     rdpq_debug_start();
     scr_width = display_get_width();

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -7,7 +7,7 @@ int main()
     debug_init_isviewer();
     debug_init_usblog();
     //Init rendering
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);
     rdpq_init();
     rdpq_debug_start();
     //Init miscellaneous system

--- a/examples/pixelshader/pixelshader.c
+++ b/examples/pixelshader/pixelshader.c
@@ -62,7 +62,7 @@ void rsp_blend_process_line(surface_t *dest, int x0, int y0, int numlines) {
 int main(void) {
     debug_init_isviewer();
     debug_init_usblog();
-    display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE);
+    display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_DISABLED);
     dfs_init(DFS_DEFAULT_LOCATION);
     joypad_init();
     rdpq_init();

--- a/examples/rtctest/rtctest.c
+++ b/examples/rtctest/rtctest.c
@@ -22,7 +22,7 @@ int main(void)
     debug_init_isviewer();
     debug_init_usblog();
 
-    display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+    display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_DISABLED );
     joypad_init();
     timer_init();
 

--- a/examples/spriteanim/spriteanim.c
+++ b/examples/spriteanim/spriteanim.c
@@ -69,7 +69,7 @@ int main()
     debug_init_usblog();
     
     //Init display
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);
     //Init DragonFS
     dfs_init(DFS_DEFAULT_LOCATION);
     //Init RDPQ

--- a/examples/test/test.c
+++ b/examples/test/test.c
@@ -38,7 +38,7 @@ sprite_t *read_sprite( const char * const spritename )
 int main(void)
 {
     /* Initialize peripherals */
-    display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+    display_init( res, bit, 2, GAMMA_NONE, FILTERS_DISABLED );
     dfs_init( DFS_DEFAULT_LOCATION );
     joypad_init();
 
@@ -127,7 +127,7 @@ int main(void)
             display_close();
 
             res = RESOLUTION_640x480;
-            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_DISABLED );
         }
 
         if( keys.d_down )
@@ -135,7 +135,7 @@ int main(void)
             display_close();
 
             res = RESOLUTION_320x240;
-            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_DISABLED );
         }
 
         if( keys.d_left )
@@ -143,7 +143,7 @@ int main(void)
             display_close();
 
             bit = DEPTH_16_BPP;
-            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_DISABLED );
         }
 
         if( keys.d_right )
@@ -151,7 +151,7 @@ int main(void)
             display_close();
 
             bit = DEPTH_32_BPP;
-            display_init( res, bit, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+            display_init( res, bit, 2, GAMMA_NONE, FILTERS_DISABLED );
         }
     }
 }

--- a/src/console.c
+++ b/src/console.c
@@ -139,7 +139,7 @@ void console_init()
 {
     /* In case they initialized the display already */
     display_close();
-    display_init( RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_RESAMPLE );
+    display_init( RESOLUTION_640x240, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_DISABLED );
 
     render_buffer = malloc(CONSOLE_SIZE);
 


### PR DESCRIPTION
Also change the console behaviour to not use resampling as well, since it has no effect