### PR TITLE
Wait for EEPROM busy bit before writing

### DIFF
--- a/include/eeprom.h
+++ b/include/eeprom.h
@@ -77,6 +77,9 @@ size_t eeprom_total_blocks( void );
 
 /**
  * @brief Read a block from EEPROM.
+ * 
+ * This operation will wait for the EEPROM busy bit to clear before reading;
+ * you may want to pause audio before calling this to prevent stuttering.
  *
  * @param[in]  block
  *             Block to read data from. Joybus accesses EEPROM in 8-byte blocks.
@@ -88,6 +91,10 @@ void eeprom_read( uint8_t block, uint8_t * dest );
 
 /**
  * @brief Write a block to EEPROM.
+ * 
+ * Once a block is written, the EEPROM will be busy for up to 15 milliseconds.
+ * This operation will wait for the EEPROM busy bit to clear before writing;
+ * you may want to pause audio before calling this to prevent stuttering.
  *
  * @param[in] block
  *            Block to write data to. Joybus accesses EEPROM in 8-byte blocks.

--- a/src/joybus/eeprom.c
+++ b/src/joybus/eeprom.c
@@ -9,48 +9,36 @@
 #include <stdlib.h>
 #include "eeprom.h"
 #include "joybus.h"
+#include "joybus_commands.h"
 
-/**
- * @brief Read the status of the EEPROM.
- *
- * The EEPROM status response contains a byte-swapped identifier half-word that
- * indicates which size EEPROM is present on the cartridge and a status byte.
- *
- * @return the normalized Joybus EEPROM status response data.
- */
-static uint32_t eeprom_status( void )
+/** @brief Joybus port for the cartridge connector */
+#define EEPROM_PORT 4
+
+static bool eeprom_maybe_busy = false;
+
+static void eeprom_maybe_wait( void )
 {
-    const uint64_t input[JOYBUS_BLOCK_DWORDS] =
+    if ( eeprom_maybe_busy )
     {
-        0x00000000ff010300,
-        0xfffffffffe000000,
-        0,
-        0,
-        0,
-        0,
-        0,
-        1
-    };
-    uint64_t output[JOYBUS_BLOCK_DWORDS];
-
-    joybus_exec( input, output );
-
-    uint8_t * recv_bytes = (uint8_t *)&output[1];
-
-    return (
-        /* Intentional un-swap of identifier bytes */
-        ((uint32_t)recv_bytes[1] << 16) |
-        ((uint32_t)recv_bytes[0] << 8)  |
-        recv_bytes[2]
-    );
+        joybus_cmd_identify_port_t cmd = { .send = {
+            .command = JOYBUS_COMMAND_ID_IDENTIFY,
+        } };
+        do { joybus_exec_cmd_struct( EEPROM_PORT, cmd ); }
+        while ( cmd.recv.status & JOYBUS_IDENTIFY_STATUS_EEPROM_BUSY );
+        eeprom_maybe_busy = false;
+    }
 }
 
 eeprom_type_t eeprom_present( void )
 {
-    switch( eeprom_status() >> 8 )
+    joybus_cmd_identify_port_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_IDENTIFY,
+    } };
+    joybus_exec_cmd_struct( EEPROM_PORT, cmd );
+    switch( cmd.recv.identifier )
     {
-        case 0xC000: return EEPROM_16K;
-        case 0x8000: return EEPROM_4K;
+        case JOYBUS_IDENTIFIER_CART_EEPROM_16KBIT: return EEPROM_16K;
+        case JOYBUS_IDENTIFIER_CART_EEPROM_4KBIT: return EEPROM_4K;
         default: return EEPROM_NONE;
     }
 }
@@ -67,44 +55,30 @@ size_t eeprom_total_blocks( void )
 
 void eeprom_read( uint8_t block, uint8_t * dest )
 {
-    const uint64_t input[JOYBUS_BLOCK_DWORDS] =
-    {
-        0x0000000002080400 | block,
-        0xffffffffffffffff,
-        0xfe00000000000000,
-        0,
-        0,
-        0,
-        0,
-        1
-    };
-    uint64_t output[JOYBUS_BLOCK_DWORDS];
+    eeprom_maybe_wait();
 
-    joybus_exec( input, output );
-
-    memcpy( dest, &output[1], EEPROM_BLOCK_SIZE );
+    joybus_cmd_eeprom_read_block_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_EEPROM_READ_BLOCK,
+        .block = block,
+    } };
+    joybus_exec_cmd_struct( EEPROM_PORT, cmd );
+    memcpy( dest, cmd.recv.data, EEPROM_BLOCK_SIZE );
 }
 
 uint8_t eeprom_write( uint8_t block, const uint8_t * src )
 {
-    uint64_t input[JOYBUS_BLOCK_DWORDS] =
-    {
-        0x000000000a010500 | block,
-        0x0000000000000000,
-        0xfffe000000000000,
-        0,
-        0,
-        0,
-        0,
-        1
-    };
-    uint64_t output[JOYBUS_BLOCK_DWORDS];
+    eeprom_maybe_wait();
 
-    memcpy( &input[1], src, EEPROM_BLOCK_SIZE );
+    joybus_cmd_eeprom_write_block_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_EEPROM_WRITE_BLOCK,
+        .block = block,
+    } };
+    memcpy( cmd.send.data, src, EEPROM_BLOCK_SIZE );
+    joybus_exec_cmd_struct( EEPROM_PORT, cmd );
 
-    joybus_exec( input, output );
-
-    return output[2] >> 56;
+    eeprom_maybe_busy = true;
+    assert(cmd.recv.status == 0x00);
+    return cmd.recv.status;
 }
 
 void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len )


### PR DESCRIPTION
Resolves data corruption issues with RetroStage N64 Blaster

Related Discord discussions:
- [libdragon-dev](https://discord.com/channels/205520502922543113/974342113850445874/1477827143408029900)
- [libdragon-forum](https://discord.com/channels/205520502922543113/1474422608551215124)