### PR TITLE
Improve GitHub Actions native toolchain matrix

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -4,12 +4,15 @@ name: Build-Native
 on:
   # This action will take about 40-70 minutes to run!
   # It is designed to only fire if the GCC toolchain build file changes.
+  workflow_dispatch: {}
   push:
     paths:
+      - '.github/workflows/build-toolchain-matrix.yml'
       - 'tools/build-toolchain.sh'
       - 'tools/build-gdb.sh'
   pull_request:
     paths:
+      - '.github/workflows/build-toolchain-matrix.yml'
       - 'tools/build-toolchain.sh'
       - 'tools/build-gdb.sh'
 
@@ -30,8 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-22.04, target-platform: Windows-x86_64, host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-22.04, target-platform: Linux-x86_64, host: '', makefile-version: '' }
+          { host-os: ubuntu-22.04, target-platform: Windows-x86_64, deb-architecture: '', rpm-architecture: '', host: x86_64-w64-mingw32, makefile-version: 4.4 },
+          { host-os: ubuntu-22.04, target-platform: Linux-x86_64, deb-architecture: amd64, rpm-architecture: x86_64, host: '', makefile-version: '' },
+          { host-os: ubuntu-22.04-arm, target-platform: Linux-aarch64, deb-architecture: arm64, rpm-architecture: aarch64, host: '', makefile-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -57,7 +61,7 @@ jobs:
 
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby
       - name: Set up Ruby
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-platform == 'Linux-x86_64' || matrix.target-platform == 'Linux-aarch64' }}
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -65,7 +69,7 @@ jobs:
         continue-on-error: true
 
       - name: Install Package Creator
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-platform == 'Linux-x86_64' || matrix.target-platform == 'Linux-aarch64' }}
         run: |
           echo installing jordansissel/fpm ruby package
           gem install fpm
@@ -119,7 +123,7 @@ jobs:
       # https://fpm.readthedocs.io/en/v1.15.0/getting-started.html
       # TODO: add --deb-changelog with versions (like we do in release)
       - name: Generate toolchain packages for Linux based OS
-        if: ${{ matrix.target-platform == 'Linux-x86_64' }}
+        if: ${{ matrix.target-platform == 'Linux-x86_64' || matrix.target-platform == 'Linux-aarch64' }}
         run: |
           echo Generate environment var file
           echo 'export N64_INST=${{ env.Package_Installation_Directory }}' > "$Package_Name-env.sh"
@@ -132,27 +136,30 @@ jobs:
           fpm \
             -t deb \
             -s dir \
-            -p $Package_Name-$Package_Architecture.deb \
+            -p $Package_Name-$Package_Deb_Architecture.deb \
             --name $Package_Name \
             --license $Package_License \
             --version $Package_Version.$Package_Revision \
-            --architecture $Package_Architecture \
+            --architecture $Package_Deb_Architecture \
             --description "$Package_Description" \
             --url "$Package_Url" \
             --maintainer "$Package_Maintainer" \
             --deb-no-default-config-files \
             $Package_Source_Directory=$Package_Installation_Directory/ \
             $Package_Name-env.sh=/etc/profile.d/$Package_Name-env.sh
+          
+          # Don't break existing links to the deb package using rpm architecture
+          cp $Package_Name-$Package_Deb_Architecture.deb $Package_Name-$Package_Rpm_Architecture.deb
 
           echo Generating rpm package
           fpm \
             -t rpm \
             -s dir \
-            -p $Package_Name-$Package_Architecture.rpm \
+            -p $Package_Name-$Package_Rpm_Architecture.rpm \
             --name $Package_Name \
             --license $Package_License \
             --version $Package_Version.$Package_Revision \
-            --architecture $Package_Architecture \
+            --architecture $Package_Rpm_Architecture \
             --description "$Package_Description" \
             --url "$Package_Url" \
             --maintainer "$Package_Maintainer" \
@@ -165,7 +172,8 @@ jobs:
           Package_Name: gcc-toolchain-mips64
           Package_Version: ${{ steps.gcc-version-generator.outputs.GCC_VERSION }}
           Package_Revision: ${{ github.run_id }}
-          Package_Architecture: x86_64
+          Package_Deb_Architecture: ${{ matrix.deb-architecture }}
+          Package_Rpm_Architecture: ${{ matrix.rpm-architecture }}
           Package_License: GPL
           Package_Description: MIPS GCC toolchain for the N64
           Package_Url: https://n64brew.com
@@ -190,6 +198,16 @@ jobs:
             ./**/*.rpm
         continue-on-error: true
 
