### PR TITLE
add c++ operator overloads for fgeom

### DIFF
--- a/include/fgeom.h
+++ b/include/fgeom.h
@@ -532,94 +532,94 @@ inline void fm_mat4_mul_vec4(fm_vec4_t *out, const fm_mat4_t *m, const fm_vec4_t
 #ifdef __cplusplus
 
   constexpr fm_vec3_t operator+(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
-    return {lhs.v[0] + rhs.v[0], lhs.v[1] + rhs.v[1], lhs.v[2] + rhs.v[2]};
+    return {lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z};
   }
 
   constexpr fm_vec3_t operator-(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
-    return {lhs.v[0] - rhs.v[0], lhs.v[1] - rhs.v[1], lhs.v[2] - rhs.v[2]};
+    return {lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z};
   }
 
   constexpr fm_vec3_t operator*(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
-    return {lhs.v[0] * rhs.v[0], lhs.v[1] * rhs.v[1], lhs.v[2] * rhs.v[2]};
+    return {lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z};
   }
 
   constexpr fm_vec3_t operator/(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
-    return {lhs.v[0] / rhs.v[0], lhs.v[1] / rhs.v[1], lhs.v[2] / rhs.v[2]};
+    return {lhs.x / rhs.x, lhs.y / rhs.y, lhs.z / rhs.z};
   }
 
   constexpr fm_vec3_t operator+(fm_vec3_t const& lhs, float rhs) {
-    return {lhs.v[0] + rhs, lhs.v[1] + rhs, lhs.v[2] + rhs};
+    return {lhs.x + rhs, lhs.y + rhs, lhs.z + rhs};
   }
 
   constexpr fm_vec3_t operator-(fm_vec3_t const& lhs, float rhs) {
-    return {lhs.v[0] - rhs, lhs.v[1] - rhs, lhs.v[2] - rhs};
+    return {lhs.x - rhs, lhs.y - rhs, lhs.z - rhs};
   }
 
   constexpr fm_vec3_t operator*(fm_vec3_t const& lhs, float rhs) {
-    return {lhs.v[0] * rhs, lhs.v[1] * rhs, lhs.v[2] * rhs};
+    return {lhs.x * rhs, lhs.y * rhs, lhs.z * rhs};
   }
 
   constexpr fm_vec3_t operator/(fm_vec3_t const& lhs, float rhs) {
-    return {lhs.v[0] / rhs, lhs.v[1] / rhs, lhs.v[2] / rhs};
+    return {lhs.x / rhs, lhs.y / rhs, lhs.z / rhs};
   }
 
   constexpr fm_vec3_t operator-(fm_vec3_t const& lhs) {
-    return {-lhs.v[0], -lhs.v[1], -lhs.v[2]};
+    return {-lhs.x, -lhs.y, -lhs.z};
   }
 
   constexpr fm_vec3_t& operator+=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
-    lhs.v[0] += rhs.v[0];
-    lhs.v[1] += rhs.v[1];
-    lhs.v[2] += rhs.v[2];
+    lhs.x += rhs.x;
+    lhs.y += rhs.y;
+    lhs.z += rhs.z;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator+=(fm_vec3_t &lhs, float rhs) {
-    lhs.v[0] += rhs;
-    lhs.v[1] += rhs;
-    lhs.v[2] += rhs;
+    lhs.x += rhs;
+    lhs.y += rhs;
+    lhs.z += rhs;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator-=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
-    lhs.v[0] -= rhs.v[0];
-    lhs.v[1] -= rhs.v[1];
-    lhs.v[2] -= rhs.v[2];
+    lhs.x -= rhs.x;
+    lhs.y -= rhs.y;
+    lhs.z -= rhs.z;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator-=(fm_vec3_t &lhs, float rhs) {
-    lhs.v[0] -= rhs;
-    lhs.v[1] -= rhs;
-    lhs.v[2] -= rhs;
+    lhs.x -= rhs;
+    lhs.y -= rhs;
+    lhs.z -= rhs;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator*=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
-    lhs.v[0] *= rhs.v[0];
-    lhs.v[1] *= rhs.v[1];
-    lhs.v[2] *= rhs.v[2];
+    lhs.x *= rhs.x;
+    lhs.y *= rhs.y;
+    lhs.z *= rhs.z;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator*=(fm_vec3_t &lhs, float rhs) {
-    lhs.v[0] *= rhs;
-    lhs.v[1] *= rhs;
-    lhs.v[2] *= rhs;
+    lhs.x *= rhs;
+    lhs.y *= rhs;
+    lhs.z *= rhs;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator/=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
-    lhs.v[0] /= rhs.v[0];
-    lhs.v[1] /= rhs.v[1];
-    lhs.v[2] /= rhs.v[2];
+    lhs.x /= rhs.x;
+    lhs.y /= rhs.y;
+    lhs.z /= rhs.z;
     return lhs;
   }
 
   constexpr fm_vec3_t& operator/=(fm_vec3_t &lhs, float rhs) {
-    lhs.v[0] /= rhs;
-    lhs.v[1] /= rhs;
-    lhs.v[2] /= rhs;
+    lhs.x /= rhs;
+    lhs.y /= rhs;
+    lhs.z /= rhs;
     return lhs;
   }
 

--- a/include/fgeom.h
+++ b/include/fgeom.h
@@ -528,4 +528,106 @@ inline void fm_mat4_mul_vec4(fm_vec4_t *out, const fm_mat4_t *m, const fm_vec4_t
 }
 #endif
 
+
+#ifdef __cplusplus
+
+  constexpr fm_vec3_t operator+(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
+    return {lhs.v[0] + rhs.v[0], lhs.v[1] + rhs.v[1], lhs.v[2] + rhs.v[2]};
+  }
+
+  constexpr fm_vec3_t operator-(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
+    return {lhs.v[0] - rhs.v[0], lhs.v[1] - rhs.v[1], lhs.v[2] - rhs.v[2]};
+  }
+
+  constexpr fm_vec3_t operator*(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
+    return {lhs.v[0] * rhs.v[0], lhs.v[1] * rhs.v[1], lhs.v[2] * rhs.v[2]};
+  }
+
+  constexpr fm_vec3_t operator/(fm_vec3_t const& lhs, fm_vec3_t const& rhs) {
+    return {lhs.v[0] / rhs.v[0], lhs.v[1] / rhs.v[1], lhs.v[2] / rhs.v[2]};
+  }
+
+  constexpr fm_vec3_t operator+(fm_vec3_t const& lhs, float rhs) {
+    return {lhs.v[0] + rhs, lhs.v[1] + rhs, lhs.v[2] + rhs};
+  }
+
+  constexpr fm_vec3_t operator-(fm_vec3_t const& lhs, float rhs) {
+    return {lhs.v[0] - rhs, lhs.v[1] - rhs, lhs.v[2] - rhs};
+  }
+
+  constexpr fm_vec3_t operator*(fm_vec3_t const& lhs, float rhs) {
+    return {lhs.v[0] * rhs, lhs.v[1] * rhs, lhs.v[2] * rhs};
+  }
+
+  constexpr fm_vec3_t operator/(fm_vec3_t const& lhs, float rhs) {
+    return {lhs.v[0] / rhs, lhs.v[1] / rhs, lhs.v[2] / rhs};
+  }
+
+  constexpr fm_vec3_t operator-(fm_vec3_t const& lhs) {
+    return {-lhs.v[0], -lhs.v[1], -lhs.v[2]};
+  }
+
+  constexpr fm_vec3_t& operator+=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
+    lhs.v[0] += rhs.v[0];
+    lhs.v[1] += rhs.v[1];
+    lhs.v[2] += rhs.v[2];
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator+=(fm_vec3_t &lhs, float rhs) {
+    lhs.v[0] += rhs;
+    lhs.v[1] += rhs;
+    lhs.v[2] += rhs;
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator-=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
+    lhs.v[0] -= rhs.v[0];
+    lhs.v[1] -= rhs.v[1];
+    lhs.v[2] -= rhs.v[2];
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator-=(fm_vec3_t &lhs, float rhs) {
+    lhs.v[0] -= rhs;
+    lhs.v[1] -= rhs;
+    lhs.v[2] -= rhs;
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator*=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
+    lhs.v[0] *= rhs.v[0];
+    lhs.v[1] *= rhs.v[1];
+    lhs.v[2] *= rhs.v[2];
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator*=(fm_vec3_t &lhs, float rhs) {
+    lhs.v[0] *= rhs;
+    lhs.v[1] *= rhs;
+    lhs.v[2] *= rhs;
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator/=(fm_vec3_t &lhs, fm_vec3_t const& rhs) {
+    lhs.v[0] /= rhs.v[0];
+    lhs.v[1] /= rhs.v[1];
+    lhs.v[2] /= rhs.v[2];
+    return lhs;
+  }
+
+  constexpr fm_vec3_t& operator/=(fm_vec3_t &lhs, float rhs) {
+    lhs.v[0] /= rhs;
+    lhs.v[1] /= rhs;
+    lhs.v[2] /= rhs;
+    return lhs;
+  }
+
+  constexpr fm_quat_t operator*(fm_quat_t const& lhs, fm_quat_t const& rhs) {
+    fm_quat_t res{};
+    fm_quat_mul(&res, const_cast<fm_quat_t*>(&lhs), const_cast<fm_quat_t*>(&rhs));
+    return res;
+  }
+#endif
+
 #endif

--- a/include/fgeom2d.h
+++ b/include/fgeom2d.h
@@ -313,4 +313,92 @@ inline void fm_mat3_mul_vec3(fm_vec3_t *out, const fm_mat3_t *m, const fm_vec3_t
 }
 #endif
 
+#ifdef __cplusplus
+
+constexpr fm_vec2_t operator+(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
+  return {lhs.v[0] + rhs.v[0], lhs.v[1] + rhs.v[1]};
+}
+
+constexpr fm_vec2_t operator-(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
+  return {lhs.v[0] - rhs.v[0], lhs.v[1] - rhs.v[1]};
+}
+
+constexpr fm_vec2_t operator*(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
+  return {lhs.v[0] * rhs.v[0], lhs.v[1] * rhs.v[1]};
+}
+
+constexpr fm_vec2_t operator/(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
+  return {lhs.v[0] / rhs.v[0], lhs.v[1] / rhs.v[1]};
+} 
+
+constexpr fm_vec2_t operator+(fm_vec2_t const& lhs, float rhs) {
+  return {lhs.v[0] + rhs, lhs.v[1] + rhs};
+}
+
+constexpr fm_vec2_t operator-(fm_vec2_t const& lhs, float rhs) {
+  return {lhs.v[0] - rhs, lhs.v[1] - rhs};
+}
+
+constexpr fm_vec2_t operator*(fm_vec2_t const& lhs, float rhs) {
+  return {lhs.v[0] * rhs, lhs.v[1] * rhs};
+}
+
+constexpr fm_vec2_t operator/(fm_vec2_t const& lhs, float rhs) {
+  return {lhs.v[0] / rhs, lhs.v[1] / rhs};
+}
+
+constexpr fm_vec2_t operator-(fm_vec2_t const& lhs) {
+  return {-lhs.v[0], -lhs.v[1]};
+}
+
+constexpr fm_vec2_t& operator+=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
+  lhs.v[0] += rhs.v[0];
+  lhs.v[1] += rhs.v[1];
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator+=(fm_vec2_t &lhs, float rhs) {
+  lhs.v[0] += rhs;
+  lhs.v[1] += rhs;
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator-=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
+  lhs.v[0] -= rhs.v[0];
+  lhs.v[1] -= rhs.v[1];
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator-=(fm_vec2_t &lhs, float rhs) {
+  lhs.v[0] -= rhs;
+  lhs.v[1] -= rhs;
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator*=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
+  lhs.v[0] *= rhs.v[0];
+  lhs.v[1] *= rhs.v[1];
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator*=(fm_vec2_t &lhs, float rhs) {
+  lhs.v[0] *= rhs;
+  lhs.v[1] *= rhs;
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator/=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
+  lhs.v[0] /= rhs.v[0];
+  lhs.v[1] /= rhs.v[1];
+  return lhs;
+}
+
+constexpr fm_vec2_t& operator/=(fm_vec2_t &lhs, float rhs) {
+  lhs.v[0] /= rhs;
+  lhs.v[1] /= rhs;
+  return lhs;
+}
+
+#endif
+
 #endif

--- a/include/fgeom2d.h
+++ b/include/fgeom2d.h
@@ -316,86 +316,86 @@ inline void fm_mat3_mul_vec3(fm_vec3_t *out, const fm_mat3_t *m, const fm_vec3_t
 #ifdef __cplusplus
 
 constexpr fm_vec2_t operator+(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
-  return {lhs.v[0] + rhs.v[0], lhs.v[1] + rhs.v[1]};
+  return {lhs.x + rhs.x, lhs.y + rhs.y};
 }
 
 constexpr fm_vec2_t operator-(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
-  return {lhs.v[0] - rhs.v[0], lhs.v[1] - rhs.v[1]};
+  return {lhs.x - rhs.x, lhs.y - rhs.y};
 }
 
 constexpr fm_vec2_t operator*(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
-  return {lhs.v[0] * rhs.v[0], lhs.v[1] * rhs.v[1]};
+  return {lhs.x * rhs.x, lhs.y * rhs.y};
 }
 
 constexpr fm_vec2_t operator/(fm_vec2_t const& lhs, fm_vec2_t const& rhs) {
-  return {lhs.v[0] / rhs.v[0], lhs.v[1] / rhs.v[1]};
+  return {lhs.x / rhs.x, lhs.y / rhs.y};
 } 
 
 constexpr fm_vec2_t operator+(fm_vec2_t const& lhs, float rhs) {
-  return {lhs.v[0] + rhs, lhs.v[1] + rhs};
+  return {lhs.x + rhs, lhs.y + rhs};
 }
 
 constexpr fm_vec2_t operator-(fm_vec2_t const& lhs, float rhs) {
-  return {lhs.v[0] - rhs, lhs.v[1] - rhs};
+  return {lhs.x - rhs, lhs.y - rhs};
 }
 
 constexpr fm_vec2_t operator*(fm_vec2_t const& lhs, float rhs) {
-  return {lhs.v[0] * rhs, lhs.v[1] * rhs};
+  return {lhs.x * rhs, lhs.y * rhs};
 }
 
 constexpr fm_vec2_t operator/(fm_vec2_t const& lhs, float rhs) {
-  return {lhs.v[0] / rhs, lhs.v[1] / rhs};
+  return {lhs.x / rhs, lhs.y / rhs};
 }
 
 constexpr fm_vec2_t operator-(fm_vec2_t const& lhs) {
-  return {-lhs.v[0], -lhs.v[1]};
+  return {-lhs.x, -lhs.y};
 }
 
 constexpr fm_vec2_t& operator+=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
-  lhs.v[0] += rhs.v[0];
-  lhs.v[1] += rhs.v[1];
+  lhs.x += rhs.x;
+  lhs.y += rhs.y;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator+=(fm_vec2_t &lhs, float rhs) {
-  lhs.v[0] += rhs;
-  lhs.v[1] += rhs;
+  lhs.x += rhs;
+  lhs.y += rhs;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator-=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
-  lhs.v[0] -= rhs.v[0];
-  lhs.v[1] -= rhs.v[1];
+  lhs.x -= rhs.x;
+  lhs.y -= rhs.y;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator-=(fm_vec2_t &lhs, float rhs) {
-  lhs.v[0] -= rhs;
-  lhs.v[1] -= rhs;
+  lhs.x -= rhs;
+  lhs.y -= rhs;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator*=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
-  lhs.v[0] *= rhs.v[0];
-  lhs.v[1] *= rhs.v[1];
+  lhs.x *= rhs.x;
+  lhs.y *= rhs.y;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator*=(fm_vec2_t &lhs, float rhs) {
-  lhs.v[0] *= rhs;
-  lhs.v[1] *= rhs;
+  lhs.x *= rhs;
+  lhs.y *= rhs;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator/=(fm_vec2_t &lhs, fm_vec2_t const& rhs) {
-  lhs.v[0] /= rhs.v[0];
-  lhs.v[1] /= rhs.v[1];
+  lhs.x /= rhs.x;
+  lhs.y /= rhs.y;
   return lhs;
 }
 
 constexpr fm_vec2_t& operator/=(fm_vec2_t &lhs, float rhs) {
-  lhs.v[0] /= rhs;
-  lhs.v[1] /= rhs;
+  lhs.x /= rhs;
+  lhs.y /= rhs;
   return lhs;
 }
 


### PR DESCRIPTION
Adds c++ operator overloads for both fm_vec3_t and fm_vec2_t.
This is mostly taken from tiny3d where this has been in for a while now.
Merging this will temporarily break t3d until i removed the functions there.