### PR TITLE
cpakfs: fix get serial

### DIFF
--- a/include/cpakfs.h
+++ b/include/cpakfs.h
@@ -273,7 +273,7 @@ int cpakfs_unmount(joypad_port_t port);
 /**
  * @brief Read the serial number of a controller pak
  * 
- * This function reads the 20-byte serial number of a controller pak.
+ * This function reads the 24-byte serial number of a controller pak.
  * This is a unique identifier that can be used to distinguish between
  * different controller paks. It is normally generated with random data
  * when the controller pak is formatted, so it does not contain printable

--- a/src/joybus/cpakfs.c
+++ b/src/joybus/cpakfs.c
@@ -997,11 +997,11 @@ int cpakfs_get_serial(joypad_port_t port, uint8_t serial[24])
     }
 
     cpakfs_id_t fsid;
-    if (!fsid_read(port, &fsid))
-        return false;
+    if (fsid_read(port, &fsid) < 0)
+        return -2;
 
     memcpy(serial, fsid.serial, 24);
-    return true;
+    return 0;
 }
 
 int cpakfs_get_stats(joypad_port_t port, cpakfs_stats_t *stats)


### PR DESCRIPTION
* prefer returning 0 on success and negative value on error like other functions and suggested by its description
* fix comparison on fsid_read return value
* fix documentation of serial argument which is 24 bytes (and not 20)