### PR TITLE
Improve CI for build-tool-windows.yml

### DIFF
--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -1,12 +1,6 @@
 name: Build-Tools-msys2-Windows
 
-on:
-  push:
-    paths:
-      - 'tools/*'
-  pull_request:
-    paths:
-      - 'tools/*'
+on: [push, pull_request]
 
 jobs:
   Build-Tools-Windows:

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -1,10 +1,16 @@
-name: Build-Tools
+name: Build-Tools-msys2-Windows
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'tools/*'
+  pull_request:
+    paths:
+      - 'tools/*'
 
 jobs:
   Build-Tools-Windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
* Improve naming of workflow to mention msys2
* Ensure job targets a known working windows runner (2022), rather than latest to ensure that the upcoming windows runner (2025) does not break things. 

split out from https://github.com/DragonMinded/libdragon/pull/721