### PR TITLE
mksprite: add bleedfix option to mitigate halos for transparent sprites WIP

### DIFF
--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -137,6 +137,8 @@ void print_args( char * name )
     fprintf(stderr, "   -f/--format <fmt>                       Specify output RDP surface format (default: AUTO)\n");
     fprintf(stderr, "   -g/--gamma                              Convert colors to linear scale (use with runtime\n");
     fprintf(stderr, "                                            VI gamma correction enabled)\n");
+    fprintf(stderr, "   -b/--bleedfix                           Extend opaque colors into transparent regions\n");
+    fprintf(stderr, "                                            to mitigate a white halo\n");
     fprintf(stderr, "   -d/--debug                              Dump computed images as PNGs (eg: mipmaps)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Lossless sprite (default mode):\n");
@@ -942,6 +944,201 @@ bool spritemaker_gamma_correct(spritemaker_t *spr) {
     }
 
     return true;
+}
+
+
+const struct {
+    int x, y;
+} bleedfix_neighbors[] = {
+    {-1, -1}, { 0, -1}, { 1, -1}, {-1,  0}, 
+    { 1,  0}, {-1,  1}, { 0,  1}, { 1,  1} 
+};
+
+void bleedfix_palette(spritemaker_t *spr, image_t *image) {
+    int pi_edge_counts[256] = {};
+    int pi_transparent = -1;
+
+    // Find transparent color
+    for (int pi=0; pi<spr->palette.used_colors; pi++) {
+        if (spr->palette.colors[pi][3] == 0) {
+            if (pi_transparent != -1) {
+                if (flag_verbose)
+                    fprintf(stderr, "bleedfix: multiple transparent colors found in palette; can't continue");
+                return;
+            }
+            pi_transparent = pi;
+        }
+    }
+
+    if (pi_transparent == -1) {
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: no fully transparent color found in palette");
+        return;
+    }
+
+    // Count number of transparent neighbors for each color
+    uint8_t *img = image->image;
+    for (int y=1;y<image->height-1;y++) {
+        for (int x=1;x<image->width-1;x++) {
+            int idx_center = y * image->width + x;
+            int pi_center = img[idx_center];
+
+            // If this pixel is opaque check for transparent neighbors
+            if (pi_center != pi_transparent) {
+                for (int k = 0; k < 8; k++) {
+                    int idx_neighbor = idx_center + bleedfix_neighbors[k].y * image->width + bleedfix_neighbors[k].x;
+                    int pi_neighbor = img[idx_neighbor];
+                    if (pi_neighbor == pi_transparent) {
+                        pi_edge_counts[pi_center]++;
+                        break;
+                    }
+                }    
+            }
+        }
+    }
+
+    int num_free_colors = (image->fmt == FMT_CI4 ? 16 : 256) - spr->palette.used_colors;
+
+    // For now, we always just average out all edge colors and use the result 
+    // for the  existing  transparent color index in the palette.
+    if (num_free_colors == 0 || true) {
+        int r = 0, g = 0, b = 0;
+        int total_count = 0;
+        for (int pi=0; pi<spr->palette.used_colors; pi++) {
+            if (pi != pi_transparent) {
+                int count = pi_edge_counts[pi];
+                total_count += count;
+                r += spr->palette.colors[pi][0] * count;
+                g += spr->palette.colors[pi][1] * count;
+                b += spr->palette.colors[pi][2] * count;
+            }
+        }
+        
+        spr->palette.colors[pi_transparent][0] = r / total_count;
+        spr->palette.colors[pi_transparent][1] = g / total_count;
+        spr->palette.colors[pi_transparent][2] = b / total_count;
+        // spr->palette.colors[pi_transparent][3] = 255;
+    }
+    else {
+        // TODO:
+        // Use exoquant to create a palette with num_free_colors entries,
+        // based on the edge colors (pi_edge_counts) and distribute those
+        // around the edges, similar to bleedfix_rgb()
+    }
+}
+
+void bleedfix_rgba(spritemaker_t *spr, image_t *image) {
+    uint8_t *img = image->image;
+
+    uint32_t num_bytes = image->width * image->height * 4;
+    uint8_t *img_scratch = malloc(num_bytes);
+    bool has_transparent_pixels = true;
+
+    for (int pass = 0; pass < BLEEDFIX_PASSES && has_transparent_pixels; pass++) {
+        has_transparent_pixels = false;
+        memcpy(img_scratch, img, num_bytes);
+
+        for (int y=0;y<image->height;y++) {
+            for (int x=0;x<image->width;x++) {
+                int idx_center = (y * image->width + x) * 4;
+
+                // If this pixel is transparent, look for opaque neighbors and
+                // average their colors.
+                if (img[idx_center + 3] == 0) {
+                    has_transparent_pixels = true;
+                    int r = 0, g = 0, b = 0, num_opaque_neighbors = 0;
+
+                    for (int k = 0; k < 8; k++) {
+                        int nx = x + bleedfix_neighbors[k].x;
+                        int ny = y + bleedfix_neighbors[k].y;
+                        if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                            int idx_neighbor = (ny * image->width + nx) * 4;
+                            
+                            if (img[idx_neighbor + 3] > 0) {
+                                r += img[idx_neighbor + 0];
+                                g += img[idx_neighbor + 1];
+                                b += img[idx_neighbor + 2];
+                                num_opaque_neighbors++;
+                            }
+                        }
+                    }
+
+                    if (num_opaque_neighbors > 0) {
+                        img_scratch[idx_center + 0] = r / num_opaque_neighbors;
+                        img_scratch[idx_center + 1] = g / num_opaque_neighbors;
+                        img_scratch[idx_center + 2] = b / num_opaque_neighbors;
+                        // img_scratch[idx_center + 3] = 255;
+                    }
+                }
+            }
+        }
+        memcpy(img, img_scratch, num_bytes);
+    }
+
+    free(img_scratch);
+}
+
+void bleedfix_grey_alpha(spritemaker_t *spr, image_t *image) {
+    uint8_t *img = image->image;
+
+    uint32_t num_bytes = image->width * image->height * 2;
+    uint8_t *img_scratch = malloc(num_bytes);
+    bool has_transparent_pixels = true;
+
+    for (int pass = 0; pass < BLEEDFIX_PASSES && has_transparent_pixels; pass++) {
+        has_transparent_pixels = false;
+        memcpy(img_scratch, img, num_bytes);
+
+        for (int y=0;y<image->height;y++) {
+            for (int x=0;x<image->width;x++) {
+                int idx_center = (y * image->width + x) * 2;
+
+                // If this pixel is transparent, look for opaque neighbors and
+                // average their colors.
+                if (img[idx_center + 1] == 0) {
+                    has_transparent_pixels = true;
+                    int c = 0, num_opaque_neighbors = 0;
+
+                    for (int k = 0; k < 8; k++) {
+                        int nx = x + bleedfix_neighbors[k].x;
+                        int ny = y + bleedfix_neighbors[k].y;
+                        if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                            int idx_neighbor = (ny * image->width + nx) * 2;
+                            
+                            if (img[idx_neighbor + 1] > 0) {
+                                c += img[idx_neighbor + 0];
+                                num_opaque_neighbors++;
+                            }
+                        }
+                    }
+
+                    if (num_opaque_neighbors > 0) {
+                        img_scratch[idx_center + 0] = c / num_opaque_neighbors;
+                        // img_scratch[idx_center + 1] = 255;
+                    }
+                }
+            }
+        }
+        memcpy(img, img_scratch, num_bytes);
+    }
+
+    free(img_scratch);
+}
+
+void spritemaker_bleedfix(spritemaker_t *spr) {
+    for (int m=0; m<MAX_IMAGES; m++) {
+        image_t *image = &spr->images[m];
+        if (image->image == NULL)
+            continue;
+
+        if (image->ct == LCT_PALETTE) {
+            bleedfix_palette(spr, image);
+        } else if (image->ct == LCT_RGBA) {
+            bleedfix_rgba(spr, image);
+        } else if (image->ct == LCT_GREY_ALPHA) {
+            bleedfix_grey_alpha(spr, image);
+        }
+    }
 }
 
 bool spritemaker_convert_ihq(spritemaker_t *spr) {
@@ -1823,6 +2020,10 @@ int convert(const char *infn, const char *outfn, const parms_t *pm, int compress
             goto error;
     }
 
+    // Run bleedfix last, importantly after quantization
+    if (pm->bleedfix)
+        spritemaker_bleedfix(&spr);
+
     // Dump TMEM usage
     if (flag_verbose) {
         int tmem_usage; spritemaker_fit_tmem(&spr, &tmem_usage);
@@ -2101,6 +2302,12 @@ int main(int argc, char *argv[])
                     return 1;
                 }
                 pm.lossy_quality = q;
+            }
+
+            /* ---------------- BLEEDFIX console argument ------------------- */
+            /* -b/--bleedfix Extend opaque colors into transparent regions to mitigate a white halo */
+            else if (!strcmp(argv[i], "-b") || !strcmp(argv[i], "--bleedfix")) {
+                pm.bleedfix = 1;
             }
 
             /* ---------------- TEXTURE PARAMETERS console argument ------------------- */

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -960,6 +960,7 @@ static int bleedfix_adjust_palette(spritemaker_t *spr) {
     int pi_edge_counts_total = 0;
     int pi_edge_counts[256] = {};
     int pi_transparent = -1;
+    int num_unique_edge_colors = 0;
 
     // Find transparent color
     for (int pi=0; pi<spr->palette.used_colors; pi++) {
@@ -996,6 +997,9 @@ static int bleedfix_adjust_palette(spritemaker_t *spr) {
                         int idx_neighbor = (ny * image->width + nx);
                         int pi_neighbor = img[idx_neighbor];
                         if (pi_neighbor != pi_transparent) {
+                            if (pi_edge_counts[pi_neighbor] == 0) {
+                                num_unique_edge_colors++;
+                            }
                             num_neighbors++;
                             pi_edge_counts[pi_neighbor]++;
                             pi_edge_counts_total++;
@@ -1009,68 +1013,91 @@ static int bleedfix_adjust_palette(spritemaker_t *spr) {
         }
     }
 
+    // Palette contains a transparent color, but the whole image is fully
+    // transparent or fully opague? We have nothing do here.
+    if (num_unique_edge_colors == 0) {
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: no transparent/opaque neighbors found\n");
+        return 0;
+    }
+
     int num_free_colors = (image->fmt == FMT_CI4 ? 16 : 256) - spr->palette.used_colors;
 
-    // No free colors left in the palette? Our only option is to replace the
-    // one existing transparent color with a better "background color" that
-    // is the average of all edge colors.
-    if (num_free_colors == 0) {
-        if (flag_verbose)
-            fprintf(stderr, "bleedfix: adjusting existing transparent color in palette\n");
-
+    // No free colors left in the palette or we only have a single unique edge
+    // color? Just replace the one existing transparent color with a better 
+    // "background color" that is the average of all edge colors.
+    if (num_free_colors == 0 || num_unique_edge_colors == 1) {
         int r = 0, g = 0, b = 0;
         for (int pi=0; pi<spr->palette.used_colors; pi++) {
             if (pi != pi_transparent) {
-                int count = pi_edge_counts[pi];
-                r += spr->palette.colors[pi][0] * count;
-                g += spr->palette.colors[pi][1] * count;
-                b += spr->palette.colors[pi][2] * count;
+                r += spr->palette.colors[pi][0] * pi_edge_counts[pi];
+                g += spr->palette.colors[pi][1] * pi_edge_counts[pi];
+                b += spr->palette.colors[pi][2] * pi_edge_counts[pi];
             }
         }
         
         spr->palette.colors[pi_transparent][0] = r / pi_edge_counts_total;
         spr->palette.colors[pi_transparent][1] = g / pi_edge_counts_total;
         spr->palette.colors[pi_transparent][2] = b / pi_edge_counts_total;
+
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: adjusted existing transparent color in palette\n");
         return 0;
     }
 
-    // We have some space for new colors. Create a buffer that contains all 
-    // edge colors and their counts to feed into exoquant. This produces a new
-    // palette with transparent colors that we can append to the existing
-    // palette. The caller can then re-quantize with this new palette.
-    // Note that we actually have one more spot than num_free_colors available: 
-    // the existing transparent color.
-    else if (pi_edge_counts_total > 0) {
-        if (flag_verbose)
-            fprintf(stderr, "bleedfix: appending %d new transparent colors to palette\n", num_free_colors);
+    // Multiple unique edge colors and some space in the palette?
+    // This produces a new palette with transparent colors that we can 
+    // append to the existing palette. The caller can then re-quantize with
+    // this new palette.
+    else {
 
-        uint8_t *img_edge = malloc(pi_edge_counts_total * 4);
-        int i = 0;
-        for (int pi=0; pi<spr->palette.used_colors; pi++) {
-            if (pi != pi_transparent) {
-                int count = pi_edge_counts[pi];
-                for (int c = 0; c < count; c++, i += 4) {
-                    img_edge[i + 0] = spr->palette.colors[pi][0];
-                    img_edge[i + 1] = spr->palette.colors[pi][1];
-                    img_edge[i + 2] = spr->palette.colors[pi][2];
-                    img_edge[i + 3] = 0;
+        // We actually have one more spot than num_free_colors available: 
+        // the existing transparent color.
+        int edge_pal_len = num_free_colors + 1;
+        uint8_t edge_pal[edge_pal_len * 4] = {};
+
+        // Can we fit all unique edge colors into the remaining palette space?
+        if (num_unique_edge_colors <= edge_pal_len) {
+            edge_pal_len = 0;
+            for (int pi=0; pi<spr->palette.used_colors; pi++) {
+                if (pi != pi_transparent && pi_edge_counts[pi] > 0) {
+                    edge_pal[edge_pal_len * 4 + 0] = spr->palette.colors[pi][0];
+                    edge_pal[edge_pal_len * 4 + 1] = spr->palette.colors[pi][1];
+                    edge_pal[edge_pal_len * 4 + 2] = spr->palette.colors[pi][2];
+                    edge_pal[edge_pal_len * 4 + 3] = 0;
+                    edge_pal_len++;
                 }
             }
         }
 
-        int edge_pal_len = num_free_colors + 1;
-        uint8_t edge_pal[edge_pal_len * 4] = {};
+        // Less free space than unique edge colors? Create a buffer that 
+        // contains all edge colors with their counts to feed into exoquant and
+        // quantize to fill the remaining palette.
+        else {
+            uint8_t *img_edge = malloc(pi_edge_counts_total * 4);
+            int i = 0;
+            for (int pi=0; pi<spr->palette.used_colors; pi++) {
+                if (pi != pi_transparent) {
+                    for (int c = 0; c < pi_edge_counts[pi]; c++, i += 4) {
+                        img_edge[i + 0] = spr->palette.colors[pi][0];
+                        img_edge[i + 1] = spr->palette.colors[pi][1];
+                        img_edge[i + 2] = spr->palette.colors[pi][2];
+                        img_edge[i + 3] = 0;
+                    }
+                }
+            }
 
-        exq_data *exq = exq_init();
-        exq->numBitsPerChannel = 5;
-        exq_no_transparency(exq);
-        exq_feed(exq, img_edge, pi_edge_counts_total);
-        exq_quantize_hq(exq, edge_pal_len);
-        exq_get_palette(exq, edge_pal, edge_pal_len);
-        exq_free(exq);
-        free(img_edge);
+            exq_data *exq = exq_init();
+            exq->numBitsPerChannel = 5;
+            exq_no_transparency(exq);
+            exq_feed(exq, img_edge, pi_edge_counts_total);
+            exq_quantize_hq(exq, edge_pal_len);
+            exq_get_palette(exq, edge_pal, edge_pal_len);
+            exq_free(exq);
+            free(img_edge);
+        }
 
-        // First color of the new edge palette is stored in the original
+        // First color of the new edge palette can be stored in the original
         // transparent color entry.
         spr->palette.colors[pi_transparent][0] = edge_pal[0 + 0];
         spr->palette.colors[pi_transparent][1] = edge_pal[0 + 1];
@@ -1086,12 +1113,14 @@ static int bleedfix_adjust_palette(spritemaker_t *spr) {
             spr->palette.colors[pal_idx][2] = edge_pal[edge_pal_idx + 2];
             spr->palette.colors[pal_idx][3] = edge_pal[edge_pal_idx + 3];
         }
-        spr->palette.used_colors += num_free_colors;
 
-        return num_free_colors;
+        int num_new_colors = edge_pal_len - 1;
+        spr->palette.used_colors += num_new_colors;
+
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: extended palette with %d new transparent colors (total used: %d)\n", num_new_colors, spr->palette.used_colors);
+        return num_new_colors;
     }
-
-    return 0;
 }
 
 static void bleedfix_silhouette(spritemaker_t *spr, image_t *image, int bytes_per_pixel) {

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -1040,52 +1040,45 @@ void bleedfix_rgba(spritemaker_t *spr, image_t *image) {
 
     uint32_t num_bytes = image->width * image->height * 4;
     uint8_t *img_scratch = malloc(num_bytes);
-    bool has_transparent_pixels = true;
+    memcpy(img_scratch, img, num_bytes);
 
-    for (int pass = 0; pass < BLEEDFIX_PASSES && has_transparent_pixels; pass++) {
-        has_transparent_pixels = false;
-        memcpy(img_scratch, img, num_bytes);
+    for (int y=0;y<image->height;y++) {
+        for (int x=0;x<image->width;x++) {
+            int idx_center = (y * image->width + x) * 4;
 
-        for (int y=0;y<image->height;y++) {
-            for (int x=0;x<image->width;x++) {
-                int idx_center = (y * image->width + x) * 4;
+            // If this pixel is transparent, look for opaque neighbors and
+            // average their colors.
+            if (img[idx_center + 3] == 0) {
+                int r = 0, g = 0, b = 0, num_opaque_neighbors = 0;
 
-                // If this pixel is transparent, look for opaque neighbors and
-                // average their colors.
-                if (img[idx_center + 3] == 0) {
-                    has_transparent_pixels = true;
-                    int r = 0, g = 0, b = 0, num_opaque_neighbors = 0;
-
-                    for (int k = 0; k < 8; k++) {
-                        int nx = x + bleedfix_neighbors[k].x;
-                        int ny = y + bleedfix_neighbors[k].y;
-                        if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
-                            int idx_neighbor = (ny * image->width + nx) * 4;
-                            
-                            if (img[idx_neighbor + 3] > 0) {
-                                r += img[idx_neighbor + 0];
-                                g += img[idx_neighbor + 1];
-                                b += img[idx_neighbor + 2];
-                                num_opaque_neighbors++;
-                            }
-                        }
-                        if (k == 3 && num_opaque_neighbors > 0) {
-                            break;
+                for (int k = 0; k < 8; k++) {
+                    int nx = x + bleedfix_neighbors[k].x;
+                    int ny = y + bleedfix_neighbors[k].y;
+                    if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                        int idx_neighbor = (ny * image->width + nx) * 4;
+                        
+                        if (img[idx_neighbor + 3] > 0) {
+                            r += img[idx_neighbor + 0];
+                            g += img[idx_neighbor + 1];
+                            b += img[idx_neighbor + 2];
+                            num_opaque_neighbors++;
                         }
                     }
-
-                    if (num_opaque_neighbors > 0) {
-                        img_scratch[idx_center + 0] = r / num_opaque_neighbors;
-                        img_scratch[idx_center + 1] = g / num_opaque_neighbors;
-                        img_scratch[idx_center + 2] = b / num_opaque_neighbors;
-                        // img_scratch[idx_center + 3] = 255;
+                    if (k == 3 && num_opaque_neighbors > 0) {
+                        break;
                     }
+                }
+
+                if (num_opaque_neighbors > 0) {
+                    img_scratch[idx_center + 0] = r / num_opaque_neighbors;
+                    img_scratch[idx_center + 1] = g / num_opaque_neighbors;
+                    img_scratch[idx_center + 2] = b / num_opaque_neighbors;
+                    // img_scratch[idx_center + 3] = 255;
                 }
             }
         }
-        memcpy(img, img_scratch, num_bytes);
     }
-
+    memcpy(img, img_scratch, num_bytes);
     free(img_scratch);
 }
 
@@ -1094,48 +1087,41 @@ void bleedfix_grey_alpha(spritemaker_t *spr, image_t *image) {
 
     uint32_t num_bytes = image->width * image->height * 2;
     uint8_t *img_scratch = malloc(num_bytes);
-    bool has_transparent_pixels = true;
+    memcpy(img_scratch, img, num_bytes);
 
-    for (int pass = 0; pass < BLEEDFIX_PASSES && has_transparent_pixels; pass++) {
-        has_transparent_pixels = false;
-        memcpy(img_scratch, img, num_bytes);
+    for (int y=0;y<image->height;y++) {
+        for (int x=0;x<image->width;x++) {
+            int idx_center = (y * image->width + x) * 2;
 
-        for (int y=0;y<image->height;y++) {
-            for (int x=0;x<image->width;x++) {
-                int idx_center = (y * image->width + x) * 2;
+            // If this pixel is transparent, look for opaque neighbors and
+            // average their colors.
+            if (img[idx_center + 1] == 0) {
+                int c = 0, num_opaque_neighbors = 0;
 
-                // If this pixel is transparent, look for opaque neighbors and
-                // average their colors.
-                if (img[idx_center + 1] == 0) {
-                    has_transparent_pixels = true;
-                    int c = 0, num_opaque_neighbors = 0;
-
-                    for (int k = 0; k < 8; k++) {
-                        int nx = x + bleedfix_neighbors[k].x;
-                        int ny = y + bleedfix_neighbors[k].y;
-                        if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
-                            int idx_neighbor = (ny * image->width + nx) * 2;
-                            
-                            if (img[idx_neighbor + 1] > 0) {
-                                c += img[idx_neighbor + 0];
-                                num_opaque_neighbors++;
-                            }
-                        }
-                        if (k == 3 && num_opaque_neighbors > 0) {
-                            break;
+                for (int k = 0; k < 8; k++) {
+                    int nx = x + bleedfix_neighbors[k].x;
+                    int ny = y + bleedfix_neighbors[k].y;
+                    if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                        int idx_neighbor = (ny * image->width + nx) * 2;
+                        
+                        if (img[idx_neighbor + 1] > 0) {
+                            c += img[idx_neighbor + 0];
+                            num_opaque_neighbors++;
                         }
                     }
-
-                    if (num_opaque_neighbors > 0) {
-                        img_scratch[idx_center + 0] = c / num_opaque_neighbors;
-                        // img_scratch[idx_center + 1] = 255;
+                    if (k == 3 && num_opaque_neighbors > 0) {
+                        break;
                     }
+                }
+
+                if (num_opaque_neighbors > 0) {
+                    img_scratch[idx_center + 0] = c / num_opaque_neighbors;
+                    // img_scratch[idx_center + 1] = 255;
                 }
             }
         }
-        memcpy(img, img_scratch, num_bytes);
     }
-
+    memcpy(img, img_scratch, num_bytes);
     free(img_scratch);
 }
 

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -950,8 +950,8 @@ bool spritemaker_gamma_correct(spritemaker_t *spr) {
 const struct {
     int x, y;
 } bleedfix_neighbors[] = {
-    {-1, -1}, { 0, -1}, { 1, -1}, {-1,  0}, 
-    { 1,  0}, {-1,  1}, { 0,  1}, { 1,  1} 
+    { 1,  0}, { 0, -1}, { 0,  1}, {-1,  0}, // 0..3 straight
+    {-1, -1}, {-1,  1}, { 1, -1}, { 1,  1}  // 4..7 diagonal
 };
 
 void bleedfix_palette(spritemaker_t *spr, image_t *image) {
@@ -976,23 +976,31 @@ void bleedfix_palette(spritemaker_t *spr, image_t *image) {
         return;
     }
 
-    // Count number of transparent neighbors for each color
+    // Count number of opaque colors for each transparent pixel
     uint8_t *img = image->image;
-    for (int y=1;y<image->height-1;y++) {
-        for (int x=1;x<image->width-1;x++) {
+    for (int y=0;y<image->height;y++) {
+        for (int x=0;x<image->width;x++) {
             int idx_center = y * image->width + x;
             int pi_center = img[idx_center];
 
-            // If this pixel is opaque check for transparent neighbors
-            if (pi_center != pi_transparent) {
+            // If this pixel is transparent, check for opaque neighbors
+            if (pi_center == pi_transparent) {
+                int num_neighbors = 0;
                 for (int k = 0; k < 8; k++) {
-                    int idx_neighbor = idx_center + bleedfix_neighbors[k].y * image->width + bleedfix_neighbors[k].x;
-                    int pi_neighbor = img[idx_neighbor];
-                    if (pi_neighbor == pi_transparent) {
-                        pi_edge_counts[pi_center]++;
+                    int nx = x + bleedfix_neighbors[k].x;
+                    int ny = y + bleedfix_neighbors[k].y;
+                    if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                        int idx_neighbor = (ny * image->width + nx);
+                        int pi_neighbor = img[idx_neighbor];
+                        if (pi_neighbor != pi_transparent) {
+                            num_neighbors++;
+                            pi_edge_counts[pi_neighbor]++;
+                        }
+                    }
+                    if (k == 3 && num_neighbors > 0) {
                         break;
                     }
-                }    
+                }
             }
         }
     }
@@ -1061,6 +1069,9 @@ void bleedfix_rgba(spritemaker_t *spr, image_t *image) {
                                 num_opaque_neighbors++;
                             }
                         }
+                        if (k == 3 && num_opaque_neighbors > 0) {
+                            break;
+                        }
                     }
 
                     if (num_opaque_neighbors > 0) {
@@ -1109,6 +1120,9 @@ void bleedfix_grey_alpha(spritemaker_t *spr, image_t *image) {
                                 c += img[idx_neighbor + 0];
                                 num_opaque_neighbors++;
                             }
+                        }
+                        if (k == 3 && num_opaque_neighbors > 0) {
+                            break;
                         }
                     }
 

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -989,7 +989,7 @@ void bleedfix_palette(spritemaker_t *spr, image_t *image) {
                 for (int k = 0; k < 8; k++) {
                     int nx = x + bleedfix_neighbors[k].x;
                     int ny = y + bleedfix_neighbors[k].y;
-                    if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                    if (nx >= 0 && nx < image->width && ny >= 0 && ny < image->height) {
                         int idx_neighbor = (ny * image->width + nx);
                         int pi_neighbor = img[idx_neighbor];
                         if (pi_neighbor != pi_transparent) {
@@ -1054,7 +1054,7 @@ void bleedfix_rgba(spritemaker_t *spr, image_t *image) {
                 for (int k = 0; k < 8; k++) {
                     int nx = x + bleedfix_neighbors[k].x;
                     int ny = y + bleedfix_neighbors[k].y;
-                    if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                    if (nx >= 0 && nx < image->width && ny >= 0 && ny < image->height) {
                         int idx_neighbor = (ny * image->width + nx) * 4;
                         
                         if (img[idx_neighbor + 3] > 0) {
@@ -1101,7 +1101,7 @@ void bleedfix_grey_alpha(spritemaker_t *spr, image_t *image) {
                 for (int k = 0; k < 8; k++) {
                     int nx = x + bleedfix_neighbors[k].x;
                     int ny = y + bleedfix_neighbors[k].y;
-                    if (nx > 0 && nx < image->width && ny > 0 && ny < image->height) {
+                    if (nx >= 0 && nx < image->width && ny >= 0 && ny < image->height) {
                         int idx_neighbor = (ny * image->width + nx) * 2;
                         
                         if (img[idx_neighbor + 1] > 0) {

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -947,14 +947,14 @@ bool spritemaker_gamma_correct(spritemaker_t *spr) {
 }
 
 
-const struct {
+static const struct {
     int x, y;
 } bleedfix_neighbors[] = {
     { 1,  0}, { 0, -1}, { 0,  1}, {-1,  0}, // 0..3 straight
     {-1, -1}, {-1,  1}, { 1, -1}, { 1,  1}  // 4..7 diagonal
 };
 
-int bleedfix_adjust_palette(spritemaker_t *spr) {
+static int bleedfix_adjust_palette(spritemaker_t *spr) {
     image_t *image = &spr->images[0];
 
     int pi_edge_counts_total = 0;
@@ -1031,7 +1031,6 @@ int bleedfix_adjust_palette(spritemaker_t *spr) {
         spr->palette.colors[pi_transparent][0] = r / pi_edge_counts_total;
         spr->palette.colors[pi_transparent][1] = g / pi_edge_counts_total;
         spr->palette.colors[pi_transparent][2] = b / pi_edge_counts_total;
-        // spr->palette.colors[pi_transparent][3] = 255;
         return 0;
     }
 
@@ -1095,88 +1094,59 @@ int bleedfix_adjust_palette(spritemaker_t *spr) {
     return 0;
 }
 
-void bleedfix_rgba(spritemaker_t *spr, image_t *image) {
-    uint8_t *img = image->image;
+static void bleedfix_silhouette(spritemaker_t *spr, image_t *image, int bytes_per_pixel) {
+    assert(bytes_per_pixel >= 2 && bytes_per_pixel <= 4);
 
-    uint32_t num_bytes = image->width * image->height * 4;
+    // We expect the alpha component in the last byte of the color, ie. after
+    // all color components.
+    uint32_t color_components = bytes_per_pixel - 1;
+
+    uint8_t *img = image->image;
+    uint32_t num_bytes = image->width * image->height * bytes_per_pixel;
     uint8_t *img_scratch = malloc(num_bytes);
     memcpy(img_scratch, img, num_bytes);
 
     for (int y=0;y<image->height;y++) {
         for (int x=0;x<image->width;x++) {
-            int idx_center = (y * image->width + x) * 4;
+            int idx_center = (y * image->width + x) * bytes_per_pixel;
 
             // If this pixel is transparent, look for opaque neighbors and
             // average their colors.
-            if (img[idx_center + 3] == 0) {
-                int r = 0, g = 0, b = 0, num_opaque_neighbors = 0;
+            if (img[idx_center + color_components] == 0) {
+                int sums[color_components] = {}; 
+                int num_opaque_neighbors = 0;
 
                 for (int k = 0; k < 8; k++) {
                     int nx = x + bleedfix_neighbors[k].x;
                     int ny = y + bleedfix_neighbors[k].y;
                     if (nx >= 0 && nx < image->width && ny >= 0 && ny < image->height) {
-                        int idx_neighbor = (ny * image->width + nx) * 4;
+                        int idx_neighbor = (ny * image->width + nx) * bytes_per_pixel;
                         
-                        if (img[idx_neighbor + 3] > 0) {
-                            r += img[idx_neighbor + 0];
-                            g += img[idx_neighbor + 1];
-                            b += img[idx_neighbor + 2];
+                        if (img[idx_neighbor + color_components] > 0) {
+                            for (int i = 0; i < color_components; i++) {
+                                sums[i] += img[idx_neighbor + i];
+                            }        
                             num_opaque_neighbors++;
                         }
                     }
+
+                    // If this transparent pixel had opaque neighbors to the
+                    // top, left, right or bottom (i.e. the first 4 entries in 
+                    // bleedfix_neighbors), we are done for this pixel. 
+                    // Otherwise continue with checking the diagonals (the 
+                    // remaining 4 entries in bleedfix_neighbors).
                     if (k == 3 && num_opaque_neighbors > 0) {
                         break;
                     }
                 }
 
+                // If we found some opaque neighbors, average all color
+                // components and write them to this pixel. The pixel's alpha
+                // component will remain at 0.
                 if (num_opaque_neighbors > 0) {
-                    img_scratch[idx_center + 0] = r / num_opaque_neighbors;
-                    img_scratch[idx_center + 1] = g / num_opaque_neighbors;
-                    img_scratch[idx_center + 2] = b / num_opaque_neighbors;
-                    // img_scratch[idx_center + 3] = 255;
-                }
-            }
-        }
-    }
-    memcpy(img, img_scratch, num_bytes);
-    free(img_scratch);
-}
-
-void bleedfix_grey_alpha(spritemaker_t *spr, image_t *image) {
-    uint8_t *img = image->image;
-
-    uint32_t num_bytes = image->width * image->height * 2;
-    uint8_t *img_scratch = malloc(num_bytes);
-    memcpy(img_scratch, img, num_bytes);
-
-    for (int y=0;y<image->height;y++) {
-        for (int x=0;x<image->width;x++) {
-            int idx_center = (y * image->width + x) * 2;
-
-            // If this pixel is transparent, look for opaque neighbors and
-            // average their colors.
-            if (img[idx_center + 1] == 0) {
-                int c = 0, num_opaque_neighbors = 0;
-
-                for (int k = 0; k < 8; k++) {
-                    int nx = x + bleedfix_neighbors[k].x;
-                    int ny = y + bleedfix_neighbors[k].y;
-                    if (nx >= 0 && nx < image->width && ny >= 0 && ny < image->height) {
-                        int idx_neighbor = (ny * image->width + nx) * 2;
-                        
-                        if (img[idx_neighbor + 1] > 0) {
-                            c += img[idx_neighbor + 0];
-                            num_opaque_neighbors++;
-                        }
+                    for (int i = 0; i < color_components; i++) {
+                        img_scratch[idx_center + i] = sums[i] / num_opaque_neighbors;
                     }
-                    if (k == 3 && num_opaque_neighbors > 0) {
-                        break;
-                    }
-                }
-
-                if (num_opaque_neighbors > 0) {
-                    img_scratch[idx_center + 0] = c / num_opaque_neighbors;
-                    // img_scratch[idx_center + 1] = 255;
                 }
             }
         }
@@ -1200,23 +1170,24 @@ void spritemaker_bleedfix(spritemaker_t *spr) {
             for (int m=0; m<MAX_IMAGES; m++) {
                 image_t *image = &spr->images[m];
                 if (image->image != NULL) {
-                    bleedfix_rgba(spr, image);
+                    bleedfix_silhouette(spr, image, 4);
                 }
             }
             spritemaker_quantize(spr, orig_palette.colors[0], fmt_colors, spr->ditheralgo);
             spr->palette = orig_palette;
         }
     }
-    else {
+    else if (spr->images[0].ct == LCT_RGBA || spr->images[0].ct == LCT_GREY_ALPHA) {
         if (flag_verbose)
             fprintf(stderr, "bleedfix: expanding sprite silhouette by 1px\n");
+
         for (int m=0; m<MAX_IMAGES; m++) {
             image_t *image = &spr->images[m];
             if (image->image != NULL) {
                 if (image->ct == LCT_RGBA) {
-                    bleedfix_rgba(spr, image);
+                    bleedfix_silhouette(spr, image, 4);
                 } else if (image->ct == LCT_GREY_ALPHA) {
-                    bleedfix_grey_alpha(spr, image);
+                    bleedfix_silhouette(spr, image, 2);
                 }    
             }            
         }

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -954,7 +954,10 @@ const struct {
     {-1, -1}, {-1,  1}, { 1, -1}, { 1,  1}  // 4..7 diagonal
 };
 
-void bleedfix_palette(spritemaker_t *spr, image_t *image) {
+int bleedfix_adjust_palette(spritemaker_t *spr) {
+    image_t *image = &spr->images[0];
+
+    int pi_edge_counts_total = 0;
     int pi_edge_counts[256] = {};
     int pi_transparent = -1;
 
@@ -963,8 +966,8 @@ void bleedfix_palette(spritemaker_t *spr, image_t *image) {
         if (spr->palette.colors[pi][3] == 0) {
             if (pi_transparent != -1) {
                 if (flag_verbose)
-                    fprintf(stderr, "bleedfix: multiple transparent colors found in palette; can't continue");
-                return;
+                    fprintf(stderr, "bleedfix: multiple transparent colors found in palette; can't continue\n");
+                return 0;
             }
             pi_transparent = pi;
         }
@@ -972,11 +975,11 @@ void bleedfix_palette(spritemaker_t *spr, image_t *image) {
 
     if (pi_transparent == -1) {
         if (flag_verbose)
-            fprintf(stderr, "bleedfix: no fully transparent color found in palette");
-        return;
+            fprintf(stderr, "bleedfix: no fully transparent color found in palette\n");
+        return 0;
     }
 
-    // Count number of opaque colors for each transparent pixel
+    // Count number of opaque neighbors for each transparent pixel
     uint8_t *img = image->image;
     for (int y=0;y<image->height;y++) {
         for (int x=0;x<image->width;x++) {
@@ -995,6 +998,7 @@ void bleedfix_palette(spritemaker_t *spr, image_t *image) {
                         if (pi_neighbor != pi_transparent) {
                             num_neighbors++;
                             pi_edge_counts[pi_neighbor]++;
+                            pi_edge_counts_total++;
                         }
                     }
                     if (k == 3 && num_neighbors > 0) {
@@ -1007,32 +1011,88 @@ void bleedfix_palette(spritemaker_t *spr, image_t *image) {
 
     int num_free_colors = (image->fmt == FMT_CI4 ? 16 : 256) - spr->palette.used_colors;
 
-    // For now, we always just average out all edge colors and use the result 
-    // for the  existing  transparent color index in the palette.
-    if (num_free_colors == 0 || true) {
+    // No free colors left in the palette? Our only option is to replace the
+    // one existing transparent color with a better "background color" that
+    // is the average of all edge colors.
+    if (num_free_colors == 0) {
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: adjusting existing transparent color in palette\n");
+
         int r = 0, g = 0, b = 0;
-        int total_count = 0;
         for (int pi=0; pi<spr->palette.used_colors; pi++) {
             if (pi != pi_transparent) {
                 int count = pi_edge_counts[pi];
-                total_count += count;
                 r += spr->palette.colors[pi][0] * count;
                 g += spr->palette.colors[pi][1] * count;
                 b += spr->palette.colors[pi][2] * count;
             }
         }
         
-        spr->palette.colors[pi_transparent][0] = r / total_count;
-        spr->palette.colors[pi_transparent][1] = g / total_count;
-        spr->palette.colors[pi_transparent][2] = b / total_count;
+        spr->palette.colors[pi_transparent][0] = r / pi_edge_counts_total;
+        spr->palette.colors[pi_transparent][1] = g / pi_edge_counts_total;
+        spr->palette.colors[pi_transparent][2] = b / pi_edge_counts_total;
         // spr->palette.colors[pi_transparent][3] = 255;
+        return 0;
     }
-    else {
-        // TODO:
-        // Use exoquant to create a palette with num_free_colors entries,
-        // based on the edge colors (pi_edge_counts) and distribute those
-        // around the edges, similar to bleedfix_rgb()
+
+    // We have some space for new colors. Create a buffer that contains all 
+    // edge colors and their counts to feed into exoquant. This produces a new
+    // palette with transparent colors that we can append to the existing
+    // palette. The caller can then re-quantize with this new palette.
+    // Note that we actually have one more spot than num_free_colors available: 
+    // the existing transparent color.
+    else if (pi_edge_counts_total > 0) {
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: appending %d new transparent colors to palette\n", num_free_colors);
+
+        uint8_t *img_edge = malloc(pi_edge_counts_total * 4);
+        int i = 0;
+        for (int pi=0; pi<spr->palette.used_colors; pi++) {
+            if (pi != pi_transparent) {
+                int count = pi_edge_counts[pi];
+                for (int c = 0; c < count; c++, i += 4) {
+                    img_edge[i + 0] = spr->palette.colors[pi][0];
+                    img_edge[i + 1] = spr->palette.colors[pi][1];
+                    img_edge[i + 2] = spr->palette.colors[pi][2];
+                    img_edge[i + 3] = 0;
+                }
+            }
+        }
+
+        int edge_pal_len = num_free_colors + 1;
+        uint8_t edge_pal[edge_pal_len * 4] = {};
+
+        exq_data *exq = exq_init();
+        exq->numBitsPerChannel = 5;
+        exq_no_transparency(exq);
+        exq_feed(exq, img_edge, pi_edge_counts_total);
+        exq_quantize_hq(exq, edge_pal_len);
+        exq_get_palette(exq, edge_pal, edge_pal_len);
+        exq_free(exq);
+        free(img_edge);
+
+        // First color of the new edge palette is stored in the original
+        // transparent color entry.
+        spr->palette.colors[pi_transparent][0] = edge_pal[0 + 0];
+        spr->palette.colors[pi_transparent][1] = edge_pal[0 + 1];
+        spr->palette.colors[pi_transparent][2] = edge_pal[0 + 2];
+        spr->palette.colors[pi_transparent][3] = edge_pal[0 + 3];
+
+        // Append all other edge colors at the end of the existing palette
+        for (int i = 1; i < edge_pal_len; i++) {
+            int pal_idx = spr->palette.used_colors + i - 1;
+            int edge_pal_idx = i * 4;
+            spr->palette.colors[pal_idx][0] = edge_pal[edge_pal_idx + 0];
+            spr->palette.colors[pal_idx][1] = edge_pal[edge_pal_idx + 1];
+            spr->palette.colors[pal_idx][2] = edge_pal[edge_pal_idx + 2];
+            spr->palette.colors[pal_idx][3] = edge_pal[edge_pal_idx + 3];
+        }
+        spr->palette.used_colors += num_free_colors;
+
+        return num_free_colors;
     }
+
+    return 0;
 }
 
 void bleedfix_rgba(spritemaker_t *spr, image_t *image) {
@@ -1126,17 +1186,39 @@ void bleedfix_grey_alpha(spritemaker_t *spr, image_t *image) {
 }
 
 void spritemaker_bleedfix(spritemaker_t *spr) {
-    for (int m=0; m<MAX_IMAGES; m++) {
-        image_t *image = &spr->images[m];
-        if (image->image == NULL)
-            continue;
+    if (spr->images[0].ct == LCT_PALETTE) {
+        int num_new_colors = bleedfix_adjust_palette(spr);
 
-        if (image->ct == LCT_PALETTE) {
-            bleedfix_palette(spr, image);
-        } else if (image->ct == LCT_RGBA) {
-            bleedfix_rgba(spr, image);
-        } else if (image->ct == LCT_GREY_ALPHA) {
-            bleedfix_grey_alpha(spr, image);
+        // If we were able to expand the palette with some new colors, we can 
+        // re-quantize all images to distribute those.
+        if (num_new_colors > 0) {
+            palette_t orig_palette = spr->palette;
+            int fmt_colors = spr->images[0].fmt == FMT_CI8 ? 256 : 16;
+
+            // Expand to RGBA, run bleedfix on all images and quantize again
+            spritemaker_expand_rgba(spr);
+            for (int m=0; m<MAX_IMAGES; m++) {
+                image_t *image = &spr->images[m];
+                if (image->image != NULL) {
+                    bleedfix_rgba(spr, image);
+                }
+            }
+            spritemaker_quantize(spr, orig_palette.colors[0], fmt_colors, spr->ditheralgo);
+            spr->palette = orig_palette;
+        }
+    }
+    else {
+        if (flag_verbose)
+            fprintf(stderr, "bleedfix: expanding sprite silhouette by 1px\n");
+        for (int m=0; m<MAX_IMAGES; m++) {
+            image_t *image = &spr->images[m];
+            if (image->image != NULL) {
+                if (image->ct == LCT_RGBA) {
+                    bleedfix_rgba(spr, image);
+                } else if (image->ct == LCT_GREY_ALPHA) {
+                    bleedfix_grey_alpha(spr, image);
+                }    
+            }            
         }
     }
 }

--- a/tools/mksprite/mksprite.c
+++ b/tools/mksprite/mksprite.c
@@ -1054,7 +1054,7 @@ static int bleedfix_adjust_palette(spritemaker_t *spr) {
         // We actually have one more spot than num_free_colors available: 
         // the existing transparent color.
         int edge_pal_len = num_free_colors + 1;
-        uint8_t edge_pal[edge_pal_len * 4] = {};
+        uint8_t edge_pal[edge_pal_len * 4];
 
         // Can we fit all unique edge colors into the remaining palette space?
         if (num_unique_edge_colors <= edge_pal_len) {
@@ -1142,7 +1142,7 @@ static void bleedfix_silhouette(spritemaker_t *spr, image_t *image, int bytes_pe
             // If this pixel is transparent, look for opaque neighbors and
             // average their colors.
             if (img[idx_center + color_components] == 0) {
-                int sums[color_components] = {}; 
+                int sums[3] = {};
                 int num_opaque_neighbors = 0;
 
                 for (int k = 0; k < 8; k++) {

--- a/tools/mksprite/mksprite.h
+++ b/tools/mksprite/mksprite.h
@@ -49,6 +49,7 @@ typedef struct parms_s {
     int mipmap_algo;
     int dither_algo;
     int gamma_correct;
+    int bleedfix;
     int lossy_quality;
     texparms_t texparms;
     struct{


### PR DESCRIPTION
This adds an optional switch to mksprite to mitigate halos around sprites with transparency.

The idea is to "radiate" the sprite outwards. These newly filled pixels will have the r,g,b values of the edges of the sprite, while still maintaining full transparency (a = 0). Only fully transparent pixels are modified; all pixels with partial transparency are left as is.

One complication arises with paletted sprites: in most cases the palette is already completely filled (with either 16 or 256 colors), so we can't create any new colors. The only option is to modify the existing palette entry with the transparent color to a *single* "background" color. This background color is simply computed as the average of all colors of the sprite's edges.

For now, all paletted images are filled with a single "background" color. We could be smarter about this *if* we have some free palette entries to use: create k-means of each of the edge colors and use those to "radiate" outwards, same as with rgba16/32. ~~I'm not yet sure if it's worth to implement this...~~ Update: this is implemented now.

I'm still doing some testing, to make sure it works as intended. I just wanted some early feedback if
- this is wanted in libdragon and 
- this PR is going in the right direction.

Also, I'm open for suggestions for a better name. `-bleedfix` is not that descriptive :]

## Examples (alpha value set to 255 for illustrative purposes):
### Source
<img width="448" height="391" alt="image" src="https://github.com/user-attachments/assets/4e859c88-b946-42e5-a9bd-63626680ec06" />

### RGBA16
<img width="446" height="396" alt="image" src="https://github.com/user-attachments/assets/edade8cc-da48-4933-a53f-89dfdd5d226b" />

### CI4
<img width="445" height="392" alt="image" src="https://github.com/user-attachments/assets/c4119cf8-1011-439a-8283-32bbe3ccb439" />

### IA8
<img width="447" height="399" alt="image" src="https://github.com/user-attachments/assets/07cd0711-bf7b-4ae1-8483-bc6b06d7f3cd" />

