### PR TITLE
Improve CI for  build-toolchain-matrix

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -1,20 +1,29 @@
-name: Build-Native
+name: Build-Native-Toolchain-Linux-Packages
 
 # This workflow will build the libdragon N64 GCC toolchain to keep it up-to-date.
 on:
   # This action will take about 40-70 minutes to run!
-  # It is designed to only fire if the GCC toolchain build file changes.
+  # It is designed to only fire if the GCC toolchain build file dependencies change.
   push:
     paths:
+      - '.github/workflows/build-toolchain-matrix.yml'
       - 'tools/build-toolchain.sh'
       - 'tools/build-gdb.sh'
   pull_request:
     paths:
+      - '.github/workflows/build-toolchain-matrix.yml'
       - 'tools/build-toolchain.sh'
       - 'tools/build-gdb.sh'
 
+# Make sure we don't have more than one active workflow to prevent race conditions
+# e.g a previous toolchain build may tag and push `latest` later if we don't have
+# this. It is ok to have parallel runs for push and PR events and from different
+# branches. We can cancel previous runs for non-trunk events.
+concurrency:
+  group: build-native-toolchain-linux-packages-${{ github.ref }}-${{ github.event_name }}
+
 jobs:
-  Build-Toolchain:
+  Build-Native-Toolchain:
     # targets the oldest ubuntu image available to create valid packages for as many versions possible.
     # TODO: move to using a docker container to support older versions.
     outputs:
@@ -30,8 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-22.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-22.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: ubuntu-22.04, target-os: Windows, target-platform: x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-22.04, target-os: Linux, target-platform: x86_64, host: '', makefile-version: '' },
+          { host-os: ubuntu-22.04-arm, target-os: Linux, target-platform: aarch64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -50,14 +60,14 @@ jobs:
         continue-on-error: true
 
       - name: Install x-compile system build dependencies
-        if: ${{ matrix.target-platform == 'Windows-x86_64' }}
+        if: ${{ matrix.target-os == 'Windows' }}
         run: |
           sudo apt-get install -y mingw-w64
           # If there are other dependencies, we should add them here and make sure the documentation is updated!
 
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby
       - name: Set up Ruby
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-os != 'Windows' }}
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -65,7 +75,7 @@ jobs:
         continue-on-error: true
 
       - name: Install Package Creator
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-os != 'Windows' }}
         run: |
           echo installing jordansissel/fpm ruby package
           gem install fpm
@@ -102,7 +112,7 @@ jobs:
           echo "MAKE_VERSION=4.4" >> $GITHUB_OUTPUT
         continue-on-error: false
 
-      - name: Build N64 MIPS GCC toolchain for ${{ matrix.target-platform }}
+      - name: Build N64 MIPS GCC toolchain for ${{ matrix.target-os }}-${{ matrix.target-platform }}
         run: |
           # required for newlib (as not the default?!)
           export PATH="$PATH:${{ runner.temp }}/${{ env.Install_Directory }}"
@@ -119,7 +129,7 @@ jobs:
       # https://fpm.readthedocs.io/en/v1.15.0/getting-started.html
       # TODO: add --deb-changelog with versions (like we do in release)
       - name: Generate toolchain packages for Linux based OS
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-os == 'Linux' }}
         run: |
           echo Generate environment var file
           echo 'export N64_INST=${{ env.Package_Installation_Directory }}' > "$Package_Name-env.sh"
@@ -165,26 +175,26 @@ jobs:
           Package_Name: gcc-toolchain-mips64
           Package_Version: ${{ steps.gcc-version-generator.outputs.GCC_VERSION }}
           Package_Revision: ${{ github.run_id }}
-          Package_Architecture: x86_64
+          Package_Architecture: ${{ matrix.target-platform }}
           Package_License: GPL
           Package_Description: MIPS GCC toolchain for the N64
           Package_Url: https://n64brew.com
           Package_Maintainer: N64 Brew Community
 
       - name: Publish Windows-x86_64 Build Artifact
-        if: ${{ matrix.target-platform == 'Windows-x86_64' }}
+        if: ${{ matrix.target-os == 'Windows' }}
         uses: actions/upload-artifact@v4
         with:
-          name: gcc-toolchain-mips64-${{ matrix.target-platform }}
+          name: gcc-toolchain-mips64-${{ matrix.target-os }}-${{ matrix.target-platform }}
           path: |
             ${{ runner.temp }}/${{ env.Install_Directory }}
         continue-on-error: true
 
-      - name: Publish Linux-x86_64 Build Artifacts
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+      - name: Publish ${{ matrix.target-os }}-${{ matrix.target-platform }} Build Artifacts
+        if: ${{ matrix.target-os == 'Linux' }}
         uses: actions/upload-artifact@v4
         with:
-          name: gcc-toolchain-mips64-${{ matrix.target-platform }}
+          name: gcc-toolchain-mips64-${{ matrix.target-os }}-${{ matrix.target-platform }}
           path: |
             ./**/*.deb
             ./**/*.rpm
