### PR TITLE
Fix audioconv64 build error with Clang

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -38,6 +38,10 @@ all:
 # Avoid many warnings for vendored code that we don't intend to ever modify
 common/shrinkler_compress.o: 	   CFLAGS += -Wno-all -Wno-error
 mkfont/freetype/FreeTypeAmalgam.o: CFLAGS += -Wno-all -Wno-error
+# Treat Clang VLA warnings as non-fatal
+ifeq ($(shell $(CC) --version | grep -c clang),1)
+audioconv64/audioconv64.o:         CXXFLAGS += -Wno-error=vla-cxx-extension
+endif
 
 common-clean:
 	rm -f common/*.o common/*.a common/*.d

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -38,9 +38,10 @@ all:
 # Avoid many warnings for vendored code that we don't intend to ever modify
 common/shrinkler_compress.o: 	   CFLAGS += -Wno-all -Wno-error
 mkfont/freetype/FreeTypeAmalgam.o: CFLAGS += -Wno-all -Wno-error
-# Treat Clang VLA warnings as non-fatal
+
+# Ignore Clang variable length array warnings when building audioconv64
 ifeq ($(shell $(CC) --version | grep -c clang),1)
-audioconv64/audioconv64.o:         CXXFLAGS += -Wno-error=vla-cxx-extension
+audioconv64/audioconv64.o:         CXXFLAGS += -Wno-vla-cxx-extension
 endif
 
 common-clean:


### PR DESCRIPTION
`make tools` fails on macOS with Clang:

```
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin24.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

```
In file included from audioconv64/audioconv64.cpp:40:
audioconv64/conv_wav64.cpp:285:35: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  285 |                 struct vadpcm_vector skip_state[skip_points.size()][2];
      |                                                 ^~~~~~~~~~~~~~~~~~
audioconv64/conv_wav64.cpp:285:47: note: non-constexpr function 'size' cannot be used in a constant expression
  285 |                 struct vadpcm_vector skip_state[skip_points.size()][2];
      |                                                             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:634:65: note: declared here
  634 |   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT {
      |                                                                 ^
In file included from audioconv64/audioconv64.cpp:40:
audioconv64/conv_wav64.cpp:541:24: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  541 |                                 uint8_t in_samples[nb];
      |                                                    ^~
audioconv64/conv_wav64.cpp:541:24: note: read of non-const variable 'nb' is not allowed in a constant expression
audioconv64/conv_wav64.cpp:533:9: note: declared here
  533 |                                 int nb = fgetc(out) << 8;
      |                                     ^
In file included from audioconv64/audioconv64.cpp:41:
audioconv64/conv_xm64.cpp:101:35: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  101 |         struct sample_checksum wave_sums[totsamples+1];
      |                                          ^~~~~~~~~~~~
audioconv64/conv_xm64.cpp:101:35: note: function parameter 'totsamples' with unknown value cannot be used in a constant expression
audioconv64/conv_xm64.cpp:93:102: note: declared here
   93 | static void xm_save_wave_internally(xm_context_t* ctx, FILE* meta, FILE* out, const char *outfn, int totsamples)
      |                                                                                                      ^
audioconv64/conv_xm64.cpp:325:19: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  325 |                 uint8_t cur_pat[pat_size];
      |                                 ^~~~~~~~
audioconv64/conv_xm64.cpp:325:19: note: read of non-const variable 'pat_size' is not allowed in a constant expression
audioconv64/conv_xm64.cpp:324:7: note: declared here
  324 |                 int pat_size = p->num_rows*ctx->module.num_channels*5;
      |                     ^
audioconv64/conv_xm64.cpp:377:20: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  377 |                 int sample_remap[ins->num_samples];
      |                                  ^~~~~~~~~~~~~~~~
audioconv64/conv_xm64.cpp:377:20: note: read of non-constexpr variable 'ins' is not allowed in a constant expression
audioconv64/conv_xm64.cpp:376:20: note: declared here
  376 |                 xm_instrument_t *ins = &ctx->module.instruments[i];
      |                                  ^
5 errors generated.
```

This is a surgical fix to disable the `vla-cxx-extension` warning when building with Clang.