### PR TITLE
Add fast acosf to fmath

### DIFF
--- a/include/fmath.h
+++ b/include/fmath.h
@@ -208,6 +208,11 @@ float fm_cosf(float x);
 void fm_sincosf(float x, float *sin, float *cos);
 
 /**
+ * @brief Faster version of acosf.
+*/
+float fm_acosf(float x);
+
+/**
  * @brief Faster version of atan2f.
  * 
  * Given a point (x,y), return the angle in radians that the vector (x,y)

--- a/src/math/fmath.c
+++ b/src/math/fmath.c
@@ -64,6 +64,27 @@ void fm_sincosf(float x, float *sin, float *cos) {
     *cos = cy;
 }
 
+float fm_acosf(float x) {
+    // Approximation of acosf using a polynomial approximation
+    // from (https://developer.download.nvidia.com/cg/acos.html)
+    // Reported error of 6.7e-5
+    
+    // TO DO: expected input range is [-1,1], how to handle this?
+    
+    float n = (float)(x < 0.0f);
+    x = fabsf(x);
+    float r = -0.0187293f;
+    r *= x;
+    r += 0.0742610f;
+    r *= x;
+    r -= 0.2121144f;
+    r *= x;
+    r += 1.5707288f;
+    r *= sqrtf(1.0f - x);
+    r -= 2.0f * n * r;
+    return n * 3.14159265358979f + r;
+}
+
 float fm_atan2f(float y, float x) {
     // Approximation of atan2f using a polynomial minmax approximation in [0,1]
     // calculated via the Remez algorithm (https://math.stackexchange.com/a/1105038).


### PR DESCRIPTION
Adds a polynomial approximation of arccosine as outline in Nvidia's [developer docs](https://developer.download.nvidia.com/cg/acos.html).

Expected input range is between [-1,1] but I'm not sure how to best implement a check for this, or if one is even necessary to begin with. (this is my first pull request pwease be gentle :3)