### PR TITLE
Update joybus_rtc.c by renaming debugf to tracef

### DIFF
--- a/src/joybus/joybus_rtc.c
+++ b/src/joybus/joybus_rtc.c
@@ -15,6 +15,17 @@
 #include "n64sys.h"
 #include "rtc_internal.h"
 
+/** @brief Set to 1 to activate debug logs */
+#define JOYBUS_RTC_TRACE   0
+
+#if JOYBUS_RTC_TRACE
+/** @brief like debugf(), but writes only if #JOYBUS_RTC_TRACE is not 0 */
+#define tracef(fmt, ...)  debugf(fmt, ##__VA_ARGS__)
+#else
+/** @brief like debugf(), but writes only if #JOYBUS_RTC_TRACE is not 0 */
+#define tracef(fmt, ...)  ({ })
+#endif 
+
 /**
  * @addtogroup joybus_rtc
  * @{
@@ -241,7 +252,7 @@ static void joybus_rtc_detect_callback( uint64_t *out_dwords, void *ctx )
     joybus_rtc_detect_state = detected ? JOYBUS_RTC_DETECTED : JOYBUS_RTC_NOT_DETECTED;
     joybus_rtc_detect_status.byte = status.byte;
 
-    debugf("joybus_rtc_detect_async: %s %s %s %s\n",
+    tracef("joybus_rtc_detect_async: %s %s %s %s\n",
         detected ? "detected" : "not detected",
         status.stopped ? "stopped" : "running",
         status.crystal_bad ? "crystal:BAD" : "crystal:OK",
@@ -271,7 +282,7 @@ void joybus_rtc_detect_async( joybus_rtc_detect_callback_t callback )
     input[i] = 0xFE;
     input[sizeof(input) - 1] = 0x01;
     // Execute the Joybus operation asynchronously
-    debugf("joybus_rtc_detect_async: probing\n");
+    tracef("joybus_rtc_detect_async: probing\n");
     joybus_exec_async( input, joybus_rtc_detect_callback, callback );
 }
 
@@ -297,7 +308,7 @@ bool joybus_rtc_detect( void )
 
 static void joybus_rtc_set_stopped_write_callback( uint64_t *out_dwords, void *ctx )
 {
-    debugf("joybus_rtc_set_stopped_async: done\n");
+    tracef("joybus_rtc_set_stopped_async: done\n");
     joybus_rtc_set_stopped_callback_t callback = ctx;
     if( callback ) callback();
 }
@@ -308,7 +319,7 @@ static void joybus_rtc_set_stopped_read_callback( uint64_t *out_dwords, void *ct
     const uint8_t *out_bytes = (void *)out_dwords;
     joybus_cmd_rtc_read_block_t *cmd = (void *)&out_bytes[JOYBUS_RTC_PORT + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_rtc_control_t control = { .data = { .dword = cmd->recv.dword } };
-    debugf("joybus_rtc_set_stopped_async: control state (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_set_stopped_async: control state (0x%llx)\n", control.data.dword);
 
     // Unpack the stop bit and the callback pointer from the context
     bool stop = ((uint32_t)ctx & 0x1);
@@ -317,7 +328,7 @@ static void joybus_rtc_set_stopped_read_callback( uint64_t *out_dwords, void *ct
     control.stop = stop;
     control.lock_block1 = !stop;
     control.lock_block2 = !stop;
-    debugf("joybus_rtc_set_stopped_async: writing control block (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_set_stopped_async: writing control block (0x%llx)\n", control.data.dword);
     joybus_rtc_write_async(
         JOYBUS_RTC_BLOCK_CONTROL,
         &control.data,
@@ -330,21 +341,21 @@ void joybus_rtc_set_stopped_async( bool stop, joybus_rtc_set_stopped_callback_t 
 {
     // Pack the stop bit and the callback pointer into the context value
     void *ctx = (void *)((uint32_t)callback | (stop & 0x1));
-    debugf("joybus_rtc_set_stopped_async: reading control block\n");
+    tracef("joybus_rtc_set_stopped_async: reading control block\n");
     joybus_rtc_read_async( JOYBUS_RTC_BLOCK_CONTROL, joybus_rtc_set_stopped_read_callback, ctx );
 }
 
 void joybus_rtc_set_stopped( bool stop )
 {
     joybus_rtc_control_t control;
-    debugf("joybus_rtc_set_stopped: reading control block\n");
+    tracef("joybus_rtc_set_stopped: reading control block\n");
     joybus_rtc_read( JOYBUS_RTC_BLOCK_CONTROL, &control.data );
-    debugf("joybus_rtc_set_stopped: control state (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_set_stopped: control state (0x%llx)\n", control.data.dword);
 
     control.stop = stop;
     control.lock_block1 = !stop;
     control.lock_block2 = !stop;
-    debugf("joybus_rtc_set_stopped: writing control block (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_set_stopped: writing control block (0x%llx)\n", control.data.dword);
     joybus_rtc_write( JOYBUS_RTC_BLOCK_CONTROL, &control.data );
 }
 
@@ -355,7 +366,7 @@ bool joybus_rtc_is_stopped( void )
     } };
     joybus_exec_cmd_struct(JOYBUS_RTC_PORT, cmd);
     joybus_rtc_status_t status = { .byte = cmd.recv.status };
-    debugf("joybus_rtc_is_stopped: status (0x%02x)\n", status.byte);
+    tracef("joybus_rtc_is_stopped: status (0x%02x)\n", status.byte);
     joybus_rtc_detect_status.byte = status.byte;
     return status.stopped;
 }
@@ -368,17 +379,17 @@ static void joybus_rtc_get_time_callback( uint64_t *out_dwords, void *ctx )
     joybus_rtc_get_time_callback_t callback = ctx;
     joybus_cmd_rtc_read_block_t *cmd = (void *)&out_bytes[JOYBUS_RTC_PORT + JOYBUS_COMMAND_METADATA_SIZE];
     joybus_rtc_data_t data = { .dword = cmd->recv.dword };
-    debugf("joybus_rtc_get_time_async: raw time (0x%llx)\n", data.dword);
+    tracef("joybus_rtc_get_time_async: raw time (0x%llx)\n", data.dword);
     time_t decoded_time = joybus_rtc_decode_time( &data );
     if (decoded_time < 0)
     {
-        debugf("joybus_rtc_get_time_async: invalid time\n");
+        tracef("joybus_rtc_get_time_async: invalid time\n");
         callback( (int)decoded_time, 0 );
         return;
     }
 
     struct tm * parsed_tm = gmtime( &decoded_time );
-    debugf("joybus_rtc_get_time_async: parsed time (%04d-%02d-%02d %02d:%02d:%02d)\n",
+    tracef("joybus_rtc_get_time_async: parsed time (%04d-%02d-%02d %02d:%02d:%02d)\n",
         parsed_tm->tm_year + 1900, parsed_tm->tm_mon + 1, parsed_tm->tm_mday,
         parsed_tm->tm_hour, parsed_tm->tm_min, parsed_tm->tm_sec
     );
@@ -390,19 +401,19 @@ void joybus_rtc_get_time_async( joybus_rtc_get_time_callback_t callback )
 {
     if( joybus_rtc_detect_state != JOYBUS_RTC_DETECTED )
     {
-        debugf("joybus_rtc_get_time_async: RTC not detected; aborting!\n");
+        tracef("joybus_rtc_get_time_async: RTC not detected; aborting!\n");
         callback( RTC_ENOCLOCK, 0 );
         return;
     }
 
     if( joybus_rtc_detect_status.crystal_bad )
     {
-        debugf("joybus_rtc_get_time_async: crystal is bad; aborting!\n");
+        tracef("joybus_rtc_get_time_async: crystal is bad; aborting!\n");
         callback( RTC_EBADCLOCK, 0 );
         return;
     }
 
-    debugf("joybus_rtc_get_time_async: reading time block\n");
+    tracef("joybus_rtc_get_time_async: reading time block\n");
     joybus_rtc_read_async( JOYBUS_RTC_BLOCK_TIME, joybus_rtc_get_time_callback, callback );
 }
 
@@ -410,27 +421,27 @@ int joybus_rtc_get_time( time_t *out )
 {
     if( joybus_rtc_detect_state != JOYBUS_RTC_DETECTED )
     {
-        debugf("joybus_rtc_get_time: RTC not detected; aborting!\n");
+        tracef("joybus_rtc_get_time: RTC not detected; aborting!\n");
         return RTC_ENOCLOCK;
     }
 
     if( joybus_rtc_detect_status.crystal_bad )
     {
-        debugf("joybus_rtc_get_time: crystal is bad; aborting!\n");
+        tracef("joybus_rtc_get_time: crystal is bad; aborting!\n");
         return RTC_EBADCLOCK;
     }
 
     joybus_rtc_data_t data = {0};
-    debugf("joybus_rtc_get_time: reading time block\n");
+    tracef("joybus_rtc_get_time: reading time block\n");
     joybus_rtc_read( JOYBUS_RTC_BLOCK_TIME, &data );
-    debugf("joybus_rtc_get_time: raw time (0x%llx)\n", data.dword);
+    tracef("joybus_rtc_get_time: raw time (0x%llx)\n", data.dword);
     time_t time = joybus_rtc_decode_time( &data );
     if (time < 0)
         return (int)time;
 
     *out = time;
     struct tm * parsed_tm = gmtime( out );
-    debugf("joybus_rtc_get_time: parsed time (%04d-%02d-%02d %02d:%02d:%02d)\n",
+    tracef("joybus_rtc_get_time: parsed time (%04d-%02d-%02d %02d:%02d:%02d)\n",
         parsed_tm->tm_year + 1900, parsed_tm->tm_mon + 1, parsed_tm->tm_mday,
         parsed_tm->tm_hour, parsed_tm->tm_min, parsed_tm->tm_sec
     );
@@ -442,19 +453,19 @@ int joybus_rtc_set_time( time_t new_time )
 {
     if( new_time < JOYBUS_RTC_TIMESTAMP_MIN || new_time > JOYBUS_RTC_TIMESTAMP_MAX )
     {
-        debugf("joybus_rtc_set_time: time out of range\n");
+        tracef("joybus_rtc_set_time: time out of range\n");
         return RTC_EBADTIME;
     }
 
     if( joybus_rtc_detect_status.crystal_bad )
     {
-        debugf("joybus_rtc_set_time: crystal is bad; aborting!\n");
+        tracef("joybus_rtc_set_time: crystal is bad; aborting!\n");
         return RTC_EBADCLOCK;
     }
 
     if( joybus_rtc_detect_status.battery_bad )
     {
-        debugf("joybus_rtc_set_time: battery is bad; aborting!\n");
+        tracef("joybus_rtc_set_time: battery is bad; aborting!\n");
         return RTC_EBADCLOCK;
     }
 
@@ -470,43 +481,43 @@ int joybus_rtc_set_time( time_t new_time )
         case CART_ED:
             if( ed64_rtc_write( buf ) != 0 )
             {
-                debugf("joybus_rtc_set_time: EverDrive 64 i2c write failed!\n");
+                tracef("joybus_rtc_set_time: EverDrive 64 i2c write failed!\n");
                 return RTC_EBADCLOCK;
             }
             return RTC_ESUCCESS;
         case CART_EDX:
             if( ed64x_rtc_write( buf ) != 0 )
             {
-                debugf("joybus_rtc_set_time: EverDrive 64 X7 i2c write failed!\n");
+                tracef("joybus_rtc_set_time: EverDrive 64 X7 i2c write failed!\n");
                 return RTC_EBADCLOCK;
             }
             return RTC_ESUCCESS;
         }
     }
 
-    debugf("joybus_rtc_set_time: reading control block\n");
+    tracef("joybus_rtc_set_time: reading control block\n");
     joybus_rtc_control_t control;
     joybus_rtc_read( JOYBUS_RTC_BLOCK_CONTROL, &control.data );
-    debugf("joybus_rtc_get_time: control state (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_get_time: control state (0x%llx)\n", control.data.dword);
 
     /* Prepare the RTC to write the time */
     control.stop = true;
     control.lock_block1 = false;
     control.lock_block2 = false;
