### PR TITLE
rspq: add rspq_block_atexit and rspq_block_is_recording

### DIFF
--- a/include/rspq.h
+++ b/include/rspq.h
@@ -797,6 +797,27 @@ void rspq_block_run(rspq_block_t *block);
 void rspq_block_free(rspq_block_t *block);
 
 /**
+ * @brief Register a callback to be called when the current block is freed.
+ * 
+ * Calling this function is only valid when a block is currently being recorded
+ * (see #rspq_block_begin). The callback will be called with the given context
+ * when the currently recorded block is freed using #rspq_block_free.
+ * 
+ * It is possible to call this function multiple times during the recording
+ * of the same block. In that case the callbacks will be called in the reverse
+ * order that they were passed into this function.
+ * 
+ * This function is useful for binding the lifetime of resources to that of a block.
+ * For example if a certain command in an rspq overlay accesses a buffer and that
+ * command is recorded into a block, it's possible to make sure that the block
+ * never outlives that buffer without any additionally required scaffolding.
+ * 
+ * @param  cb   The callback function
+ * @param  ctx  The context that will be passed to the callback
+ */
+void rspq_block_atexit(void (*cb)(void*), void* ctx);
+
+/**
  * @brief Start building a high-priority queue.
  * 
  * This function enters a special mode in which a high-priority queue is

--- a/include/rspq.h
+++ b/include/rspq.h
@@ -796,6 +796,18 @@ void rspq_block_run(rspq_block_t *block);
  */
 void rspq_block_free(rspq_block_t *block);
 
+/** 
+ * @brief Returns true if a block is currently being built. 
+ * 
+ * This function returns true if, and only if, it is called after
+ * #rspq_block_begin was called and before #rspq_block_end is called.
+ * Use this function to determine whether a block is currently being recorded.
+ */
+static inline bool rspq_block_is_recording(void) {
+    extern rspq_block_t *rspq_block;
+    return rspq_block != NULL;
+}
+
 /**
  * @brief Register a callback to be called when the current block is freed.
  * 

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -541,7 +541,7 @@ void rdpq_exec(void *buffer, int size)
     // TODO: to implement support in blocks, we need a way to notify the block state machine that
     // after this command, a new RSPQ_CMD_RDP_SET_BUFFER is required to be sent, to resume playing
     // the static buffer.
-    assertf(!rspq_in_block(), "cannot call rdpq_exec() inside a block");
+    assertf(!rspq_block_is_recording(), "cannot call rdpq_exec() inside a block");
 
     void *end = buffer + size;
     rspq_int_write(RSPQ_CMD_RDP_SET_BUFFER, PhysicalAddr(end), PhysicalAddr(buffer), PhysicalAddr(end));

--- a/src/rdpq/rdpq_internal.h
+++ b/src/rdpq/rdpq_internal.h
@@ -166,7 +166,7 @@ extern volatile int __rdpq_syncpoint_at_syncfull;
  * @hideinitializer
  */
 #define rdpq_passthrough_write(rdp_cmd) ({ \
-    if (__builtin_expect(rspq_in_block(), 0)) { \
+    if (__builtin_expect(rspq_block_is_recording(), 0)) { \
         extern rdpq_block_state_t rdpq_block_state; \
         int nwords = 0; __rdpcmd_count_words(rdp_cmd); \
         if (__builtin_expect(rdpq_block_state.wptr + nwords > rdpq_block_state.wend, 0)) \

--- a/src/rspq/rspq.c
+++ b/src/rspq/rspq.c
@@ -1184,6 +1184,15 @@ void rspq_block_free(rspq_block_t *block)
         // this is an invalid chunk of a block, better assert.
         assertf(0, "invalid terminator command in block: %08lx\n", cmd);
     }
+
+    // Lastly, invoke callbacks (in reverse order of registration)
+    rspq_block_cb_t *cb = block->atexit;
+    while (cb) {
+        cb->cb(cb->ctx);
+        rspq_block_cb_t *next = cb->next;
+        free(cb);
+        cb = next;
+    }
 }
 
 void rspq_block_run(rspq_block_t *block)
@@ -1221,6 +1230,18 @@ void rspq_block_run_rsp(int nesting_level)
         assertf(rspq_block->nesting_level < RSPQ_MAX_BLOCK_NESTING_LEVEL,
             "reached maximum number of nested block runs");
     }    
+}
+
+void rspq_block_atexit(void (*cb)(void*), void* ctx)
+{
+    assertf(rspq_block, "no block is being created");
+    rspq_block_cb_t *new_cb = malloc(sizeof(rspq_block_cb_t));
+    new_cb->cb = cb;
+    new_cb->ctx = ctx;
+    // Insert at the front of the list.
+    // This means that iteration will happen in reverse order of insertion.
+    new_cb->next = rspq_block->atexit;
+    rspq_block->atexit = new_cb;
 }
 
 void rspq_noop()

--- a/src/rspq/rspq_internal.h
+++ b/src/rspq/rspq_internal.h
@@ -149,7 +149,17 @@ enum {
 
 ///@cond
 typedef struct rdpq_block_s rdpq_block_t;
+typedef struct rspq_block_cb_s rspq_block_cb_t;
 ///@endcond
+
+/**
+ * @brief Linked list of callbacks for storage inside a rspq block.
+ */
+typedef struct rspq_block_cb_s {
+    void (*cb)(void*);      ///< The callback function pointer
+    void* ctx;              ///< The context that will be passed into the callback
+    rspq_block_cb_t *next;  ///< Next callback in the linked list
+} rspq_block_cb_t;
 
 /**
  * @brief A rspq block: pre-recorded array of commands
@@ -162,6 +172,7 @@ typedef struct rdpq_block_s rdpq_block_t;
 typedef struct rspq_block_s {
     uint32_t nesting_level;     ///< Nesting level of the block
     rdpq_block_t *rdp_block;    ///< Option RDP static buffer (with RDP commands)
+    rspq_block_cb_t *atexit;    ///< List of callbacks to call upon freeing the block
     uint32_t cmds[];            ///< Block contents (commands)
 } rspq_block_t;
 

--- a/src/rspq/rspq_internal.h
+++ b/src/rspq/rspq_internal.h
@@ -268,12 +268,6 @@ rspq_syncpoint_t __rspq_call_deferred(void (*func)(void *), void *arg, bool wait
 /** @brief Polls the deferred calls list, calling callbacks ready to be called. */
 bool __rspq_deferred_poll(void);
 
-/** @brief True if we are currently building a block. */
-static inline bool rspq_in_block(void) {
-    extern rspq_block_t *rspq_block;
-    return rspq_block != NULL;
-}
-
 /** @brief True if we are currently in highpri mode */
 bool rspq_in_highpri(void);
 


### PR DESCRIPTION
This does two things:
- Add the new function rspq_block_atexit
- Rename rspq_in_block to rspq_block_is_recording and expose it in the public API

Both are required for the upcoming improved GL implementation.