### PR TITLE
Retry accessory read/write that returns NO_PAK status

### DIFF
--- a/include/joybus_accessory.h
+++ b/include/joybus_accessory.h
@@ -26,9 +26,16 @@ typedef enum
     JOYBUS_ACCESSORY_IO_STATUS_OK        = 0,
     /** @brief No N64 controller is connected. */
     JOYBUS_ACCESSORY_IO_STATUS_NO_DEVICE = -1,
-    /** @brief No N64 accessory is connected. */
+    /**
+     * @brief Joybus accessory communication was not successful.
+     * 
+     * This could be caused by any of the following:
+     * - Nothing is connected to the accessory port.
+     * - A new accessory has been connected since the last identify command.
+     * - The accessory command address checksum validation failed.
+     */
     JOYBUS_ACCESSORY_IO_STATUS_NO_PAK    = -2,
-    /** @brief Joybus accessory communication was not successful. */
+    /** @brief Joybus accessory data transfer was not successful. */
     JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC   = -3,
 } joybus_accessory_io_status_t;
 
@@ -40,7 +47,7 @@ typedef enum
  * @param[out] data The 32 bytes of data that was read from the accessory.
  *
  * @retval #JOYBUS_ACCESSORY_IO_STATUS_OK The data was read successfully.
- * @retval #JOYBUS_ACCESSORY_IO_STATUS_NO_PAK No accessory is present.
+ * @retval #JOYBUS_ACCESSORY_IO_STATUS_NO_PAK Accessory communication failed.
  * @retval #JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC The data was not read successfully.
  */
 int joybus_accessory_read(int port, uint16_t addr, uint8_t *data);
@@ -53,7 +60,7 @@ int joybus_accessory_read(int port, uint16_t addr, uint8_t *data);
  * @param[in] data The 32 bytes of data to write to the accessory.
  *
  * @retval #JOYBUS_ACCESSORY_IO_STATUS_OK The data was written successfully.
- * @retval #JOYBUS_ACCESSORY_IO_STATUS_NO_PAK No accessory is present.
+ * @retval #JOYBUS_ACCESSORY_IO_STATUS_NO_PAK Accessory communication failed.
  * @retval #JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC The data was not written successfully.
  */
 int joybus_accessory_write(int port, uint16_t addr, const uint8_t *data);

