### PR TITLE
toolchain: Update binutils to 2.44

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-20.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-20.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: ubuntu-22.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-22.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -36,7 +36,7 @@ JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
 GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
-BINUTILS_V=2.43.1
+BINUTILS_V=2.44
 GCC_V=14.2.0
 NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0


### PR DESCRIPTION
Some modern host systems with GCC 15 have problems compiling binutils 2.43., while 2.44 builds fine. Let's update the binutils version as the easiest way to fix this issue since we were going to update soon anyway.