### PR TITLE
Bio-Sensor subsystem and example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,5 @@
 EXAMPLES += audioplayer
+EXAMPLES += biosensortest
 EXAMPLES += brew-volley
 #EXAMPLES += compression # Disabled due to missing assets
 EXAMPLES += controllertest

--- a/examples/biosensortest/Makefile
+++ b/examples/biosensortest/Makefile
@@ -1,0 +1,17 @@
+all: biosensortest.z64
+.PHONY: all
+
+BUILD_DIR = build
+include $(N64_INST)/include/n64.mk
+
+OBJS = $(BUILD_DIR)/biosensortest.o
+
+biosensortest.z64: N64_ROM_TITLE = "Bio Sensor Test"
+
+$(BUILD_DIR)/biosensortest.elf: $(OBJS)
+
+clean:
+	rm -rf $(BUILD_DIR) *.z64
+.PHONY: clean
+
+-include $(wildcard $(BUILD_DIR)/*.d)

--- a/examples/biosensortest/biosensortest.c
+++ b/examples/biosensortest/biosensortest.c
@@ -1,0 +1,83 @@
+/**
+ * @file biosensortest.c
+ * @author Christopher Bonhage (me@christopherbonhage.com)
+ * @brief N64 test ROM for Bio Sensor subsystem
+ */
+
+#include <string.h>
+#include <libdragon.h>
+
+int main(void)
+{
+    joypad_buttons_t pressed;
+    joypad_accessory_type_t accessory_type;
+    int bpm;
+
+    timer_init();
+    joypad_init();
+    debug_init_isviewer();
+
+    console_init();
+    console_set_render_mode(RENDER_MANUAL);
+    console_set_debug(false);
+
+    bio_sensor_init();
+
+    while (1)
+    {
+        console_clear();
+        joypad_poll();
+
+        printf("LibDragon Bio Sensor Subsystem Test ROM\n\n");
+        printf("Connect up to 4 controllers with Bio Sensor accessories\n");
+        printf("\n");
+        printf("Press A to start reading the Bio Sensor\n");
+        printf("Press B to stop reading the Bio Sensor\n");
+        printf("\n");
+
+        JOYPAD_PORT_FOREACH (port)
+        {
+            pressed = joypad_get_buttons_pressed(port);
+            accessory_type = joypad_get_accessory_type(port);
+            bpm = bio_sensor_get_bpm(port);
+
+            printf("Port %d ", port + 1);
+            printf("BPM: %03d ", bpm);
+            if (bio_sensor_get_active(port))
+            {
+                if (pressed.b)
+                {
+                    bio_sensor_read_stop(port);
+                    printf("(Stopping)");
+                }
+                else if (bio_sensor_get_pulsing(port))
+                {
+                    printf("(Pulsing)");
+                }
+                else
+                {
+                    printf("(Resting)");
+                }
+            }
+            else if (accessory_type == JOYPAD_ACCESSORY_TYPE_BIO_SENSOR)
+            {
+                if (pressed.a)
+                {
+                    bio_sensor_read_start(port);
+                    printf("(Starting)");
+                }
+                else
+                {
+                    printf("(Stopped)");
+                }
+            }
+            else
+            {
+                printf("(Unavailable)");
+            }
+            printf("\n");
+        }
+
+        console_render();
+    }
+}

--- a/include/bio_sensor.h
+++ b/include/bio_sensor.h
@@ -1,0 +1,120 @@
+/**
+ * @file bio_sensor.h
+ * @author Christopher Bonhage <me@christopherbonhage.com>
+ * @brief Bio Sensor subsystem
+ * @ingroup bio_sensor
+ */
+
+#ifndef LIBDRAGON_BIO_SENSOR_H
+#define LIBDRAGON_BIO_SENSOR_H
+
+#include <stdbool.h>
+
+#include "joypad.h"
+
+/**
+ * @defgroup bio_sensor Bio Sensor Subsystem
+ * @ingroup peripherals
+ * @brief Bio Sensor accessory interface.
+ * @author Christopher Bonhage <me@christopherbonhage.com>
+ *
+ * Bio Sensor (NUS-A-BIO-JPN) is an N64 controller accessory to read a player's
+ * heartbeat using an infrared sensor. It was only released in Japan, and was
+ * only supported by a single retail game, "Tetris 64". The Bio Sensor is a
+ * video game accessory. It is NOT a medical device and is for entertainment
+ * purposes only.
+ *
+ * The Bio Sensor subsystem provides an interface for reading heartbeat data
+ * from multiple Bio Sensor accessories connected to different joypad ports.
+ * Each port can be independently started and stopped for reading heartbeat data.
+ *
+ * Bio Sensor reads are performed at 60Hz (NTSC) or 50Hz (PAL) using the
+ * vertical interrupt (VI) handler. The subsystem maintains a rolling window of
+ * heartbeat counts to calculate the current heart rate in beats per minute (BPM).
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the Bio Sensor subsystem
+ *
+ * Must be called before starting Bio Sensor reads on any port.
+ *
+ * Registers the VI interrupt handler for periodic sensor reads.
+ * Uses reference counting to support multiple init/close pairs.
+ */
+void bio_sensor_init(void);
+
+/**
+ * @brief Close the Bio Sensor subsystem
+ *
+ * Should be called when Bio Sensor functionality is no longer needed.
+ *
+ * Decrements the reference count and unregisters the VI interrupt handler
+ * when the count reaches zero.
+ */
+void bio_sensor_close(void);
+
+/**
+ * @brief Start reading heartbeat data from a Bio Sensor
+ *
+ * Initializes the reader context for the specified port and begins
+ * continuous heartbeat monitoring. The sensor will be read at 60Hz (NTSC)
+ * or 50Hz (PAL) via the VI interrupt handler. After starting, it will
+ * take 4-5 seconds to accumulate enough data for a heart rate reading.
+ *
+ * @param port The joypad port with the Bio Sensor accessory attached
+ */
+void bio_sensor_read_start(joypad_port_t port);
+
+/**
+ * @brief Stop reading heartbeat data from a Bio Sensor
+ *
+ * Clears the reader context for the specified port and stops all
+ * heartbeat monitoring. Also called automatically if the Bio Sensor
+ * is disconnected during reading.
+ *
+ * @param port The joypad port to stop reading from
+ */
+void bio_sensor_read_stop(joypad_port_t port);
+
+/**
+ * @brief Check if Bio Sensor is actively reading heartbeat data
+ *
+ * @param port The joypad port to check
+ * @return true if heartbeat monitoring is active, false if stopped
+ */
+bool bio_sensor_get_active(joypad_port_t port);
+
+/**
+ * @brief Check if a heartbeat pulse is currently detected
+ *
+ * @param port The joypad port to check
+ * @return true if the heart is currently beating (pulsing state), false otherwise
+ */
+bool bio_sensor_get_pulsing(joypad_port_t port);
+
+/**
+ * @brief Calculate the current heart rate in beats per minute (BPM)
+ *
+ * Calculates the average BPM based on heartbeat counts from multiple
+ * measurement periods. Requires at least 8 measurement periods (4 seconds)
+ * of data before returning a valid BPM. Uses up to 16 periods (8 seconds)
+ * for the rolling average calculation.
+ *
+ * @param port The joypad port to read BPM from
+ * @return Heart rate in beats per minute, or 0 if insufficient data
+ */
+int bio_sensor_get_bpm(joypad_port_t port);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */ /* bio_sensor */
+
+#endif /* LIBDRAGON_BIO_SENSOR_H */

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -36,6 +36,7 @@
 #include "joypad.h"
 #include "controller.h"
 #include "rtc.h"
+#include "bio_sensor.h"
 #include "mempak.h"
 #include "cpak.h"
 #include "cpakfs.h"

--- a/src/joybus/bio_sensor.c
+++ b/src/joybus/bio_sensor.c
@@ -1,0 +1,230 @@
+/**
+ * @file bio_sensor.c
+ * @author Christopher Bonhage <me@christopherbonhage.com>
+ * @brief Bio Sensor Subsystem
+ * @ingroup bio_sensor
+ */
+
+#include <string.h>
+#include <libdragon.h>
+
+#include "bio_sensor.h"
+#include "joybus_commands.h"
+#include "joybus_accessory_internal.h"
+
+/**
+ * @addtogroup bio_sensor
+ * @{
+ */
+
+/** @brief Minimum number of measurement periods required before calculating BPM */
+#define BIO_SENSOR_PERIODS_MINIMUM 8
+/** @brief Maximum number of measurement periods stored in the rolling window */
+#define BIO_SENSOR_PERIODS_MAXIMUM 16
+/** @brief Timer ticks per measurement period (500ms or half-second intervals) */
+#define BIO_SENSOR_PERIOD_INTERVAL_TICKS (TICKS_PER_SECOND / 2)
+/** @brief Number of measurement periods in one minute (120 half-second periods) */
+#define BIO_SENSOR_PERIODS_PER_MINUTE (60 * 2)
+
+/**
+ * @brief Bio Sensor reading states
+ *
+ * Tracks the current state of heartbeat detection from the Bio Sensor.
+ */
+typedef enum
+{
+    /** @brief Sensor reading is stopped or not initialized */
+    BIO_SENSOR_STATE_STOPPED = 0,
+    /** @brief Heart is between beats (sensor value: 0x03) */
+    BIO_SENSOR_STATE_RESTING,
+    /** @brief Heart is actively beating (sensor value: 0x00) */
+    BIO_SENSOR_STATE_PULSING,
+} bio_sensor_state_t;
+
+/**
+ * @brief Bio Sensor reader context structure
+ *
+ * Maintains state and statistics for heartbeat detection on a single port.
+ * Uses a rolling window to track beats across multiple measurement periods.
+ */
+typedef struct
+{
+    /** @brief Flag indicating an async read operation is in progress */
+    bool read_pending;
+    /** @brief Current heartbeat detection state */
+    bio_sensor_state_t state;
+    /** @brief Timer tick value when the current measurement period started */
+    int64_t period_start_ticks;
+    /** @brief Number of heartbeats detected in the current measurement period */
+    unsigned period_beats;
+    /** @brief Current write position in the circular buffer of beat counts */
+    unsigned period_cursor;
+    /** @brief Total number of completed measurement periods since reading started */
+    unsigned period_counter;
+    /** @brief Circular buffer storing heartbeat counts for each measurement period */
+    unsigned beats_per_period[BIO_SENSOR_PERIODS_MAXIMUM];
+} bio_sensor_reader_t;
+
+/** @brief Reference count tracking #bio_sensor_init vs #bio_sensor_close calls */
+static int bio_sensor_init_refcount = 0;
+
+/** @brief Array of Bio Sensor reader contexts, one per controller port */
+static volatile bio_sensor_reader_t bio_sensor_readers[JOYPAD_PORT_COUNT] = {0};
+
+/**
+ * @brief Callback function for asynchronous Bio Sensor data reads
+ *
+ * Processes heartbeat data from the Bio Sensor accessory. Detects state transitions
+ * from PULSING to RESTING to count heartbeats. Maintains a rolling window of beat
+ * counts across multiple measurement periods for BPM calculation.
+ *
+ * @param out_dwords Pointer to the Joybus response data containing sensor readings
+ * @param ctx        Context pointer containing the joypad port number
+ */
+static void bio_sensor_read_callback(uint64_t *out_dwords, void *ctx)
+{
+    const uint8_t *out_bytes = (void *)out_dwords;
+    joypad_port_t port = (joypad_port_t)ctx;
+    volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
+    bio_sensor_state_t current_state = reader->state;
+    // Ignore this read if this sensor has been stopped
+    if (current_state == BIO_SENSOR_STATE_STOPPED) return;
+
+    const joybus_cmd_n64_accessory_read_port_t *recv_cmd = (void *)&out_bytes[port];
+    int crc_status = joybus_accessory_compare_data_crc(recv_cmd->recv.data, recv_cmd->recv.data_crc);
+    if (crc_status != JOYBUS_ACCESSORY_IO_STATUS_OK)
+    {
+        // Stop reading if the Bio Sensor has been disconnected
+        if (crc_status == JOYBUS_ACCESSORY_IO_STATUS_NO_PAK)
+        {
+            bio_sensor_read_stop(port);
+        }
+        // Skip this read if it fails the CRC check
+        reader->read_pending = false;
+        return;
+    }
+
+    int64_t now_ticks = timer_ticks();
+    if (reader->period_start_ticks + BIO_SENSOR_PERIOD_INTERVAL_TICKS < now_ticks)
+    {
+        unsigned cursor = reader->period_cursor;
+        reader->beats_per_period[cursor++] = reader->period_beats;
+        if (cursor >= BIO_SENSOR_PERIODS_MAXIMUM) cursor = 0;
+        reader->period_cursor = cursor;
+        reader->period_beats = 0;
+        reader->period_counter++;
+        reader->period_start_ticks = now_ticks;
+    }
+
+    uint8_t sensor_data = recv_cmd->recv.data[0];
+    bio_sensor_state_t next_state = BIO_SENSOR_STATE_STOPPED;
+    if (sensor_data == 0x00) next_state = BIO_SENSOR_STATE_PULSING;
+    if (sensor_data == 0x03) next_state = BIO_SENSOR_STATE_RESTING;
+
+    if (
+        current_state == BIO_SENSOR_STATE_PULSING &&
+        next_state == BIO_SENSOR_STATE_RESTING
+    ) {
+        reader->period_beats += 1;
+    }
+    reader->state = next_state;
+    reader->read_pending = false;
+}
+
+/**
+ * @brief VI interrupt handler for periodic Bio Sensor reads
+ *
+ * Called on every vertical interrupt (60Hz NTSC / 50Hz PAL) to initiate
+ * asynchronous reads from all active Bio Sensor accessories. Ensures
+ * continuous monitoring of heartbeat data across all controller ports.
+ */
+static void bio_sensor_vi_interrupt_callback(void)
+{
+    JOYPAD_PORT_FOREACH (port)
+    {
+        if (
+            bio_sensor_readers[port].read_pending == false &&
+            bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED
+        )
+        {
+            bio_sensor_readers[port].read_pending = true;
+            joybus_accessory_read_async(
+                port, JOYBUS_ACCESSORY_ADDR_BIO_PULSE,
+                bio_sensor_read_callback, (void *)port
+            );
+        }
+    }
+}
+
+void bio_sensor_init(void)
+{
+    // Just increment the refcount if already initialized
+	if (bio_sensor_init_refcount++ > 0) { return; }
+
+    register_VI_handler(bio_sensor_vi_interrupt_callback);
+}
+
+void bio_sensor_close(void)
+{
+    // Do nothing if there are still dangling references.
+	if (--bio_sensor_init_refcount > 0) { return; }
+
+    unregister_VI_handler(bio_sensor_vi_interrupt_callback);
+}
+
+void bio_sensor_read_start(joypad_port_t port)
+{
+    if (bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED) return;
+    volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
+    memset((void *)reader, 0, sizeof(*reader));
+    reader->state = BIO_SENSOR_STATE_RESTING;
+    reader->period_start_ticks = timer_ticks();
+}
+
+void bio_sensor_read_stop(joypad_port_t port)
+{
+    volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
+    memset((void *)reader, 0, sizeof(*reader));
+}
+
+bool bio_sensor_get_active(joypad_port_t port)
+{
+    return bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED;
+}
+
+bool bio_sensor_get_pulsing(joypad_port_t port)
+{
+    return bio_sensor_readers[port].state == BIO_SENSOR_STATE_PULSING;
+}
+
+int bio_sensor_get_bpm(joypad_port_t port)
+{
+    volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
+    int num_periods = reader->period_counter;
+    if (num_periods < BIO_SENSOR_PERIODS_MINIMUM)
+    {
+        // Insufficient data to calculate BPM
+        return 0;
+    }
+    if (num_periods > BIO_SENSOR_PERIODS_MAXIMUM)
+    {
+        num_periods = BIO_SENSOR_PERIODS_MAXIMUM;
+    }
+    float sum = 0.0;
+    // Read from the circular buffer in chronological order
+    // When buffer is full, oldest data starts at period_cursor
+    unsigned start_index = 0;
+    if (reader->period_counter >= BIO_SENSOR_PERIODS_MAXIMUM)
+    {
+        // Buffer has wrapped around, start from oldest entry
+        start_index = reader->period_cursor;
+    }
+    for (size_t i = 0; i < num_periods; i++)
+    {
+        unsigned index = (start_index + i) % BIO_SENSOR_PERIODS_MAXIMUM;
+        sum += reader->beats_per_period[index];
+    }
+    return (sum / (float)num_periods) * BIO_SENSOR_PERIODS_PER_MINUTE;
+}
+
+/** @} */ /* bio_sensor */

--- a/src/joybus/bio_sensor.c
+++ b/src/joybus/bio_sensor.c
@@ -25,6 +25,9 @@
 #define BIO_SENSOR_PERIOD_INTERVAL_TICKS (TICKS_PER_SECOND / 2)
 /** @brief Number of measurement periods in one minute (120 half-second periods) */
 #define BIO_SENSOR_PERIODS_PER_MINUTE (60 * 2)
+/** @brief Convenience macro for joypad accessory type comparison */
+#define BIO_SENSOR_CONNECTED(port) \
+    (joypad_get_accessory_type(port) == JOYPAD_ACCESSORY_TYPE_BIO_SENSOR)
 
 /**
  * @brief Bio Sensor reading states
@@ -85,13 +88,17 @@ static void bio_sensor_read_callback(uint64_t *out_dwords, void *ctx)
 {
     const uint8_t *out_bytes = (void *)out_dwords;
     joypad_port_t port = (joypad_port_t)ctx;
-    volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
-    bio_sensor_state_t current_state = reader->state;
-    // Ignore this read if this sensor has been stopped
-    if (current_state == BIO_SENSOR_STATE_STOPPED) return;
 
-    const joybus_cmd_n64_accessory_read_port_t *recv_cmd = (void *)&out_bytes[port];
-    int crc_status = joybus_accessory_compare_data_crc(recv_cmd->recv.data, recv_cmd->recv.data_crc);
+    // Extract the "N64 Accessory Read" command struct from the Joybus response
+    const joybus_cmd_n64_accessory_read_port_t *cmd =
+        (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
+    assert(cmd->send.command == JOYBUS_COMMAND_ID_N64_ACCESSORY_READ);
+
+    volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
+    // Ignore this read if this sensor has been stopped
+    if (reader->state == BIO_SENSOR_STATE_STOPPED) { return; }
+
+    int crc_status = joybus_accessory_compare_data_crc(cmd->recv.data, cmd->recv.data_crc);
     if (crc_status != JOYBUS_ACCESSORY_IO_STATUS_OK)
     {
         // Stop reading if the Bio Sensor has been disconnected
@@ -116,13 +123,13 @@ static void bio_sensor_read_callback(uint64_t *out_dwords, void *ctx)
         reader->period_start_ticks = now_ticks;
     }
 
-    uint8_t sensor_data = recv_cmd->recv.data[0];
+    uint8_t sensor_data = cmd->recv.data[0];
     bio_sensor_state_t next_state = BIO_SENSOR_STATE_STOPPED;
     if (sensor_data == 0x00) next_state = BIO_SENSOR_STATE_PULSING;
     if (sensor_data == 0x03) next_state = BIO_SENSOR_STATE_RESTING;
 
     if (
-        current_state == BIO_SENSOR_STATE_PULSING &&
+        reader->state == BIO_SENSOR_STATE_PULSING &&
         next_state == BIO_SENSOR_STATE_RESTING
     ) {
         reader->period_beats += 1;
@@ -147,6 +154,12 @@ static void bio_sensor_vi_interrupt_callback(void)
             bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED
         )
         {
+            if (!BIO_SENSOR_CONNECTED(port))
+            {
+                // Stop reading if the Bio Sensor has been disconnected
+                bio_sensor_read_stop(port);
+                continue;
+            }
             bio_sensor_readers[port].read_pending = true;
             joybus_accessory_read_async(
                 port, JOYBUS_ACCESSORY_ADDR_BIO_PULSE,
@@ -170,11 +183,13 @@ void bio_sensor_close(void)
 	if (--bio_sensor_init_refcount > 0) { return; }
 
     unregister_VI_handler(bio_sensor_vi_interrupt_callback);
+    JOYPAD_PORT_FOREACH (port) { bio_sensor_read_stop(port); }
 }
 
 void bio_sensor_read_start(joypad_port_t port)
 {
-    if (bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED) return;
+    if (!BIO_SENSOR_CONNECTED(port)) { return; }
+    if (bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED) { return; }
     volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
     memset((void *)reader, 0, sizeof(*reader));
     reader->state = BIO_SENSOR_STATE_RESTING;
@@ -189,16 +204,19 @@ void bio_sensor_read_stop(joypad_port_t port)
 
 bool bio_sensor_get_active(joypad_port_t port)
 {
+    if (!BIO_SENSOR_CONNECTED(port)) { return false; }
     return bio_sensor_readers[port].state != BIO_SENSOR_STATE_STOPPED;
 }
 
 bool bio_sensor_get_pulsing(joypad_port_t port)
 {
+    if (!BIO_SENSOR_CONNECTED(port)) { return false; }
     return bio_sensor_readers[port].state == BIO_SENSOR_STATE_PULSING;
 }
 
 int bio_sensor_get_bpm(joypad_port_t port)
 {
+    if (!BIO_SENSOR_CONNECTED(port)) { return 0; }
     volatile bio_sensor_reader_t *reader = &bio_sensor_readers[port];
     int num_periods = reader->period_counter;
     if (num_periods < BIO_SENSOR_PERIODS_MINIMUM)

--- a/src/joybus/libdragon.mk
+++ b/src/joybus/libdragon.mk
@@ -1,5 +1,6 @@
 
 LIBDRAGON_OBJS += \
+	$(BUILD_DIR)/joybus/bio_sensor.o \
 	$(BUILD_DIR)/joybus/controller.o \
 	$(BUILD_DIR)/joybus/cpak.o \
 	$(BUILD_DIR)/joybus/cpakfs.o \


### PR DESCRIPTION
Continuing my trend of adding support for obscure and esoteric hardware to LibDragon, I am finally contributing the Bio Sensor library that I experimented with during development of the Joypad subsystem.

This introduces a new Bio Sensor subsystem which allows developers to read players' heart-rate in beats-per-minute (BPM) using the Bio Sensor (NUS-A-BIO-JPN) accessory, which was only ever officially supported by the Japan-exclusive game "Tetris 64".

Sadly, the Bio Sensor has become quite expensive and rare, there are currently no hardware clones of it, and there is currently no emulator support for it. In an effort to raise awareness and hopefully encourage the preservation of this weird device, I hope that this subsystem breathes new life into the Bio Sensor by making it easier for homebrew developers to support it.

There is also an example ROM that demonstrates how to use the Bio Sensor subsystem. You will need at least one Bio Sensor accessory to meaningfully use the example ROM.