### PR TITLE
examples: Fix typo in ctest

### DIFF
--- a/examples/ctest/ctest.c
+++ b/examples/ctest/ctest.c
@@ -67,7 +67,7 @@ int main(void)
                 joypad_set_rumble_active(port, true);
             }
 
-            if (pressed.a)
+            if (pressed.b)
             {
                 joypad_set_rumble_active(port, false);
             }


### PR DESCRIPTION
Made a mistake during refactoring (probably copy&paste programming) https://github.com/dragonminded/libdragon/commit/1bfc783747#diff-e8b27f292d2ecddbdbb1e2c4a89bf3e767046be255b507fbc421322b16a84bdf