### PR TITLE
build: Support custom target triples with N64_TARGET variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ tools/dumpdfs/dumpdfs
 tools/mkdfs/mkdfs
 tools/mksprite/convtool
 tools/mksprite/mksprite
+tools/cpaktool/cpaktool
+tools/mkmaterial/mkmaterial
 tools/n64tool
 tools/n64sym
 tools/**/*.exe

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include n64.mk
 INSTALLDIR = $(N64_INST)
 
 # N64_INCLUDEDIR is normally (when building roms) a path to the installed include files
-# (e.g. /opt/libdragon/mips64-elf/include), set in n64.mk
+# (e.g. /opt/libdragon/$(N64_TARGET)/include), set in n64.mk
 # When building libdragon, override it to use the source include files instead (./include)
 N64_INCLUDEDIR = $(CURDIR)/include
 
@@ -121,26 +121,26 @@ $(INSTALLDIR)/include/n64.mk: n64.mk
 	install -cv -m 0644 n64.mk $(INSTALLDIR)/include/n64.mk
 
 install: install-mk libdragon
-	mkdir -p $(INSTALLDIR)/mips64-elf/lib
-	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/mips64-elf/lib/libdragon.a
-	install -Cv -m 0644 n64.ld $(INSTALLDIR)/mips64-elf/lib/n64.ld
-	install -Cv -m 0644 dso.ld $(INSTALLDIR)/mips64-elf/lib/dso.ld
-	install -Cv -m 0644 rsp.ld $(INSTALLDIR)/mips64-elf/lib/rsp.ld
-	install -Cv -m 0644 libdragonsys.a $(INSTALLDIR)/mips64-elf/lib/libdragonsys.a
-	mkdir -p $(INSTALLDIR)/mips64-elf/include
-	install -Cv -m 0644 include/*.h $(INSTALLDIR)/mips64-elf/include/
-	install -Cv -m 0644 include/*.inc $(INSTALLDIR)/mips64-elf/include/
-	install -Cv -m 0644 include/ucode.S $(INSTALLDIR)/mips64-elf/include/
-	mkdir -p $(INSTALLDIR)/mips64-elf/include/GL
-	install -Cv -m 0644 include/GL/*.h $(INSTALLDIR)/mips64-elf/include/GL/
-	mkdir -p $(INSTALLDIR)/mips64-elf/include/newlib_overrides
-	install -Cv -m 0644 include/newlib_overrides/*.h $(INSTALLDIR)/mips64-elf/include/newlib_overrides/
-	mkdir -p $(INSTALLDIR)/mips64-elf/include/libcart
-	install -Cv -m 0644 src/libcart/cart.h $(INSTALLDIR)/mips64-elf/include/libcart/cart.h
-	mkdir -p $(INSTALLDIR)/mips64-elf/include/fatfs
-	install -Cv -m 0644 src/fatfs/diskio.h $(INSTALLDIR)/mips64-elf/include/fatfs/diskio.h
-	install -Cv -m 0644 src/fatfs/ff.h $(INSTALLDIR)/mips64-elf/include/fatfs/ff.h
-	install -Cv -m 0644 src/fatfs/ffconf.h $(INSTALLDIR)/mips64-elf/include/fatfs/ffconf.h
+	mkdir -p $(INSTALLDIR)/$(N64_TARGET)/lib
+	install -Cv -m 0644 libdragon.a $(INSTALLDIR)/$(N64_TARGET)/lib/libdragon.a
+	install -Cv -m 0644 n64.ld $(INSTALLDIR)/$(N64_TARGET)/lib/n64.ld
+	install -Cv -m 0644 dso.ld $(INSTALLDIR)/$(N64_TARGET)/lib/dso.ld
+	install -Cv -m 0644 rsp.ld $(INSTALLDIR)/$(N64_TARGET)/lib/rsp.ld
+	install -Cv -m 0644 libdragonsys.a $(INSTALLDIR)/$(N64_TARGET)/lib/libdragonsys.a
+	mkdir -p $(INSTALLDIR)/$(N64_TARGET)/include
+	install -Cv -m 0644 include/*.h $(INSTALLDIR)/$(N64_TARGET)/include/
+	install -Cv -m 0644 include/*.inc $(INSTALLDIR)/$(N64_TARGET)/include/
+	install -Cv -m 0644 include/ucode.S $(INSTALLDIR)/$(N64_TARGET)/include/
+	mkdir -p $(INSTALLDIR)/$(N64_TARGET)/include/GL
+	install -Cv -m 0644 include/GL/*.h $(INSTALLDIR)/$(N64_TARGET)/include/GL/
+	mkdir -p $(INSTALLDIR)/$(N64_TARGET)/include/newlib_overrides
+	install -Cv -m 0644 include/newlib_overrides/*.h $(INSTALLDIR)/$(N64_TARGET)/include/newlib_overrides/
+	mkdir -p $(INSTALLDIR)/$(N64_TARGET)/include/libcart
+	install -Cv -m 0644 src/libcart/cart.h $(INSTALLDIR)/$(N64_TARGET)/include/libcart/cart.h
+	mkdir -p $(INSTALLDIR)/$(N64_TARGET)/include/fatfs
+	install -Cv -m 0644 src/fatfs/diskio.h $(INSTALLDIR)/$(N64_TARGET)/include/fatfs/diskio.h
+	install -Cv -m 0644 src/fatfs/ff.h $(INSTALLDIR)/$(N64_TARGET)/include/fatfs/ff.h
+	install -Cv -m 0644 src/fatfs/ffconf.h $(INSTALLDIR)/$(N64_TARGET)/include/fatfs/ffconf.h
 
 clean:
 	rm -f *.o *.a

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -11,7 +11,8 @@ else
 endif
 
 N64_GCCPREFIX ?= $(N64_INST)
-N64_GCCPREFIX_TRIPLET = $(N64_GCCPREFIX)/bin/mips64-elf-
+N64_TARGET ?= mips64-elf
+N64_GCCPREFIX_TRIPLET = $(N64_GCCPREFIX)/bin/$(addsuffix -,$(N64_TARGET))
 N64_CC = $(N64_GCCPREFIX_TRIPLET)gcc
 N64_AS = $(N64_GCCPREFIX_TRIPLET)as
 N64_LD = $(N64_GCCPREFIX_TRIPLET)ld
@@ -21,8 +22,8 @@ N64_SIZE = $(N64_GCCPREFIX_TRIPLET)size
 N64_READELF = $(N64_GCCPREFIX_TRIPLET)readelf
 
 N64_ROOTDIR = $(N64_INST)
-N64_INCLUDEDIR = $(N64_ROOTDIR)/mips64-elf/include
-N64_LIBDIR = $(N64_ROOTDIR)/mips64-elf/lib
+N64_INCLUDEDIR = $(N64_ROOTDIR)/$(N64_TARGET)/include
+N64_LIBDIR = $(N64_ROOTDIR)/$(N64_TARGET)/lib
 
 N64_CFLAGS =  -march=vr4300 -mtune=vr4300 -MMD
 N64_CFLAGS += -DN64 -Os -Wall -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always

--- a/n64.mk
+++ b/n64.mk
@@ -27,18 +27,19 @@ N64_BACKTRACE_FILE_PREFIX=
 
 # Override this to use a toolchain installed separately from libdragon
 N64_GCCPREFIX ?= $(N64_INST)
+N64_TARGET ?= mips64-elf
 N64_ROOTDIR = $(N64_INST)
 N64_BINDIR = $(N64_ROOTDIR)/bin
-N64_INCLUDEDIR = $(N64_ROOTDIR)/mips64-elf/include
-N64_LIBDIR = $(N64_ROOTDIR)/mips64-elf/lib
-N64_GCCPREFIX_TRIPLET = $(N64_GCCPREFIX)/bin/mips64-elf-
+N64_INCLUDEDIR = $(N64_ROOTDIR)/$(N64_TARGET)/include
+N64_LIBDIR = $(N64_ROOTDIR)/$(N64_TARGET)/lib
+N64_GCCPREFIX_TRIPLET = $(N64_GCCPREFIX)/bin/$(addsuffix -,$(N64_TARGET))
 
 COMMA:=,
 
 N64_CC = $(CCACHE) $(N64_GCCPREFIX_TRIPLET)gcc
 N64_CXX = $(CCACHE) $(N64_GCCPREFIX_TRIPLET)g++
 N64_AS = $(N64_GCCPREFIX_TRIPLET)as
-N64_AR = $(N64_GCCPREFIX_TRIPLET)ar
+N64_AR = $(N64_GCCPREFIX_TRIPLET)gcc-ar
 N64_LD = $(N64_GCCPREFIX_TRIPLET)ld
 N64_OBJCOPY = $(N64_GCCPREFIX_TRIPLET)objcopy
 N64_OBJDUMP = $(N64_GCCPREFIX_TRIPLET)objdump
@@ -59,7 +60,7 @@ N64_DSO = $(N64_BINDIR)/n64dso
 N64_DSOEXTERN = $(N64_BINDIR)/n64dso-extern
 N64_DSOMSYM = $(N64_BINDIR)/n64dso-msym
 
-N64_C_AND_CXX_FLAGS =  -march=vr4300 -mtune=vr4300 -I$(N64_INCLUDEDIR)/newlib_overrides -I$(N64_INCLUDEDIR) -include ktls.h
+N64_C_AND_CXX_FLAGS =  -march=vr4300 -mtune=vr4300 -mabi=o64 -I$(N64_INCLUDEDIR)/newlib_overrides -I$(N64_INCLUDEDIR) -include ktls.h
 N64_C_AND_CXX_FLAGS += -falign-functions=32   # NOTE: if you change this, also change backtrace() in backtrace.c
 N64_C_AND_CXX_FLAGS += -ffunction-sections -fdata-sections -g -ffile-prefix-map="$(CURDIR)"=$(N64_BACKTRACE_FILE_PREFIX)
 N64_C_AND_CXX_FLAGS += -ffast-math -ftrapping-math -fno-associative-math
@@ -68,7 +69,7 @@ N64_C_AND_CXX_FLAGS += -Wno-error=unused-variable -Wno-error=unused-but-set-vari
 N64_C_AND_CXX_FLAGS += -ftrivial-auto-var-init=pattern
 N64_CFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu17
 N64_CXXFLAGS = $(N64_C_AND_CXX_FLAGS) -std=gnu++17
-N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
+N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -mabi=o64 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings -I$(N64_INCLUDEDIR)
 N64_LDFLAGS = -g -L$(N64_LIBDIR) -ldragon -lm -ldragonsys -Tn64.ld --gc-sections --wrap __do_global_ctors
 N64_DSOLDFLAGS = --emit-relocs --unresolved-symbols=ignore-all --nmagic -T$(N64_LIBDIR)/dso.ld
@@ -204,10 +205,10 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp
 	EXTERNS_FILE="$(filter %.externs, $^)"; \
 	if [ -z "$$EXTERNS_FILE" ]; then \
 		$(CXX) -o $@ $(filter %.o, $^) $(filter-out $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a, $(filter %.a, $^)) \
-			-lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
+			-lc -mabi=o64 $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
 	else \
 		$(CXX) -o $@ $(filter %.o, $^) $(filter-out $(N64_LIBDIR)/libdragon.a $(N64_LIBDIR)/libdragonsys.a, $(filter %.a, $^)) \
-			-lc $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-T"$$EXTERNS_FILE" -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
+			-lc -mabi=o64 $(patsubst %,-Wl$(COMMA)%,$(LDFLAGS)) -Wl,-T"$$EXTERNS_FILE" -Wl,-Map=$(BUILD_DIR)/$(notdir $(basename $@)).map; \
 	fi
 	$(N64_SIZE) -G $@
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,7 @@
 N64_GCCPREFIX ?= $(N64_INST)
+N64_TARGET ?= mips64-elf
 INSTALLDIR ?= $(N64_INST)
+N64_GCCPREFIX_TRIPLET = $(N64_GCCPREFIX)/bin/$(addsuffix -,$(N64_TARGET))
 
 C_CXX_FLAGS += -O2 -pthread -Wall -Werror
 C_CXX_FLAGS += -I../include -MMD
@@ -67,8 +69,8 @@ common/mips_decomp_l3.bin: ../src/compress/shrinkler_dec_fast.S
 
 $(DECOMP_STUBS):
 	@echo "    [MIPS] $@"
-	$(N64_GCCPREFIX)/bin/mips64-elf-gcc -c -o $@.o $<
-	$(N64_GCCPREFIX)/bin/mips64-elf-objcopy -O binary $@.o $@
+	$(N64_GCCPREFIX_TRIPLET)gcc -c -o $@.o $<
+	$(N64_GCCPREFIX_TRIPLET)objcopy -O binary $@.o $@
 	rm $@.o
 
 -include $(wildcard common/*.d)

--- a/tools/common/utils.h
+++ b/tools/common/utils.h
@@ -75,6 +75,35 @@ static const char *n64_toolchain_dir(void)
     return n64_inst;
 }
 
+// Find the prefix to be prepended for GCC commands.
+// This is everything before gcc, ld, objdump, etc
+__attribute__((used))
+static const char *n64_gccprefix_triplet(void)
+{
+    static char *n64_gccprefix_triplet = NULL;
+    if (n64_gccprefix_triplet)
+        return n64_gccprefix_triplet;
+
+    const char *inst = n64_toolchain_dir();
+    if (!inst)
+        return NULL;
+    const char *target = getenv("N64_TARGET");
+    if (!target)
+        target = "mips64-elf";
+
+    int ret;
+    if (target[0])
+        ret = asprintf(&n64_gccprefix_triplet, "%s/bin/%s-", inst, target);
+    else
+        ret = asprintf(&n64_gccprefix_triplet, "%s/bin/", inst);
+
+    if (ret < 0) {
+        perror("asprintf");
+        exit(1);
+    }
+    return n64_gccprefix_triplet;
+}
+
 // Find the directory where the libdragon tools are installed.
 // This is where you can find mksprite, mkfont, etc.
 __attribute__((used))

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -8,6 +8,9 @@
 
     For more information, please refer to <http://unlicense.org/>
 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include "mkmaterial.h"
 #include <regex>
 #include <fstream>

--- a/tools/n64dso/n64dso-msym.c
+++ b/tools/n64dso/n64dso-msym.c
@@ -20,6 +20,7 @@
 #include "../common/polyfill.h"
 #include "../common/binout.c"
 #include "../common/binout.h"
+#include "../common/utils.h"
 
 //DSO Symbol Table Internals
 #include "../../src/dso_format.h"
@@ -30,7 +31,7 @@ dso_sym_t *export_syms = NULL;
 
 bool export_all = false;
 bool verbose_flag = false;
-char *n64_inst = NULL;
+const char *gccprefix_triplet = NULL;
 
 // Printf to stderr if verbose
 void verbose(const char *fmt, ...) {
@@ -81,7 +82,7 @@ void get_export_syms(char *infn)
     FILE *readelf_stdout = NULL;
     char *line_buf = NULL;
     size_t line_buf_size = 0;
-    asprintf(&readelf_bin, "%s/bin/mips64-elf-readelf", n64_inst);
+    asprintf(&readelf_bin, "%sreadelf", gccprefix_triplet);
     args[0] = readelf_bin;
     args[1] = "-s"; //Output symbol table
     args[2] = "-W"; //Wide output
@@ -197,27 +198,12 @@ int main(int argc, char **argv)
         return 1;
     }
     //Get libdragon install directory
-    if (!n64_inst) {
-        // n64.mk supports having a separate installation for the toolchain and
-        // libdragon. So first check if N64_GCCPREFIX is set; if so the toolchain
-        // is there. Otherwise, fallback to N64_INST which is where we expect
-        // the toolchain to reside.
-        n64_inst = getenv("N64_GCCPREFIX");
-        if (!n64_inst)
-            n64_inst = getenv("N64_INST");
-        if (!n64_inst) {
-            // Do not mention N64_GCCPREFIX in the error message, since it is
-            // a seldom used configuration.
-            fprintf(stderr, "Error: N64_INST environment variable not set.\n");
-            return 1;
-        }
-        // Remove the trailing backslash if any. On some system, running
-        // popen with a path containing double backslashes will fail, so
-        // we normalize it here.
-        n64_inst = strdup(n64_inst);
-        int n = strlen(n64_inst);
-        if (n64_inst[n-1] == '/' || n64_inst[n-1] == '\\')
-            n64_inst[n-1] = 0;
+    gccprefix_triplet = n64_gccprefix_triplet();
+    if (!gccprefix_triplet) {
+        // Do not mention N64_GCCPREFIX in the error message, since it is
+        // a seldom used configuration.
+        fprintf(stderr, "Error: N64_INST environment variable not set.\n");
+        return 1;
     }
     for(i=1; i<argc && argv[i][0] == '-'; i++) {
         if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {

--- a/tools/n64sym.c
+++ b/tools/n64sym.c
@@ -24,7 +24,7 @@
 bool flag_verbose = false;
 int flag_max_sym_len = 64;
 bool flag_inlines = true;
-const char *n64_inst = NULL;
+const char *gccprefix_triplet = NULL;
 
 // Printf if verbose
 void verbose(const char *fmt, ...) {
@@ -118,7 +118,7 @@ void symbol_add(const char *elf, uint32_t addr, bool is_func)
             cur_elf = NULL; addr2line_r = addr2line_w = NULL;
         }
         if (!addrbin)
-            asprintf(&addrbin, "%s/bin/mips64-elf-addr2line", n64_inst);
+            asprintf(&addrbin, "%saddr2line", gccprefix_triplet);
 
         const char *cmd_addr[16] = {0}; int i = 0;
         cmd_addr[i++] = addrbin;
@@ -199,7 +199,7 @@ bool elf_find_callsites(const char *elf)
 {
     // Start objdump to parse the disassembly of the ELF file
     char *cmd = NULL;
-    asprintf(&cmd, "%s/bin/mips64-elf-objdump -d %s", n64_inst, elf);
+    asprintf(&cmd, "%sobjdump -d %s", gccprefix_triplet, elf);
     verbose("Running: %s\n", cmd);
     FILE *disasm = popen(cmd, "r");
     if (!disasm) {
@@ -390,8 +390,8 @@ int main(int argc, char *argv[])
     }
 
     // Find n64 installation directory
-    n64_inst = n64_toolchain_dir();
-    if (!n64_inst) {
+    gccprefix_triplet = n64_gccprefix_triplet();
+    if (!gccprefix_triplet) {
         // Do not mention N64_GCCPREFIX in the error message, since it is
         // a seldom used configuration.
         fprintf(stderr, "Error: N64_INST environment variable not set\n");


### PR DESCRIPTION
This makes it possible to use libdragon with additional toolchains installed alongside the officially supported one. I have been using this to develop/test some GCC patches without clobbering my main libdragon install.

Also refactored n64dso to use the util functions instead of using its own copy.