### PR TITLE
Fix audioconv64 build on macOS using GCC

### DIFF
--- a/tools/audioconv64/libsamplerate.c
+++ b/tools/audioconv64/libsamplerate.c
@@ -1,3 +1,8 @@
+#ifndef __MINGW32__
+// Enable usage of visibility attributes for GCC and Clang, except when using MinGW
+#define HAVE_VISIBILITY
+#endif
+
 #include "libsamplerate.h"
 
 #include "libsamplerate/samplerate.c"


### PR DESCRIPTION
`make tools` fails on macOS when building with GCC 15:
```bash
export CC=/opt/homebrew/bin/gcc-15 CXX=/opt/homebrew/bin/g++-15
```

```
gcc-15 (Homebrew GCC 15.1.0) 15.1.0
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
In file included from audioconv64/libsamplerate.c:4:
audioconv64/libsamplerate/src_sinc.c:167:27: error: expected ';' before 'const'
  167 | LIBSAMPLERATE_DLL_PRIVATE const char*
      |                           ^~~~~
audioconv64/libsamplerate/src_sinc.c:186:27: error: expected ';' before 'const'
  186 | LIBSAMPLERATE_DLL_PRIVATE const char*
      |                           ^~~~~
In file included from audioconv64/libsamplerate/samplerate.c:19,
                 from audioconv64/libsamplerate.c:3:
audioconv64/libsamplerate/common.h:52:37: error: unknown type name '__private_extern__'
   52 |   #define LIBSAMPLERATE_DLL_PRIVATE __private_extern__
      |                                     ^~~~~~~~~~~~~~~~~~
audioconv64/libsamplerate/src_sinc.c:260:1: note: in expansion of macro 'LIBSAMPLERATE_DLL_PRIVATE'
  260 | LIBSAMPLERATE_DLL_PRIVATE SRC_STATE *
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Root cause appears to be that libdragon's vendored checkout of libsamplerate does not set the `HAVE_VISIBILITY` preprocessor definition when compiling, and [GCC on macOS does not support `__private_extern__`](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106672)