### PR TITLE
sram: Create module for helper functions to access cartridge SRAM save memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ LIBDRAGON_OBJS += \
 	$(BUILD_DIR)/hashtable.o \
 	$(BUILD_DIR)/string_hash.o \
 	$(BUILD_DIR)/model64.o \
-	$(BUILD_DIR)/a3d.o
+	$(BUILD_DIR)/a3d.o \
+	$(BUILD_DIR)/sram.o
 
 include $(SOURCE_DIR)/kernel/libdragon.mk
 include $(SOURCE_DIR)/audio/libdragon.mk

--- a/include/sram.h
+++ b/include/sram.h
@@ -13,13 +13,14 @@
 #define LIBDRAGON_SRAM_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define SRAM_ADDRESS 0x08000000
-#define SRAM_SIZE    0x00008000  // 32 KiB
+#define SRAM_ADDRESS 0x08000000 ///< Base address of SRAM in PI address space.
+#define SRAM_SIZE    0x00008000 ///< Size of SRAM (32 KiB).
 
 /**
  * @brief Initialize the SRAM subsystem
@@ -28,6 +29,15 @@ extern "C" {
  * in the cartridge. It must be called before any other SRAM functions are used.
  */
 void sram_init(void);
+
+/**
+ * @brief Detect if SRAM is present in the cartridge
+ * 
+ * This function checks if the cartridge has SRAM available for use.
+ * 
+ * @return true if SRAM is detected, false otherwise.
+ */
+bool sram_detect(void);
 
 /**
  * @brief Read data from SRAM

--- a/include/sram.h
+++ b/include/sram.h
@@ -20,7 +20,6 @@ extern "C" {
 #endif
 
 #define SRAM_ADDRESS 0x08000000 ///< Base address of SRAM in PI address space.
-#define SRAM_SIZE    0x00008000 ///< Size of SRAM (32 KiB).
 
 /**
  * @brief Initialize the SRAM subsystem
@@ -35,16 +34,16 @@ void sram_init(void);
  * 
  * This function checks if the cartridge has SRAM available for use.
  * 
- * @return true if SRAM is detected, false otherwise.
+ * @return Size of available SRAM if is detected, -1 otherwise.
  */