--- a/src/joybus/bio_sensor.c
+++ b/src/joybus/bio_sensor.c
@@ -101,7 +101,7 @@ static void bio_sensor_read_callback(uint64_t *out_dwords, void *ctx)
     int crc_status = joybus_accessory_compare_data_crc(cmd->recv.data, cmd->recv.data_crc);
     if (crc_status != JOYBUS_ACCESSORY_IO_STATUS_OK)
     {
-        // Stop reading if the Bio Sensor has been disconnected
+        // Stop reading if the Bio Sensor communication fails
         if (crc_status == JOYBUS_ACCESSORY_IO_STATUS_NO_PAK)
         {
             bio_sensor_read_stop(port);

--- a/src/joybus/joybus_accessory_internal.h
+++ b/src/joybus/joybus_accessory_internal.h
@@ -238,7 +238,7 @@ uint8_t joybus_accessory_calculate_data_crc(const uint8_t *data);
  * @param data_crc The CRC8 checksum to compare against
  * 
  * @retval #JOYBUS_ACCESSORY_IO_STATUS_OK The checksums match.
- * @retval #JOYBUS_ACCESSORY_IO_STATUS_NO_PAK The checksum indicates that no accessory is present.
+ * @retval #JOYBUS_ACCESSORY_IO_STATUS_NO_PAK Accessory communication failed.
  * @retval #JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC The data checksum does not match the provided checksum.
  */
 joybus_accessory_io_status_t joybus_accessory_compare_data_crc(const uint8_t *data, uint8_t data_crc);

--- a/src/joybus/joypad_accessory.c
+++ b/src/joybus/joypad_accessory.c
@@ -63,21 +63,38 @@ static bool joypad_accessory_check_read_crc_error(
         }
         case JOYBUS_ACCESSORY_IO_STATUS_NO_PAK:
         {
-            // Accessory is no longer connected!
-            device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
-            device->rumble_active = false;
-            accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-            accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
-            accessory->status = JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT;
-            accessory->error = JOYPAD_ACCESSORY_ERROR_ABSENT;
-            return true;
+            size_t retries = accessory->retries;
+            if (retries < JOYPAD_ACCESSORY_IO_STATUS_NO_PAK_RETRY_LIMIT)
+            {
+                // Retry: Possibly bad communication, or the accessory was disconnected
+                accessory->retries = retries + 1;
+                accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+                uint16_t retry_addr = cmd->send.addr_checksum;
+                retry_addr &= JOYBUS_ACCESSORY_ADDR_MASK_OFFSET;
+                joybus_accessory_read_async(
+                    port, retry_addr,
+                    retry_callback, retry_ctx
+                );
+                return true;
+            }
+            else
+            {
+                // Accessory is no longer connected!
+                device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
+                device->rumble_active = false;
+                accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+                accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
+                accessory->status = JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT;
+                accessory->error = JOYPAD_ACCESSORY_ERROR_ABSENT;
+                return true;
+            }
         }
         case JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC:
         {
             size_t retries = accessory->retries;
-            if (retries < JOYPAD_ACCESSORY_RETRY_LIMIT)
+            if (retries < JOYPAD_ACCESSORY_IO_STATUS_BAD_CRC_RETRY_LIMIT)
             {
-                // Retry: Bad communication with the accessory
+                // Retry: Bad communication with the controller
                 accessory->retries = retries + 1;
                 accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
                 uint16_t retry_addr = cmd->send.addr_checksum;
@@ -139,19 +156,36 @@ static bool joypad_accessory_check_write_crc_error(
         }
         case JOYBUS_ACCESSORY_IO_STATUS_NO_PAK:
         {
-            // Accessory is no longer connected!
-            device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
-            device->rumble_active = false;
-            accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-            accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
-            accessory->status = JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT;
-            accessory->error = JOYPAD_ACCESSORY_ERROR_ABSENT;
-            return true;
+            size_t retries = accessory->retries;
+            if (retries < JOYPAD_ACCESSORY_IO_STATUS_NO_PAK_RETRY_LIMIT)
+            {
+                // Retry: Possibly bad communication, or the accessory was disconnected
+                accessory->retries = retries + 1;
+                accessory->error = JOYPAD_ACCESSORY_ERROR_PENDING;
+                uint16_t retry_addr = cmd->send.addr_checksum;
+                retry_addr &= JOYBUS_ACCESSORY_ADDR_MASK_OFFSET;
+                joybus_accessory_write_async(
+                    port, retry_addr, cmd->send.data,
+                    retry_callback, retry_ctx
+                );
+                return true;
+            }
+            else
+            {
+                // Accessory is no longer connected!
+                device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
+                device->rumble_active = false;
+                accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+                accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
+                accessory->status = JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT;
+                accessory->error = JOYPAD_ACCESSORY_ERROR_ABSENT;
+                return true;
+            }
         }
         case JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC:
         {
             size_t retries = accessory->retries;
-            if (retries < JOYPAD_ACCESSORY_RETRY_LIMIT)
+            if (retries < JOYPAD_ACCESSORY_IO_STATUS_BAD_CRC_RETRY_LIMIT)
             {
                 // Retry: Bad communication with the accessory
                 // Intentionally preserve accessory status in this case

--- a/src/joybus/joypad_accessory.h
+++ b/src/joybus/joypad_accessory.h
@@ -28,8 +28,10 @@ typedef struct timer_link timer_link_t;
 extern "C" {
 #endif
 
-/** @brief Number of times to retry accessory commands. */
-#define JOYPAD_ACCESSORY_RETRY_LIMIT 2
+/** @brief Number of times to retry accessory commands with NO_PAK error. */
+#define JOYPAD_ACCESSORY_IO_STATUS_NO_PAK_RETRY_LIMIT 1
+/** @brief Number of times to retry accessory commands with BAD_CRC error. */
+#define JOYPAD_ACCESSORY_IO_STATUS_BAD_CRC_RETRY_LIMIT 2
 
 /** @brief Joypad accessory states enumeration */
 typedef enum


### PR DESCRIPTION
Update the meaning of `JOYBUS_ACCESSORY_IO_STATUS_NO_PAK` to indicate any of the following:

* Nothing is connected to the accessory port.
* The accessory command address checksum was invalid.
* A new accessory has been connected since the last identify command. 

Attempt to retry accessory read/write commands that encounter `JOYBUS_ACCESSORY_IO_STATUS_NO_PAK` once before treating it as an accessory disconnect event in case there was a transmission error.