### PR TITLE
Introduce rdpq_xform API

### DIFF
--- a/include/fgeom2d.h
+++ b/include/fgeom2d.h
@@ -190,16 +190,27 @@ inline void fm_mat3_translate(fm_mat3_t *out, const fm_vec2_t *translate)
 }
 
 /**
- * @brief Apply rotation to a 3x3 matrix.
+ * @brief Apply a counterclockwise rotation to a 3x3 matrix.
  */
 void fm_mat3_rotate(fm_mat3_t *out, float rotation);
 
 /**
  * @brief Create a 3x3 affine transformation matrix from scale, rotation and translation.
  * 
- * The rotation is accepted as an angle in radians.
+ * The rotation is accepted as a counterclockwise angle in radians.
+ * It creates an equivalent matrix to multiplying an identity matrix by a scale,
+ * a rotation, and a translation matrix in that order.
  */
 void fm_mat3_from_srt(fm_mat3_t *out, const fm_vec2_t *scale, float rotation, const fm_vec2_t *translate);
+
+/**
+ * @brief Create a 3x3 affine transformation matrix from rotation, scale, and translation.
+ * 
+ * The rotation is accepted as a counterclockwise angle in radians.
+ * It creates an equivalent matrix to multiplying an identity matrix by a rotation,
+ * a scale, and a translation matrix in that order.
+ */
+void fm_mat3_from_rst(fm_mat3_t *out, float rotation, const fm_vec2_t *scale, const fm_vec2_t *translate);
 
 /**
  * @brief Create a 3x3 rigid transformation matrix from rotation and translation.
@@ -282,7 +293,7 @@ float fm_mat3_det(const fm_mat3_t *m);
 void fm_mat3_inverse(fm_mat3_t *out, const fm_mat3_t *m);
 
 /**
- * @brief Multiply a 2D vector by a 3x3 matrix by assuming 1 as the hypothetical 4th component of the vector.
+ * @brief Multiply a 2D vector by a 3x3 matrix by assuming 1 as the hypothetical 3rd component of the vector.
  */
 inline void fm_mat3_mul_vec2(fm_vec3_t *out, const fm_mat3_t *m, const fm_vec2_t *v)
 {

--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -88,6 +88,7 @@
 #include "rdpq_debug.h"
 #include "rdpq_macros.h"
 #include "rdpq_mat.h"
+#include "rdpq_xform.h"
 #include "surface.h"
 #include "sprite.h"
 #include "debugcpp.h"

--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -314,7 +314,9 @@ typedef struct rdpq_blitparms_s {
     float scale_x;      ///< Horizontal scale factor to apply to the surface. If 0, no scaling is performed (the same as 1.0f). If negative, horizontal flipping is applied
     float scale_y;      ///< Vertical scale factor to apply to the surface. If 0, no scaling is performed (the same as 1.0f). If negative, vertical flipping is applied
     float theta;        ///< Rotation angle in radians
-
+    
+    bool allow_xform;   ///< True if blit should be affected by transforms applied by rdpq_xform
+    
     // FIXME: replace this with CPU tracking of filtering mode?
     bool filtering;     ///< True if texture filtering is enabled (activates workaround for filtering artifacts when splitting textures in chunks)
 

--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -311,9 +311,9 @@ typedef struct rdpq_blitparms_s {
 
     int cx;             ///< Transformation center (aka "hotspot") X coordinate, relative to (s0, t0). Used for all transformations
     int cy;             ///< Transformation center (aka "hotspot") X coordinate, relative to (s0, t0). Used for all transformations
-    float scale_x;      ///< Horizontal scale factor to apply to the surface. If 0, no scaling is performed (the same as 1.0f). If negative, horizontal flipping is applied
-    float scale_y;      ///< Vertical scale factor to apply to the surface. If 0, no scaling is performed (the same as 1.0f). If negative, vertical flipping is applied
-    float theta;        ///< Rotation angle in radians
+    float scale_x;      ///< Horizontal scale factor to apply to the surface. This scaling is applied along the X axis after rotation. If 0, no scaling is performed (the same as 1.0f). If negative, horizontal flipping is applied
+    float scale_y;      ///< Vertical scale factor to apply to the surface. This scaling is applied along the Y axis after rotation. If 0, no scaling is performed (the same as 1.0f). If negative, vertical flipping is applied
+    float theta;        ///< Counter-clockwise rotation angle in radians
     
     bool allow_xform;   ///< True if blit should be affected by transforms applied by rdpq_xform
     

--- a/include/rdpq_xform.h
+++ b/include/rdpq_xform.h
@@ -3,7 +3,7 @@
  * @brief RDP Command queue: 2D transformation API.
  * @ingroup rdpq
  * 
- * This file contains functions for 2D transfomations and transformed primitives.
+ * This file contains functions for 2D transformations and transformed primitives.
  */
 
 #ifndef LIBDRAGON_RDPQ_XFORM_H

--- a/include/rdpq_xform.h
+++ b/include/rdpq_xform.h
@@ -1,0 +1,156 @@
+/**
+ * @file rdpq_xform.h
+ * @brief RDP Command queue: 2D transformation API.
+ * @ingroup rdpq
+ * 
+ * This file contains functions for 2D transfomations and transformed primitives.
+ */
+
+#ifndef LIBDRAGON_RDPQ_XFORM_H
+#define LIBDRAGON_RDPQ_XFORM_H
+
+#include <stdint.h>
+#include "fgeom2d.h"
+#include "rdpq_tri.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Replace current transformation matrix with another 3x3 matrix.
+ *
+ * @param mtx   Pointer to 3x3 matrix to load
+ */
+void rdpq_xform_mtx_load(fm_mat3_t *mtx);
+/**
+ * @brief Multiply current transformation matrix by another 3x3 matrix.
+ *
+ * @param mtx   Pointer to 3x3 matrix to multiply by
+ */
+void rdpq_xform_mtx_mult(fm_mat3_t *mtx);
+
+/**
+ * @brief Replace current transformation matrix with the identity matrix.
+ *
+ * This clears any transformations that may have been applied.
+ */
+void rdpq_xform_identity(void);
+/**
+ * @brief Multiplies current transformation matrix by rotation matrix.
+ *
+ * @param theta     Counterclockwise angle to rotate by in radians
+ */
+void rdpq_xform_rotate(float theta);
+/**
+ * @brief Multiplies current transformation matrix by translation matrix.
+ *
+ * @param x     X component of translation vector
+ * @param y     Y component of translation vector
+ */
+void rdpq_xform_translate(float x, float y);
+/**
+ * @brief Multiplies current transformation matrix by scaling matrix.
+ *
+ * @param x     Scaling factor along X axis
+ * @param y     Scaling factor along Y axis
+ */
+void rdpq_xform_scale(float x, float y);
+/**
+ * @brief Push current matrix to matrix stack.
+ */
+void rdpq_xform_push(void);
+/**
+ * @brief Pop from matrix stack.
+ *
+ * This replaces the current matrix with the matrix one below it on the stack.
+ */
+void rdpq_xform_pop(void);
+
+/**
+ * @brief Replace current transformation matrix with a combined scale, rotation and translation matrix
+ *
+ * It is equivalent to loading an identity matrix followed by multiplying
+ * by a scale, a rotation, and a translation matrix in that order.
+ *
+ * @param x         X component of translation vector
+ * @param y         Y component of translation vector
+ * @param theta     Counterclockwise angle to rotate by in radians
+ * @param scale_x   Scaling factor along X axis
+ * @param scale_y   Scaling factor along Y axis
+ */
+void rdpq_xform_load_srt(float x, float y, float theta, float scale_x, float scale_y);
+/**
+ * @brief Multiply current transformation matrix by a combined scale, rotation and translation matrix
+ *
+ * It is equivalent to multiplying by a scale, a rotation, and a translation matrix in that order.
+ *
+ * @param x         X component of translation vector
+ * @param y         Y component of translation vector
+ * @param theta     Counterclockwise angle to rotate by in radians
+ * @param scale_x   Scaling factor along X axis
+ * @param scale_y   Scaling factor along Y axis
+ */
+void rdpq_xform_mult_srt(float x, float y, float theta, float scale_x, float scale_y);
+
+/**
+ * @brief Replace current transformation matrix with a combined rotation, scale and translation matrix
+ *
+ * It is equivalent to loading an identity matrix followed by multiplying
+ * by a rotation, a scale, and a translation matrix in that order.
+ *
+ * @param x         X component of translation vector
+ * @param y         Y component of translation vector
+ * @param theta     Counterclockwise angle to rotate by in radians
+ * @param scale_x   Scaling factor along X axis
+ * @param scale_y   Scaling factor along Y axis
+ */
+void rdpq_xform_load_rst(float x, float y, float theta, float scale_x, float scale_y);
+/**
+ * @brief Multiply current transformation matrix by a combined rotation, scale and translation matrix
+ *
+ * It is equivalent to multiplying by a rotation, a scale, and a translation matrix in that order.
+ *
+ * @param x         X component of translation vector
+ * @param y         Y component of translation vector
+ * @param theta     Counterclockwise angle to rotate by in radians
+ * @param scale_x   Scaling factor along X axis
+ * @param scale_y   Scaling factor along Y axis
+ */
+void rdpq_xform_mult_rst(float x, float y, float theta, float scale_x, float scale_y);
+
+/**
+ * @brief Draw a filled rectangle with the current transformation applied.
+ *
+ * This function works as a replacement for #rdpq_fill_rectangle in contexts
+ * where a transformation should be applied.
+*/
+void rdpq_xform_fill_rectangle(float x0, float y0, float x1, float y1);
+
+/**
+ * @brief Draw a filled rectangle with the current transformation applied.
+ *
+ * This function works as a replacement for #rdpq_texture_rectangle in contexts
+ * where a transformation should be applied.
+*/
+void rdpq_xform_texture_rectangle(rdpq_tile_t tile, float x0, float y0, float x1, float y1, float s, float t);
+/**
+ * @brief Draw a textured rectangle with the current transformation applied and scaling applied.
+ *
+ * This function works as a replacement for #rdpq_texture_rectangle_scaled in contexts
+ * where a transformation should be applied.
+*/
+void rdpq_xform_texture_rectangle_scaled(rdpq_tile_t tile, float x0, float y0, float x1, float y1, float s0, float t0, float s1, float t1);
+/**
+ * @brief Draw a triangle with the current transformation applied.
+ *
+ * This function works as a replacement for #rdpq_triangle in contexts
+ * where a transformation should be applied.
+*/
+void rdpq_xform_triangle(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/math/fgeom2d.c
+++ b/src/math/fgeom2d.c
@@ -12,7 +12,7 @@ void fm_mat3_rotate(fm_mat3_t *out, float rotation)
     fm_mat3_mul(out, &rotation_matrix, out);
 }
 
-void fm_mat3_from_srt(fm_mat3_t *out, const fm_vec2_t *scale, float rotation, const fm_vec2_t *translate)
+void fm_mat3_from_rst(fm_mat3_t *out, float rotation, const fm_vec2_t *scale, const fm_vec2_t *translate)
 {
     float s, c;
 
@@ -22,6 +22,20 @@ void fm_mat3_from_srt(fm_mat3_t *out, const fm_vec2_t *scale, float rotation, co
     *out = (fm_mat3_t){{
         { c*sx, -s*sy, 0 },
         { s*sx, c*sy, 0 },
+        { translate->x, translate->y, 1 }
+    }};
+}
+
+void fm_mat3_from_srt(fm_mat3_t *out, const fm_vec2_t *scale, float rotation, const fm_vec2_t *translate)
+{
+    float s, c;
+
+    fm_sincosf(rotation, &s, &c);
+    float sx = scale->x, sy = scale->y;
+
+    *out = (fm_mat3_t){{
+        { c*sx, -s*sx, 0 },
+        { s*sy, c*sy, 0 },
         { translate->x, translate->y, 1 }
     }};
 }

--- a/src/rdpq/libdragon.mk
+++ b/src/rdpq/libdragon.mk
@@ -11,4 +11,5 @@ LIBDRAGON_OBJS += \
 	$(BUILD_DIR)/rdpq/rdpq_attach.o \
 	$(BUILD_DIR)/rdpq/rdpq_font.o \
 	$(BUILD_DIR)/rdpq/rdpq_text.o \
-	$(BUILD_DIR)/rdpq/rdpq_paragraph.o 
+	$(BUILD_DIR)/rdpq/rdpq_paragraph.o \
+	$(BUILD_DIR)/rdpq/rdpq_xform.o 

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -363,6 +363,7 @@
 #include "rdpq_internal.h"
 #include "rdpq_constants.h"
 #include "rdpq_debug_internal.h"
+#include "rdpq_xform_internal.h"
 #include "rspq.h"
 #include "rspq/rspq_internal.h"
 #include "rspq_constants.h"
@@ -457,7 +458,8 @@ void rdpq_init()
         return;
 
     rspq_init();
-
+    __rdpq_xform_init();
+    
     // Get a pointer to the RDRAM copy of the rdpq ucode state.
     rdpq_state = UncachedAddr(rspq_overlay_get_state(&rsp_rdpq));
 
@@ -499,7 +501,8 @@ void rdpq_close()
     
     rspq_overlay_unregister(RDPQ_OVL_ID);
     __rdpq_attach_close();
-
+    __rdpq_xform_close();
+    
     set_DP_interrupt( 0 );
     unregister_DP_handler(__rdpq_interrupt);
 

--- a/src/rdpq/rdpq_internal.h
+++ b/src/rdpq/rdpq_internal.h
@@ -10,6 +10,7 @@
 
 #include "pputils.h"
 #include "rspq.h"
+#include "fgeom2d.h"
 #include "../rspq/rspq_internal.h"
 
 /** @brief True if the rdpq module was inited */
@@ -130,7 +131,7 @@ void __rdpq_write8(uint32_t cmd_id, uint32_t arg0, uint32_t arg1);
 void __rdpq_write16(uint32_t cmd_id, uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3);
 
 void rdpq_triangle_cpu(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3);
-void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3);
+void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx);
 
 extern volatile int __rdpq_syncpoint_at_syncfull;
 

--- a/src/rdpq/rdpq_tex.c
+++ b/src/rdpq/rdpq_tex.c
@@ -13,6 +13,7 @@
 #include "rdpq_tri.h"
 #include "rdpq_rect.h"
 #include "rdpq_tex.h"
+#include "rdpq_xform.h"
 #include "rdpq_tex_internal.h"
 #include "utils.h"
 #include "fmath.h"
@@ -668,12 +669,50 @@ static void tex_xblit(const surface_t *surf, float x0, float y0, const rdpq_blit
     }
 }
 
+__attribute__((noinline))
+static void tex_xblit_xform(const surface_t *surf, float x0, float y0, const rdpq_blitparms_t *parms, large_tex_draw ltd)
+{
+    rdpq_tile_t tile = parms->tile;
+    int src_width = parms->width ? parms->width : surf->width;
+    int src_height = parms->height ? parms->height : surf->height;
+    int os0 = parms->s0;
+    int ot0 = parms->t0;
+    int os1 = os0 + src_width;
+    int ot1 = ot0 + src_height;
+    bool flip_x = parms->flip_x;
+    bool flip_y = parms->flip_y;
+    float ofs_x = -(os0 + parms->cx);
+    float ofs_y = -(ot0 + parms->cy);
+    
+    float scalex = parms->scale_x == 0 ? 1.0f : parms->scale_x;
+    float scaley = parms->scale_y == 0 ? 1.0f : parms->scale_y;
+    rdpq_xform_push();
+    rdpq_xform_mult_rst(x0, y0, parms->theta, scalex, scaley);
+    
+    void draw_cb(rdpq_tile_t tile, int s0, int t0, int s1, int t1)
+    {
+        int ks0 = s0, kt0 = t0, ks1 = s1, kt1 = t1;
+
+        if (flip_x) { ks0 = os1 - s0 + os0 - 1; ks1 = os1 - s1 + os0 - 1; }
+        if (flip_y) { kt0 = ot1 - t0 + ot0 - 1; kt1 = ot1 - t1 + ot0 - 1; }
+
+        rdpq_xform_texture_rectangle(tile, ofs_x + ks0, ofs_y + kt0, ofs_x + ks1, ofs_y + kt1, s0, t0);
+    }
+
+    (*ltd)(tile, surf, os0, ot0, os1, ot1, draw_cb, parms->filtering);
+    rdpq_xform_pop();
+}
+
 /** @brief Internal implementation of #rdpq_tex_blit, using a custom large tex loader callback function */
 void __rdpq_tex_blit(const surface_t *surf, float x0, float y0, const rdpq_blitparms_t *parms, large_tex_draw ltd)
 {
     static const rdpq_blitparms_t default_parms = {0};
     if (!parms) parms = &default_parms;
-
+    
+    if(parms->allow_xform) {
+        tex_xblit_xform(surf, x0, y0, parms, ltd);
+        return;
+    }
     // Check which implementation to use, depending on the requested features.
     if (F2I(parms->theta) == 0) {
         if (F2I(parms->scale_x) == 0 && F2I(parms->scale_y) == 0)

--- a/src/rdpq/rdpq_tri.c
+++ b/src/rdpq/rdpq_tri.c
@@ -532,6 +532,7 @@ void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v
         (fmt->tex_tile & 7));
 }
 
+/** @brief Internal helper function for rendering transformed triangle */
 void __rdpq_triangle_rsp_xform(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx)
 {
     uint32_t res = AUTOSYNC_PIPE;

--- a/src/rdpq/rdpq_tri.c
+++ b/src/rdpq/rdpq_tri.c
@@ -25,6 +25,7 @@
 #include "rdpq_constants.h"
 #include "utils.h"
 #include "debug.h"
+#include "fgeom2d.h"
 
 /** @brief Set to 1 to activate tracing of all parameters of all triangles. */
 #define TRIANGLE_TRACE   0
@@ -490,6 +491,76 @@ void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v
         // X,Y: s13.2
         int16_t x = floorf(v[fmt->pos_offset+0] * 4.0f);
         int16_t y = floorf(v[fmt->pos_offset+1] * 4.0f);
+        
+        int16_t z = 0;
+        if (fmt->z_offset >= 0) {
+            z = v[fmt->z_offset+0] * 0x7FFF;
+        } 
+
+        int32_t rgba = 0;
+        if (fmt->shade_offset >= 0) {
+            const float *v_shade = fmt->shade_flat ? v1 : v;
+            uint32_t r = v_shade[fmt->shade_offset+0] * 255.0;
+            uint32_t g = v_shade[fmt->shade_offset+1] * 255.0;
+            uint32_t b = v_shade[fmt->shade_offset+2] * 255.0;
+            uint32_t a = v_shade[fmt->shade_offset+3] * 255.0;
+            rgba = (r << 24) | (g << 16) | (b << 8) | a;
+        }
+
+        int16_t s=0, t=0;
+        int32_t w=0, inv_w=0;
+        if (fmt->tex_offset >= 0) {
+            s     = v[fmt->tex_offset+0] * 32.0f;
+            t     = v[fmt->tex_offset+1] * 32.0f;
+            w     = float_to_s16_16(1.0f / v[fmt->tex_offset+2]);
+            inv_w = float_to_s16_16(       v[fmt->tex_offset+2]);
+        }
+
+        rspq_write(RDPQ_OVL_ID, RDPQ_CMD_TRIANGLE_DATA,
+            TRI_DATA_LEN * i, 
+            (x << 16) | (y & 0xFFFF), 
+            (z << 16), 
+            rgba, 
+            (s << 16) | (t & 0xFFFF), 
+            w,
+            inv_w);
+    }
+
+    rspq_write(RDPQ_OVL_ID, RDPQ_CMD_TRIANGLE, 
+        0xC000 | (cmd_id << 8) | 
+        (fmt->tex_mipmaps ? (fmt->tex_mipmaps-1) << 3 : 0) | 
+        (fmt->tex_tile & 7));
+}
+
+void __rdpq_triangle_rsp_xform(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx)
+{
+    uint32_t res = AUTOSYNC_PIPE;
+    if (fmt->tex_offset >= 0) {
+        // FIXME: this can be using multiple tiles depending on color combiner and texture
+        // effects such as detail and sharpen. Figure it out a way to handle these in the
+        // autosync engine.
+        res |= AUTOSYNC_TILE(fmt->tex_tile);
+        res |= AUTOSYNC_TMEM(0);
+    }
+    __rdpq_autosync_use(res);
+
+    uint32_t cmd_id = RDPQ_CMD_TRI;
+    if (fmt->shade_offset >= 0) cmd_id |= 0x4;
+    if (fmt->tex_offset >= 0)   cmd_id |= 0x2;
+    if (fmt->z_offset >= 0)     cmd_id |= 0x1;
+
+    const int TRI_DATA_LEN = ROUND_UP((2+1+1+3)*4, 16);
+
+    const float *vtx[3] = {v1, v2, v3};
+    for (int i=0;i<3;i++) {
+        const float *v = vtx[i];
+        //Transform vertex
+        fm_vec2_t pos = {{v[fmt->pos_offset+0], v[fmt->pos_offset+1]}};
+        fm_vec3_t temp;
+        fm_mat3_mul_vec2(&temp, mtx, &pos);
+        // X,Y: s13.2
+        int16_t x = floorf(temp.x * 4.0f);
+        int16_t y = floorf(temp.y * 4.0f);
         
         int16_t z = 0;
         if (fmt->z_offset >= 0) {

--- a/src/rdpq/rdpq_tri.c
+++ b/src/rdpq/rdpq_tri.c
@@ -465,75 +465,7 @@ void rdpq_triangle_cpu(const rdpq_trifmt_t *fmt, const float *v1, const float *v
 }
 
 /** @brief RDP triangle primitive assembled on the RSP */
-void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3)
-{
-    uint32_t res = AUTOSYNC_PIPE;
-    if (fmt->tex_offset >= 0) {
-        // FIXME: this can be using multiple tiles depending on color combiner and texture
-        // effects such as detail and sharpen. Figure it out a way to handle these in the
-        // autosync engine.
-        res |= AUTOSYNC_TILE(fmt->tex_tile);
-        res |= AUTOSYNC_TMEM(0);
-    }
-    __rdpq_autosync_use(res);
-
-    uint32_t cmd_id = RDPQ_CMD_TRI;
-    if (fmt->shade_offset >= 0) cmd_id |= 0x4;
-    if (fmt->tex_offset >= 0)   cmd_id |= 0x2;
-    if (fmt->z_offset >= 0)     cmd_id |= 0x1;
-
-    const int TRI_DATA_LEN = ROUND_UP((2+1+1+3)*4, 16);
-
-    const float *vtx[3] = {v1, v2, v3};
-    for (int i=0;i<3;i++) {
-        const float *v = vtx[i];
-
-        // X,Y: s13.2
-        int16_t x = floorf(v[fmt->pos_offset+0] * 4.0f);
-        int16_t y = floorf(v[fmt->pos_offset+1] * 4.0f);
-        
-        int16_t z = 0;
-        if (fmt->z_offset >= 0) {
-            z = v[fmt->z_offset+0] * 0x7FFF;
-        } 
-
-        int32_t rgba = 0;
-        if (fmt->shade_offset >= 0) {
-            const float *v_shade = fmt->shade_flat ? v1 : v;
-            uint32_t r = v_shade[fmt->shade_offset+0] * 255.0;
-            uint32_t g = v_shade[fmt->shade_offset+1] * 255.0;
-            uint32_t b = v_shade[fmt->shade_offset+2] * 255.0;
-            uint32_t a = v_shade[fmt->shade_offset+3] * 255.0;
-            rgba = (r << 24) | (g << 16) | (b << 8) | a;
-        }
-
-        int16_t s=0, t=0;
-        int32_t w=0, inv_w=0;
-        if (fmt->tex_offset >= 0) {
-            s     = v[fmt->tex_offset+0] * 32.0f;
-            t     = v[fmt->tex_offset+1] * 32.0f;
-            w     = float_to_s16_16(1.0f / v[fmt->tex_offset+2]);
-            inv_w = float_to_s16_16(       v[fmt->tex_offset+2]);
-        }
-
-        rspq_write(RDPQ_OVL_ID, RDPQ_CMD_TRIANGLE_DATA,
-            TRI_DATA_LEN * i, 
-            (x << 16) | (y & 0xFFFF), 
-            (z << 16), 
-            rgba, 
-            (s << 16) | (t & 0xFFFF), 
-            w,
-            inv_w);
-    }
-
-    rspq_write(RDPQ_OVL_ID, RDPQ_CMD_TRIANGLE, 
-        0xC000 | (cmd_id << 8) | 
-        (fmt->tex_mipmaps ? (fmt->tex_mipmaps-1) << 3 : 0) | 
-        (fmt->tex_tile & 7));
-}
-
-/** @brief Internal helper function for rendering transformed triangle */
-void __rdpq_triangle_rsp_xform(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx)
+void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx)
 {
     uint32_t res = AUTOSYNC_PIPE;
     if (fmt->tex_offset >= 0) {
@@ -558,7 +490,12 @@ void __rdpq_triangle_rsp_xform(const rdpq_trifmt_t *fmt, const float *v1, const 
         //Transform vertex
         fm_vec2_t pos = {{v[fmt->pos_offset+0], v[fmt->pos_offset+1]}};
         fm_vec3_t temp;
-        fm_mat3_mul_vec2(&temp, mtx, &pos);
+        if(mtx != NULL) {
+            fm_mat3_mul_vec2(&temp, mtx, &pos);
+        } else {
+            temp.x = pos.x;
+            temp.y = pos.y;
+        }
         // X,Y: s13.2
         int16_t x = floorf(temp.x * 4.0f);
         int16_t y = floorf(temp.y * 4.0f);
@@ -608,6 +545,6 @@ void rdpq_triangle(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, c
 #if RDPQ_TRIANGLE_REFERENCE
     rdpq_triangle_cpu(fmt, v1, v2, v3);
 #else
-    rdpq_triangle_rsp(fmt, v1, v2, v3);
+    rdpq_triangle_rsp(fmt, v1, v2, v3, NULL);
 #endif
 }

--- a/src/rdpq/rdpq_xform.c
+++ b/src/rdpq/rdpq_xform.c
@@ -24,9 +24,12 @@ typedef enum {
 
 #define RDPQ_XFORM_STACK_SIZE 16
 
+/**
+ * @brief Data for RDPQ transformation
+ */
 typedef struct rdpq_xform_s {
-    fm_mat3_t mtx;
-    rdpq_xform_type type;
+    fm_mat3_t mtx; ///< 3x3 Transformation matrix associated with transformaton
+    rdpq_xform_type type; ///< Type of transformation
 } rdpq_xform_t;
 
 static rdpq_xform_t *curr_xform;

--- a/src/rdpq/rdpq_xform.c
+++ b/src/rdpq/rdpq_xform.c
@@ -30,6 +30,9 @@ typedef enum {
     RDPQ_XFORM_ALL ///< Any 2D transformation
 } rdpq_xform_type;
 
+/**
+ * @brief Maximum size of matrix stack used by RDPQ Transform
+ */
 #define RDPQ_XFORM_STACK_SIZE 16
 
 /**

--- a/src/rdpq/rdpq_xform.c
+++ b/src/rdpq/rdpq_xform.c
@@ -1,8 +1,9 @@
 /**
- * @file rdpq_text.c
+ * @file rdpq_xform.c
  */
 #include "fgeom2d.h"
 #include "rdpq_xform_internal.h"
+#include "rdpq_internal.h"
 #include "rdpq_xform.h"
 #include "rdpq_rect.h"
 #include "rdpq_tri.h"
@@ -13,13 +14,20 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-//List of transformation types
-//This is ordered from most strict to least strict
+/**
+ * @brief Type of the transformation
+ * 
+ * This affects the type of primitive required to be generated when drawing
+ * transformed rectangles (both texture and fill rectangles).
+ *
+ * Ordering is based on the primitive that must be emitted after the transformation.
+ * Earlier values can use more direct paths for emitting the primitive.
+ */
 typedef enum {
-    RDPQ_XFORM_IDENTITY, //No transformation
-    RDPQ_XFORM_RECT, //Transformation with only translation
-    RDPQ_XFORM_SCALERECT, //Any transformation that has no rotation or skew
-    RDPQ_XFORM_TRI //Any 2D transformation
+    RDPQ_XFORM_NONE, ///< No transformation
+    RDPQ_XFORM_TRANSLATE, ///< Transformation with only translation
+    RDPQ_XFORM_SCALE, ///< Any transformation that has no rotation or skew
+    RDPQ_XFORM_ALL ///< Any 2D transformation
 } rdpq_xform_type;
 
 #define RDPQ_XFORM_STACK_SIZE 16
@@ -28,7 +36,7 @@ typedef enum {
  * @brief Data for RDPQ transformation
  */
 typedef struct rdpq_xform_s {
-    fm_mat3_t mtx; ///< 3x3 Transformation matrix associated with transformaton
+    fm_mat3_t mtx; ///< 3x3 Transformation matrix associated with transformation
     rdpq_xform_type type; ///< Type of transformation
 } rdpq_xform_t;
 
@@ -46,20 +54,20 @@ void __rdpq_xform_init(void)
 
 void __rdpq_xform_close(void)
 {
-    //Make sure that trying to push/load matrices causes crashed
+    //Make sure that trying to push/load matrices causes crashes
     curr_xform = NULL;
 }
 
 static rdpq_xform_type get_mtx_type(fm_mat3_t *mtx)
 {
     if(mtx->m[0][1] != 0.0f || mtx->m[1][0] != 0.0f) { //Check for skew/rotation
-        return RDPQ_XFORM_TRI;
+        return RDPQ_XFORM_ALL;
     } else if(mtx->m[0][0] != 1.0f || mtx->m[1][1] != 1.0f) { //Check for non-identity scale
-        return RDPQ_XFORM_SCALERECT;
+        return RDPQ_XFORM_SCALE;
     } else if(mtx->m[2][0] != 0.0f || mtx->m[2][1] != 0.0f) { //Check for translation
-        return RDPQ_XFORM_RECT;
+        return RDPQ_XFORM_TRANSLATE;
     } else {
-        return RDPQ_XFORM_IDENTITY;
+        return RDPQ_XFORM_NONE;
     }
 }
 
@@ -148,6 +156,7 @@ void rdpq_xform_mult_srt(float x, float y, float theta, float scale_x, float sca
 void rdpq_xform_push(void)
 {
     int new_depth = xform_stack_depth+1;
+    assertf(curr_xform, "RDPQ Transform not Initialized");
     assertf(new_depth < RDPQ_XFORM_STACK_SIZE, "RDPQ Transform Stack has reached maximum depth of %d", RDPQ_XFORM_STACK_SIZE);
     //Copy matrix to top of stack
     xform_stack[new_depth] = xform_stack[new_depth-1];
@@ -159,29 +168,29 @@ void rdpq_xform_push(void)
 void rdpq_xform_pop(void)
 {
     int new_depth = xform_stack_depth-1;
+    assertf(curr_xform, "RDPQ Transform not Initialized");
     assertf(new_depth >= 0, "RDPQ Transform Stack is already at depth 0");
     //Update current matrix and depth
     curr_xform = &xform_stack[new_depth];
     xform_stack_depth = new_depth;
 }
 
-static void transform_point(fm_vec2_t *out, float x, float y)
+static fm_vec2_t transform_point(float x, float y)
 {
     fm_vec2_t in = {{x, y}};
     fm_vec3_t temp;
     fm_mat3_mul_vec2(&temp, &curr_xform->mtx, &in);
-    out->x = temp.x;
-    out->y = temp.y;
+    return (fm_vec2_t){{temp.x, temp.y}};
 }
 
 void rdpq_xform_fill_rectangle(float x0, float y0, float x1, float y1)
 {
     switch(curr_xform->type) {
-        case RDPQ_XFORM_IDENTITY:
+        case RDPQ_XFORM_NONE:
             rdpq_fill_rectangle(x0, y0, x1, y1);
             break;
         
-        case RDPQ_XFORM_RECT:
+        case RDPQ_XFORM_TRANSLATE:
             //Apply X Translation to x0 and x1
             x0 += curr_xform->mtx.m[2][0];
             x1 += curr_xform->mtx.m[2][0];
@@ -191,37 +200,25 @@ void rdpq_xform_fill_rectangle(float x0, float y0, float x1, float y1)
             rdpq_fill_rectangle(x0, y0, x1, y1);
             break;
         
-        case RDPQ_XFORM_SCALERECT:
+        case RDPQ_XFORM_SCALE:
         {
             //Transform corner vertex coordinates
-            fm_vec2_t p0;
-            fm_vec2_t p1;
-            transform_point(&p0, x0, y0);
-            transform_point(&p1, x1, y1);
+            fm_vec2_t p0 = transform_point(x0, y0);
+            fm_vec2_t p1 = transform_point(x1, y1);
             rdpq_fill_rectangle(p0.x, p0.y, p1.x, p1.y);
         }
             break;
         
-        case RDPQ_XFORM_TRI:
+        case RDPQ_XFORM_ALL:
         {
             //Transform corner vertex coordinates
-            fm_vec2_t p0;
-            fm_vec2_t p1;
-            fm_vec2_t p2;
-            fm_vec2_t p3;
-            transform_point(&p0, x0, y0);
-            transform_point(&p1, x1, y0);
-            transform_point(&p2, x1, y1);
-            transform_point(&p3, x0, y1);
-            
-            //Generate vertex buffers for pair of triangles
-            float v0[2] = { p0.x, p0.y };
-            float v1[2] = { p1.x, p1.y };
-            float v2[2] = { p2.x, p2.y };
-            float v3[2] = { p3.x, p3.y };
+            fm_vec2_t p0 = transform_point(x0, y0);
+            fm_vec2_t p1 = transform_point(x1, y0);
+            fm_vec2_t p2 = transform_point(x1, y1);
+            fm_vec2_t p3 = transform_point(x0, y1);
             //Draw quadrilateral
-            rdpq_triangle(&TRIFMT_FILL, v0, v1, v2);
-            rdpq_triangle(&TRIFMT_FILL, v0, v2, v3);
+            rdpq_triangle(&TRIFMT_FILL, p0.v, p1.v, p2.v);
+            rdpq_triangle(&TRIFMT_FILL, p0.v, p2.v, p3.v);
         }
             break;
     }
@@ -230,11 +227,11 @@ void rdpq_xform_fill_rectangle(float x0, float y0, float x1, float y1)
 void rdpq_xform_texture_rectangle(rdpq_tile_t tile, float x0, float y0, float x1, float y1, float s, float t)
 {
     switch(curr_xform->type) {
-        case RDPQ_XFORM_IDENTITY:
+        case RDPQ_XFORM_NONE:
             rdpq_texture_rectangle(tile, x0, y0, x1, y1, s, t);
             break;
         
-        case RDPQ_XFORM_RECT:
+        case RDPQ_XFORM_TRANSLATE:
             //Apply X Translation to x0 and x1
             x0 += curr_xform->mtx.m[2][0];
             x1 += curr_xform->mtx.m[2][0];
@@ -244,25 +241,7 @@ void rdpq_xform_texture_rectangle(rdpq_tile_t tile, float x0, float y0, float x1
             rdpq_texture_rectangle(tile, x0, y0, x1, y1, s, t);
             break;
         
-        case RDPQ_XFORM_SCALERECT:
-        {
-            //Calculate texture coordinates
-            //Absolute value of width (x1-x0) and height (y1-y0) are needed to
-            //calculate texture coordinates for flipped textures properly
-            float s0 = s;
-            float t0 = t;
-            float s1 = fabsf(x1-x0)+s0;
-            float t1 = fabsf(y1-y0)+t0;
-            //Transform upper-left and lower-right vertex coordinates
-            fm_vec2_t p0;
-            fm_vec2_t p1;
-            transform_point(&p0, x0, y0);
-            transform_point(&p1, x1, y1);
-            rdpq_texture_rectangle_scaled(tile, p0.x, p0.y, p1.x, p1.y, s0, t0, s1, t1);
-        }
-            break;
-        
-        case RDPQ_XFORM_TRI:
+        case RDPQ_XFORM_SCALE:
         {
             //Calculate texture coordinates
             //Absolute value of width (x1-x0) and height (y1-y0) are needed to
@@ -272,15 +251,27 @@ void rdpq_xform_texture_rectangle(rdpq_tile_t tile, float x0, float y0, float x1
             float s1 = fabsf(x1-x0)+s0;
             float t1 = fabsf(y1-y0)+t0;
             //Transform corner vertex coordinates
-            fm_vec2_t p0;
-            fm_vec2_t p1;
-            fm_vec2_t p2;
-            fm_vec2_t p3;
-            transform_point(&p0, x0, y0);
-            transform_point(&p1, x1, y0);
-            transform_point(&p2, x1, y1);
-            transform_point(&p3, x0, y1);
-            
+            fm_vec2_t p0 = transform_point(x0, y0);
+            fm_vec2_t p1 = transform_point(x1, y1);
+            rdpq_texture_rectangle_scaled(tile, p0.x, p0.y, p1.x, p1.y, s0, t0, s1, t1);
+        }
+            break;
+        
+        case RDPQ_XFORM_ALL:
+        {
+            //Calculate texture coordinates
+            //Absolute value of width (x1-x0) and height (y1-y0) are needed to
+            //calculate texture coordinates for flipped textures properly
+            float s0 = s;
+            float t0 = t;
+            float s1 = fabsf(x1-x0)+s0;
+            float t1 = fabsf(y1-y0)+t0;
+            //Transform corner vertex coordinates
+            fm_vec2_t p0 = transform_point(x0, y0);
+            fm_vec2_t p1 = transform_point(x1, y0);
+            fm_vec2_t p2 = transform_point(x1, y1);
+            fm_vec2_t p3 = transform_point(x0, y1);
+
             //Generate vertex buffers for pair of triangles
             float v0[5] = { p0.x, p0.y, s0, t0, 1.0f };
             float v1[5] = { p1.x, p1.y, s1, t0, 1.0f };
@@ -297,11 +288,11 @@ void rdpq_xform_texture_rectangle(rdpq_tile_t tile, float x0, float y0, float x1
 void rdpq_xform_texture_rectangle_scaled(rdpq_tile_t tile, float x0, float y0, float x1, float y1, float s0, float t0, float s1, float t1)
 {
     switch(curr_xform->type) {
-        case RDPQ_XFORM_IDENTITY:
+        case RDPQ_XFORM_NONE:
             rdpq_texture_rectangle_scaled(tile, x0, y0, x1, y1, s0, t0, s1, t1);
             break;
         
-        case RDPQ_XFORM_RECT:
+        case RDPQ_XFORM_TRANSLATE:
             x0 += curr_xform->mtx.m[2][0];
             x1 += curr_xform->mtx.m[2][0];
             //Apply Y Translation to y0 and y1
@@ -310,28 +301,22 @@ void rdpq_xform_texture_rectangle_scaled(rdpq_tile_t tile, float x0, float y0, f
             rdpq_texture_rectangle_scaled(tile, x0, y0, x1, y1, s0, t0, s1, t1);
             break;
         
-        case RDPQ_XFORM_SCALERECT:
+        case RDPQ_XFORM_SCALE:
         {
-            //Transform upper-left and lower-right vertex coordinates
-            fm_vec2_t p0;
-            fm_vec2_t p1;
-            transform_point(&p0, x0, y0);
-            transform_point(&p1, x1, y1);
+            //Transform corner vertex coordinates
+            fm_vec2_t p0 = transform_point(x0, y0);
+            fm_vec2_t p1 = transform_point(x1, y1);
             rdpq_texture_rectangle_scaled(tile, p0.x, p0.y, p1.x, p1.y, s0, t0, s1, t1);
         }
             break;
         
-        case RDPQ_XFORM_TRI:
+        case RDPQ_XFORM_ALL:
         {
             //Transform corner vertex coordinates
-            fm_vec2_t p0;
-            fm_vec2_t p1;
-            fm_vec2_t p2;
-            fm_vec2_t p3;
-            transform_point(&p0, x0, y0);
-            transform_point(&p1, x1, y0);
-            transform_point(&p2, x1, y1);
-            transform_point(&p3, x0, y1);
+            fm_vec2_t p0 = transform_point(x0, y0);
+            fm_vec2_t p1 = transform_point(x1, y0);
+            fm_vec2_t p2 = transform_point(x1, y1);
+            fm_vec2_t p3 = transform_point(x0, y1);
 
             //Generate vertex buffers for pair of triangles
             float v0[5] = { p0.x, p0.y, s0, t0, 1.0f };
@@ -349,16 +334,15 @@ void rdpq_xform_texture_rectangle_scaled(rdpq_tile_t tile, float x0, float y0, f
 void rdpq_xform_triangle(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3)
 {
     switch(curr_xform->type) {
-        case RDPQ_XFORM_IDENTITY:
+        case RDPQ_XFORM_NONE:
             rdpq_triangle(fmt, v1, v2, v3);
             break;
             
-        case RDPQ_XFORM_RECT:
-        case RDPQ_XFORM_SCALERECT:
-        case RDPQ_XFORM_TRI:
-            //Call private helper function for transformed triangle to avoid copy
-            extern void __rdpq_triangle_rsp_xform(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx);
-            __rdpq_triangle_rsp_xform(fmt, v1, v2, v3, &curr_xform->mtx);
+        case RDPQ_XFORM_TRANSLATE:
+        case RDPQ_XFORM_SCALE:
+        case RDPQ_XFORM_ALL:
+            //Call RSP Triangle Implementation Directly
+            rdpq_triangle_rsp(fmt, v1, v2, v3, &curr_xform->mtx);
             break;
     }
 }

--- a/src/rdpq/rdpq_xform.c
+++ b/src/rdpq/rdpq_xform.c
@@ -1,0 +1,361 @@
+/**
+ * @file rdpq_text.c
+ */
+#include "fgeom2d.h"
+#include "rdpq_xform_internal.h"
+#include "rdpq_xform.h"
+#include "rdpq_rect.h"
+#include "rdpq_tri.h"
+
+#include "debug.h"
+#include "utils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+//List of transformation types
+//This is ordered from most strict to least strict
+typedef enum {
+    RDPQ_XFORM_IDENTITY, //No transformation
+    RDPQ_XFORM_RECT, //Transformation with only translation
+    RDPQ_XFORM_SCALERECT, //Any transformation that has no rotation or skew
+    RDPQ_XFORM_TRI //Any 2D transformation
+} rdpq_xform_type;
+
+#define RDPQ_XFORM_STACK_SIZE 16
+
+typedef struct rdpq_xform_s {
+    fm_mat3_t mtx;
+    rdpq_xform_type type;
+} rdpq_xform_t;
+
+static rdpq_xform_t *curr_xform;
+static rdpq_xform_t xform_stack[RDPQ_XFORM_STACK_SIZE];
+static int xform_stack_depth;
+
+void __rdpq_xform_init(void)
+{
+    //Initialize matrix stack to point to top
+    xform_stack_depth = 0;
+    curr_xform = &xform_stack[xform_stack_depth];
+    rdpq_xform_identity();
+}
+
+void __rdpq_xform_close(void)
+{
+    //Make sure that trying to push/load matrices causes crashed
+    curr_xform = NULL;
+}
+
+static rdpq_xform_type get_mtx_type(fm_mat3_t *mtx)
+{
+    if(mtx->m[0][1] != 0.0f || mtx->m[1][0] != 0.0f) { //Check for skew/rotation
+        return RDPQ_XFORM_TRI;
+    } else if(mtx->m[0][0] != 1.0f || mtx->m[1][1] != 1.0f) { //Check for non-identity scale
+        return RDPQ_XFORM_SCALERECT;
+    } else if(mtx->m[2][0] != 0.0f || mtx->m[2][1] != 0.0f) { //Check for translation
+        return RDPQ_XFORM_RECT;
+    } else {
+        return RDPQ_XFORM_IDENTITY;
+    }
+}
+
+void rdpq_xform_mtx_load(fm_mat3_t *mtx)
+{
+    curr_xform->mtx = *mtx;
+    curr_xform->type = get_mtx_type(mtx);
+}
+
+void rdpq_xform_mtx_mult(fm_mat3_t *mtx)
+{
+    fm_mat3_mul(&curr_xform->mtx, &curr_xform->mtx, mtx);
+    //Prefer least strict transformation type
+    int type = get_mtx_type(mtx);
+    if(type > curr_xform->type) {
+        curr_xform->type = type;
+    }
+}
+
+void rdpq_xform_identity(void)
+{
+    fm_mat3_t mtx;
+    fm_mat3_identity(&mtx);
+    rdpq_xform_mtx_load(&mtx);
+}
+
+void rdpq_xform_rotate(float theta)
+{
+    fm_mat3_t mtx;
+    fm_mat3_from_rotation(&mtx, theta);
+    rdpq_xform_mtx_mult(&mtx);
+}
+
+void rdpq_xform_translate(float x, float y)
+{
+    fm_mat3_t mtx;
+    fm_vec2_t translate = {{ x, y }};
+    fm_mat3_from_translation(&mtx, &translate);
+    rdpq_xform_mtx_mult(&mtx);
+}
+
+void rdpq_xform_scale(float x, float y)
+{
+    fm_mat3_t mtx;
+    fm_vec2_t scale = {{ x, y }};
+    fm_mat3_from_scale(&mtx, &scale);
+    rdpq_xform_mtx_mult(&mtx);
+}
+
+void rdpq_xform_load_rst(float x, float y, float theta, float scale_x, float scale_y)
+{
+    fm_mat3_t mtx;
+    fm_vec2_t scale = {{ scale_x, scale_y }};
+    fm_vec2_t translate = {{ x, y }};
+    fm_mat3_from_rst(&mtx, theta, &scale, &translate);
+    rdpq_xform_mtx_load(&mtx);
+}
+
+void rdpq_xform_mult_rst(float x, float y, float theta, float scale_x, float scale_y)
+{
+    fm_mat3_t mtx;
+    fm_vec2_t scale = {{ scale_x, scale_y }};
+    fm_vec2_t translate = {{ x, y }};
+    fm_mat3_from_rst(&mtx, theta, &scale, &translate);
+    rdpq_xform_mtx_mult(&mtx);
+}
+
+void rdpq_xform_load_srt(float x, float y, float theta, float scale_x, float scale_y)
+{
+    fm_mat3_t mtx;
+    fm_vec2_t scale = {{ scale_x, scale_y }};
+    fm_vec2_t translate = {{ x, y }};
+    fm_mat3_from_srt(&mtx, &scale, theta, &translate);
+    rdpq_xform_mtx_load(&mtx);
+}
+
+void rdpq_xform_mult_srt(float x, float y, float theta, float scale_x, float scale_y)
+{
+    fm_mat3_t mtx;
+    fm_vec2_t scale = {{ scale_x, scale_y }};
+    fm_vec2_t translate = {{ x, y }};
+    fm_mat3_from_srt(&mtx, &scale, theta, &translate);
+    rdpq_xform_mtx_mult(&mtx);
+}
+
+void rdpq_xform_push(void)
+{
+    int new_depth = xform_stack_depth+1;
+    assertf(new_depth < RDPQ_XFORM_STACK_SIZE, "RDPQ Transform Stack has reached maximum depth of %d", RDPQ_XFORM_STACK_SIZE);
+    //Copy matrix to top of stack
+    xform_stack[new_depth] = xform_stack[new_depth-1];
+    xform_stack_depth = new_depth;
+    //Update current matrix
+    curr_xform = &xform_stack[new_depth];
+}
+
+void rdpq_xform_pop(void)
+{
+    int new_depth = xform_stack_depth-1;
+    assertf(new_depth >= 0, "RDPQ Transform Stack is already at depth 0");
+    //Update current matrix and depth
+    curr_xform = &xform_stack[new_depth];
+    xform_stack_depth = new_depth;
+}
+
+static void transform_point(fm_vec2_t *out, float x, float y)
+{
+    fm_vec2_t in = {{x, y}};
+    fm_vec3_t temp;
+    fm_mat3_mul_vec2(&temp, &curr_xform->mtx, &in);
+    out->x = temp.x;
+    out->y = temp.y;
+}
+
+void rdpq_xform_fill_rectangle(float x0, float y0, float x1, float y1)
+{
+    switch(curr_xform->type) {
+        case RDPQ_XFORM_IDENTITY:
+            rdpq_fill_rectangle(x0, y0, x1, y1);
+            break;
+        
+        case RDPQ_XFORM_RECT:
+            //Apply X Translation to x0 and x1
+            x0 += curr_xform->mtx.m[2][0];
+            x1 += curr_xform->mtx.m[2][0];
+            //Apply Y Translation to y0 and y1
+            y0 += curr_xform->mtx.m[2][1];
+            y1 += curr_xform->mtx.m[2][1];
+            rdpq_fill_rectangle(x0, y0, x1, y1);
+            break;
+        
+        case RDPQ_XFORM_SCALERECT:
+        {
+            //Transform corner vertex coordinates
+            fm_vec2_t p0;
+            fm_vec2_t p1;
+            transform_point(&p0, x0, y0);
+            transform_point(&p1, x1, y1);
+            rdpq_fill_rectangle(p0.x, p0.y, p1.x, p1.y);
+        }
+            break;
+        
+        case RDPQ_XFORM_TRI:
+        {
+            //Transform corner vertex coordinates
+            fm_vec2_t p0;
+            fm_vec2_t p1;
+            fm_vec2_t p2;
+            fm_vec2_t p3;
+            transform_point(&p0, x0, y0);
+            transform_point(&p1, x1, y0);
+            transform_point(&p2, x1, y1);
+            transform_point(&p3, x0, y1);
+            
+            //Generate vertex buffers for pair of triangles
+            float v0[2] = { p0.x, p0.y };
+            float v1[2] = { p1.x, p1.y };
+            float v2[2] = { p2.x, p2.y };
+            float v3[2] = { p3.x, p3.y };
+            //Draw quadrilateral
+            rdpq_triangle(&TRIFMT_FILL, v0, v1, v2);
+            rdpq_triangle(&TRIFMT_FILL, v0, v2, v3);
+        }
+            break;
+    }
+}
+
+void rdpq_xform_texture_rectangle(rdpq_tile_t tile, float x0, float y0, float x1, float y1, float s, float t)
+{
+    switch(curr_xform->type) {
+        case RDPQ_XFORM_IDENTITY:
+            rdpq_texture_rectangle(tile, x0, y0, x1, y1, s, t);
+            break;
+        
+        case RDPQ_XFORM_RECT:
+            //Apply X Translation to x0 and x1
+            x0 += curr_xform->mtx.m[2][0];
+            x1 += curr_xform->mtx.m[2][0];
+            //Apply Y Translation to y0 and y1
+            y0 += curr_xform->mtx.m[2][1];
+            y1 += curr_xform->mtx.m[2][1];
+            rdpq_texture_rectangle(tile, x0, y0, x1, y1, s, t);
+            break;
+        
+        case RDPQ_XFORM_SCALERECT:
+        {
+            //Calculate texture coordinates
+            //Absolute value of width (x1-x0) and height (y1-y0) are needed to
+            //calculate texture coordinates for flipped textures properly
+            float s0 = s;
+            float t0 = t;
+            float s1 = fabsf(x1-x0)+s0;
+            float t1 = fabsf(y1-y0)+t0;
+            //Transform upper-left and lower-right vertex coordinates
+            fm_vec2_t p0;
+            fm_vec2_t p1;
+            transform_point(&p0, x0, y0);
+            transform_point(&p1, x1, y1);
+            rdpq_texture_rectangle_scaled(tile, p0.x, p0.y, p1.x, p1.y, s0, t0, s1, t1);
+        }
+            break;
+        
+        case RDPQ_XFORM_TRI:
+        {
+            //Calculate texture coordinates
+            //Absolute value of width (x1-x0) and height (y1-y0) are needed to
+            //calculate texture coordinates for flipped textures properly
+            float s0 = s;
+            float t0 = t;
+            float s1 = fabsf(x1-x0)+s0;
+            float t1 = fabsf(y1-y0)+t0;
+            //Transform corner vertex coordinates
+            fm_vec2_t p0;
+            fm_vec2_t p1;
+            fm_vec2_t p2;
+            fm_vec2_t p3;
+            transform_point(&p0, x0, y0);
+            transform_point(&p1, x1, y0);
+            transform_point(&p2, x1, y1);
+            transform_point(&p3, x0, y1);
+            
+            //Generate vertex buffers for pair of triangles
+            float v0[5] = { p0.x, p0.y, s0, t0, 1.0f };
+            float v1[5] = { p1.x, p1.y, s1, t0, 1.0f };
+            float v2[5] = { p2.x, p2.y, s1, t1, 1.0f };
+            float v3[5] = { p3.x, p3.y, s0, t1, 1.0f };
+            //Draw quadrilateral
+            rdpq_triangle(&TRIFMT_TEX, v0, v1, v2);
+            rdpq_triangle(&TRIFMT_TEX, v0, v2, v3);
+        }
+            break;
+    }
+}
+
+void rdpq_xform_texture_rectangle_scaled(rdpq_tile_t tile, float x0, float y0, float x1, float y1, float s0, float t0, float s1, float t1)
+{
+    switch(curr_xform->type) {
+        case RDPQ_XFORM_IDENTITY:
+            rdpq_texture_rectangle_scaled(tile, x0, y0, x1, y1, s0, t0, s1, t1);
+            break;
+        
+        case RDPQ_XFORM_RECT:
+            x0 += curr_xform->mtx.m[2][0];
+            x1 += curr_xform->mtx.m[2][0];
+            //Apply Y Translation to y0 and y1
+            y0 += curr_xform->mtx.m[2][1];
+            y1 += curr_xform->mtx.m[2][1];
+            rdpq_texture_rectangle_scaled(tile, x0, y0, x1, y1, s0, t0, s1, t1);
+            break;
+        
+        case RDPQ_XFORM_SCALERECT:
+        {
+            //Transform upper-left and lower-right vertex coordinates
+            fm_vec2_t p0;
+            fm_vec2_t p1;
+            transform_point(&p0, x0, y0);
+            transform_point(&p1, x1, y1);
+            rdpq_texture_rectangle_scaled(tile, p0.x, p0.y, p1.x, p1.y, s0, t0, s1, t1);
+        }
+            break;
+        
+        case RDPQ_XFORM_TRI:
+        {
+            //Transform corner vertex coordinates
+            fm_vec2_t p0;
+            fm_vec2_t p1;
+            fm_vec2_t p2;
+            fm_vec2_t p3;
+            transform_point(&p0, x0, y0);
+            transform_point(&p1, x1, y0);
+            transform_point(&p2, x1, y1);
+            transform_point(&p3, x0, y1);
+
+            //Generate vertex buffers for pair of triangles
+            float v0[5] = { p0.x, p0.y, s0, t0, 1.0f };
+            float v1[5] = { p1.x, p1.y, s1, t0, 1.0f };
+            float v2[5] = { p2.x, p2.y, s1, t1, 1.0f };
+            float v3[5] = { p3.x, p3.y, s0, t1, 1.0f };
+            //Draw quadrilateral
+            rdpq_triangle(&TRIFMT_TEX, v0, v1, v2);
+            rdpq_triangle(&TRIFMT_TEX, v0, v2, v3);
+        }
+            break;
+    }
+}
+
+void rdpq_xform_triangle(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3)
+{
+    switch(curr_xform->type) {
+        case RDPQ_XFORM_IDENTITY:
+            rdpq_triangle(fmt, v1, v2, v3);
+            break;
+            
+        case RDPQ_XFORM_RECT:
+        case RDPQ_XFORM_SCALERECT:
+        case RDPQ_XFORM_TRI:
+            //Call private helper function for transformed triangle to avoid copy
+            extern void __rdpq_triangle_rsp_xform(const rdpq_trifmt_t *fmt, const float *v1, const float *v2, const float *v3, fm_mat3_t *mtx);
+            __rdpq_triangle_rsp_xform(fmt, v1, v2, v3, &curr_xform->mtx);
+            break;
+    }
+}

--- a/src/rdpq/rdpq_xform_internal.h
+++ b/src/rdpq/rdpq_xform_internal.h
@@ -6,7 +6,13 @@
 
 #include "rdpq.h"
 
+/**
+ * @brief Internal function to initialize the RDPQ Transform Library
+ */
 void __rdpq_xform_init(void);
+/**
+ * @brief Internal function to shut down the RDPQ Transform Library
+ */
 void __rdpq_xform_close(void);
 
 #endif

--- a/src/rdpq/rdpq_xform_internal.h
+++ b/src/rdpq/rdpq_xform_internal.h
@@ -1,0 +1,12 @@
+/**
+ * @file rdpq_xform_internal.h
+ */
+#ifndef LIBDRAGON_RDPQ_XFORM_INTERNAL_H
+#define LIBDRAGON_RDPQ_XFORM_INTERNAL_H
+
+#include "rdpq.h"
+
+void __rdpq_xform_init(void);
+void __rdpq_xform_close(void);
+
+#endif

--- a/tests/test_rdpq_tri.c
+++ b/tests/test_rdpq_tri.c
@@ -68,7 +68,7 @@ void test_rdpq_triangle(TestContext *ctx) {
         rdpq_debug_log_msg("CPU");
         rdpq_triangle_cpu(&trifmt, v1, v2, v3);
         rdpq_debug_log_msg("RSP");
-        rdpq_triangle_rsp(&trifmt, v1, v2, v3);
+        rdpq_triangle_rsp(&trifmt, v1, v2, v3, NULL);
         rspq_wait();
         
         const int RDP_TRI_SIZE = 22;


### PR DESCRIPTION
This is an API for 2D transformations and transformed primitives. This API is presently done CPU-side. The API can be optionally used for sprites by setting allow_xform to true in rdpq_blitparms_t during a call to rdpq_tex_blit or rdpq_sprite_blit.