-bool sram_detect(void);
+int sram_detect(void);
 
 /**
  * @brief Read data from SRAM
  * 
  * This function reads data from the SRAM in the cartridge and stores them into
  * the provided destination buffer. To read the entire content of the SRAM,
- * the length should be set to SRAM_SIZE (32 KiB).
+ * the length should be set to the size of the SRAM as detected by sram_detect().
  * 
  * @param dst Destination buffer to store the read data.
  * @param offset Offset in SRAM to read from. Allowed range is 0 to 0x7FFF.
@@ -58,7 +57,7 @@ int sram_read(void* dst, size_t offset, size_t len);
  * 
  * This function writes data to the SRAM in the cartridge from the provided
  * source buffer. To write the entire content of the SRAM, the length should
- * be set to SRAM_SIZE (32 KiB).
+ * be set to the size of the SRAM as detected by sram_detect().
  * 
  * @param src Source buffer containing the data to write.
  * @param offset Offset in SRAM to write to. Allowed range is 0 to 0x7FFF.

--- a/include/sram.h
+++ b/include/sram.h
@@ -1,0 +1,64 @@
+/**
+ * @file sram.h
+ * @author thekovic <https://github.com/thekovic>
+ * @brief SRAM access functions for N64 cartridges
+ *
+ * This header defines the interface for accessing SRAM present in certain N64
+ * cartridges for the purposes of saving game data. It provides functions to
+ * initialize the SRAM subsystem, read from SRAM, and write to SRAM.
+ *
+ */
+
+#ifndef LIBDRAGON_SRAM_H
+#define LIBDRAGON_SRAM_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SRAM_ADDRESS 0x08000000
+#define SRAM_SIZE    0x00008000  // 32 KiB
+
+/**
+ * @brief Initialize the SRAM subsystem
+ * 
+ * This function configures the PI DOM2 registers to enable access to the SRAM
+ * in the cartridge. It must be called before any other SRAM functions are used.
+ */
+void sram_init(void);
+
+/**
+ * @brief Read data from SRAM
+ * 
+ * This function reads data from the SRAM in the cartridge and stores them into
+ * the provided destination buffer. To read the entire content of the SRAM,
+ * the length should be set to SRAM_SIZE (32 KiB).
+ * 
+ * @param dst Destination buffer to store the read data.
+ * @param offset Offset in SRAM to read from. Allowed range is 0 to 0x7FFF.
+ * @param len Number of bytes to read.
+ * @return int Number of bytes read, or negative value in case of error.
+ */
+int sram_read(void* dst, size_t offset, size_t len);
+
+/**
+ * @brief Write data to SRAM
+ * 
+ * This function writes data to the SRAM in the cartridge from the provided
+ * source buffer. To write the entire content of the SRAM, the length should
+ * be set to SRAM_SIZE (32 KiB).
+ * 
+ * @param src Source buffer containing the data to write.
+ * @param offset Offset in SRAM to write to. Allowed range is 0 to 0x7FFF.
+ * @param len Number of bytes to write.
+ * @return int Number of bytes written, or negative value in case of error.
+ */
+int sram_write(const void* src, size_t offset, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/sram.c
+++ b/src/sram.c
@@ -1,0 +1,59 @@
+/**
+ * @file sram.c
+ * @author thekovic <https://github.com/thekovic>
+ * @brief SRAM access functions for N64 cartridges
+ * 
+ */
+
+#include "sram.h"
+#include "dma.h"
+#include "interrupt.h"
+#include <errno.h>
+
+#define PI_BSD_DOM2_LAT ((volatile uint32_t*) 0xA4600024)
+#define PI_BSD_DOM2_PWD ((volatile uint32_t*) 0xA4600028)
+#define PI_BSD_DOM2_PGS ((volatile uint32_t*) 0xA460002C)
+#define PI_BSD_DOM2_RLS ((volatile uint32_t*) 0xA4600030)
+
+void sram_init(void)
+{
+    // Configure PI DOM2 registers to enable access to SRAM
+    disable_interrupts();
+    *PI_BSD_DOM2_LAT = 0x5;
+    *PI_BSD_DOM2_PWD = 0xc;
+    *PI_BSD_DOM2_PGS = 0xd;
+    *PI_BSD_DOM2_RLS = 0x2;
+    enable_interrupts();
+}
+
+int sram_read(void* dst, size_t offset, size_t len)
+{
+    // Check if the read operation is within bounds.
+    if (offset + len > SRAM_SIZE)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    pi_addr_t sram_address = SRAM_ADDRESS + offset;
+    dma_read_raw_async(dst, sram_address, len);
+    dma_wait();
+
+    return (int) len;
+}
+
+int sram_write(const void* src, size_t offset, size_t len)
+{
+    // Check if the write operation is within bounds.
+    if (offset + len > SRAM_SIZE)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    pi_addr_t sram_address = SRAM_ADDRESS + offset;
+    dma_write_raw_async(src, sram_address, len);
+    dma_wait();
+
+    return (int) len;
+}

--- a/src/sram.c
+++ b/src/sram.c
@@ -17,6 +17,9 @@
 #define PI_BSD_DOM2_PWD ((volatile uint32_t*) 0xA4600028)
 #define PI_BSD_DOM2_PGS ((volatile uint32_t*) 0xA460002C)
 #define PI_BSD_DOM2_RLS ((volatile uint32_t*) 0xA4600030)
+
+// TODO: Replace fixed size with detection of other SRAM sizes.
+#define SRAM_SIZE    0x00008000 ///< Size of standard SRAM in commercial cartridges (32 KiB).
 /// @endcond
 
 bool __sram_inited = false; ///< True if sram_init() was called
@@ -37,7 +40,7 @@ void sram_init(void)
     __sram_inited = true;
 }
 
-bool sram_detect(void)
+int sram_detect(void)
 {
     assertf(__sram_inited, "sram accessed, but sram_init() hasn't been called yet");
 
@@ -53,7 +56,7 @@ bool sram_detect(void)
     // Restore the old data.
     *sram_ptr = data_old;
 
-    return is_detected;
+    return (is_detected) ? SRAM_SIZE : 0;
 }
 
 int sram_read(void* dst, size_t offset, size_t len)

