### PR TITLE
dragonfs: add a real stat() function instead of falling back to fstat

### DIFF
--- a/examples/dfsdemo/dfsdemo.c
+++ b/examples/dfsdemo/dfsdemo.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <libdragon.h>
+#include <sys/stat.h>
 
 #define MAX_LIST            20
 
@@ -12,6 +13,7 @@ typedef struct
 {
     uint32_t type;
     char filename[MAX_FILENAME_LEN+1];
+    char fullpath[MAX_FILENAME_LEN+1];
 } direntry_t;
 
 char dir[512] = "rom://";
@@ -95,6 +97,8 @@ direntry_t *populate_dir(int *count)
     {
         list[(*count)-1].type = buf.d_type;
         strcpy(list[(*count)-1].filename, buf.d_name);
+        strcpy(list[(*count)-1].fullpath, dir);
+        strcat(list[(*count)-1].fullpath, buf.d_name);
 
         /* Grab next */
         ret = dir_findnext(dir,&buf);
@@ -209,6 +213,30 @@ void display_dir(direntry_t *list, int cursor, int page, int max, int count)
     }
 }
 
+void display_file_info(direntry_t *list, int cursor)
+{
+    if (list == NULL) return;
+
+    /* File info display */
+    printf("\n");
+    printf("Info for '%s':\n", list[cursor].fullpath);
+
+    struct stat s;
+    if (stat(list[cursor].fullpath, &s) != 0) 
+    {
+        printf("stat failed...\n");
+        return;
+    };
+
+    printf("  Type: ");
+    switch (s.st_mode & S_IFMT) {
+    case S_IFDIR:  printf("Directory\n"); break;
+    case S_IFREG:  printf("Regular file\n"); break;
+    default:       printf("Unknown\n"); break;
+    }
+    printf("  Size: 0x%X\n",(int)(s.st_size));
+}
+
 int main(void)
 {
     /* Initialize video */
@@ -237,6 +265,7 @@ int main(void)
         {
             console_clear();
             display_dir(list, cursor, page, MAX_LIST, count);
+            display_file_info(list, cursor);
             console_render();
 
             joypad_poll();

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -28,7 +28,9 @@ enum
     /** @brief Walk the directory structure for the purpose of changing directories */
     WALK_CHDIR,
     /** @brief Walk the directory structure for the purpose of opening a file or directory */
-    WALK_OPEN
+    WALK_OPEN,
+    /** @brief Walk the directory structure for the purpose of inspecting a file or directory */
+    WALK_STAT
 };
 
 /**
@@ -405,13 +407,17 @@ static pi_addr_t find_dirent(char *name, pi_addr_t cur_node)
  * itself is returned.  If it is a directory, the directory entry of the first
  * file or directory inside that directory is returned. 
  *
+ * If mode is WALK_STAT, the result of this function is the same as WALK_OPEN,
+ * except directories return their own directory entry, instead of the first
+ * file or directory inside that directory.
+ *
  * The type specifier allows a person to specify that only a directory or file
- * should be returned.  This works for WALK_OPEN only.
+ * should be returned.  This works for WALK_OPEN and WALK_STAT only.
  * 
  * @param[in]     path
  *                The path to walk through
  * @param[in]     mode
- *                Either #WALK_CHDIR or #WALK_OPEN.
+ *                Either #WALK_CHDIR, #WALK_OPEN or #WALK_STAT.
  * @param[in,out] dirent
  *                Directory entry to start at, directory entry finished at
  * @param[in]     type
@@ -485,8 +491,17 @@ static int recurse_path(const char * const path, int mode, pi_addr_t *dirent, in
 
                 if(FILETYPE(flags) == FLAGS_DIR)
                 {
-                    /* Push subdirectory onto stack and loop */
-                    push_directory(get_first_entry(&node));
+                    /* Only perform special handling if this is the last thing we are doing */
+                    if(mode == WALK_STAT && !cur_path) 
+                    {
+                        /* Push current directory onto stack in preparation of a return */
+                        push_directory(tmp_node);
+                    } 
+                    else 
+                    {
+                        /* Push subdirectory onto stack and loop */
+                        push_directory(get_first_entry(&node));
+                    }
                     last_type = TYPE_DIR;
                 }
                 else
