### PR TITLE
Restrict msym to exported symbols if externs file is provided

### DIFF
--- a/examples/overlays/actor/Makefile
+++ b/examples/overlays/actor/Makefile
@@ -31,7 +31,7 @@ filesystem/n64brew.dso: $(n64brew_SRC:%.c=$(BUILD_DIR)/%.o)
 overlays_actor.z64: N64_ROM_TITLE="Actor Overlay Demo"
 overlays_actor.z64: $(BUILD_DIR)/overlays_actor.dfs $(BUILD_DIR)/overlays_actor.msym
 
-$(BUILD_DIR)/overlays_actor.msym: $(BUILD_DIR)/overlays_actor.elf
+$(BUILD_DIR)/overlays_actor.msym: $(BUILD_DIR)/overlays_actor.elf $(MAIN_ELF_EXTERNS)
 
 clean:
 	rm -rf $(BUILD_DIR) filesystem $(DSO_LIST) overlays_actor.z64

--- a/examples/overlays/scene/Makefile
+++ b/examples/overlays/scene/Makefile
@@ -30,7 +30,7 @@ filesystem/scene_common.dso: $(scene_common_SRC:%.cpp=$(BUILD_DIR)/%.o)
 filesystem/scene/bg_test.dso: $(bgtest_SRC:%.cpp=$(BUILD_DIR)/%.o)
 filesystem/scene/sprite_test.dso: $(spritetest_SRC:%.cpp=$(BUILD_DIR)/%.o)
 
-$(BUILD_DIR)/overlays_scene.msym: $(BUILD_DIR)/overlays_scene.elf
+$(BUILD_DIR)/overlays_scene.msym: $(BUILD_DIR)/overlays_scene.elf $(MAIN_ELF_EXTERNS)
 
 overlays_scene.z64: N64_ROM_TITLE="Actor Overlay Demo"
 overlays_scene.z64: $(BUILD_DIR)/overlays_scene.dfs $(BUILD_DIR)/overlays_scene.msym

--- a/examples/ovldemo/Makefile
+++ b/examples/ovldemo/Makefile
@@ -38,7 +38,7 @@ ovldemo.z64: N64_ROM_TITLE="Overlay Demo"
 # Main Executable Symbol Table is required for overlay linking
 ovldemo.z64: $(BUILD_DIR)/ovldemo.dfs $(MAIN_ELF_SYMBOLS)
 # Rule for Main Executable Symbol Table
-$(MAIN_ELF_SYMBOLS): $(BUILD_DIR)/ovldemo.elf
+$(MAIN_ELF_SYMBOLS): $(BUILD_DIR)/ovldemo.elf $(MAIN_ELF_EXTERNS)
 
 clean:
 	rm -rf $(BUILD_DIR) filesystem $(DSO_LIST) ovldemo.z64

--- a/n64.mk
+++ b/n64.mk
@@ -258,10 +258,16 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp
 	@echo "    [DSOEXTERN] $@"
 	$(N64_DSOEXTERN) -o $@ $^ 
 	
-%.msym: %.elf
+%.msym:
 	@echo "    [MSYM] $@"
