### PR TITLE
n64sys: Remove magic numbers in cache op definitions

### DIFF
--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -365,18 +365,12 @@ void die(void);
  * that first writebacks the affected cachelines to RDRAM, guaranteeing integrity
  * of memory areas that share cachelines with the region that must be invalidated.
  *
- * @param[in] addr_
+ * @param[in] addr
  *            Pointer to memory in question
- * @param[in] sz_
+ * @param[in] length
  *            Length in bytes of the data pointed at by addr
  */
-#define data_cache_hit_invalidate(addr_, sz_) ({ \
-	void *addr = (addr_); unsigned long sz = (sz_); \
-	assert(((uint32_t)addr % 16) == 0 && (sz % 16) == 0); \
-	__data_cache_hit_invalidate(addr, sz); \
-})
-
-void __data_cache_hit_invalidate(volatile void * addr, unsigned long length);
+void data_cache_hit_invalidate(volatile void* addr, unsigned long length);
 
 /**
  * @brief Force a data cache writeback over a memory region

--- a/src/n64sys.c
+++ b/src/n64sys.c
@@ -27,6 +27,39 @@ static uint32_t ticks64_base_tick;
 /** @brief Last value of the 64-bit counter */
 static uint64_t ticks64_base;
 
+/// @cond
+
+// Instruction cache defines.
+#define CACHE_INST_FLAG                 (0)
+#define CACHE_INST_SIZE                 (16 * 1024)
+#define CACHE_INST_LINESIZE             (32)
+// Data cache defines.
+#define CACHE_DATA_FLAG                 (1)
+#define CACHE_DATA_SIZE                 (8 * 1024)
+#define CACHE_DATA_LINESIZE             (16)
+// Cache ops described in VR4300 manual on page 404.
+#define INDEX_INVALIDATE                (0)
+#define INDEX_LOAD_TAG                  (1)
+#define INDEX_STORE_TAG                 (2)
+#define INDEX_CREATE_DIRTY              (3)
+#define HIT_INVALIDATE                  (4)
+#define HIT_WRITEBACK_INVALIDATE        (5)
+#define HIT_WRITEBACK                   (6)
+
+/// @endcond
+
+/**
+ * @brief Helper macro to create the opcode for a cache operation.
+ * Operation is encoded in 5 bits where bits 4..2 contain the operation type
+ * and bits 0..1 determine the cache that is to be operated on. 
+ * 
+ * @param[in] op
+ *            Operation type to perform.
+ * @param[in] cache
+ *            Specific cache to perform the operation on.
+ */
+#define build_opcode(op, cache)             (((op) << 2) | (cache))
+
 /**
  * @brief Helper macro to perform cache refresh operations
  *
@@ -46,23 +79,23 @@ static uint64_t ticks64_base;
 
 void data_cache_hit_writeback(volatile const void * addr, unsigned long length)
 {
-    cache_op(0x19, 16);
+    cache_op(build_opcode(HIT_WRITEBACK, CACHE_DATA_FLAG), CACHE_DATA_LINESIZE);
 }
 
-/** @brief Underlying implementation of data_cache_hit_invalidate */
-void __data_cache_hit_invalidate(volatile void * addr, unsigned long length)
+void data_cache_hit_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x11, 16);
+    assert(((uint32_t)addr % 16) == 0 && (length % 16) == 0);
+    cache_op(build_opcode(HIT_INVALIDATE, CACHE_DATA_FLAG), CACHE_DATA_LINESIZE);
 }
 
 void data_cache_hit_writeback_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x15, 16);
+    cache_op(build_opcode(HIT_WRITEBACK_INVALIDATE, CACHE_DATA_FLAG), CACHE_DATA_LINESIZE);
 }
 
 void data_cache_index_writeback_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x01, 16);
+    cache_op(build_opcode(INDEX_INVALIDATE, CACHE_DATA_FLAG), CACHE_DATA_LINESIZE);
 }
 
 void data_cache_writeback_invalidate_all(void)
@@ -73,17 +106,17 @@ void data_cache_writeback_invalidate_all(void)
 
 void inst_cache_hit_writeback(volatile const void * addr, unsigned long length)
 {
-    cache_op(0x18, 32);
+    cache_op(build_opcode(HIT_WRITEBACK, CACHE_INST_FLAG), CACHE_INST_LINESIZE);
 }
 
 void inst_cache_hit_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x10, 32);
+    cache_op(build_opcode(HIT_INVALIDATE, CACHE_INST_FLAG), CACHE_INST_LINESIZE);
 }
 
 void inst_cache_index_invalidate(volatile void * addr, unsigned long length)
 {
-    cache_op(0x00, 32);
+    cache_op(build_opcode(INDEX_INVALIDATE, CACHE_INST_FLAG), CACHE_INST_LINESIZE);
 }
 
 void inst_cache_invalidate_all(void)


### PR DESCRIPTION
This PR makes a non-functional change, adding proper defines for cache operations (based on information from the VR4300 manual) to the source code to replace the hardcoded magic numbers passed into `cache_op`.