### PR TITLE
joybus: refactor to split off detection system from joypad

### DIFF
--- a/include/joybus.h
+++ b/include/joybus.h
@@ -101,13 +101,9 @@ typedef uint16_t joybus_identifier_t;
  * @{
  */
 /**
- * @brief Joybus identifier for an unknown or malfunctioning device.
- */
-#define JOYBUS_IDENTIFIER_UNKNOWN               0x0000
-/**
  * @brief Joybus identifier for a port with no device connected.
  */
-#define JOYBUS_IDENTIFIER_NONE                  0xFFFF
+#define JOYBUS_IDENTIFIER_NONE                  0x0000
 /**
  * @brief Joybus identifier for the Nintendo 64 voice recognition peripheral (NUS-020).
  * 
@@ -248,6 +244,30 @@ typedef uint16_t joybus_identifier_t;
  */
 #define JOYBUS_IDENTIFY_STATUS_EEPROM_BUSY                0x80
 /** @} */
+
+/** @brief Joybus detection events enumeration */
+typedef enum {
+    JOYBUS_DETECT_DISCONNECTED = 0,      ///< Device was just disconnected
+    JOYBUS_DETECT_POLLED = 1,            ///< Device status was polled
+    JOYBUS_DETECT_CONNECTED = 2,         ///< Device was just connected
+} joybus_detection_event_t;
+
+
+/**
+ * @brief Initialize the Joybus subsystem, and background detection support
+ * 
+ * This function starts the Joybus subsystem. It begins periodically monitoring
+ * all the controller ports (by default, once per second), to check
+ * whether new Joybus devices (normally, controllers) are plugged-in or removed.
+ *
+ * Libraries can register callbacks to be notified of detection events for
+ * any type of device via #joybus_register_detection_callback.
+ */
+void joybus_init(void);
+
+/** @brief Deinitialize the joybus subsystem and detection support */
+void joybus_close(void);
+
 
 /**
  * @brief Callback function signature for #joybus_exec_async
@@ -404,10 +424,103 @@ inline void joybus_exec_cmd(
         (void *)&cmd.recv                 \
     )
 
+/**
+ * @brief Joybus detection callback function type.
+ * 
+ * This function is called during the periodic poll of devices performed by
+ * the joybus module. It allows libraries to build upon the Joybus subsystem
+ * to provide higher-level functionality, and being notified of changes in the
+ * connected devices.
+ * 
+ * At any point the callback is called, the device could have been just plugged,
+ * just unplugged, or just polled with no change. Since the hardware protocol
+ * allows the device to also relay a 8-bit status byte, this is also provided
+ * to the callback; the interpretation is device-specific.
+ * 
+ * @param identifier        The identifier of the Joybus device.
+ * @param event             Whether the device was just plugged in, unplugged, or
+ *                          just polled with no change.
+ * @param port              The Joybus port the device is connected to.
+ * @param device_status     The status of the Joybus device as returned by it.
+ * @param ctx               User-defined context pointer.
+ */
+typedef void (*joybus_detection_callback_t)(
+    joybus_identifier_t identifier,  joybus_detection_event_t event,
+    int port, uint8_t device_status, void *ctx);
+
+/**
+ * @brief Register a callback to be notified of Joybus detection events.
+ * 
+ * This function registers a callback to be called whenever a Joybus device
+ * is plugged in or removed. The callback is called under interrupt, so it
+ * should either issue followup joybus commands asynchronously (via
+ * #joybus_exec_async), or arrange to handle the event later in a safer context.
+ * 
+ * Multiple callbacks can be registered and they will all receive events for
+ * all devices on all ports. To unregister a callback, use
+ * #joybus_unregister_detection_callback.
+ * 
+ * If you are building support for a specific joybus device, you should register
+ * your callback, filter events for the device identifier you support, and 
+ * handle them accordingly.
+ * 
+ * @note When calling this function, the callback will be immediately notified
+ *       of all currently connected devices, with the #JOYBUS_DETECT_CONNECTED event.
+ * 
+ * @param callback      The callback function to register.
+ * @param ctx           User-defined context pointer to pass to the callback.
+ * 
+ * @see #joybus_unregister_detection_callback
+ */
+void joybus_register_detection_callback(joybus_detection_callback_t callback, void *ctx);
+
+/**
+ * @brief Unregister a callback for Joybus detection events.
+ * 
+ * @param callback      The callback function to unregister.
+ * @param ctx           User-defined context pointer passed to the callback.
+ */
+void joybus_unregister_detection_callback(joybus_detection_callback_t callback, void *ctx);
+
+/**
+ * @brief Immediately poll all Joybus ports for connected devices.
+ * 
+ * This function immediately polls all Joybus ports for connected devices,
+ * and calls any registered hotplug callbacks if any device was connected
+ * or disconnected.
+ * 
+ * Normally, the Joybus subsystem automatically polls all ports once per
+ * second. This function can be used to force an immediate poll, for example
+ * after initializing the Joybus subsystem via #joybus_init.
+ */
+void joybus_detect_now(void);
+
+/**
+ * @brief Get the Joybus identifier for a specific port.
+ * 
+ * This function returns the last known identifier for a specific Joybus port.
+ * The identifier is updated automatically by the Joybus subsystem during
+ * periodic polling, or when #joybus_detect_now is called.
+ * 
+ * @note The values returned by this function can change at any time as they
+ *       react to interrupts.
+ * 
+ * @param[in]  port                  The Joybus port (0-4) to query.
+ * @param[out] status                Optional pointer to a variable to store the device status.
+ * @return joypad_identifier_t       The Joybus identifier for the specified port.
+ */
+joybus_identifier_t joybus_get_identifier(int port, uint8_t *status);
+
+
 #ifdef __cplusplus
 }
 #endif
 
 /** @} */ /* joybus */