+      - name: Publish Linux-aarch64 Build Artifacts
+        if: ${{ matrix.target-platform == 'Linux-aarch64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcc-toolchain-mips64-${{ matrix.target-platform }}
+          path: |
+            ./**/*.deb
+            ./**/*.rpm
+        continue-on-error: true
+
   Publish-Toolchain:
     runs-on: ubuntu-latest
     needs: Build-Toolchain
@@ -197,19 +215,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Download Windows artifact
-        id: download-windows-artifact
+      - name: Download Windows-x86_64 artifact
+        id: download-windows-x86_64-artifact
         uses: actions/download-artifact@v4
         with:
           name: gcc-toolchain-mips64-Windows-x86_64
           path: ${{ runner.temp }}/gcc-toolchain-mips64-Windows-x86_64
 
-      - name: Download Linux artifact
-        id: download-linux-artifact
+      - name: Download Linux-x86_64 artifact
+        id: download-linux-x86_64-artifact
         uses: actions/download-artifact@v4
         with:
           name: gcc-toolchain-mips64-Linux-x86_64
           path: ${{ runner.temp }}/gcc-toolchain-mips64-Linux-x86_64
+
+      - name: Download Linux-aarch64 artifact
+        id: download-linux-arm64-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gcc-toolchain-mips64-Linux-aarch64
+          path: ${{ runner.temp }}/gcc-toolchain-mips64-Linux-aarch64
 
       - name: Convert files for release upload
         run: |
@@ -244,7 +269,7 @@ jobs:
       # Compress and move the windows folder ready for upload.
       - name: Compress and move windows artifacts
         run: |
-          cd ${{ steps.download-windows-artifact.outputs.download-path }}
+          cd ${{ steps.download-windows-x86_64-artifact.outputs.download-path }}
           zip -r -q ${{ runner.temp }}/gcc-toolchain-mips64-win64.zip *
 
       - name: Generate Release

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -33,9 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { host-os: ubuntu-22.04, target-platform: Windows-x86_64, deb-architecture: '', rpm-architecture: '', host: x86_64-w64-mingw32, makefile-version: 4.4 },
-          { host-os: ubuntu-22.04, target-platform: Linux-x86_64, deb-architecture: amd64, rpm-architecture: x86_64, host: '', makefile-version: '' },
-          { host-os: ubuntu-22.04-arm, target-platform: Linux-aarch64, deb-architecture: arm64, rpm-architecture: aarch64, host: '', makefile-version: '' }
+          { host-os: ubuntu-22.04, target-platform: Windows-x86_64, deb-architecture: '', rpm-architecture: '', host: x86_64-w64-mingw32, makefile-version: 4.4, zlib-version: 1.2.13 },
+          { host-os: ubuntu-22.04, target-platform: Linux-x86_64, deb-architecture: amd64, rpm-architecture: x86_64, host: '', makefile-version: '', zlib-version: '' },
+          { host-os: ubuntu-22.04-arm, target-platform: Linux-aarch64, deb-architecture: arm64, rpm-architecture: aarch64, host: '', makefile-version: '', zlib-version: '' }
         ]
     runs-on: ${{ matrix.host-os }}
 
@@ -56,7 +56,7 @@ jobs:
       - name: Install x-compile system build dependencies
         if: ${{ matrix.target-platform == 'Windows-x86_64' }}
         run: |
-          sudo apt-get install -y mingw-w64
+          sudo apt-get install -y m4 mingw-w64
           # If there are other dependencies, we should add them here and make sure the documentation is updated!
 
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby
@@ -114,7 +114,9 @@ jobs:
           export N64_INST=${{ runner.temp }}/${{ env.Install_Directory }}
           export N64_HOST=${{ matrix.host }}
           cd ./tools/
-          MAKE_V=${{ matrix.makefile-version }} ./build-toolchain.sh
+          MAKE_V=${{ matrix.makefile-version }} \
+          ZLIB_V=${{ matrix.zlib-version }} \
+          ./build-toolchain.sh
           ./build-gdb.sh
           echo "Removing un-necessary content"
           rm -rf ${N64_INST}/share/locale/*

--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -72,6 +72,11 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         "--with-mpc=$(brew --prefix)"
         "--with-zlib=$(brew --prefix)"
     )
+elif [ "$N64_HOST" == "x86_64-w64-mingw32" ]; then
+    # Configure GDB arguments for Windows cross-compilation
+    GDB_CONFIGURE_ARGS+=("--with-zlib=$N64_INST")
+    GDB_CONFIGURE_ARGS+=("--with-gmp=$N64_INST")
+    GDB_CONFIGURE_ARGS+=("--with-mpfr=$N64_INST")
 else
     # Configure GDB arguments for non-macOS platforms
     GDB_CONFIGURE_ARGS+=("--with-system-zlib")

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -42,6 +42,7 @@ NEWLIB_V=4.4.0.20231231
 GMP_V=6.3.0
 MPC_V=1.3.1
 MPFR_V=4.2.1
+ZLIB_V=${ZLIB_V:-""}
 MAKE_V=${MAKE_V:-""}
 
 # Create build and download directories
@@ -145,6 +146,11 @@ if [ "$MAKE_V" != "" ]; then
     test -d "$BUILD_PATH/make-$MAKE_V"               || tar -xzf "$DOWNLOAD_PATH/make-$MAKE_V.tar.gz" -C "$BUILD_PATH"
 fi
 
+if [ "$ZLIB_V" != "" ]; then
+    test -f "$DOWNLOAD_PATH/zlib-$ZLIB_V.tar.gz"     || download "https://zlib.net/fossils/zlib-$ZLIB_V.tar.gz"
+    test -d "$BUILD_PATH/zlib-$ZLIB_V"               || tar -xzf "$DOWNLOAD_PATH/zlib-$ZLIB_V.tar.gz" -C "$BUILD_PATH"
+fi
+
 cd "$BUILD_PATH"
 
 # Deduce build triplet using config.guess (if not specified)
@@ -192,6 +198,49 @@ else
             echo "Unimplemented option: we support building a Windows toolchain only, for now."
         fi
     fi
+fi
+
+if [ "$ZLIB_V" != "" ]; then
+    pushd "zlib-$ZLIB_V"
+    if [ "$N64_HOST" = "x86_64-w64-mingw32" ]; then
+        sed -e s/"PREFIX ="/"PREFIX = $N64_HOST-"/ -i win32/Makefile.gcc
+        make -f win32/Makefile.gcc -j "$JOBS"
+        (
+            export \
+                BINARY_PATH="$INSTALL_PATH/bin" \
+                INCLUDE_PATH="$INSTALL_PATH/include" \
+                LIBRARY_PATH="$INSTALL_PATH/lib"
+            make -f win32/Makefile.gcc install || \
+            sudo make -f win32/Makefile.gcc install || \
+            su -c "make -f win32/Makefile.gcc install"
+        )
+    fi
+    popd
+fi
+
+if [ "$N64_HOST" = "x86_64-w64-mingw32" ]; then
+    pushd "gmp-$GMP_V"
+    ./configure \
+        --prefix="$INSTALL_PATH" \
+        --host="$N64_HOST" \
+        --enable-static \
+        --disable-shared
+    make -j "$JOBS"
+    make install-strip || sudo make install-strip || su -c "make install-strip"
+    make distclean
+    popd
+
+    pushd "mpfr-$MPFR_V"
+    ./configure \
+        --prefix="$INSTALL_PATH" \
+        --host="$N64_HOST" \
+        --with-gmp="$INSTALL_PATH" \
+        --enable-static \
+        --disable-shared
+    make -j "$JOBS"
+    make install-strip || sudo make install-strip || su -c "make install-strip"
+    make distclean
+    popd
 fi
 
 # Compile BUILD->TARGET binutils
@@ -323,7 +372,7 @@ fi
 if [ "$MAKE_V" != "" ]; then
     pushd "make-$MAKE_V"
     ./configure \
-      --prefix="$INSTALL_PATH" \
+        --prefix="$INSTALL_PATH" \
         --disable-largefile \
         --disable-nls \
         --disable-rpath \


### PR DESCRIPTION
1. Add Linux-aarch64 target platform to the toolchain matrix
2. Rename .deb package architecture to match [Debian packaging conventions](https://wiki.debian.org/SupportedArchitectures)
    - Confusingly, [Debian package convention is `amd64,arm64`; RPM package convention is `x86_x64,aarch64`](https://memgraph.com/blog/ship-it-on-arm64-or-is-it-aarch64)
    - Retain the existing  `gcc-toolchain-mips64-x86_64.deb` to prevent downstream breakage
3. Fix GDB installation for `x86_64-w64-mingw32` package
    - Cross-compile zlib, libgmp, and libmpfr so that GDB's configure script has what it needs
5. Rebuild toolchains when the toolchain workflow is modified
6. Allow toolchain workflow to be run ad-hoc with [`workflow_dispatch`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch)

[Built successfully on my fork](https://github.com/meeq/libdragon/actions/runs/15638554503)