### PR TITLE
Fix building the toolchain on Mac OS X

### DIFF
--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -34,6 +34,9 @@ JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
 # GDB configure arguments to use system GMP/MPC/MFPF
 GDB_CONFIGURE_ARGS=()
 
+# Create build and download directories
+mkdir -p "$BUILD_PATH" "$DOWNLOAD_PATH"
+
 # Resolve absolute paths for build and download directories
 BUILD_PATH=$(cd "$BUILD_PATH" && pwd)
 DOWNLOAD_PATH=$(cd "$DOWNLOAD_PATH" && pwd)
@@ -67,10 +70,11 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     # Tell GDB configure to use Homebrew's GMP, MPFR, MPC, and Zlib.
     # These should have already been installed by build-toolchain.sh
     GDB_CONFIGURE_ARGS=(
-        "--with-gmp=$(brew --prefix)"
-        "--with-mpfr=$(brew --prefix)"
-        "--with-mpc=$(brew --prefix)"
-        "--with-zlib=$(brew --prefix)"
+        "--with-gmp=$(brew --prefix gmp)"
+        "--with-mpfr=$(brew --prefix mpfr)"
+        "--with-mpc=$(brew --prefix libmpc)"
+        "--with-isl=$(brew --prefix isl)"
+        "--with-system-zlib"
     )
 elif [ "$N64_HOST" == "x86_64-w64-mingw32" ]; then
     # Configure GDB arguments for Windows cross-compilation

--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -74,6 +74,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         "--with-mpfr=$(brew --prefix mpfr)"
         "--with-mpc=$(brew --prefix libmpc)"
         "--with-isl=$(brew --prefix isl)"
+        "--with-python=python3"
         "--with-system-zlib"
     )
 elif [ "$N64_HOST" == "x86_64-w64-mingw32" ]; then

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -33,6 +33,7 @@ JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN)}"
 JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
 
 # GCC configure arguments to use system GMP/MPC/MFPF
+BINUTILS_CONFIGURE_ARGS=()
 GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
@@ -82,7 +83,8 @@ if [[ $OSTYPE == 'darwin'* ]]; then
 
     # Install required dependencies. gsed is really required, the others are optionals
     # and just speed up build.
-    brew install -q gmp mpfr libmpc gsed gcc isl libpng lz4 make mpc texinfo zlib
+    # zlib is part of the base OS, and doesn't need to be installed here.
+    brew install -q gmp mpfr libmpc gsed isl make texinfo
 
     # FIXME: we could avoid download/symlink GMP and friends for a cross-compiler
     # but we need to symlink them for the canadian compiler.
@@ -90,12 +92,20 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     #MPC_V=""
     #MPFR_V=""
 
-    # Tell GCC configure where to find the dependent libraries
+    # Tell Binutils and GCC configure where to find the dependent libraries
+    BINUTILS_CONFIGURE_ARGS=(
+        "--with-gmp=$(brew --prefix gmp)"
+        "--with-mpfr=$(brew --prefix mpfr)"
+        "--with-mpc=$(brew --prefix libmpc)"
+        "--with-isl=$(brew --prefix isl)"
+        "--with-system-zlib"
+    )
     GCC_CONFIGURE_ARGS=(
-        "--with-gmp=$(brew --prefix)"
-        "--with-mpfr=$(brew --prefix)"
-        "--with-mpc=$(brew --prefix)"
-        "--with-zlib=$(brew --prefix)"
+        "--with-gmp=$(brew --prefix gmp)"
+        "--with-mpfr=$(brew --prefix mpfr)"
+        "--with-mpc=$(brew --prefix libmpc)"
+        "--with-isl=$(brew --prefix isl)"
+        "--with-system-zlib"
     )
 
     # Install GNU sed as default sed in PATH. GCC compilation fails otherwise,
@@ -103,7 +113,8 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     PATH="$(brew --prefix gsed)/libexec/gnubin:$PATH"
     export PATH
 else
-    # Configure GCC arguments for non-macOS platforms
+    # Configure Binutils and GCC arguments for non-macOS platforms
+    BINUTILS_CONFIGURE_ARGS+=("--with-system-zlib")
     GCC_CONFIGURE_ARGS+=("--with-system-zlib")
 fi
 
@@ -250,7 +261,7 @@ fi
 # Compile BUILD->TARGET binutils
 mkdir -p binutils_compile_target
 pushd binutils_compile_target
-../"binutils-$BINUTILS_V"/configure \
+../"binutils-$BINUTILS_V"/configure ${BINUTILS_CONFIGURE_ARGS[@]} \
     --prefix="$CROSS_PREFIX" \
     --target="$N64_TARGET" \
     --with-cpu=mips64vr4300 \

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -84,7 +84,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     # Install required dependencies. gsed is really required, the others are optionals
     # and just speed up build.
     # zlib is part of the base OS, and doesn't need to be installed here.
-    brew install -q gmp mpfr libmpc gsed isl make texinfo
+    brew install -q gmp mpfr libmpc gsed isl make python3 texinfo
 
     # FIXME: we could avoid download/symlink GMP and friends for a cross-compiler
     # but we need to symlink them for the canadian compiler.


### PR DESCRIPTION
The build scripts weren't properly detecting the system version of zlib, and was falling back to the bundled version which doesn't build correctly on recent systems. The list of brew packages has also been simplified.