+
+///@cond
+// Deprecated variant of JOYBUS_IDENTIFIER_NONE
+#define JOYBUS_IDENTIFIER_UNKNOWN               0x0000
+///@endcond
 
 #endif

--- a/src/joybus/joybus.c
+++ b/src/joybus/joybus.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "debug.h"
+#include "timer.h"
 #include "interrupt.h"
 #include "joybus.h"
 #include "joybus_commands.h"
@@ -49,7 +50,8 @@ typedef struct {
     void *context;                                                     ///< callback context
 } joybus_msg_t;
 
-#define MAX_JOYBUS_MSGS            8    ///< Maximum number of pending joybus messages
+#define MAX_JOYBUS_MSGS                   8    ///< Maximum number of pending joybus messages
+#define MAX_JOYBUS_DETECTION_CALLBACKS    8    ///< Maximum number of registered detection callbacks
 
 /**
  * @anchor JOYBUS_STATE
@@ -72,11 +74,48 @@ static joybus_msg_t joybus_msgs[MAX_JOYBUS_MSGS];
 static volatile int msgs_widx;
 /** @brief Pending messages read index */
 static volatile int msgs_ridx;
+/** @brief Init counter */
+static int joybus_init_count = 0;
+/** @brief Are we in the middle of identifying the devices? */
+static volatile bool joybus_identify_pending = false;
+/** @brief Is the cached Joybus input block for identifying Joypads valid? */
+static volatile uint8_t joybus_identify_input_valid = false;
+/** @brief Cached Joybus input block for identifying all Joypads. */
+static volatile uint8_t joybus_identify_input[JOYBUS_BLOCK_SIZE] = {0};
+/** @brief Joybus identifiers for each port. */
+volatile joybus_identifier_t joybus_identifiers_hot[JOYBUS_PORT_COUNT] = {0};
+/** @brief Joybus identify status bytes for each port. */
+volatile uint8_t joybus_identify_status_hot[JOYBUS_PORT_COUNT] = {0};
+/** @brief Timer used to periodically identify the devices. */
+static timer_link_t *identify_timer = NULL;
+
+/**
+ * @brief Number of ticks between Joybus identify commands.
+ *
+ * During VI interrupt, the Joypad subsystem will periodically re-identify
+ * the connected devices to check if the identifier has changed or if any
+ * accessories have been connected/disconnected.
+ */
+#define JOYBUS_IDENTIFY_INTERVAL_TICKS      (1 * TICKS_PER_SECOND)
+
+/** @brief Detection callback entry */
+typedef struct {
+    joybus_detection_callback_t callback;       ///< callback function
+    void *ctx;                                  ///< callback context
+} detection_entry_t;
+
+/** @brief Callbacks for detection events */
+static detection_entry_t detection_callbacks[MAX_JOYBUS_DETECTION_CALLBACKS];
 
 static void si_interrupt(void);
 
 /**
  * @brief Initialize the joybus subsystem
+ * 
+ * NOTE: historically, the low-level part of the joybus subsystem (eg: joybus_exec)
+ * has always worked without an init function. So even if a proper #joybus_init
+ * exists now, we still need to initialize the low-level part of the subsystem
+ * automatically before the first use. This is done via a constructor function.
  */
 __attribute__((constructor))
 void __joybus_init(void)
@@ -246,6 +285,235 @@ void joybus_exec( const void * input, void * output )
             enable_interrupts();
         }
     }
