### PR TITLE
joypad: Add custom command to inform controllers of the player #

### DIFF
--- a/include/joypad.h
+++ b/include/joypad.h
@@ -631,6 +631,17 @@ int joypad_get_axis_released(joypad_port_t port, joypad_axis_t axis);
  */
 int joypad_get_axis_held(joypad_port_t port, joypad_axis_t axis);
 
+/**
+ * @brief Sends the player ID to each controller.
+ *
+ * This function sends the player ID to each controller coresponding to the
+ * joybus slot the controller is plugged in to.
+ *
+ * This is a custom command which is not supported by official controllers.
+ *
+ */
+ void joypad_send_player_id(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/joybus_commands.h
+++ b/src/joybus_commands.h
@@ -129,6 +129,13 @@
  * extended controller data, including analog A and B button values.
  */
 #define JOYBUS_COMMAND_ID_GCN_CONTROLLER_READ_LONG    0x43
+
+/**
+ * @brief "Player ID" Joybus command identifier.
+ * 
+ * Custom command that is not supported by official controllers.
+ */
+#define JOYBUS_COMMAND_ID_PLAYER_IDENTIFY 0xF0
 /** @} */ /* JOYBUS_COMMAND_ID */
 
 #ifdef __cplusplus
@@ -505,6 +512,27 @@ typedef joybus_cmd_gcn_controller_read_long_port_t joybus_cmd_gcn_controller_rec
  * @see #JOYBUS_COMMAND_ID_GCN_CONTROLLER_ORIGIN
  */
 typedef joybus_cmd_gcn_controller_read_long_port_t joybus_cmd_gcn_controller_origin_port_t;
+
+/**
+ * @brief "Player ID" Joybus command structure.
+ *
+ * This is a custom command not supported by official controllers.
+ * 
+ * @see #JOYBUS_COMMAND_ID_PLAYER_IDENTIFY
+ */
+ typedef struct __attribute__((packed)) joybus_cmd_player_id_s
+ {
+    /** @brief "Player ID" command send data */
+    struct __attribute__((__packed__))
+    {
+        /** @brief Joybus command ID (#JOYBUS_COMMAND_ID_PLAYER_IDENTIFY) */
+        uint8_t command;
+        /** @brief Bitmask with a single bit set indicating the port number */
+        uint8_t bitmask;
+    } send;
+    /** @brief Controller responds with the old bitmask */
+     uint8_t recv;
+ } joybus_cmd_player_id_t;
 
 #ifdef __cplusplus
 }

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -1132,4 +1132,32 @@ joypad_8way_t joypad_get_direction(joypad_port_t port, joypad_2d_t axes)
     return JOYPAD_8WAY_NONE;
 }
 
+void joypad_send_player_id(void) {
+    uint8_t input[JOYBUS_BLOCK_SIZE] = {0};
+    joybus_cmd_player_id_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_PLAYER_IDENTIFY,
+    }};
+    const size_t recv_offset = offsetof(typeof(cmd), recv);
+    size_t i = 0;
+
+    // Populate the Joybus commands on each port
+    JOYPAD_PORT_FOREACH (port)
+    {
+        cmd.send.bitmask = 1 << port;
+        // Set the command metadata
+        input[i++] = sizeof(cmd.send);
+        input[i++] = sizeof(cmd.recv);
+        // Micro-optimization: Minimize copy length
+        memcpy(&input[i], &cmd, recv_offset);
+        i += sizeof(cmd);
+    }
+
+    // Close out the Joybus operation block
+    input[i] = 0xFE;
+    input[JOYBUS_BLOCK_SIZE - 1] = 0x01;
+
+    // This is a fire-and-forget command where the response can be ignored
+    joybus_exec_async(input, NULL, NULL);
+}
+
 /** @} */ /* joypad */


### PR DESCRIPTION
Useful to light up player LEDs on various custom controllers like the NSO N64 controller or an Xbox 360 controller.