### PR TITLE
n64.mk: Add support for native Windows-style path in N64_INST

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,23 +19,17 @@ if [[ -z ${N64_INST-} ]]; then
   exit 1
 fi
 
-# Run sanity checks for MinGW environment on Windows. There are a few common things
+# Run sanity checks for MSYS2 environments on Windows. There are a few common things
 # that can go wrong, and it's better to explicitly diagnose them here rather than
 # have the build fail mysteriously later.
-# Msys identifies itself via the OSTYPE variable as msys (before Feb 2025)
-# and "cygwin" (after Feb 2025). We want to detect both.
-if [[ $OSTYPE == 'msys'* || $OSTYPE == 'cygwin'* ]]; then
-  if [ "${MSYSTEM:-}" != "MINGW64" ]; then
-    # We only support building host tools via mingw-x64 at the moment, so
-    # enforce that to help users during installation.
-    echo This script must be run from the \"MSYS2 MinGW x64\" shell
-    echo Plase open that shell and run it again from there
-    exit 1
-  fi
-  # Check if N64_INST contains backslashes, which is not supported by the build system
-  if [[ "$N64_INST" == *\\* ]]; then
-    echo "N64_INST contains backslashes, which is not supported by the build system."
-    echo "Please set N64_INST to use forward slashes instead."
+# MSYS2 environments can be identified by running 'uname' and checking the MSYSTEM
+# environment variable that the shells set.
+if [[ "$(uname)" == MSYS* || "$(uname)" == MINGW* ]]; then
+  if [ "${MSYSTEM:-}" != "MINGW64" ] && [ "${MSYSTEM:-}" != "UCRT64" ]; then
+    # We only support building host tools via MINGW64 and UCRT64 environments at the moment,
+    # so enforce that to help users during installation.
+    echo This script must be run from the \"MSYS2 MINGW64\" or \"MSYS2 UCRT64\" shell
+    echo Please open such a shell and run it again from there
     exit 1
   fi
 fi

--- a/n64.mk
+++ b/n64.mk
@@ -28,6 +28,13 @@ N64_BACKTRACE_FILE_PREFIX=
 
 # Override this to use a toolchain installed separately from libdragon
 N64_GCCPREFIX ?= $(N64_INST)
+
+# Convert backslashes in N64_INST and N64_GCCPREFIX to forward slashes on Windows systems.
+ifneq ($(filter MSYS% MINGW%,$(shell uname)),)
+	N64_INST := $(shell cygpath -m "$(N64_INST)")
+	N64_GCCPREFIX := $(shell cygpath -m "$(N64_GCCPREFIX)")
+endif
+
 N64_TARGET ?= mips64-elf
 N64_ROOTDIR = $(N64_INST)
 N64_BINDIR = $(N64_ROOTDIR)/bin


### PR DESCRIPTION
### Motivation
In anticipation of Pyrite 64 (which I would like to run as native Windows binary) and with growing frustration over how slow I/O between WSL filesystem and NTFS filesystem is, I have decided to switch to native Windows toolchain and libdragon install. However, I don't like the MSYS terminal and bash in general; and I love my riced Powershell setup. So I wanted to make libdragon work and build from Powershell. The Makefile is too tied to bash, though, so I decided to take the path of least resistance and just invoke MSYS's bash in-place from Powershell to execute problematic commands for me with

```
function Invoke-Bash {
    if (-not (Get-Command bash -ErrorAction SilentlyContinue)) {
        Write-Error "'bash' was not found. Please install MSYS2 and ensure bash.exe is on PATH."
        return
    }

    $convertedArgs = $args | ForEach-Object {
        '"' + ($_ -replace '\\', '/') + '"'
    }

    Start-Process bash -NoNewWindow -Wait -ArgumentList ($convertedArgs -join ' ') -Environment @{
        MSYSTEM = 'UCRT64'
    }
}

Set-Alias msys Invoke-Bash
```

This PR is the set of changes necessary to make my setup work and I believe it doesn't hurt other users so it would be nice if they could be upstreamed.

### Change notes
~~I removed the block with MSYS-specific checks from `build.sh` because both checks became problematic. The check for MinGW64 environment is too restrictive~~ and the check for backwards slashes is obsolete because backwards slashes are now handled and properly converted in `n64.mk`. Now users can set `N64_INST` to a format expected by Windows (and applied by default by the Windows Environment Variables tool) such as `C:\n64`.