### PR TITLE
boot: Add missing append operator character for N64_ASFLAGS in Makefile

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -33,7 +33,7 @@ N64_CFLAGS += -mabi=32 -mgp32 -mfp32 -msingle-float # Can't compile for 64bit AB
 #N64_CFLAGS += -flto
 
 N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings
-N64_ASFLAGS =  -mabi=32 -mgp32 -mfp32 -msingle-float -G0
+N64_ASFLAGS +=  -mabi=32 -mgp32 -mfp32 -msingle-float -G0
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings
 N64_LDFLAGS = -Wl,-T$(IPL3_LDSCRIPT) -Wl,-Map=build/ipl3.map -Wl,--gc-sections
 

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -32,8 +32,8 @@ N64_CFLAGS += -G0 # gp is not initialized (don't use it)
 N64_CFLAGS += -mabi=32 -mgp32 -mfp32 -msingle-float # Can't compile for 64bit ABI because DMEM/IMEM don't support 64-bit access
 #N64_CFLAGS += -flto
 
-N64_ASFLAGS = -mtune=vr4300 -march=vr4300 -Wa,--fatal-warnings
-N64_ASFLAGS +=  -mabi=32 -mgp32 -mfp32 -msingle-float -G0
+N64_ASFLAGS = -mtune=vr4300 -march=vr4300
+N64_ASFLAGS += -mabi=32 -mgp32 -mfp32 -msingle-float -G0
 N64_RSPASFLAGS = -march=mips1 -mabi=32 -Wa,--fatal-warnings
 N64_LDFLAGS = -Wl,-T$(IPL3_LDSCRIPT) -Wl,-Map=build/ipl3.map -Wl,--gc-sections
 


### PR DESCRIPTION
Also added optional 2nd commit that syncs the warnings options for N64_ASFLAGS from the preview branch