### PR TITLE
Joypad APIs for individual buttons

### DIFF
--- a/include/joypad.h
+++ b/include/joypad.h
@@ -225,6 +225,31 @@ typedef union joypad_buttons_u
     /// @endcond
 } joypad_buttons_t;
 
+/**
+ * @brief Enumeration of individual joypad buttons.
+ *
+ * Button values correspond to bit positions in #joypad_buttons_t::raw
+ */
+typedef enum
+{
+    JOYPAD_BUTTON_A       = 0,   ///< @brief A button
+    JOYPAD_BUTTON_B       = 1,   ///< @brief B button
+    JOYPAD_BUTTON_Z       = 2,   ///< @brief Z button
+    JOYPAD_BUTTON_START   = 3,   ///< @brief Start button
+    JOYPAD_BUTTON_D_UP    = 4,   ///< @brief D-Pad Up
+    JOYPAD_BUTTON_D_DOWN  = 5,   ///< @brief D-Pad Down
+    JOYPAD_BUTTON_D_LEFT  = 6,   ///< @brief D-Pad Left
+    JOYPAD_BUTTON_D_RIGHT = 7,   ///< @brief D-Pad Right
+    JOYPAD_BUTTON_Y       = 8,   ///< @brief Y button (GameCube only)
+    JOYPAD_BUTTON_X       = 9,   ///< @brief X button (GameCube only)
+    JOYPAD_BUTTON_L       = 10,  ///< @brief L trigger (digital)
+    JOYPAD_BUTTON_R       = 11,  ///< @brief R trigger (digital)
+    JOYPAD_BUTTON_C_UP    = 12,  ///< @brief C-Up button
+    JOYPAD_BUTTON_C_DOWN  = 13,  ///< @brief C-Down button
+    JOYPAD_BUTTON_C_LEFT  = 14,  ///< @brief C-Left button
+    JOYPAD_BUTTON_C_RIGHT = 15,  ///< @brief C-Right button
+} joypad_button_t;
+
 /** @brief Joypad Inputs Unified State Structure */
 typedef struct __attribute__((packed)) joypad_inputs_s
 {
@@ -572,6 +597,42 @@ joypad_buttons_t joypad_get_buttons_released(joypad_port_t port);
  * @return Joypad buttons structure (#joypad_buttons_t)
  */
 joypad_buttons_t joypad_get_buttons_held(joypad_port_t port);
+
+/**
+ * @brief Get the current state of a specific button.
+ *
+ * @param port Joypad port number (#joypad_port_t)
+ * @param button Button to check (#joypad_button_t)
+ * @return true if button is currently pressed, false otherwise
+ */
+bool joypad_get_button(joypad_port_t port, joypad_button_t button);
+
+/**
+ * @brief Check if a specific button was just pressed this frame.
+ *
+ * @param port Joypad port number (#joypad_port_t)
+ * @param button Button to check (#joypad_button_t)
+ * @return true if button transitioned from released to pressed, false otherwise
+ */
+bool joypad_get_button_pressed(joypad_port_t port, joypad_button_t button);
+
+/**
+ * @brief Check if a specific button was just released this frame.
+ *
+ * @param port Joypad port number (#joypad_port_t)
+ * @param button Button to check (#joypad_button_t)
+ * @return true if button transitioned from pressed to released, false otherwise
+ */
+bool joypad_get_button_released(joypad_port_t port, joypad_button_t button);
+
+/**
+ * @brief Check if a specific button is being held.
+ *
+ * @param port Joypad port number (#joypad_port_t)
+ * @param button Button to check (#joypad_button_t)
+ * @return true if button was pressed last frame and is still pressed, false otherwise
+ */
+bool joypad_get_button_held(joypad_port_t port, joypad_button_t button);
 
 /**
  * @brief Get the 8-way direction for a Joypad port's directional axes.

--- a/include/joypad.h
+++ b/include/joypad.h
@@ -644,6 +644,16 @@ bool joypad_get_button_held(joypad_port_t port, joypad_button_t button);
 joypad_8way_t joypad_get_direction(joypad_port_t port, joypad_2d_t axes);
 
 /**
+ * @brief Get the current analog value of an axis on a Joypad port.
+ * 
+ * @param port Joypad port number (#joypad_port_t)
+ * @param axis Joypad axis enumeration value (#joypad_axis_t)
+ * 
+ * @return Current analog axis value
+ */
+int joypad_get_axis(joypad_port_t port, joypad_axis_t axis);
+
+/**
  * @brief Get the direction of a "press" of an axis on a Joypad port.
  * 
  * @param port Joypad port number (#joypad_port_t)

--- a/src/joybus/joypad.c
+++ b/src/joybus/joypad.c
@@ -831,6 +831,26 @@ joypad_buttons_t joypad_get_buttons_held(joypad_port_t port)
     return (joypad_buttons_t){ .raw = current & previous };
 }
 
+bool joypad_get_button(joypad_port_t port, joypad_button_t button)
+{
+    return (joypad_get_buttons(port).raw >> button) & 1;
+}
+
+bool joypad_get_button_pressed(joypad_port_t port, joypad_button_t button)
+{
+    return (joypad_get_buttons_pressed(port).raw >> button) & 1;
+}
+
+bool joypad_get_button_released(joypad_port_t port, joypad_button_t button)
+{
+    return (joypad_get_buttons_released(port).raw >> button) & 1;
+}
+
+bool joypad_get_button_held(joypad_port_t port, joypad_button_t button)
+{
+    return (joypad_get_buttons_held(port).raw >> button) & 1;
+}
+
 /**
  * @brief Get the analog values for a Joypad port's axis.
  * 

--- a/src/joybus/joypad.c
+++ b/src/joybus/joypad.c
@@ -903,6 +903,13 @@ static void joypad_get_axis_values(
     }
 }
 
+int joypad_get_axis(joypad_port_t port, joypad_axis_t axis)
+{
+    int current = 0;
+    joypad_get_axis_values(port, axis, &current, NULL, NULL);
+    return current;
+}
+
 int joypad_get_axis_pressed(joypad_port_t port, joypad_axis_t axis)
 {
     int current = 0, previous = 0, threshold = 0;


### PR DESCRIPTION
Introduces convenience functions to assist with dynamic button mapping.

* Adds `joypad_button_t` enum to `joypad.h`: Button constants mapped to bit positions 0-15
* Adds accessor functions for getting individual buttons using `joypad_button_t`:
  * `joypad_get_button(port, button)`: current state
  * `joypad_get_button_pressed(port, button)`: just pressed this frame
  * `joypad_get_button_released(port, button)`: just released this frame
  * `joypad_get_button_held(port, button)`: held across frames
* Adds `joypad_get_axis` function for dynamic analog mapping
 
### Example usage:

```c
struct InputMap {
  joypad_button_t jump;
  joypad_button_t attack;
}

struct InputMap inputMap = {
  .jump = JOYPAD_BUTTON_A,
  .attack = JOYPAD_BUTTON_B
};

bool jumping = joypad_get_button_pressed(port, inputMap.jump);
bool attacking = joypad_get_button_pressed(port, inputMap.attack);
```