@@ -531,7 +546,7 @@ static int recurse_path(const char * const path, int mode, pi_addr_t *dirent, in
         ret = DFS_ENOFILE;
     }
 
-    if(mode == WALK_OPEN)
+    if(mode == WALK_OPEN || mode == WALK_STAT)
     {
         /* Must return the node found if we found one */
         if(ret == DFS_ESUCCESS && dirent)
@@ -540,7 +555,7 @@ static int recurse_path(const char * const path, int mode, pi_addr_t *dirent, in
         }
     }
 
-    if(mode == WALK_OPEN || ret != DFS_ESUCCESS)
+    if(mode == WALK_OPEN || mode == WALK_STAT || ret != DFS_ESUCCESS)
     {
         /* Restore stack */
         directory_top = dir_loc;
@@ -1170,6 +1185,57 @@ static int __fstat( void *file, struct stat *st )
 }
 
 /**
+ * @brief Newlib-compatible stat
+ *
+ * @param[in]  file
+ *             File name of the file in question
+ * @param[out] st
+ *             Stat structure to populate
+ *
+ * @return 0 on success or a negative value on error.
+ */
+static int __stat( char *name, struct stat *st )
+{
+    pi_addr_t dirent;
+    int ret = recurse_path(name, WALK_STAT, &dirent, TYPE_ANY);
+
+    if(ret != DFS_ESUCCESS) {
+        /* File not found, or other error */
+        return ret;
+    }
+
+    /* We now have the pointer to the first entry */
+    directory_entry_t t_node;
+    grab_sector(dirent, &t_node);
+
+    /* Populate the structure with the proper values */
+    uint32_t flags = get_flags(&t_node);
+    if (FILETYPE(flags) == FLAGS_FILE) {
+        st->st_mode = S_IFREG;
+        st->st_size = (int)(get_size(&t_node));
+    } else {
+        st->st_mode = S_IFDIR;
+        st->st_size = 0;
+    }
+
+    /* Fill the rest of the structure with placeholders */
+    st->st_dev = 0;
+    st->st_ino = 0;
+    st->st_nlink = 1;
+    st->st_uid = 0;
+    st->st_gid = 0;
+    st->st_rdev = 0;
+    st->st_atime = 0;
+    st->st_mtime = 0;
+    st->st_ctime = 0;
+    st->st_blksize = 0;
+    st->st_blocks = 0;
+    //st->st_attr = S_IAREAD | S_IAREAD;
+
+    return DFS_ESUCCESS;
+}
+
+/**
  * @brief Newlib-compatible lseek
  *
  * @param[in] file
@@ -1310,6 +1376,7 @@ static int __ioctl(void *file, unsigned long cmd, void *argp)
 static filesystem_t dragon_fs = {
     .open = __open,
     .fstat = __fstat,
+    .stat = __stat,
     .lseek = __lseek,
     .read = __read,
     .close = __close,


### PR DESCRIPTION
Up until now, DragonFS did not have a proper implementation of the stat syscall, instead falling back to fstat. I've implemented a proper stat function for DragonFS with the goal of being able to query directories as well - this can be useful to query for the type of directory entry a given path is (directory, regular file)

This will also result in the stat call being slightly less wasteful, as it will no longer always call an allocation for the file handle.

To demonstrate this, I've updated dfsdemo to add a small info display for the currently selected file/directory, showing the absolute path, the kind of file (directory, regular file) and the file size.

<img width="639" height="478" alt="image" src="https://github.com/user-attachments/assets/0c709bbb-4bd2-4853-9e41-7f7080482cc6" />
<img width="638" height="479" alt="image" src="https://github.com/user-attachments/assets/b8bd457f-61b3-483f-93c9-d622f9527761" />