+}
+
+static void send_detection_event(joybus_identifier_t identifier, joybus_detection_event_t event, int port, uint8_t device_status)
+{
+    for (int i = 0; i < MAX_JOYBUS_DETECTION_CALLBACKS; i++) {
+        if (detection_callbacks[i].callback) {
+            detection_callbacks[i].callback(identifier, event, port, device_status, detection_callbacks[i].ctx);
+        }
+    }
+}
+
+void joybus_register_detection_callback(joybus_detection_callback_t callback, void *ctx)
+{
+    disable_interrupts();
+    for (int i = 0; i < MAX_JOYBUS_DETECTION_CALLBACKS; i++) {
+        if (detection_callbacks[i].callback == NULL) {
+            detection_callbacks[i].callback = callback;
+            detection_callbacks[i].ctx = ctx;
+
+            // Notify the callback of all currently connected devices
+            for (int port = 0; port < JOYBUS_PORT_COUNT; port++) {
+                joybus_identifier_t identifier = joybus_identifiers_hot[port];
+                uint8_t device_status = joybus_identify_status_hot[port];
+                if (identifier != JOYBUS_IDENTIFIER_NONE) {
+                    callback(identifier, JOYBUS_DETECT_POLLED, port, device_status, ctx);
+                }
+            }
+
+            enable_interrupts();
+            return;
+        }
+    }
+    assertf(false, "Too many detection callbacks registered");
+    enable_interrupts();
+}
+
+void joybus_unregister_detection_callback(joybus_detection_callback_t callback, void *ctx)
+{
+    disable_interrupts();
+    for (int i = 0; i < MAX_JOYBUS_DETECTION_CALLBACKS; i++) {
+        if (detection_callbacks[i].callback == callback && detection_callbacks[i].ctx == ctx) {
+            detection_callbacks[i].callback = NULL;
+            detection_callbacks[i].ctx = NULL;
+            enable_interrupts();
+            return;
+        }
+    }
+    assertf(false, "Callback was not registered");
+    enable_interrupts();
+}
+
+static void joybus_input_identify( uint8_t input[JOYBUS_BLOCK_SIZE], bool reset )
+{
+    const joybus_cmd_identify_port_t cmd = { .send = {
+        .command = reset ? JOYBUS_COMMAND_ID_RESET : JOYBUS_COMMAND_ID_IDENTIFY,
+    } };
+    const size_t recv_offset = offsetof(typeof(cmd), recv);
+    size_t i = 0;
+
+    // Populate the Joybus commands on each port
+    memset(input, 0x00, JOYBUS_BLOCK_SIZE);
+    for (int port = 0; port < JOYBUS_PORT_COUNT-1; port++)
+    {
+        // iQue PIF requires a NOP (0xFF) before each command
+        if (sys_bbplayer()) input[i++] = 0xFF;
+        // Set the command metadata
+        input[i++] = sizeof(cmd.send);
+        input[i++] = sizeof(cmd.recv);
+        // Micro-optimization: Minimize copy length
+        memcpy(&input[i], &cmd, recv_offset);
+        i += sizeof(cmd);
+        // iQue PIF requires commands to be 8-byte aligned
+        if (sys_bbplayer()) while (i & 7) input[i++] = 0xFF;
+    }
+
+    // Close out the Joybus operation block
+    input[i] = 0xFE;
+    input[JOYBUS_BLOCK_SIZE - 1] = 0x01;
+}
+
+/**
+ * @brief Callback for identifying Joypads.
+ * 
+ * @param[in] out_dwords Joybus output block.
+ * @param[in,out] ctx Not used.
+ */
+static void joybus_identify_callback(uint64_t *out_dwords, void *ctx)
+{
+    const uint8_t *out_bytes = (void *)out_dwords;
+    const joybus_cmd_identify_port_t *cmd;
+    size_t i = 0;
+
+    for (int port = 0; port < JOYBUS_PORT_COUNT; port++)
+    {
+        if (sys_bbplayer()) {
+            // iQue has a very fixed layout for commands, and it also tends
+            // to corrupt other parts of PIF-RAM. So better jump to fixed positions
+            // while parsing.
+            if (port == 4) break;
+            i = (port * 8) + 1;
+        }
+
+        volatile joybus_identifier_t *old_identifier = &joybus_identifiers_hot[port];
+        volatile uint8_t *old_status = &joybus_identify_status_hot[port];
+
+        cmd = (void *)&out_bytes[i + JOYBUS_COMMAND_METADATA_SIZE];
+
+        joybus_identifier_t new_identifier = cmd->recv.identifier;
+        uint8_t new_status = cmd->recv.status;
+        if (out_bytes[i+1] & 0x80) {
+            // If the error flag is set, no device is connected here
+            new_identifier = JOYBUS_IDENTIFIER_NONE;
+            new_status = 0;
+        }
+
+        // Now check if the identifier has changed since last time
+        if (new_identifier != *old_identifier)
+        {
+            if (*old_identifier != JOYBUS_IDENTIFIER_NONE)
+                send_detection_event(*old_identifier, JOYBUS_DETECT_DISCONNECTED, port, *old_status);
+            if (new_identifier != JOYBUS_IDENTIFIER_NONE)
+                send_detection_event(new_identifier, JOYBUS_DETECT_CONNECTED, port, new_status);
+        }
+        else if (new_identifier != JOYBUS_IDENTIFIER_NONE)
+        {
+            send_detection_event(new_identifier, JOYBUS_DETECT_POLLED, port, new_status);
+        }
+        
+        *old_identifier = new_identifier;
+        *old_status = new_status;
+        i += JOYBUS_COMMAND_METADATA_SIZE + sizeof(*cmd);
+    }
+
+    joybus_identify_pending = false;
+}
+
+/**
+ * @brief Identify Joypads asynchronously.
+ * 
+ * @param reset Whether to reset the devices.
+ */
+static void joybus_identify_async(bool reset)
+{
+    // Async operations are disabled during reset
+    if( exception_reset_time() > 0 ) { return; }
+
+    // Bail if this operation is already in-progress
+    if (joybus_identify_pending) { return; }
+    joybus_identify_pending = true;
+
+    uint8_t * const input = (void *)joybus_identify_input;
+    // Reset invalidates the cached input block
+    if (!joybus_identify_input_valid || reset)
+    {
+        joybus_input_identify(input, reset);
+        // Identify is more common than reset, so don't cache resets
+        joybus_identify_input_valid = !reset;
+    }
+
+    joybus_exec_async(input, joybus_identify_callback, NULL);
+}
+
+static void joybus_identify_wait(void)
+{
+    kirq_wait_t w = kirq_begin_wait_si();
+    while (joybus_identify_pending) {
+        if (__kernel)
+            kirq_wait(&w);
+    }
+}
+
+static void timer_callback(int ovfl, void *ctx)
+{
+    bool reset = (bool)ctx;
+    joybus_identify_async(reset);
+}
+
+void joybus_init(void)
+{
+    // NOTE: the actual SI/interrupt initialization is done in __joybus_init()
+    // which is a constructor function that runs before main().
+    // This function effectively just initializes the periodic polling and
+    // background detection system.
+    if (joybus_init_count++ > 0) { return; }
+
+    // Start a timer (period 1 second) to periodically identify the devices
+    timer_init();
+    identify_timer = new_timer_context(JOYBUS_IDENTIFY_INTERVAL_TICKS, TF_CONTINUOUS, timer_callback, (void*)false);
+
+    // Run a first detection pass immediately, so that after joybus_init(),
+    // at least we have a first snapshot of the connected devices.
+    joybus_identify_async(true);
+    joybus_identify_wait();
+}
+
+void joybus_close(void)
+{
+    if (--joybus_init_count > 0) { return; }
+
+    // Stop the identify timer, and deinitialize the timer subsystem
+    delete_timer(identify_timer); identify_timer = NULL;
+    timer_close();
+    
+    // Make sure we are not in the middle of an identify operation, otherwise
+    // we must wait until it's finished
+    joybus_identify_wait();
+
+    // Clear all registered detection callbacks.
+    memset(detection_callbacks, 0, sizeof(detection_callbacks));
+}
+
+void joybus_detect_now(void)
+{
+    joybus_identify_async(false);
+    joybus_identify_wait();
+}
+
+joybus_identifier_t joybus_get_identifier(int port, uint8_t *status)
+{
+    assert((port >= 0) && (port < JOYBUS_PORT_COUNT));
+    joybus_identifier_t identifier;
+
+    // Return a consistent snapshot of identifier and status
+    disable_interrupts();
+    if (status) *status = joybus_identify_status_hot[port];
+    identifier = joybus_identifiers_hot[port];
+    enable_interrupts();
+
+    return identifier;
 }
 
 extern inline void joybus_exec_cmd(int port, size_t send_len, size_t recv_len, const void *send_data, void *recv_data);

