### PR TITLE
mkmaterial fixes

### DIFF
--- a/tools/mkmaterial/combexpr.cpp
+++ b/tools/mkmaterial/combexpr.cpp
@@ -29,7 +29,7 @@ static const std::vector<std::string> ALPHA_SLOTS_B = { "combined", "tex0", "tex
 static const std::vector<std::string> ALPHA_SLOTS_C = { "lod_frac", "tex0", "tex1", "prim", "shade", "env", "prim_lod_frac", "0" };
 static const std::vector<std::string> ALPHA_SLOTS_D = { "combined", "tex0", "tex1", "prim", "shade", "env", "1", "0" };
 
-static const std::unordered_set<std::string> ALL_SLOTS = { "combined", "tex0", "tex1", "shade", "prim", "env", "noise", "1", "0", "k4", "k5", "tex0.a", "tex1.a", "shade.a", "prim.a", "env.a", "lod_frac", "prim_lod_frac", "keycenter", "keyscale" };
+static const std::unordered_set<std::string> ALL_SLOTS = { "combined", "tex0", "tex1", "shade", "prim", "env", "noise", "1", "0", "k4", "k5", "combined.a", "tex0.a", "tex1.a", "shade.a", "prim.a", "env.a", "lod_frac", "prim_lod_frac", "keycenter", "keyscale" };
 
 enum CombinerChannel {
     RGB = 0,

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -106,7 +106,7 @@ struct Combiner {
 };
 
 struct Blender {
-    MyEnum mode{0, {"off", "multiply", "multiply_const", "additive"}};
+    MyEnum mode{0, {"none", "multiply", "multiply_const", "additive"}};
     float constant{-1};
 
     void parse_attr(std::string key, std::string value);

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -90,7 +90,7 @@ std::string parse_enum(std::string value, const std::vector<std::string> &enums)
 
 void Combiner::parse_attr(std::string key, std::string value)
 {
-    static const std::regex expr(R"(\s*\(\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*\)(?:\s*,\s*\(\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*\))?)");
+    static const std::regex expr(R"(\s*\(\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*\)(?:\s*,\s*\(\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*\))?)");
 
     if (key == "rgb") {
         combexpr::Parser parser(value);
@@ -111,7 +111,7 @@ void Combiner::parse_attr(std::string key, std::string value)
         std::smatch match;
         if (std::regex_match(value, match, expr)) {
             rgb = combexpr::CombinerExpr(combexpr::CombinerChannel::RGB, match[1], match[2], match[3], match[4]);
-            if (match.length() > 5) {
+            if (match[5].matched) {
                 rgb.set(1, 'a', match[5]); rgb.set(1, 'b', match[6]); rgb.set(1, 'c', match[7]); rgb.set(1, 'd', match[8]);
             }
             full = combexpr::CombinerExprFull(rgb, alpha);
@@ -123,7 +123,7 @@ void Combiner::parse_attr(std::string key, std::string value)
         std::smatch match;
         if (std::regex_match(value, match, expr)) {
             alpha = combexpr::CombinerExpr(combexpr::CombinerChannel::ALPHA, match[1], match[2], match[3], match[4]);
-            if (match.length() > 5) {
+            if (match[5].matched) {
                 alpha.set(1, 'a', match[5]); alpha.set(1, 'b', match[6]); alpha.set(1, 'c', match[7]); alpha.set(1, 'd', match[8]);
             }
             full = combexpr::CombinerExprFull(rgb, alpha);
@@ -441,7 +441,7 @@ std::vector<Material> parse_jmat(const char *fn)
             try {
                 mat.parse_attr(key, value.get<std::string>());
             } catch (std::runtime_error &e) {
-                fprintf(stderr, "%s: error: %s (material: %s)\n", fn, e.what(), material_name.c_str());
+                fprintf(stderr, "%s: error: %s (material: %s, key: %s)\n", fn, e.what(), material_name.c_str(), key.c_str());
                 mat_error = true;
             }
         }


### PR DESCRIPTION
- combined.a was missing from ALL_SLOTS
- the "none" value for the blender was mistyped as "off"
- the regex for raw combiners used \w but some slots have dots `.`
- `match.length() > 5` was checking for the string length of the full match when the intent was to check if groups 5+ were captured
- also print the key that caused an error on parse error