-    debugf("joybus_rtc_set_time: writing control block (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_set_time: writing control block (0x%llx)\n", control.data.dword);
     joybus_rtc_write( JOYBUS_RTC_BLOCK_CONTROL, &control.data );
     wait_ms( JOYBUS_RTC_WRITE_BLOCK_DELAY );
 
     /* Determine if the RTC implementation supports writes. */
     if( !joybus_rtc_is_stopped() )
     {
-        debugf("joybus_rtc_set_time: rtc did not stop; aborting!\n");
+        tracef("joybus_rtc_set_time: rtc did not stop; aborting!\n");
         return RTC_EBADCLOCK;
     }
 
     /* Write the time block to RTC */
     struct tm * rtc_time = gmtime( &new_time );
-    debugf("joybus_rtc_set_time: parsed time (%02d:%02d:%02d %02d/%02d/%04d)\n",
+    tracef("joybus_rtc_set_time: parsed time (%02d:%02d:%02d %02d/%02d/%04d)\n",
         rtc_time->tm_hour, rtc_time->tm_min, rtc_time->tm_sec,
         rtc_time->tm_mon + 1, rtc_time->tm_mday, rtc_time->tm_year + 1900
     );
@@ -520,7 +531,7 @@ int joybus_rtc_set_time( time_t new_time )
         bcd_encode( rtc_time->tm_year ),
         bcd_encode( rtc_time->tm_year / 100 ),
     } };
