### PR TITLE
mkfont: Support custom axis values in variable fonts

### DIFF
--- a/tools/mkfont/mkfont.cpp
+++ b/tools/mkfont/mkfont.cpp
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <assert.h>
 #include <vector>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "../../include/surface.h"
@@ -54,6 +55,7 @@ float flag_ttf_char_spacing = 0;
 float flag_ttf_aspect_ratio = 1.0;
 tex_format_t flag_bmfont_format = FMT_NONE;
 std::unordered_set<uint32_t> flag_charset;
+std::unordered_map<uint32_t, float> flag_var_axis_values;
 
 typedef struct {
     const char *name;
@@ -382,6 +384,9 @@ void print_args( char * name )
     fprintf(stderr, "                             Default assumes 4:3 display ratio\n");
     fprintf(stderr, "   --format <format>         Specify the output texture format for color fonts.\n");
     fprintf(stderr, "                             Valid options are: RGBA16, RGBA32, CI4, CI8 (default: autoselect)\n");
+    fprintf(stderr, "   --var-axis <tag=value>    Override axis value of variable font\n");
+    fprintf(stderr, "                             (e.g., --var-axis wght=800))\n");
+    fprintf(stderr, "                             Can be specified multiple times.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "   Glyph selection modes (choose one of the following):\n");
     fprintf(stderr, "   --charset <file>          Create a font that covers all and only the glyphs used in the\n");
@@ -622,6 +627,22 @@ int main(int argc, char *argv[])
                     fprintf(stderr, "invalid format: %s\n", argv[i]);
                     return 1;
                 }
+            } else if (!strcmp(argv[i], "--var-axis")) {
+                if (++i == argc) {
+                    fprintf(stderr, "missing argument for %s\n", argv[i-1]);
+                    return 1;
+                }
+
+                char tag[4];
+                float value;
+                char extra;
+
+                if (sscanf(argv[i], "%c%c%c%c=%f%c", &tag[0], &tag[1], &tag[2], &tag[3], &value, &extra) != 5) {
+                    fprintf(stderr, "invalid argument for %s: %s \n", argv[i-1], argv[i]);
+                    return 1;
+
+                }
+                flag_var_axis_values[(tag[0] << 24) | (tag[1] << 16) | (tag[2] << 8) | tag[3]] = value;
             } else {
                 fprintf(stderr, "invalid flag: %s\n", argv[i]);
                 return 1;

--- a/tools/mkfont/mkfont_ttf.cpp
+++ b/tools/mkfont/mkfont_ttf.cpp
@@ -224,6 +224,48 @@ int convert_ttf(const char *infn, const char *outfn, std::vector<int>& ranges)
         font.bmp_outfmt = flag_bmfont_format;
     }
 
+    if (FT_HAS_MULTIPLE_MASTERS(face)) {
+        FT_MM_Var* mm_var;
+        if (FT_Get_MM_Var(face, &mm_var) != 0) {
+            fprintf(stderr, "error: could not read variable font data\n");
+            return 1;
+        }
+
+        std::vector<FT_Fixed> coords(mm_var->num_axis);
+        if (FT_Get_Var_Design_Coordinates(face, mm_var->num_axis, coords.data()) != 0) {
+            fprintf(stderr, "error: could not retrieve default variable axis values\n");
+            return 1;
+        }
+        for (FT_UInt i = 0; i < mm_var->num_axis; i++) {
+            auto& axis = mm_var->axis[i];
+            auto it = flag_var_axis_values.find(axis.tag);
+            if (it != flag_var_axis_values.end()) {
+                FT_Fixed fixed = round(it->second * (1 << 16)); // Convert value to 16.16 fixed point
+                if (fixed < axis.minimum || fixed > axis.maximum) {
+                    fprintf(stderr, "error: axis value '%c%c%c%c' outside allowed range\n",
+                            (char) (axis.tag >> 24), (char) (axis.tag >> 16), (char) (axis.tag >> 8), (char) axis.tag);
+                    return 1;
+                }
+                coords[i] = fixed;
+            }
+            flag_var_axis_values.erase(axis.tag);
+        }
+        if (!flag_var_axis_values.empty()) {
+            auto tag = flag_var_axis_values.begin()->first;
+            fprintf(stderr, "error: font does not support specified axis '%c%c%c%c'\n",
+                    (char) (tag >> 24), (char) (tag >> 16), (char) (tag >> 8), (char) tag);
+            return 1;
+        }
+        if (FT_Set_Var_Design_Coordinates(face, mm_var->num_axis, coords.data()) != 0) {
+            fprintf(stderr, "error: could not set variable axis values\n");
+            return 1;
+        }
+        FT_Done_MM_Var(ftlib, mm_var);
+    } else if (!flag_var_axis_values.empty()) {
+        fprintf(stderr, "error: specified axis overrides on non-variable font\n");
+        return 1;
+    }
+
     // Create a map from font64 glyph indices to truetype indices
     std::unordered_map<int, int> gidx_to_ttfidx;
 


### PR DESCRIPTION
This feature allows the developer to specify custom parameters for variable fonts in mkfont using the new `--var-axis` flag, e.g. `--var-axis wght=800` for very bold text or `--var-axis wght=100` for very thin text.

Example below with the same font ([Science Gothic](https://github.com/googlefonts/science-gothic)) with different custom slants, weights and widths:
<img width="642" height="557" alt="Skärmbild_20250902_224659" src="https://github.com/user-attachments/assets/0ae5012e-d57a-4c13-8518-f815ccf730f9" />
<img width="642" height="557" alt="Skärmbild_20250902_225003" src="https://github.com/user-attachments/assets/eab70609-d9a5-4a27-8477-1774494fb377" />