--- a/src/joybus/joypad.c
+++ b/src/joybus/joypad.c
@@ -22,14 +22,6 @@
  * @{
  */
 
-/**
- * @brief Number of ticks between Joybus identify commands.
- *
- * During VI interrupt, the Joypad subsystem will periodically re-identify
- * the connected devices to check if the identifier has changed or if any
- * accessories have been connected/disconnected.
- */
-#define JOYPAD_IDENTIFY_INTERVAL_TICKS TICKS_PER_SECOND
 
 /** @brief Convenience macro to ensure Joypad subsystem is initialized. */
 #define ASSERT_JOYPAD_INITIALIZED() \
@@ -61,15 +53,6 @@ static joypad_port_t bb_hack_flags_swap_port( joypad_port_t port )
  * @name "Hot" (interrupt-driven) global state
  * @{
  */
-/** @brief Timer ticks when the Joypads were last identified. */
-static volatile uint32_t joypad_identify_last_ticks = 0;
-/** @brief Are we in the middle of identifying the Joypads? */
-static volatile bool joypad_identify_pending = false;
-/** @brief Is the cached Joybus input block for identifying Joypads valid? */
-static volatile uint8_t joypad_identify_input_valid = false;
-/** @brief Cached Joybus input block for identifying all Joypads. */
-static volatile uint8_t joypad_identify_input[JOYBUS_BLOCK_SIZE] = {0};
-
 /** @brief Are we in the middle of reading the Joypads? */
 static volatile bool joypad_read_pending = false;
 /** @brief Is the cached Joybus input block for reading Joypads valid? */
@@ -88,8 +71,6 @@ static volatile bool joypad_gcn_origin_input_valid = false;
 /** @brief Cached Joybus input block for reading GameCube origins. */
 static volatile uint8_t joypad_gcn_origin_input[JOYBUS_BLOCK_SIZE] = {0};
 
-/** @brief Joypad identifiers for each port. */
-volatile joybus_identifier_t joypad_identifiers_hot[JOYPAD_PORT_COUNT] = {0};
 /** @brief Joypad "hot" devices for each port. */
 volatile joypad_device_hot_t joypad_devices_hot[JOYPAD_PORT_COUNT] = {0};
 /** @brief Joypad origins for each port. */
@@ -108,50 +89,6 @@ static int joypad_init_refcount = 0;
 /** @brief Joypad "cold" devices for each port. */
 static joypad_device_cold_t joypad_devices_cold[JOYPAD_PORT_COUNT] = {0};
 /** @} */ /* joypad_cold_state */
-
-/**
- * @brief Reinitialize the state of a Joypad device when its identifier changes.
- * 
- * @param port Joypad port to reinitialize.
- * @param identifier New Joypad identifier for the port.
- */
-static void joypad_device_changed(joypad_port_t port, joybus_identifier_t identifier)
-{
-    joypad_identifiers_hot[port] = identifier;
-    joypad_origins_hot[port] = JOYPAD_GCN_ORIGIN_INIT;
-    memset((void *)&joypad_devices_cold[port], 0, sizeof(joypad_devices_cold[port]));
-    memset((void *)&joypad_devices_hot[port], 0, sizeof(joypad_devices_hot[port]));
-    joypad_accessory_reset(port);
-}
-
-static void joybus_input_identify( uint8_t input[JOYBUS_BLOCK_SIZE], bool reset )
-{
-    const joybus_cmd_identify_port_t cmd = { .send = {
-        .command = reset ? JOYBUS_COMMAND_ID_RESET : JOYBUS_COMMAND_ID_IDENTIFY,
-    } };
-    const size_t recv_offset = offsetof(typeof(cmd), recv);
-    size_t i = 0;
-
-    // Populate the Joybus commands on each port
-    memset(input, 0x00, JOYBUS_BLOCK_SIZE);
-    JOYPAD_PORT_FOREACH (port)
-    {
-        // iQue PIF requires a NOP (0xFF) before each command
-        if (sys_bbplayer()) input[i++] = 0xFF;
-        // Set the command metadata
-        input[i++] = sizeof(cmd.send);
-        input[i++] = sizeof(cmd.recv);
-        // Micro-optimization: Minimize copy length
-        memcpy(&input[i], &cmd, recv_offset);
-        i += sizeof(cmd);
-        // iQue PIF requires commands to be 8-byte aligned
-        if (sys_bbplayer()) while (i & 7) input[i++] = 0xFF;
-    }
-
-    // Close out the Joybus operation block
-    input[i] = 0xFE;
-    input[JOYBUS_BLOCK_SIZE - 1] = 0x01;
-}
 
 static void joybus_input_read_n64_controllers( uint8_t input[JOYBUS_BLOCK_SIZE] )
 {
@@ -391,45 +328,66 @@ static void joypad_gcn_origin_check_async(void)
     joybus_exec_async(input, joypad_gcn_origin_callback, NULL);
 }
 
-/**
- * @brief Callback for identifying Joypads.
- * 
- * @param[in] out_dwords Joybus output block.
- * @param[in,out] ctx Not used.
- */
-static void joypad_identify_callback(uint64_t *out_dwords, void *ctx)
+static void joypad_device_reset(int port)
 {
-    const uint8_t *out_bytes = (void *)out_dwords;
-    const joybus_cmd_identify_port_t *cmd;
-    volatile joypad_device_hot_t *device;
-    volatile joypad_accessory_t *accessory;
-    bool devices_changed = false;
-    size_t i = 0;
+    memset((void *)&joypad_devices_hot[port], 0, sizeof(joypad_devices_hot[port]));
+    joypad_origins_hot[port] = JOYPAD_GCN_ORIGIN_INIT;
+    joypad_accessory_reset(port);
+    joypad_read_input_valid = false;
+}
 
-    JOYPAD_PORT_FOREACH (port)
+/**
+ * @brief Process a new status byte for an N64 controller to handle accessory changes.
+ */
+static void joypad_accessory_polled(int port, uint8_t new_status)
+{
+    volatile joypad_device_hot_t *device = &joypad_devices_hot[port];   
+    volatile joypad_accessory_t *accessory = &joypad_accessories_hot[port];
+    assert(device->style == JOYPAD_STYLE_N64); // Only N64 controllers have accessories
+
+    uint8_t prev_accessory_status = accessory->status;
+    uint8_t accessory_status = new_status & JOYBUS_IDENTIFY_STATUS_ACCESSORY_MASK;
+    // Work-around third-party controllers that don't correctly report accessory status
+    bool accessory_absent = (
+        accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT ||
+        accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED
+    );
+    bool accessory_changed = (
+        accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_CHANGED ||
+        (
+            accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
+            prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
+            prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_CHANGED
+        )
+    );
+    if (accessory_absent || accessory_changed)
     {
-        if (sys_bbplayer()) {
-            // iQue has a very fixed layout for commands, and it also tends
-            // to corrupt other parts of PIF-RAM. So better jump to fixed positions
-            // while parsing.
-            i = (port * 8) + 1;
-        }
-        device = &joypad_devices_hot[port];
-        accessory = &joypad_accessories_hot[port];
-        cmd = (void *)&out_bytes[i + JOYBUS_COMMAND_METADATA_SIZE];
+        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
+        accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
+        device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
+        device->rumble_active = false;
+    }
+    if (accessory_changed)
+    {
+        accessory->type = JOYPAD_ACCESSORY_TYPE_UNKNOWN;
+        joypad_accessory_detect_async(port);
+    }
+    accessory->status = accessory_status;
+}
 
-        joybus_identifier_t identifier = cmd->recv.identifier;
-        if (out_bytes[i+1] & 0x80) {
-            // If the error flag is set, no device is connected here
-            identifier = JOYBUS_IDENTIFIER_NONE;
-        }
-        if (joypad_identifiers_hot[port] != identifier)
-        {
-            // The identifier has changed; reinitialize device state
-            joypad_device_changed(port, identifier);
-            devices_changed = true;
-        }
+/** @brief Callback when a new device is installed or removed. */
+static void joypad_detect_callback(
+    joybus_identifier_t identifier,  joybus_detection_event_t event,
+    int port, uint8_t device_status, void *ctx
+) {
+    volatile joypad_device_hot_t *device = &joypad_devices_hot[port];
 
+    debugf("port: %d, id: 0x%04X, event: %d, status: 0x%02X\n",
+        port, identifier, event, device_status
+    );
+
+    switch (event) {
+    case JOYBUS_DETECT_CONNECTED:
         if (
             (identifier & JOYBUS_IDENTIFIER_MASK_PLATFORM) == JOYBUS_IDENTIFIER_PLATFORM_GCN &&
             (identifier & JOYBUS_IDENTIFIER_MASK_GCN_CONTROLLER)
@@ -441,76 +399,31 @@ static void joypad_identify_callback(uint64_t *out_dwords, void *ctx)
               ? JOYPAD_RUMBLE_METHOD_GCN_CONTROLLER
               : JOYPAD_RUMBLE_METHOD_NONE;
             device->rumble_active = has_rumble && device->rumble_active;
+            joypad_read_input_valid = false;
         }
         else if (identifier == JOYBUS_IDENTIFIER_N64_CONTROLLER)
         {
             device->style = JOYPAD_STYLE_N64;
-            uint8_t prev_accessory_status = accessory->status;
-            uint8_t accessory_status = cmd->recv.status & JOYBUS_IDENTIFY_STATUS_ACCESSORY_MASK;
-            // Work-around third-party controllers that don't correctly report accessory status
-            bool accessory_absent = (
-                accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT ||
-                accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED
-            );
-            bool accessory_changed = (
-                accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_CHANGED ||
-                (
-                    accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
-                    prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
-                    prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_CHANGED
-                )
-            );
-            if (accessory_absent || accessory_changed)
-            {
-                accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-                accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
-                device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
-                device->rumble_active = false;
-            }
-            if (accessory_changed)
-            {
-                accessory->type = JOYPAD_ACCESSORY_TYPE_UNKNOWN;
-                joypad_accessory_detect_async(port);
-            }
-            accessory->status = accessory_status;
+            joypad_accessory_polled(port, device_status);
+            joypad_read_input_valid = false;
         }
         else if (identifier == JOYBUS_IDENTIFIER_N64_MOUSE)
         {
             device->style = JOYPAD_STYLE_MOUSE;
+            joypad_read_input_valid = false;
         }
+        break;
 
-        i += JOYBUS_COMMAND_METADATA_SIZE + sizeof(*cmd);
+    case JOYBUS_DETECT_POLLED:
+        if (device->style == JOYPAD_STYLE_N64)
+            joypad_accessory_polled(port, device_status);
+        break;
+
+    case JOYBUS_DETECT_DISCONNECTED:
+        joypad_device_reset(port);
+        break;
+
     }
-
-    if (devices_changed) joypad_read_input_valid = false;
-    joypad_identify_last_ticks = TICKS_READ();
-    joypad_identify_pending = false;
-}
-
-/**
- * @brief Identify Joypads asynchronously.
- * 
- * @param reset Whether to reset the devices.
- */
-static void joypad_identify_async(bool reset)
-{
-    // Async operations are disabled during reset
-    if( exception_reset_time() > 0 ) { return; }
-
-    // Bail if this operation is already in-progress
-    if (joypad_identify_pending) { return; }
-    joypad_identify_pending = true;
-
-    uint8_t * const input = (void *)joypad_identify_input;
-    // Reset invalidates the cached input block
-    if (!joypad_identify_input_valid || reset)
-    {
-        joybus_input_identify(input, reset);
-        // Identify is more common than reset, so don't cache resets
-        joypad_identify_input_valid = !reset;
-    }
-
-    joybus_exec_async(input, joypad_identify_callback, NULL);
 }
 
 /**
@@ -549,7 +462,6 @@ static void joypad_read_async(void)
     if (!joypad_read_input_valid)
     {
         volatile joypad_device_hot_t *device;
-        joybus_identifier_t identifier;
         size_t i = 0;
 
         // Populate Joybus controller read commands on each port
@@ -558,10 +470,9 @@ static void joypad_read_async(void)
         {
             joypad_read_input_offsets[port] = i;
             device = &joypad_devices_hot[port];
-            identifier = joypad_identifiers_hot[port];
 
-             if (device->style == JOYPAD_STYLE_GCN)
-            {
+            switch (device->style) {
+            case JOYPAD_STYLE_GCN: {
                 const joybus_cmd_gcn_controller_read_port_t cmd = { .send = {
                     .command = JOYBUS_COMMAND_ID_GCN_CONTROLLER_READ,
                     .mode = 3, // Most-compatible analog mode
@@ -574,12 +485,9 @@ static void joypad_read_async(void)
                 const size_t recv_offset = offsetof(typeof(cmd), recv);
                 memcpy(&input[i], &cmd, recv_offset);
                 i += sizeof(cmd);
-            }
-            else if (
-                identifier == JOYBUS_IDENTIFIER_N64_CONTROLLER ||
-                identifier == JOYBUS_IDENTIFIER_N64_MOUSE
-            )
-            {
+            }   break;
+            case JOYPAD_STYLE_N64:
+            case JOYPAD_STYLE_MOUSE: {
                 const joybus_cmd_n64_controller_read_port_t cmd = { .send = {
                     .command = JOYBUS_COMMAND_ID_N64_CONTROLLER_READ,
                 } };
@@ -590,11 +498,11 @@ static void joypad_read_async(void)
                 const size_t recv_offset = offsetof(typeof(cmd), recv);
                 memcpy(&input[i], &cmd, recv_offset);
                 i += sizeof(cmd);
-            }
-            else
-            {
+            }   break;
+            default:
                 // Skip this port
                 i += JOYBUS_COMMAND_SKIP_SIZE;
+                break;
             }
         }
 
@@ -614,11 +522,6 @@ static void joypad_read_async(void)
 static void joypad_vi_interrupt_callback(void* ctx)
 {
     joypad_read_async();
-    int32_t ticks_since_identify = TICKS_SINCE(joypad_identify_last_ticks);
-    if (ticks_since_identify > JOYPAD_IDENTIFY_INTERVAL_TICKS)
-    {
-        joypad_identify_async(false);
-    }
 }
 
 /**
@@ -656,23 +559,6 @@ static void joypad_reset_interrupt_callback(void)
                 break;
         }
     }
-}
-
-/**
- * @brief Re-identify and reset all Joypads and wait for completion.
- */
-static void joypad_reset(void)
-{
-    ASSERT_JOYPAD_INITIALIZED();
-    // Async operations are disabled during reset
-    if( exception_reset_time() > 0 ) { return; }
-
-    // Wait for pending identify/reset operation to resolve
-    while (joypad_identify_pending) { /* Spinlock */ }
-    // Enqueue this identify/reset operation
-    joypad_identify_async(true);
-    // Wait for the operation to finish
-    while (joypad_identify_pending) { /* Spinlock */ }
 }
 
 /**
@@ -722,20 +608,26 @@ void joypad_init(void)
     // Just increment the refcount if already initialized
 	if (joypad_init_refcount++ > 0) { return; }
 
+    // We depend on the joybus subsystem
+    joybus_init();
+
     // Initialize the VI subsystem so that we can poll in sync with VI interrupts
     vi_init();
 
-    // Initialize the timer subsystem (or increment its refcount)
+    // Initialize the timer subsystem (used by accessory detection)
     timer_init();
 
-    // Reinitialize all Joypad devices to unknown state
+    // Reset global structures
     JOYPAD_PORT_FOREACH (port)
     {
-        joypad_device_changed(port, JOYBUS_IDENTIFIER_UNKNOWN);
+        joypad_device_reset(port);
     }
 
+    // Register callbacks for device detection
+    joybus_register_detection_callback(joypad_detect_callback, NULL);
+
     // Ensure the Joypads are ready immediately after init returns
-    joypad_reset();
+    joybus_detect_now();
     joypad_read();
 
     // Update the Joypads on vblank interrupt
@@ -756,6 +648,7 @@ void joypad_close(void)
     // Decrement the timer subsystem refcount (possibly closing it)
     timer_close();
     vi_close();
+    joybus_close();
 }
 
 void joypad_poll(void)
@@ -772,7 +665,6 @@ void joypad_poll(void)
     disable_interrupts();
     memcpy(output, (void *)joypad_read_output, sizeof(output));
     memcpy(origins, (void *)joypad_origins_hot, sizeof(origins));
-    memcpy(identifiers, (void *)joypad_identifiers_hot, sizeof(identifiers));
     enable_interrupts();
 
     uint8_t send_len, recv_len, command_id, command_len;
@@ -864,8 +756,7 @@ bool joypad_is_connected(joypad_port_t port)
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
     switch( joypad_devices_cold[port].identifier ) {
-        case JOYBUS_IDENTIFIER_NONE:
-        case JOYBUS_IDENTIFIER_UNKNOWN: return false;
+        case JOYBUS_IDENTIFIER_NONE:    return false;
         default:                        return true;
     }
 }
@@ -889,20 +780,6 @@ joypad_accessory_type_t joypad_get_accessory_type(joypad_port_t port)
     ASSERT_JOYPAD_INITIALIZED();
     ASSERT_JOYPAD_PORT_VALID(port);
     return joypad_accessories_hot[port].type;
-}
-
-int joypad_get_accessory_state(joypad_port_t port)
-{
-    ASSERT_JOYPAD_INITIALIZED();
-    ASSERT_JOYPAD_PORT_VALID(port);
-    return joypad_accessories_hot[port].state;
-}
-
-int joypad_get_accessory_error(joypad_port_t port)
-{
-    ASSERT_JOYPAD_INITIALIZED();
-    ASSERT_JOYPAD_PORT_VALID(port);
-    return joypad_accessories_hot[port].error;
 }
 
 uint8_t joypad_get_transfer_pak_status(joypad_port_t port)

--- a/src/joybus/joypad_internal.h
+++ b/src/joybus/joypad_internal.h
@@ -105,7 +105,6 @@ typedef struct joypad_device_hot_s
     bool rumble_active;
 } joypad_device_hot_t;
 
-extern volatile joybus_identifier_t joypad_identifiers_hot[JOYPAD_PORT_COUNT];
 extern volatile joypad_device_hot_t joypad_devices_hot[JOYPAD_PORT_COUNT];
 extern volatile joypad_gcn_origin_t joypad_origins_hot[JOYPAD_PORT_COUNT];
 extern volatile joypad_accessory_t  joypad_accessories_hot[JOYPAD_PORT_COUNT];
@@ -124,23 +123,6 @@ extern volatile joypad_accessory_t  joypad_accessories_hot[JOYPAD_PORT_COUNT];
  * @return Joypad inputs structure (#joypad_inputs_t)
  */
 joypad_inputs_t joypad_read_n64_inputs(joypad_port_t port);
-
-/**
- * @brief Get the Joypad accessory state for a Joypad port.
- * 
- * @param port Joypad port number (#joypad_port_t)
- * 
- * @return Joypad accessory state enumeration value 
- */
-int joypad_get_accessory_state(joypad_port_t port);
-
-/**
- * @brief Get the Joypad accessory error for a Joypad port.
- * 
- * @param port Joypad port number (#joypad_port_t)
- * @return Joypad accessory error enumeration value 
- */
-int joypad_get_accessory_error(joypad_port_t port);
 
 #ifdef __cplusplus
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -424,6 +424,9 @@ kthread_t* kernel_init(void)
 	// Initialize IRQ condition variables
 	__kirq_init();
 
+	// Initialize TLS support
+	__ktls_init();
+
 	// Kernel is now initialized
 	__kernel = true;
 
@@ -448,7 +451,7 @@ void kernel_close(void)
 	th_cur = NULL;
 	__kernel = false;
 	__isr_force_schedule = false;
-	__th_cur_tp = KERNEL_TP_INVALID;
+	__ktls_close();
 }
 
 kthread_t* __kthread_new_internal(const char *name, int stack_size, int8_t pri, uint8_t flag, int (*user_entry)(void*), void *user_data)

--- a/src/kernel/ktls.c
+++ b/src/kernel/ktls.c
@@ -6,7 +6,4 @@
 #include "ktls_internal.h"
 
 /** Initialize TLS pointer to the tls_base area in RAM */
-void *th_cur_tp = __tls_base + TP_OFFSET;
-
-/** @brief Current thread TLS pointer */
-void *__th_cur_tp;
+void *__th_cur_tp = __tls_base + TP_OFFSET;

--- a/src/kernel/ktls.c
+++ b/src/kernel/ktls.c
@@ -5,5 +5,17 @@
 
 #include "ktls_internal.h"
 
-/** Initialize TLS pointer to the tls_base area in RAM */
-void *__th_cur_tp = __tls_base + TP_OFFSET;
+/** @brief Current thread TLS pointer */
+void *__th_cur_tp;
+
+void __ktls_init(void)
+{
+    // Set the initial thread pointer to the TLS area in the data section,
+    // which will be used for the main thread
+    __th_cur_tp = __tls_base + TP_OFFSET;
+}
+
+void __ktls_close(void)
+{
+    __th_cur_tp = KERNEL_TP_INVALID;
+}

--- a/src/kernel/ktls_internal.h
+++ b/src/kernel/ktls_internal.h
@@ -40,4 +40,10 @@ extern char __tbss_end[];
 
 extern void *__th_cur_tp;
 
+/** @brief Initialize TLS support */
+void __ktls_init(void);
+
+/** @brief Close TLS support */
+void __ktls_close(void);
+
 #endif


### PR DESCRIPTION
This PR splits off the background detection system from joypad, and move it into joybus.

This creates a clear, lower-level API to detect plugging / unplugging of any joybus devices to the 5 ports (the fifth channel has only been used until now for fixed devices like eeprom or RTC, it doesn't mean that future flashcart couldn't allow to hotplug those or other devices). 

Somebody willing to develop a new joybus device (not joypad related) can now use the joybus API as a base layer to implement a module to drive it. Using detection callbacks, the library can also be automatically informed automatically whenever the device is plugged/unplugged, without having to implement its own polling.

This also means that the joypad module is now more clearly only related to joypads or joypad-like devices (mouse), plus of course the whole pak ecosystem that builds upon the N64 controller.

Followups:
 • We should really come up with a nice API to build and parse PIF packets (multiple channels). The structures used by joypad.c somehow simplify building a single joybus command but not assembling or parsing the whole PIF packet. That would remove even more code from the joypad library, making it available.
 • Should we port also eeprom.c to the new joybus detection? Currently, eeprom_status() issues its own identify command but it could probably just rely on `joybus_get_identifer()` now. Also eeprom.c could use the previous API once it exists.
 • Should we deprecate `joypad_get_identifier`? It seems the main difference compared to `joybus_get_identifier` is that it returns the cold state instead of the hot state. But this said, now that there is a joybus API to read the low-level identifier, maybe `joypad_get_style()` is sufficient.