### PR TITLE
Add a new PAL60 VI timing preset based on the NTSC one

### DIFF
--- a/src/vi.c
+++ b/src/vi.c
@@ -61,6 +61,18 @@ const vi_timing_preset_t VI_TIMING_MPAL = {
     },
 };
 
+const vi_timing_preset_t VI_TIMING_PAL60 = {
+    .vi_h_total = VI_H_TOTAL_SET(0b00000, 789),
+    .vi_h_total_leap = VI_H_TOTAL_LEAP_SET(789, 789),
+    .vi_v_total = VI_V_TOTAL_SET(526),
+    .vi_burst = VI_BURST_SET(62, 5, 34, 57),
+    .vi_v_burst = VI_V_BURST_SET(14, 516),
+    .display = {
+        .x0 = 115, .y0 = 35,
+        .width = 640, .height = 480,
+    },
+};
+
 static const vi_timing_preset_t *default_presets[3] = {
     [TV_NTSC] = &VI_TIMING_NTSC,
     [TV_PAL]  = &VI_TIMING_PAL,


### PR DESCRIPTION
This pull request adds a new PAL60 VI timing preset to go along with the previous commits that added the option to set a custom preset.

Some captures of other consoles discussed on the N64Brew Discord revealed that other consoles use NTSC timings when displaying their PAL60 modes rather than modified PAL timings like libdragon's (currently commented out) PAL60 mode, doing as those other consoles seems to be more compatible so the new timings are almost identical to the default NTSC ones, except with H total lengthened to compensate for the faster VI clock on PAL N64s as well as panning the picture right slightly as that seems to center it better on PAL TVs.

I had tried to adjust the hblank/burst timings to make them closer to what they would've been when output by an NTSC console, but that seemed to reduce compatibility, so I have left them as is.

More testing and slight tweaking might still be needed to maximize compatibility but I believe this preset should work well for the majority of people, especially those using CRT TVs.