### PR TITLE
Fix IPL3 install on Linux

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -82,8 +82,10 @@ build/ipl3.elf: $(IPL3_LDSCRIPT) $(OBJS)
 	$(N64_CC) $(N64_CFLAGS) $(N64_LDFLAGS) -o $@ $(filter %.o,$^)
 	$(N64_READELF) --wide --sections $@ | grep .text
 
+# Install the IPL3 ROM in the tools directory as a C header file for n64tool.
 install: $(IPL3_ROM)
-	xxd -i -n default_ipl3 $< >../tools/ipl3.h
+	BIN_VAR_NAME=$$(echo "$<" | ${SED} 's/[^a-zA-Z0-9]/_/g') ; \
+	xxd -i "$<" | ${SED} "s/$${BIN_VAR_NAME}/default_ipl3/" >../tools/ipl3.h
 
 run: ipl3.z64
 	g64drive upload --autocic=false ipl3.z64 && g64drive cic 6102 && g64drive debug


### PR DESCRIPTION
The `xxd` command on Linux does not support the `-n` option.

This is a surgical fix that renames the variable name in the header using `sed`, which works on all platforms.

A grander-scoped fix would be to use incbin or `#embed` to embed the IPL3 ROM into n64tool, but this approach just addresses the symptom of the problem instead.