-	$(N64_DSOMSYM) $< $@
-    
+	EXTERNS_FILE="$(filter %.externs, $^)"; \
+	INPUT_FILE="$(filter %.elf, $^)"; \
+	if [ -z "$$EXTERNS_FILE" ]; then \
+		$(N64_DSOMSYM) "$$INPUT_FILE" $@; \
+	else \
+		$(N64_DSOMSYM) -e "$$EXTERNS_FILE" "$$INPUT_FILE" $@; \
+	fi
+	
 ifneq ($(V),1)
 .SILENT:
 endif

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -3,3 +3,4 @@ filesystem/*.dso.sym
 filesystem/*.sprite
 filesystem/*.mdb
 filesystem/texdb/
+filesystem/test_dir/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -68,8 +68,8 @@ $(BUILD_DIR)/testrom_emu.o: $(SOURCE_DIR)/testrom.c
 
 ${BUILD_DIR}/rsp_test.o: IS_OVERLAY=1
 
-$(BUILD_DIR)/testrom_emu.msym: $(BUILD_DIR)/testrom_emu.elf
-$(BUILD_DIR)/testrom.msym: $(BUILD_DIR)/testrom.elf
+$(BUILD_DIR)/testrom_emu.msym: $(BUILD_DIR)/testrom_emu.elf $(MAIN_ELF_EXTERNS)
+$(BUILD_DIR)/testrom.msym: $(BUILD_DIR)/testrom.elf $(MAIN_ELF_EXTERNS)
 
 $(MAIN_ELF_EXTERNS): $(DSO_LIST)
 filesystem/dl_test_syms.dso: $(BUILD_DIR)/dl_test_syms.o

--- a/tools/n64dso/n64dso-msym.c
+++ b/tools/n64dso/n64dso-msym.c
@@ -25,11 +25,12 @@
 //DSO Symbol Table Internals
 #include "../../src/dso_format.h"
 
-struct { char *key; int64_t value; } *imports_hash = NULL;
+struct { char *key; int value; } *extern_hash = NULL;
 
 dso_sym_t *export_syms = NULL;
 
-bool export_all = false;
+bool use_extern_syms = false;
+
 bool verbose_flag = false;
 const char *gccprefix_triplet = NULL;
 
@@ -123,10 +124,15 @@ void get_export_syms(char *infn)
                 line_buf[linebuf_len-2] = 0;
             }
             char *sym_name = &bind_ptr[20]; //Get symbol name pointer
-            size_t sym_value = strtoull(&line_buf[8], NULL, 16); //Read symbol value
-            //Read symbol size
-            size_t sym_size = strtoull(&line_buf[17], NULL, 0); //Read symbol size
-            add_export_sym(sym_name, sym_value, sym_size);
+            //Add externed symbols (or all if externed symbols are not used)
+            if(!use_extern_syms || stbds_shgeti(extern_hash, sym_name) != -1) {
+                
+                size_t sym_value = strtoull(&line_buf[8], NULL, 16); //Read symbol value
+                //Read symbol size
+                size_t sym_size = strtoull(&line_buf[17], NULL, 0); //Read symbol size
+                add_export_sym(sym_name, sym_value, sym_size);
+            }
+            
         }
     }
     //Free resources
@@ -187,6 +193,30 @@ void process(char *infn, char *outfn)
     write_msym(outfn);
 }
 
+void read_externs(char *infn)
+{
+    char *line_buf = NULL;
+    size_t line_buf_size = 0;
+    
+    FILE *file = fopen(infn, "r");
+    
+    
+    //Read symbol table output from readelf
+    while(getline(&line_buf, &line_buf_size, file) != -1) {
+        char *start_ptr = strstr(line_buf, "EXTERN(");
+        if(start_ptr) {
+            char *end_ptr = strchr(start_ptr, ')');
+            if(end_ptr) {
+                start_ptr += 7;
+                *end_ptr = 0;
+                stbds_shput(extern_hash, start_ptr, 0);
+            }
+        }
+    }
+    fclose(file);
+    
+}
+
 int main(int argc, char **argv)
 {
     winconsole_utf8();
@@ -214,6 +244,14 @@ int main(int argc, char **argv)
         } else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) {
             //Specify verbose flag
             verbose_flag = true;
+        } else if (!strcmp(argv[i], "-e") || !strcmp(argv[i], "--externs")) {
+            if (++i == argc) {
+                fprintf(stderr, "missing argument for %s\n", argv[i-1]);
+                return 1;
+            }
+            stbds_sh_new_arena(extern_hash);
+            read_externs(argv[i]);
+            use_extern_syms = true;
         } else {
             //Output invalid flag warning
             fprintf(stderr, "invalid flag: %s\n", argv[i]);


### PR DESCRIPTION
This shrinks the msym file by a considerable amount especially in libdragon overlay examples.