-    debugf("joybus_rtc_set_time: writing time block (0x%llx)\n", data.dword);
+    tracef("joybus_rtc_set_time: writing time block (0x%llx)\n", data.dword);
     joybus_rtc_write( JOYBUS_RTC_BLOCK_TIME, &data );
     wait_ms( JOYBUS_RTC_WRITE_BLOCK_DELAY );
 
@@ -528,12 +539,12 @@ int joybus_rtc_set_time( time_t new_time )
     control.stop = false;
     control.lock_block1 = true;
     control.lock_block2 = true;
-    debugf("joybus_rtc_set_time: writing control block (0x%llx)\n", control.data.dword);
+    tracef("joybus_rtc_set_time: writing control block (0x%llx)\n", control.data.dword);
     joybus_rtc_write( JOYBUS_RTC_BLOCK_CONTROL, &control.data );
 
     if( joybus_rtc_is_stopped() )
     {
-        debugf("joybus_rtc_set_time: rtc did not restart?\n");
+        tracef("joybus_rtc_set_time: rtc did not restart?\n");
         return RTC_EBADCLOCK;
     }
 


### PR DESCRIPTION
Rename debugf to tracef and add defines.

When debugging on a Summercart64, there was some noise produced from the joybus_rtc source. This removes it when un-needed, but keeps the option for when ED64 (or other flashcarts, emulators and such) require further debugging.