--- a/src/sram.c
+++ b/src/sram.c
@@ -45,16 +45,15 @@ int sram_detect(void)
     assertf(__sram_inited, "sram accessed, but sram_init() hasn't been called yet");
 
     uint32_t test_pattern = 0x12345678;
-    // Convert to virtual address to attempt to perform direct I/O to SRAM.
-    volatile uint32_t* sram_ptr = VirtualUncachedAddr(SRAM_ADDRESS);
+
     // Test read, save the existing data to restore it later.
-    uint32_t data_old = *sram_ptr;
+    uint32_t data_old = io_read(SRAM_ADDRESS);
     // Write a test pattern to SRAM and check it.
-    *sram_ptr = test_pattern;
-    uint32_t data_new = *sram_ptr;
+    io_write(SRAM_ADDRESS, test_pattern);
+    uint32_t data_new = io_read(SRAM_ADDRESS);
     bool is_detected = (data_new == test_pattern);
     // Restore the old data.
-    *sram_ptr = data_old;
+    io_write(SRAM_ADDRESS, data_old);
 
     return (is_detected) ? SRAM_SIZE : 0;
 }

--- a/src/sram.c
+++ b/src/sram.c
@@ -6,17 +6,26 @@
  */
 
 #include "sram.h"
+#include "debug.h"
 #include "dma.h"
 #include "interrupt.h"
+#include "n64sys.h"
 #include <errno.h>
 
+/// @cond
 #define PI_BSD_DOM2_LAT ((volatile uint32_t*) 0xA4600024)
 #define PI_BSD_DOM2_PWD ((volatile uint32_t*) 0xA4600028)
 #define PI_BSD_DOM2_PGS ((volatile uint32_t*) 0xA460002C)
 #define PI_BSD_DOM2_RLS ((volatile uint32_t*) 0xA4600030)
+/// @endcond
+
+bool __sram_inited = false; ///< True if sram_init() was called
 
 void sram_init(void)
 {
+    if (__sram_inited)
+        return;
+
     // Configure PI DOM2 registers to enable access to SRAM
     disable_interrupts();
     *PI_BSD_DOM2_LAT = 0x5;
@@ -24,10 +33,33 @@ void sram_init(void)
     *PI_BSD_DOM2_PGS = 0xd;
     *PI_BSD_DOM2_RLS = 0x2;
     enable_interrupts();
+
+    __sram_inited = true;
+}
+
+bool sram_detect(void)
+{
+    assertf(__sram_inited, "sram accessed, but sram_init() hasn't been called yet");
+
+    uint32_t test_pattern = 0x12345678;
+    // Convert to virtual address to attempt to perform direct I/O to SRAM.
+    volatile uint32_t* sram_ptr = VirtualUncachedAddr(SRAM_ADDRESS);
+    // Test read, save the existing data to restore it later.
+    uint32_t data_old = *sram_ptr;
+    // Write a test pattern to SRAM and check it.
+    *sram_ptr = test_pattern;
+    uint32_t data_new = *sram_ptr;
+    bool is_detected = (data_new == test_pattern);
+    // Restore the old data.
+    *sram_ptr = data_old;
+
+    return is_detected;
 }
 
 int sram_read(void* dst, size_t offset, size_t len)
 {
+    assertf(__sram_inited, "sram accessed, but sram_init() hasn't been called yet");
+
     // Check if the read operation is within bounds.
     if (offset + len > SRAM_SIZE)
     {
@@ -44,6 +76,8 @@ int sram_read(void* dst, size_t offset, size_t len)
 
 int sram_write(const void* src, size_t offset, size_t len)
 {
+    assertf(__sram_inited, "sram accessed, but sram_init() hasn't been called yet");
+
     // Check if the write operation is within bounds.
     if (offset + len > SRAM_SIZE)
     {


### PR DESCRIPTION
I put together a simple module to help access (read/write) SRAM saves to improve SRAM "support" from "it's easy to do but figure it out yourself" to "just call these".

Untested so far; please help me test before merging.

Side note: I think it would be nice to move PI register definitions from dma.h into its own pi.h header and properly define all the registers, including DOM1/DOM2 setup registers. Ideally, we would also use the "access via volatile struct" pattern over preprocessor definitions but that would require a lot of refactoring all over the place so perhaps that ship has sailed. Let's discuss here or on Discord.