@@ -192,7 +202,7 @@ jobs:
 
   Publish-Toolchain:
     runs-on: ubuntu-latest
-    needs: Build-Toolchain
+    needs: Build-Native-Toolchain
 
     steps:
       - uses: actions/checkout@v4
@@ -224,18 +234,18 @@ jobs:
           CHANGELOG_TEXT+='Installation instructions are [available in the wiki](https://github.com/DragonMinded/libdragon/wiki/Installing-libdragon)</br>'
           CHANGELOG_TEXT+='</br>'
           CHANGELOG_TEXT+="Builds toolchain dependencies:</br>"
-          CHANGELOG_TEXT+="  * GCC:      V${{ needs.build-toolchain.outputs.gcc-version }}</br>"
-          CHANGELOG_TEXT+="  * Newlib:   V${{ needs.build-toolchain.outputs.newlib-version }}</br>"
-          CHANGELOG_TEXT+="  * BinUtils: V${{ needs.build-toolchain.outputs.binutils-version }}</br>"
-          CHANGELOG_TEXT+="  * GDB:      V${{ needs.build-toolchain.outputs.gdb-version }}</br>"
+          CHANGELOG_TEXT+="  * GCC:      V${{ needs.Build-Native-Toolchain.outputs.gcc-version }}</br>"
+          CHANGELOG_TEXT+="  * Newlib:   V${{ needs.Build-Native-Toolchain.outputs.newlib-version }}</br>"
+          CHANGELOG_TEXT+="  * BinUtils: V${{ needs.Build-Native-Toolchain.outputs.binutils-version }}</br>"
+          CHANGELOG_TEXT+="  * GDB:      V${{ needs.Build-Native-Toolchain.outputs.gdb-version }}</br>"
           CHANGELOG_TEXT+='</br>'
           CHANGELOG_TEXT+="With dependencies:</br>"
-          CHANGELOG_TEXT+="  * GMP:      V${{ needs.build-toolchain.outputs.gmp-version }}</br>"
-          CHANGELOG_TEXT+="  * MPC:      V${{ needs.build-toolchain.outputs.mpc-version }}</br>"
-          CHANGELOG_TEXT+="  * MPFR:     V${{ needs.build-toolchain.outputs.mpfr-version }}</br>"
+          CHANGELOG_TEXT+="  * GMP:      V${{ needs.Build-Native-Toolchain.outputs.gmp-version }}</br>"
+          CHANGELOG_TEXT+="  * MPC:      V${{ needs.Build-Native-Toolchain.outputs.mpc-version }}</br>"
+          CHANGELOG_TEXT+="  * MPFR:     V${{ needs.Build-Native-Toolchain.outputs.mpfr-version }}</br>"
           CHANGELOG_TEXT+='</br>'
           CHANGELOG_TEXT+="Also generates Windows toolchain dependencies:</br>"
-          CHANGELOG_TEXT+="  * MAKEFILE: V${{ needs.build-toolchain.outputs.make-version }}</br>"
+          CHANGELOG_TEXT+="  * MAKEFILE: V${{ needs.Build-Native-Toolchain.outputs.make-version }}</br>"
           CHANGELOG_TEXT+='</br>'
           CHANGELOG_TEXT+='The GCC toolchain is licensed under GPLv3</br>'
           CHANGELOG_TEXT+='</br>'
@@ -255,7 +265,7 @@ jobs:
           prerelease: false
           body_path: CHANGELOG
           generate_release_notes: false
-          name: 'V${{ needs.build-toolchain.outputs.gcc-version }}-${{ github.run_id }}'
+          name: 'V${{ needs.Build-Native-Toolchain.outputs.gcc-version }}-${{ github.run_id }}'
           tag_name: "toolchain-continuous-prerelease"
           files: |
             ${{ runner.temp }}/**/*.deb

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -1,4 +1,4 @@
-name: Build-Native-Toolchain-Linux-Packages
+name: Build-Native-Toolchain-Packages
 
 # This workflow will build the libdragon N64 GCC toolchain to keep it up-to-date.
 on:
@@ -20,7 +20,7 @@ on:
 # this. It is ok to have parallel runs for push and PR events and from different
 # branches. We can cancel previous runs for non-trunk events.
 concurrency:
-  group: build-native-toolchain-linux-packages-${{ github.ref }}-${{ github.event_name }}
+  group: build-native-toolchain-packages-${{ github.ref }}-${{ github.event_name }}
 
 jobs:
   Build-Native-Toolchain:


### PR DESCRIPTION
* Improve job name and adjust subsequent variables.
* Add detection of workflow file change.
* Add concurrency to stop race conditions.
* Split target platform and operating system to enable build scenarios.
* Add ARM64 package build, and publish it.

split out from https://github.com/DragonMinded/libdragon/pull/721