### PR TITLE
Remove all deprecations warnings from existing examples

### DIFF
--- a/examples/controllertest/Makefile
+++ b/examples/controllertest/Makefile
@@ -4,6 +4,8 @@ all: controllertest.z64
 BUILD_DIR = build
 include $(N64_INST)/include/n64.mk
 
+CFLAGS += -Wno-deprecated-declarations
+
 OBJS = $(BUILD_DIR)/controllertest.o
 
 controllertest.z64: N64_ROM_TITLE = "Controller Test"

--- a/examples/controllertest/controllertest.c
+++ b/examples/controllertest/controllertest.c
@@ -26,31 +26,31 @@ const char *format_accessory_type(int accessory_type)
     }
 }
 
-void print_inputs(_SI_condat *inputs)
+void print_inputs(joypad_inputs_t inputs)
 {
     printf(
         "Stick: %+04d,%+04d\n",
-        inputs->x, inputs->y
+        inputs.stick_x, inputs.stick_y
     );
     printf(
         "D-U:%d D-D:%d D-L:%d D-R:%d C-U:%d C-D:%d C-L:%d C-R:%d\n",
-        inputs->up, inputs->down,
-        inputs->left, inputs->right,
-        inputs->C_up, inputs->C_down,
-        inputs->C_left, inputs->C_right
+        inputs.btn.d_up, inputs.btn.d_down,
+        inputs.btn.d_left, inputs.btn.d_right,
+        inputs.btn.c_up, inputs.btn.c_down,
+        inputs.btn.c_left, inputs.btn.c_right
     );
     printf(
         "A:%d B:%d L:%d R:%d Z:%d Start:%d\n",
-        inputs->A, inputs->B,
-        inputs->L, inputs->R,
-        inputs->Z, inputs->start
+        inputs.btn.a, inputs.btn.b,
+        inputs.btn.l, inputs.btn.r,
+        inputs.btn.z, inputs.btn.start
     );
 }
 
 int main(void)
 {
     timer_init();
-    controller_init();
+    joypad_init();
     debug_init_isviewer();
     console_init();
     console_set_render_mode(RENDER_MANUAL);
@@ -62,17 +62,20 @@ int main(void)
 
         printf("LibDragon Controller Subsystem Test\n\n");
 
-        controller_scan();
-        struct controller_data inputs = get_keys_pressed();
+        joypad_poll();
 
         for (int port = 0; port < 4; port++)
         {
-            int accessory_type = identify_accessory(port);
+            if (!joypad_is_connected(port)) continue;
+
+            joypad_inputs_t in = joypad_get_inputs(port);
+
+            int accessory_type = joypad_get_accessory_type(port);
 
             printf("Port %d ", port + 1);
             printf("Accessory: %s ", format_accessory_type(accessory_type));
             printf("\n");
-            print_inputs(&inputs.c[port]);
+            print_inputs(in);
             printf("\n");
         }
 

--- a/examples/controllertest/controllertest.c
+++ b/examples/controllertest/controllertest.c
@@ -4,6 +4,10 @@
  * @brief N64 test ROM for Controller subsystem
  */
 
+/* NOTE: This example intentionally uses the deprecated controller.c API
+ * to ensure backward compatibility is not broken. Deprecation warnings
+ * are disabled for this example in its Makefile. */
+
 #include <string.h>
 #include <libdragon.h>
 
@@ -26,31 +30,31 @@ const char *format_accessory_type(int accessory_type)
     }
 }
 
-void print_inputs(joypad_inputs_t inputs)
+void print_inputs(_SI_condat *inputs)
 {
     printf(
         "Stick: %+04d,%+04d\n",
-        inputs.stick_x, inputs.stick_y
+        inputs->x, inputs->y
     );
     printf(
         "D-U:%d D-D:%d D-L:%d D-R:%d C-U:%d C-D:%d C-L:%d C-R:%d\n",
-        inputs.btn.d_up, inputs.btn.d_down,
-        inputs.btn.d_left, inputs.btn.d_right,
-        inputs.btn.c_up, inputs.btn.c_down,
-        inputs.btn.c_left, inputs.btn.c_right
+        inputs->up, inputs->down,
+        inputs->left, inputs->right,
+        inputs->C_up, inputs->C_down,
+        inputs->C_left, inputs->C_right
     );
     printf(
         "A:%d B:%d L:%d R:%d Z:%d Start:%d\n",
-        inputs.btn.a, inputs.btn.b,
-        inputs.btn.l, inputs.btn.r,
-        inputs.btn.z, inputs.btn.start
+        inputs->A, inputs->B,
+        inputs->L, inputs->R,
+        inputs->Z, inputs->start
     );
 }
 
 int main(void)
 {
     timer_init();
-    joypad_init();
+    controller_init();
     debug_init_isviewer();
     console_init();
     console_set_render_mode(RENDER_MANUAL);
@@ -62,20 +66,17 @@ int main(void)
 
         printf("LibDragon Controller Subsystem Test\n\n");
 
-        joypad_poll();
+        controller_scan();
+        struct controller_data inputs = get_keys_pressed();
 
         for (int port = 0; port < 4; port++)
         {
-            if (!joypad_is_connected(port)) continue;
-
-            joypad_inputs_t in = joypad_get_inputs(port);
-
-            int accessory_type = joypad_get_accessory_type(port);
+            int accessory_type = identify_accessory(port);
 
             printf("Port %d ", port + 1);
             printf("Accessory: %s ", format_accessory_type(accessory_type));
             printf("\n");
-            print_inputs(in);
+            print_inputs(&inputs.c[port]);
             printf("\n");
         }
 

--- a/examples/micro-ui/lib/microuiN64.c
+++ b/examples/micro-ui/lib/microuiN64.c
@@ -62,7 +62,7 @@ void mu64_init(joypad_port_t joypad_idx, uint8_t font_idx)
   mu_ctx._style.colors[MU_COLOR_BORDER]  = (mu_Color){0x10, 0x10, 0x10, 0xFF};
 
   cursor_active = true;
-  is_n64_mouse = joypad_get_identifier(joypad_index) == JOYBUS_IDENTIFIER_N64_MOUSE;
+  is_n64_mouse = joybus_get_identifier(joypad_index, NULL) == JOYBUS_IDENTIFIER_N64_MOUSE;
 }
 
 void mu64_start_frame()


### PR DESCRIPTION
- Updating `controllertest.c` to latest joypad API
- Replaced deprecated joypad identifier call with joybus API in `microuiN64.c`