### PR TITLE
Eeprom async + eepfs integrity

### DIFF
--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -32,7 +32,7 @@ typedef struct
     int16_t map_pos_y;
     uint16_t max_hp;
     uint16_t current_hp;
-    uint8_t inventory[256];
+    uint8_t inventory[64];
 } game_save_state_t;
 
 static void press_a_to_continue(void)
@@ -133,7 +133,7 @@ static int validate_game_high_scores(char * path)
     int result;
 
     result = read_game_high_scores(path);
-    if ( result != 0 ) return result;
+    if ( result != 0 ) printf("Ivalid high scores!\n");
     press_a_to_continue();
 
     result = write_game_high_scores(path);
@@ -200,7 +200,7 @@ static int validate_game_settings(char * path)
     int result;
 
     result = read_game_settings(path);
-    if ( result != 0 ) return result;
+    if ( result != 0 ) printf("Invalid settings! (error: %d)\n", result);
     press_a_to_continue();
 
     result = write_game_settings(path);
@@ -268,7 +268,7 @@ static int write_game_save_state(char * path)
         -120,
         40,
         36,
-        { 1, 22, [254] = 52 }
+        { 1, 22, [63] = 52 }
     };
 
     printf( "Writing '%s'\n", path );
@@ -291,7 +291,7 @@ static int validate_game_save_state(char * path)
     int result;
 
     result = read_game_save_state(path);
-    if ( result != 0 ) return result;
+    if ( result != 0 ) printf("Invalid save state! (error: %d)\n", result);
     press_a_to_continue();
 
     result = write_game_save_state(path);
@@ -367,12 +367,12 @@ static int validate_eeprom_16k(void)
 {
     int result;
     const eepfs_entry_t eeprom_16k_files[] = {
-        { "high_scores.dat", sizeof(game_high_scores)  },
-        { "settings.dat",    sizeof(game_settings_t)   },
-        { "saves/slot1.sav", sizeof(game_save_state_t) },
-        { "saves/slot2.sav", sizeof(game_save_state_t) },
-        { "saves/slot3.sav", sizeof(game_save_state_t) },
-        { "saves/slot4.sav", sizeof(game_save_state_t) }
+        { .path ="high_scores.dat", .size = sizeof(game_high_scores),  .checksum = true, .backup = true },
+        { .path ="settings.dat",    .size = sizeof(game_settings_t),   .checksum = true, .backup = true },
+        { .path ="saves/slot1.sav", .size = sizeof(game_save_state_t), .checksum = true, .backup = true },
+        { .path ="saves/slot2.sav", .size = sizeof(game_save_state_t), .checksum = true, .backup = true },
+        { .path ="saves/slot3.sav", .size = sizeof(game_save_state_t), .checksum = true, .backup = true },
+        { .path ="saves/slot4.sav", .size = sizeof(game_save_state_t), .checksum = true, .backup = true }
     };
 
     printf( "EEPROM Detected: 16 Kibit (256 blocks)\n" );
@@ -452,11 +452,15 @@ static int validate_eeprom(eeprom_type_t eeprom_type)
 
 int main(void)
 {
+    debug_init_isviewer();
+    debug_init_usblog();
+
     /* Initialize peripherals */
     console_init();
     joypad_init();
 
     console_set_render_mode(RENDER_AUTOMATIC);
+    console_set_debug(true);
     console_clear();
 
     const eeprom_type_t eeprom_type = eeprom_present();

--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -133,7 +133,7 @@ static int validate_game_high_scores(char * path)
     int result;
 
     result = read_game_high_scores(path);
-    if ( result != 0 ) printf("Ivalid high scores!\n");
+    if ( result != 0 ) printf("Invalid high scores!\n");
     press_a_to_continue();
 
     result = write_game_high_scores(path);

--- a/include/eeprom.h
+++ b/include/eeprom.h
@@ -61,7 +61,7 @@
  * and gracefully handles the case where no EEPROM is present, even if it
  * was requested.
  *
- * Cheap chinese flashcarts might not support the advanced homebrew header,
+ * Cheap flashcarts might not support the advanced homebrew header,
  * and they most likely default to a 4k EEPROM as default save states for
  * non-commercial ROMs. If your ROM requires a 16k EEPROM to operate
  * properly, users of those flashcarts will need to manually configure the
@@ -135,7 +135,7 @@ void eeprom_read( uint8_t block, void * dest );
  * will want to use #eeprom_write_bytes instead, which is more flexible.
  *
  * @note Writes are eventually consistent to the EEPROM, so they will be
- *       persisted in background to the actual EEPROM. THe written data is
+ *       persisted in background to the actual EEPROM. The written data is
  *       immediately visible to read APIs though.
  *
  * @param[in] block

--- a/include/eeprom.h
+++ b/include/eeprom.h
@@ -30,8 +30,26 @@
  *  * A higher-level API (eepromfs.h) for higher-level access to EEPROM
  *    with structured data.
  *
+ * The low-level API exposes:
+ * - #eeprom_present and #eeprom_total_blocks to probe EEPROM capacity
+ * - #eeprom_read and #eeprom_read_bytes to read save data
+ * - #eeprom_write and #eeprom_write_bytes to update save data
+ * - #eeprom_is_busy to query whether background flush is still pending
+ *
+ * Current implementation uses a RAM master-copy with background write-back:
+ * reads are served from RAM cache (with lazy block fetch from EEPROM),
+ * writes update RAM immediately and are persisted asynchronously.
+ * This implies eventual consistency with physical EEPROM.
+ *
+ * Since writes happen in background, make sure to provide user feedback
+ * while writes are happening, checking with #eeprom_is_busy and telling
+ * the user that a write is in progress.
+ *
+ * Shutting down the console while a write is in progress can result in 
+ * the block being corrupted.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -90,7 +108,7 @@ size_t eeprom_total_blocks( void );
  * @param[out] dest
  *             Destination buffer for the eight bytes read from EEPROM.
  */
-void eeprom_read( uint8_t block, uint8_t * dest );
+void eeprom_read( uint8_t block, void * dest );
 
 /**
  * @brief Write a block to EEPROM.
@@ -107,7 +125,7 @@ void eeprom_read( uint8_t block, uint8_t * dest );
  *
  * @return the EEPROM status byte
  */
-uint8_t eeprom_write( uint8_t block, const uint8_t * src );
+uint8_t eeprom_write( uint8_t block, const void * src );
 
 /**
  * @brief Read a buffer of bytes from EEPROM.
@@ -122,7 +140,7 @@ uint8_t eeprom_write( uint8_t block, const uint8_t * src );
  * @param[in]  len
  *             Byte length of data to read into buffer
  */
-void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len );
+void eeprom_read_bytes( void * dest, size_t start, size_t len );
 
 /**
  * @brief Write a buffer of bytes to EEPROM.
@@ -147,7 +165,36 @@ void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len );
  * @param[in] len
  *            Byte length of the src buffer
  */
-void eeprom_write_bytes( const uint8_t * src, size_t start, size_t len );
+void eeprom_write_bytes( const void * src, size_t start, size_t len );
+
+/**
+ * @brief Return whether EEPROM flush is currently running.
+ *
+ * This function reports whether the background flusher is actively persisting
+ * data to EEPROM.
+ *
+ * Typical usage is to continue gameplay/UI while periodically checking this,
+ * and show feedback such as "saving..." until it returns false.
+ *
+ * @return true if background flush is currently active, false otherwise.
+ */
+bool eeprom_is_busy(void);
+
+
+/**
+ * @brief Wait until the EEPROM is completely idle.
+ * 
+ * This function will block until the EEPROM is completely idle, i.e. until
+ * all background writes have completed.
+ *
+ * This is similar to making a loop around #eeprom_is_busy, but it allows
+ * to switch to other threads while waiting.
+ *
+ * @note EEPROM writes are quite slow, so this function can block for a
+ *       long time, up to hundreds of milliseconds. Therefore it should be
+ *       used only when there is no graphics or audio to process.
+ */
+void eeprom_wait_idle(void);
 
 #ifdef __cplusplus
 }

--- a/include/eeprom.h
+++ b/include/eeprom.h
@@ -46,7 +46,26 @@
  * the user that a write is in progress.
  *
  * Shutting down the console while a write is in progress can result in 
- * the block being corrupted.
+ * the block being corrupted. EEPFS (eepromfs.h) provides higher-level
+ * filesystem integrity features to mitigate this.
+ *
+ * Activating EEPROM in emulators or flashcarts
+ * --------------------------------------------
+ * Libdragon offers support to advertise the need of an EEPROM to emulators
+ * and flashcarts. To do so, add <code>N64_ROM_SAVETYPE=eeprom4k</code> or
+ * <code>N64_ROM_SAVETYPE=eeprom16k</code> to your Makefile. 
+ *
+ * This uses the advanced homebrew header which is supported by most emulators
+ * and flashcarts compatible with libdragon. It still advised to use the
+ * #eeprom_present and #eeprom_total_blocks functions to probe the EEPROM
+ * and gracefully handles the case where no EEPROM is present, even if it
+ * was requested.
+ *
+ * Cheap chinese flashcarts might not support the advanced homebrew header,
+ * and they most likely default to a 4k EEPROM as default save states for
+ * non-commercial ROMs. If your ROM requires a 16k EEPROM to operate
+ * properly, users of those flashcarts will need to manually configure the
+ * EEPROM type using flashcart-specific instructions.
  */
 
 #include <stdbool.h>
@@ -96,26 +115,28 @@ size_t eeprom_total_blocks( void );
 /**
  * @brief Read a block from EEPROM.
  * 
- * This operation will wait for the EEPROM busy bit to clear before reading;
- * you may want to pause audio before calling this to prevent stuttering.
- *
- * This operation is quite fast (compared to writes) as it takes approximately
- * 750 µs.
+ * This function will read a block of data from EEPROM (8 bytes). Most users
+ * will want to use #eeprom_read_bytes instead, which is more flexible.
  *
  * @param[in]  block
  *             Block to read data from. Joybus accesses EEPROM in 8-byte blocks.
  *
  * @param[out] dest
  *             Destination buffer for the eight bytes read from EEPROM.
+ *
+ * @see #eeprom_read_bytes
  */
 void eeprom_read( uint8_t block, void * dest );
 
 /**
  * @brief Write a block to EEPROM.
  * 
- * Once a block is written, the EEPROM will be busy for up to 6 milliseconds.
- * This operation will wait for the EEPROM busy bit to clear before writing;
- * you may want to pause audio before calling this to prevent stuttering.
+ * This function writes a block of data to EEPROM (8 bytes). Most users
+ * will want to use #eeprom_write_bytes instead, which is more flexible.
+ *
+ * @note Writes are eventually consistent to the EEPROM, so they will be
+ *       persisted in background to the actual EEPROM. THe written data is
+ *       immediately visible to read APIs though.
  *
  * @param[in] block
  *            Block to write data to. Joybus accesses EEPROM in 8-byte blocks.
@@ -130,8 +151,10 @@ uint8_t eeprom_write( uint8_t block, const void * src );
 /**
  * @brief Read a buffer of bytes from EEPROM.
  *
- * This is a high-level convenience helper that abstracts away the
- * one-at-a-time EEPROM block access pattern.
+ * Read an arbitrary amount of data from the EEPROM. Normally reads are quite
+ * fast, even more so if the internal cache is already populated. In general
+ * you should be able to use reads without long stalls that might affect
+ * graphics or audio.
  *
  * @param[out] dest
  *             Destination buffer to read data into
@@ -145,16 +168,21 @@ void eeprom_read_bytes( void * dest, size_t start, size_t len );
 /**
  * @brief Write a buffer of bytes to EEPROM.
  *
- * This is a high-level convenience helper that abstracts away the
- * one-at-a-time EEPROM block access pattern.
+ * Writes an arbitrary amount of data to the EEPROM. Notice that writes are
+ * eventually consistent to the EEPROM: this function will return immediately,
+ * but the data will be persisted in background to the actual EEPROM.
  *
- * Each EEPROM block write takes approximately 6 milliseconds;
- * this operation may block for a while with large buffer sizes:
+ * The background persistence is quite slow. These are measured times for
+ * writing the whole EEPROM:
  *
- * * 4k EEPROM: 64 blocks * 6ms = 384ms!
- * * 16k EEPROM: 256 blocks * 6ms = 1536ms!
+ * * 4k EEPROM: 64 blocks * 6ms = 384ms
+ * * 16k EEPROM: 256 blocks * 6ms = 1536ms
  *
- * You may want to pause audio before calling this.
+ * Make sure the user is aware that a write is in progress and do not turn off
+ * the console, otherwise the EEPROM contents might get corrupted. You may want
+ * to display a "save in progress" message or indicator on the screen.
+ *
+ * You can use #eeprom_is_busy to check if a write is in progress at any point.
  *
  * @param[in] src
  *            Source buffer containing data to write
@@ -164,6 +192,8 @@ void eeprom_read_bytes( void * dest, size_t start, size_t len );
  *
  * @param[in] len
  *            Byte length of the src buffer
+ *
+ * @see #eeprom_is_busy
  */
 void eeprom_write_bytes( const void * src, size_t start, size_t len );
 

--- a/include/eepromfs.h
+++ b/include/eepromfs.h
@@ -136,8 +136,10 @@ int eepfs_read(const char * path, void * dest, size_t size);
 /**
  * @brief Writes an entire file to the EEPROM filesystem.
  * 
- * Each EEPROM block write takes approximately 15 milliseconds;
- * this operation may block for a while!
+ * @note Writes are eventually consistent, so they will be
+ * performed in background and may take a while to complete.
+ * Use #eeprom_is_busy or #eeprom_wait_idle to check the status
+ * of the write.
  *
  * @param[in] path
  *            Path of file in EEPROM filesystem to write to
@@ -157,10 +159,12 @@ int eepfs_write(const char * path, const void * src, size_t size);
  * All files in the filesystem must always exist at the size specified
  * during #eepfs_init
  * 
- * Each EEPROM block write takes approximately 15 milliseconds;
- * this operation may block for a while!
- * 
  * Be advised: this is a destructive operation that cannot be undone!
+ *
+ * @note Writes are eventually consistent, so they will be
+ * performed in background and may take a while to complete.
+ * Use #eeprom_is_busy or #eeprom_wait_idle to check the status
+ * of the write.
  * 
  * @retval EEPFS_ESUCCESS if successful
  * @retval EEPFS_ENOFILE if the path is not a valid file
@@ -199,9 +203,6 @@ bool eepfs_verify_signature(void);
  * 
  * This is useful when you want to erase all files in the filesystem.
  * 
- * Each EEPROM block write takes approximately 15 milliseconds;
- * this operation may block for a while:
- * 
  * * 4k EEPROM: 64 blocks * 15ms = 960ms!
  * * 16k EEPROM: 256 blocks * 15ms = 3840ms!
  * 
@@ -209,6 +210,11 @@ bool eepfs_verify_signature(void);
  * 
  * Be advised: this is a destructive operation that cannot be undone!
  * 
+ * @note Writes are eventually consistent, so they will be
+ * performed in background and may take a while to complete.
+ * Use #eeprom_is_busy or #eeprom_wait_idle to check the status
+ * of the write.
+ *
  * @see #eepfs_verify_signature
  */
 void eepfs_wipe(void);

--- a/include/eepromfs.h
+++ b/include/eepromfs.h
@@ -22,7 +22,7 @@
 #define EEPFS_EBADINPUT  -1
 /** @brief File does not exist */
 #define EEPFS_ENOFILE    -2
-/** @brief Bad filesystem */
+/** @brief Filesystem is too big for the EEPROM */
 #define EEPFS_EBADFS     -3
 /** @brief No memory for operation */
 #define EEPFS_ENOMEM     -4
@@ -30,6 +30,8 @@
 #define EEPFS_EBADHANDLE -5
 /** @brief Filesystem already initialized */
 #define EEPFS_ECONFLICT  -6
+/** @brief File is corrupted (checksum mismatch) */
+#define EEPFS_CORRUPTED  -7
 /** @} */
 
 #ifdef __cplusplus
@@ -53,7 +55,7 @@ typedef struct eepfs_entry_t
      * 
      * A leading '/' is optional and will be ignored if set.
      * 
-     * The filesytem does not support entries for directories,
+     * The filesystem does not support entries for directories,
      * nor does it support listing files in a given directory.
      */
     const char * path;
@@ -73,6 +75,30 @@ typedef struct eepfs_entry_t
      * * 16k EEPROM: 2048 - 8 = 2040 bytes (255 blocks) free.
      */
     size_t size;
+    /**
+     * @brief Automatically store and verify a checksum of the file
+     * 
+     * When this flag is set, eepfs will calculate a 16-bit checksum
+     * of the file and append it to the file itself. The checksum
+     * will also be automatically verified when the file is read.
+     */
+    bool checksum;
+    /**
+      * @brief Keep a backup copy of the file in the EEPROM.
+      *
+      * When this flag is set, eepfs will automatically keep a backup
+      * copy of the file in the EEPROM. The backup copy is automatically
+      * retrieved if the main copy is corrupted (use of checksum is strongly
+      * recommended if backup is enabled).
+      *
+      * This is useful to prevent data loss in case of corruption or
+      * power failure.
+      *
+      * In addition to the backup copy, the filesystem will also need
+      * to store 2 extra bytes (1 per copy) to keep a reference to the
+      * newest copy of the file.
+      */
+     bool backup;
 } eepfs_entry_t;
 
 /**
@@ -190,7 +216,6 @@ int eepfs_erase(const char * path);
  * filesystem expects. If not, the best move is to erase everything
  * and start from zero.
  * 
- * @see eepfs_generate_signature
  * @see #eepfs_wipe
  * 
  * @retval true if the signature in EEPROM matches the filesystem signature

--- a/src/joybus/eeprom.c
+++ b/src/joybus/eeprom.c
@@ -245,7 +245,6 @@ static void eeprom_flush_write_callback(uint64_t *out_dwords, void *ctx)
 /** Start one async write for a dirty block (if flusher is idle). */
 static void eeprom_flush_kick(void)
 {
-    if (!eeprom_cache) return;
     uint8_t block;
     const uint8_t *src;
 
@@ -351,10 +350,12 @@ uint8_t eeprom_write( uint8_t block, const void * src )
 
 void eeprom_read_bytes( void * dest, size_t start, size_t len )
 {
-    if (len == 0) return;
     eeprom_cache_alloc_if_needed();
-    if (!eeprom_cache) return;
-    assert((start + len) <= (eeprom_num_blocks * EEPROM_BLOCK_SIZE));
+    assertf(eeprom_num_blocks > 0, "EEPROM not present");
+    if (len == 0) return;
+    assertf((start + len) <= (eeprom_num_blocks * EEPROM_BLOCK_SIZE), 
+            "EEPROM read out of bounds: start=%zu, len=%zu, total_size=%zu",
+            start, len, eeprom_num_blocks * EEPROM_BLOCK_SIZE);
 
     size_t first_block = start / EEPROM_BLOCK_SIZE;
     size_t last_block = (start + len - 1) / EEPROM_BLOCK_SIZE;
@@ -368,10 +369,12 @@ void eeprom_read_bytes( void * dest, size_t start, size_t len )
 
 void eeprom_write_bytes( const void * src, size_t start, size_t len )
 {
-    if (len == 0) return;
     eeprom_cache_alloc_if_needed();
-    if (!eeprom_cache) return;
-    assert((start + len) <= (eeprom_num_blocks * EEPROM_BLOCK_SIZE));
+    assertf(eeprom_num_blocks > 0, "EEPROM not present");
+    if (len == 0) return;
+    assertf((start + len) <= (eeprom_num_blocks * EEPROM_BLOCK_SIZE), 
+            "EEPROM write out of bounds: start=%zu, len=%zu, total_size=%zu",
+            start, len, eeprom_num_blocks * EEPROM_BLOCK_SIZE);
 
     // For partial writes we need existing data to preserve untouched bytes.
     size_t first_block = start / EEPROM_BLOCK_SIZE;

--- a/src/joybus/eeprom.c
+++ b/src/joybus/eeprom.c
@@ -4,10 +4,65 @@
  * @author Christopher Bonhage <christopher.bonhage@meeq.tech>
  * @brief EEPROM support
  * @ingroup eeprom
+ *
+ *
+ * EEPROM implementation overview
+ * ==============================
+ *
+ * This module implements EEPROM access using a RAM write-back cache. EEPROM
+ * writes in fact tend to be extremely slow, while reads are quite fast.
+ * 
+ * Public API remains synchronous and unchanged from the historical one, but
+ * persistence to hardware is decoupled from logical writes. This achieves what
+ * is normally called "eventual consistency".
+ *
+ * High-level model
+ * ----------------
+ * The RAM cache is the authoritative copy seen by callers, while EEPROM
+ * hardware acts as a backing store flushed in background. The cache is
+ * allocated lazily on first EEPROM access and then populated lazily per block,
+ * so blocks are fetched from hardware only when they are actually needed.
+ *
+ * Read path
+ * ---------
+ * eeprom_read and eeprom_read_bytes serve data from RAM cache. When a cache
+ * miss happens, the module performs a synchronous single-block fetch from
+ * hardware. If the flusher is currently writing one block, read-miss logic
+ * waits for that single in-flight write to complete before fetching.
+ *
+ * Write path
+ * ----------
+ * eeprom_write and eeprom_write_bytes immediately update cache contents and
+ * mark touched blocks as dirty in a bitmap. For partial writes, required
+ * blocks are validated first so read-modify-write semantics are preserved.
+ *
+ * Background flush
+ * ----------------
+ * A single async state machine persists one dirty block at a time. On each
+ * completion, it schedules the next dirty block. Dirty selection starts from
+ * a randomized index to avoid always favoring low-index blocks. If a write
+ * fails, the block is marked dirty again and retried later.
+ *
+ * Read priority over flush
+ * ------------------------
+ * When a read is requested while background writes are active, this module
+ * tries to keep blocking time low. A read miss requests temporary flush yield,
+ * so the write callback stops chaining while the miss is being resolved. Once
+ * the missing block has been fetched, flush resumes if it was active before.
+ *
+ * Busy semantics
+ * --------------
+ * eeprom_is_busy reports whether a flush write is currently in progress.
+ * Hardware busy is still honored for direct synchronous read-block fetches.
  */
 
 #include <string.h>
 #include <stdlib.h>
+#include "debug.h"
+#include "interrupt.h"
+#include "kernel/kernel_internal.h"
+#include "kirq.h"
+#include "../rand_internal.h"
 #include "eeprom.h"
 #include "joybus.h"
 #include "joybus_commands.h"
@@ -17,132 +72,349 @@
 
 static bool eeprom_maybe_busy = false;
 
-static void eeprom_maybe_wait( void )
+/** @brief EEPROM background flushing state machine */
+typedef enum {
+    EEPROM_FLUSH_IDLE = 0,    ///< No background flush is in progress
+    EEPROM_FLUSH_WRITE_BLOCK, ///< A block is being flushed asynchronously
+} eeprom_flush_state_t;
+
+static volatile eeprom_flush_state_t eeprom_flush_state = EEPROM_FLUSH_IDLE;
+
+static uint8_t eeprom_flush_block = 0;     ///< The block currently being flushed
+static uint8_t eeprom_last_hw_status = 0x00; ///< The last hardware status byte received
+static volatile bool eeprom_read_miss_pending = false; ///< Whether a read miss is pending
+
+static eeprom_type_t eeprom_cached_type = EEPROM_NONE;
+static size_t eeprom_num_blocks = 0;
+static uint8_t *eeprom_cache;
+static uint8_t *eeprom_valid_bitmap;
+static uint8_t *eeprom_dirty_bitmap;
+
+static void eeprom_flush_write_callback(uint64_t *out_dwords, void *ctx);
+
+/** Return one bit from a compact bitmap. */
+static inline bool bitmap_get(const uint8_t *bitmap, size_t idx)
 {
-    if ( eeprom_maybe_busy )
-    {
-        joybus_cmd_identify_port_t cmd = { .send = {
-            .command = JOYBUS_COMMAND_ID_IDENTIFY,
-        } };
-        do { joybus_exec_cmd_struct( EEPROM_PORT, cmd ); }
-        while ( cmd.recv.status & JOYBUS_IDENTIFY_STATUS_EEPROM_BUSY );
-        eeprom_maybe_busy = false;
-    }
+    return (bitmap[idx >> 3] & (1u << (idx & 7))) != 0;
 }
 
-eeprom_type_t eeprom_present( void )
+/** Set one bit in a compact bitmap. */
+static inline void bitmap_set(uint8_t *bitmap, size_t idx)
 {
+    bitmap[idx >> 3] |= (1u << (idx & 7));
+}
+
+/** Clear one bit in a compact bitmap. */
+static inline void bitmap_clear(uint8_t *bitmap, size_t idx)
+{
+    bitmap[idx >> 3] &= ~(1u << (idx & 7));
+}
+
+/** Send one asynchronous EEPROM block write on Joybus. */
+static void eeprom_write_block_async_hw(uint8_t block, const uint8_t *src, joybus_callback_t callback)
+{
+    joybus_cmd_eeprom_write_block_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_EEPROM_WRITE_BLOCK,
+        .block = block,
+    } };
+    uint8_t input[JOYBUS_BLOCK_SIZE] = {0};
+    size_t i = EEPROM_PORT;
+    input[i++] = sizeof(cmd.send);
+    input[i++] = sizeof(cmd.recv);
+    const size_t data_offset = offsetof(typeof(cmd.send), data);
+    memcpy(&input[i], (void *)&cmd.send, data_offset);
+    memcpy(&input[i + data_offset], src, sizeof(cmd.send.data));
+    i += sizeof(cmd.send) + sizeof(cmd.recv);
+    input[i] = 0xFE;
+    input[sizeof(input) - 1] = 0x01;
+    joybus_exec_async(input, callback, NULL);
+}
+
+/** Block until EEPROM busy bit is cleared, if a write happened before. */
+static void eeprom_wait_ready(void)
+{
+    if (!eeprom_maybe_busy) return;
+
     joybus_cmd_identify_port_t cmd = { .send = {
         .command = JOYBUS_COMMAND_ID_IDENTIFY,
     } };
-    joybus_exec_cmd_struct( EEPROM_PORT, cmd );
-    switch( cmd.recv.identifier )
-    {
-        case JOYBUS_IDENTIFIER_CART_EEPROM_16KBIT: return EEPROM_16K;
-        case JOYBUS_IDENTIFIER_CART_EEPROM_4KBIT: return EEPROM_4K;
-        default: return EEPROM_NONE;
-    }
+    do { joybus_exec_cmd_struct(EEPROM_PORT, cmd); }
+    while (cmd.recv.status & JOYBUS_IDENTIFY_STATUS_EEPROM_BUSY);
+    eeprom_maybe_busy = false;
 }
 
-size_t eeprom_total_blocks( void )
+/** Read one EEPROM block synchronously from hardware. */
+static void eeprom_read_block_hw(uint8_t block, uint8_t *dest)
 {
-    switch ( eeprom_present() )
-    {
-        case EEPROM_16K: return 256;
-        case EEPROM_4K: return 64;
-        default: return 0;
-    }
-}
-
-void eeprom_read( uint8_t block, uint8_t * dest )
-{
-    eeprom_maybe_wait();
+    eeprom_wait_ready();
 
     joybus_cmd_eeprom_read_block_t cmd = { .send = {
         .command = JOYBUS_COMMAND_ID_EEPROM_READ_BLOCK,
         .block = block,
     } };
-    joybus_exec_cmd_struct( EEPROM_PORT, cmd );
-    memcpy( dest, cmd.recv.data, EEPROM_BLOCK_SIZE );
+    joybus_exec_cmd_struct(EEPROM_PORT, cmd);
+    memcpy(dest, cmd.recv.data, EEPROM_BLOCK_SIZE);
 }
 
-uint8_t eeprom_write( uint8_t block, const uint8_t * src )
+/** Probe EEPROM type/capacity once and cache the result. */
+static void eeprom_probe_capacity_if_needed(void)
 {
-    eeprom_maybe_wait();
+    if (eeprom_num_blocks) return;
 
-    joybus_cmd_eeprom_write_block_t cmd = { .send = {
-        .command = JOYBUS_COMMAND_ID_EEPROM_WRITE_BLOCK,
-        .block = block,
+    joybus_cmd_identify_port_t cmd = { .send = {
+        .command = JOYBUS_COMMAND_ID_IDENTIFY,
     } };
-    memcpy( cmd.send.data, src, EEPROM_BLOCK_SIZE );
-    joybus_exec_cmd_struct( EEPROM_PORT, cmd );
+    joybus_exec_cmd_struct(EEPROM_PORT, cmd);
+    switch (cmd.recv.identifier)
+    {
+        case JOYBUS_IDENTIFIER_CART_EEPROM_16KBIT:
+            eeprom_cached_type = EEPROM_16K;
+            eeprom_num_blocks = 256;
+            break;
+        case JOYBUS_IDENTIFIER_CART_EEPROM_4KBIT:
+            eeprom_cached_type = EEPROM_4K;
+            eeprom_num_blocks = 64;
+            break;
+        default:
+            eeprom_cached_type = EEPROM_NONE;
+            eeprom_num_blocks = 0;
+            break;
+    }
+}
 
+/** Lazily allocate cache and bitmaps on first EEPROM use. */
+static void eeprom_cache_alloc_if_needed(void)
+{
+    if (eeprom_cache) return;
+
+    eeprom_probe_capacity_if_needed();
+    if (!eeprom_num_blocks) return;
+
+    size_t bitmap_bytes = (eeprom_num_blocks + 7) / 8;
+    eeprom_cache = malloc(eeprom_num_blocks * EEPROM_BLOCK_SIZE);
+    assertf(eeprom_cache, "Out of memory");
+    eeprom_valid_bitmap = calloc(bitmap_bytes, 1);
+    assertf(eeprom_valid_bitmap, "Out of memory");
+    eeprom_dirty_bitmap = calloc(bitmap_bytes, 1);
+    assertf(eeprom_dirty_bitmap, "Out of memory");
+
+}
+
+/** Try to schedule the next dirty block flush. */
+static void eeprom_flush_kick(void);
+
+/** Find a dirty block using randomized scan start to avoid bias. */
+static int eeprom_find_next_dirty_block(void)
+{
+    if (!eeprom_num_blocks) return -1;
+
+    size_t block = __randn(eeprom_num_blocks);
+    for (size_t i = 0; i < eeprom_num_blocks; i++)
+    {
+        block++;
+        if (block == eeprom_num_blocks) block = 0;
+        if (bitmap_get(eeprom_dirty_bitmap, block))
+            return block;
+    }
+    return -1;
+}
+
+/** Handle completion of one async write and chain next flush step. */
+static void eeprom_flush_write_callback(uint64_t *out_dwords, void *ctx)
+{
+    (void)ctx;
+    if (eeprom_flush_state != EEPROM_FLUSH_WRITE_BLOCK) return;
+
+    const uint8_t *out_bytes = (void *)out_dwords;
+    const joybus_cmd_eeprom_write_block_t *cmd = (void *)&out_bytes[EEPROM_PORT + JOYBUS_COMMAND_METADATA_SIZE];
+    eeprom_last_hw_status = cmd->recv.status;
     eeprom_maybe_busy = true;
-    assert(cmd.recv.status == 0x00);
-    return cmd.recv.status;
+
+    if (cmd->recv.status != 0x00)
+    {
+        // Keep data pending so a later kick can retry persistence.
+        bitmap_set(eeprom_dirty_bitmap, eeprom_flush_block);
+    }
+
+    eeprom_flush_state = EEPROM_FLUSH_IDLE;
+    // Yield to an outstanding read miss before continuing the flush chain.
+    if (eeprom_read_miss_pending) return;
+    eeprom_flush_kick();
 }
 
-void eeprom_read_bytes( uint8_t * dest, size_t start, size_t len )
+/** Start one async write for a dirty block (if flusher is idle). */
+static void eeprom_flush_kick(void)
 {
-    size_t bytes_left = len;
-    uint8_t buf[EEPROM_BLOCK_SIZE];
-    uint8_t current_block = start / EEPROM_BLOCK_SIZE;
-    // If we need to read a partial block to start off...
-    size_t block_offset = start % EEPROM_BLOCK_SIZE;
-    if (block_offset)
+    if (!eeprom_cache) return;
+    uint8_t block;
+    const uint8_t *src;
+
+    // Atomically claim one dirty block and transition the flusher state.
+    disable_interrupts();
+    if (eeprom_flush_state != EEPROM_FLUSH_IDLE)
     {
-        eeprom_read( current_block++, buf );
-        bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
-        while (block_offset < EEPROM_BLOCK_SIZE)
-        {
-            *dest++ = buf[block_offset++];
-        }
+        enable_interrupts();
+        return;
     }
-    // Read whole blocks at a time
-    while ( bytes_left >= EEPROM_BLOCK_SIZE )
+
+    int next_block = eeprom_find_next_dirty_block();
+    if (next_block < 0)
     {
-        eeprom_read( current_block++, dest );
-        dest += EEPROM_BLOCK_SIZE;
-        bytes_left -= EEPROM_BLOCK_SIZE;
+        enable_interrupts();
+        return;
     }
-    // If we need to read a partial block at the end...
-    if (bytes_left)
+
+    block = (uint8_t)next_block;
+    eeprom_flush_block = block;
+    bitmap_clear(eeprom_dirty_bitmap, block);
+    eeprom_flush_state = EEPROM_FLUSH_WRITE_BLOCK;
+    src = &eeprom_cache[(size_t)block * EEPROM_BLOCK_SIZE];
+    enable_interrupts();
+
+    eeprom_write_block_async_hw(
+        block,
+        src,
+        eeprom_flush_write_callback
+    );
+}
+
+/** Wait until there is no async write currently in-flight. */
+static void eeprom_flush_wait_idle(void)
+{
+    kirq_wait_t w = kirq_begin_wait_si();
+    while (eeprom_flush_state != EEPROM_FLUSH_IDLE)
     {
-        eeprom_read( current_block, buf );
-        memcpy( dest, buf, bytes_left );
+        if (__kernel) kirq_wait(&w);
     }
 }
 
-void eeprom_write_bytes( const uint8_t * src, size_t start, size_t len )
+/**
+ * Pause flush chaining while serving foreground cache misses.
+ *
+ * Returns true if a flush write was already active and had to be drained first.
+ */
+static bool eeprom_flush_pause(void)
 {
-    size_t bytes_left = len;
-    uint8_t buf[EEPROM_BLOCK_SIZE];
-    uint8_t current_block = start / EEPROM_BLOCK_SIZE;
-    // If we need to write a partial block to start off...
-    size_t block_offset = start % EEPROM_BLOCK_SIZE;
-    if (block_offset)
-    {
-        eeprom_read( current_block, buf );
-        bytes_left -= (EEPROM_BLOCK_SIZE - block_offset);
-        while (block_offset < EEPROM_BLOCK_SIZE)
-        {
-            buf[block_offset++] = *src++;
-        }
-        eeprom_write( current_block++, buf );
+    bool had_flush_in_progress;
+    disable_interrupts();
+    had_flush_in_progress = (eeprom_flush_state != EEPROM_FLUSH_IDLE);
+    eeprom_read_miss_pending = true;
+    enable_interrupts();
+
+    // At most one block can be in-flight, wait for it once.
+    if (had_flush_in_progress) eeprom_flush_wait_idle();
+    return had_flush_in_progress;
+}
+
+/** Resume flush chaining after foreground cache-miss handling. */
+static void eeprom_flush_resume(bool had_flush_in_progress)
+{
+    disable_interrupts();
+    eeprom_read_miss_pending = false;
+    enable_interrupts();
+
+    if (had_flush_in_progress) eeprom_flush_kick();
+}
+
+/** Ensure one block is valid in cache, fetching it lazily if needed. */
+static void eeprom_cache_ensure_block_valid(size_t block)
+{
+    if (bitmap_get(eeprom_valid_bitmap, block) || bitmap_get(eeprom_dirty_bitmap, block))
+        return;
+
+    eeprom_read_block_hw((uint8_t)block, &eeprom_cache[block * EEPROM_BLOCK_SIZE]);
+    bitmap_set(eeprom_valid_bitmap, block);
+}
+
+eeprom_type_t eeprom_present( void )
+{
+    eeprom_probe_capacity_if_needed();
+    return eeprom_cached_type;
+}
+
+size_t eeprom_total_blocks( void )
+{
+    eeprom_probe_capacity_if_needed();
+    return eeprom_num_blocks;
+}
+
+void eeprom_read( uint8_t block, void * dest )
+{
+    eeprom_read_bytes(dest, (size_t)block * EEPROM_BLOCK_SIZE, EEPROM_BLOCK_SIZE);
+}
+
+uint8_t eeprom_write( uint8_t block, const void * src )
+{
+    eeprom_write_bytes(src, (size_t)block * EEPROM_BLOCK_SIZE, EEPROM_BLOCK_SIZE);
+    return eeprom_last_hw_status;
+}
+
+void eeprom_read_bytes( void * dest, size_t start, size_t len )
+{
+    if (len == 0) return;
+    eeprom_cache_alloc_if_needed();
+    if (!eeprom_cache) return;
+    assert((start + len) <= (eeprom_num_blocks * EEPROM_BLOCK_SIZE));
+
+    size_t first_block = start / EEPROM_BLOCK_SIZE;
+    size_t last_block = (start + len - 1) / EEPROM_BLOCK_SIZE;
+    bool had_flush_in_progress = eeprom_flush_pause();
+    for (size_t block = first_block; block <= last_block; block++)
+        eeprom_cache_ensure_block_valid(block);
+    eeprom_flush_resume(had_flush_in_progress);
+
+    memcpy(dest, &eeprom_cache[start], len);
+}
+
+void eeprom_write_bytes( const void * src, size_t start, size_t len )
+{
+    if (len == 0) return;
+    eeprom_cache_alloc_if_needed();
+    if (!eeprom_cache) return;
+    assert((start + len) <= (eeprom_num_blocks * EEPROM_BLOCK_SIZE));
+
+    // For partial writes we need existing data to preserve untouched bytes.
+    size_t first_block = start / EEPROM_BLOCK_SIZE;
+    size_t last_block = (start + len - 1) / EEPROM_BLOCK_SIZE;
+    size_t first_offset = start % EEPROM_BLOCK_SIZE;
+    size_t end_offset = (start + len) % EEPROM_BLOCK_SIZE;
+    bool need_rmw_prefix = first_offset || (last_block != first_block && end_offset);
+    if (need_rmw_prefix) {
+        bool had_flush_in_progress = eeprom_flush_pause();
+        if (first_offset)
+            eeprom_cache_ensure_block_valid(first_block);
+        if (last_block != first_block && end_offset)
+            eeprom_cache_ensure_block_valid(last_block);
+        eeprom_flush_resume(had_flush_in_progress);
     }
-    // Write whole blocks at a time
-    while (bytes_left >= EEPROM_BLOCK_SIZE)
+
+    // Keep cache write + dirty/valid bitmap updates coherent vs flush callback.
+    disable_interrupts();
+    memcpy(&eeprom_cache[start], src, len);
+    for (size_t block = first_block; block <= last_block; block++)
     {
-        memcpy( buf, src, EEPROM_BLOCK_SIZE );
-        eeprom_write( current_block++, buf );
-        src += EEPROM_BLOCK_SIZE;
-        bytes_left -= EEPROM_BLOCK_SIZE;
+        bitmap_set(eeprom_valid_bitmap, block);
+        bitmap_set(eeprom_dirty_bitmap, block);
     }
-    // If we need to write a partial block at the end...
-    if (bytes_left)
+    enable_interrupts();
+
+    eeprom_flush_kick();
+}
+
+bool eeprom_is_busy(void)
+{
+    bool busy;
+    disable_interrupts();
+    busy = (eeprom_flush_state != EEPROM_FLUSH_IDLE);
+    enable_interrupts();
+    return busy;
+}
+
+void eeprom_wait_idle(void)
+{
+    kirq_wait_t w = kirq_begin_wait_si();
+    while (eeprom_is_busy())
     {
-        eeprom_read( current_block, buf );
-        memcpy( buf, src, bytes_left );
-        eeprom_write( current_block, buf );
+        if (__kernel) kirq_wait(&w);
     }
 }

--- a/src/joybus/eepromfs.c
+++ b/src/joybus/eepromfs.c
@@ -11,6 +11,12 @@
 #include "utils.h"
 #include "eeprom.h"
 #include "eepromfs.h"
+#include "debug.h"
+
+/** @brief Flags for the file */
+#define EEPFS_FLAGS_CHECKSUM    (1<<0)
+/** @brief Flags for the file */
+#define EEPFS_FLAGS_BACKUP      (1<<1)
 
 /**
  * @brief EEPROM Filesystem file descriptor.
@@ -32,11 +38,13 @@
 typedef struct eepfs_file_t
 {
     /** @brief File path */
-    const char * const path;
+    const char *path;
     /** @brief Files must start on a block boundary */
-    const size_t start_block;
+    uint16_t start_block;
     /** @brief Size of the file (in bytes) */
-    const size_t num_bytes;
+    uint16_t num_bytes;
+    /** @brief Flags for the file */
+    uint16_t flags;
 } eepfs_file_t;
 
 /**
@@ -66,6 +74,9 @@ static eepfs_file_t * eepfs_files = NULL;
  */
 static uint16_t eepfs_files_checksum = 0;
 
+/** @brief Initial value for the CRC-16 checksum */
+#define CRC16_INIT      0xFFFF
+
 /**
  * @brief Calculates a CRC-16 checksum from an array of bytes.
  * 
@@ -74,14 +85,11 @@ static uint16_t eepfs_files_checksum = 0;
  * 
  * @see https://stackoverflow.com/a/23726131
  */
-static uint16_t calculate_crc16(const uint8_t * data, size_t len)
+static uint16_t calculate_crc16(uint16_t crc, const uint8_t * data, size_t len)
 {
-    uint8_t x;
-    uint16_t crc = 0xFFFF;
-
     while ( len-- )
     {
-        x = crc >> 8 ^ *(data++);
+        uint8_t x = crc >> 8 ^ *(data++);
         x ^= x>>4;
         crc = (
             (crc << 8) ^ 
@@ -90,7 +98,6 @@ static uint16_t calculate_crc16(const uint8_t * data, size_t len)
             ((uint16_t)x)
         );
     }
-
     return crc;
 }
 
@@ -243,8 +250,10 @@ int eepfs_init(const eepfs_entry_t * entries, size_t count)
     /* Configure a file descriptor for each entry */
     for ( size_t i = 1; i < eepfs_files_count; ++i )
     {
+        uint16_t flags = 0;
         file_path = entries[i - 1].path;
         file_size = entries[i - 1].size;
+        uint16_t file_total_size = file_size;
 
         /* Sanity check the file details */
         if ( file_path == NULL || file_size == 0 )
@@ -253,19 +262,35 @@ int eepfs_init(const eepfs_entry_t * entries, size_t count)
             return EEPFS_EBADINPUT;
         }
 
+        /* If the file has a checksum, add 2 bytes for the checksum */
+        if ( entries[i - 1].checksum )
+        {
+            file_total_size += 2;
+            flags |= EEPFS_FLAGS_CHECKSUM;
+        }
+        /* If the file has a backup, add the generation count plus the copy */
+        if ( entries[i - 1].backup )
+        {
+            file_total_size += 1;
+            file_total_size = ROUND_UP(file_total_size, EEPROM_BLOCK_SIZE);
+            file_total_size *= 2;
+            flags |= EEPFS_FLAGS_BACKUP;
+        }
+
         /* Strip the leading '/' on paths for consistency */
         file_path += ( file_path[0] == '/' );
 
         /* Create a file descriptor and copy it into the table */
         const eepfs_file_t entry_file = {
-            file_path,
-            total_blocks,
-            file_size,
+            .path = file_path,
+            .start_block = total_blocks,
+            .num_bytes = file_size,
+            .flags = flags,
         };
         memcpy(&eepfs_files[i], &entry_file, sizeof(entry_file));
 
         /* Files must start on a block boundary */
-        total_blocks += DIVIDE_CEIL(file_size, EEPROM_BLOCK_SIZE);
+        total_blocks += DIVIDE_CEIL(file_total_size, EEPROM_BLOCK_SIZE);
     }
 
     /* Ensure the filesystem will actually fit in available EEPROM */
@@ -276,8 +301,15 @@ int eepfs_init(const eepfs_entry_t * entries, size_t count)
     }
 
     /* Calculate and store the CRC-16 checksum for the declared entries */
-    const size_t entries_size = sizeof(eepfs_entry_t) * count;
-    eepfs_files_checksum = calculate_crc16((void *)entries, entries_size);
+    uint16_t crc = CRC16_INIT;
+    for ( size_t i = 0; i < count; ++i )
+    {
+        crc = calculate_crc16(crc, (uint8_t *)entries[i].path, strlen(entries[i].path));
+        crc = calculate_crc16(crc, (uint8_t *)&entries[i].size, sizeof(entries[i].size));
+        crc = calculate_crc16(crc, (uint8_t *)&entries[i].checksum, sizeof(entries[i].checksum));
+        crc = calculate_crc16(crc, (uint8_t *)&entries[i].backup, sizeof(entries[i].backup));
+    }
+    eepfs_files_checksum = crc;
 
     return EEPFS_ESUCCESS;
 }
@@ -287,7 +319,7 @@ int eepfs_close(void)
     /* If eepfs was not initialized, don't do anything. */
     if ( eepfs_files == NULL || eepfs_files_count == 0 )
     {
-        return EEPFS_EBADFS;
+        return EEPFS_EBADINPUT;
     }
 
     /* Clear the file descriptor table */
@@ -297,6 +329,69 @@ int eepfs_close(void)
     eepfs_files_count = 0;
 
     return EEPFS_ESUCCESS;
+}
+
+static int read_file(size_t start_bytes, void * dest, size_t size, int flags)
+{
+    uint16_t checksum, computed_checksum = CRC16_INIT;
+    if ( flags & EEPFS_FLAGS_CHECKSUM )
+    {
+        eeprom_read_bytes(&checksum, start_bytes, 2);
+        start_bytes += 2;
+    }
+
+    if ( flags & EEPFS_FLAGS_BACKUP )
+    {
+        if ( flags & EEPFS_FLAGS_CHECKSUM )
+        {
+            uint8_t gen;
+            eeprom_read_bytes(&gen, start_bytes, 1);
+            computed_checksum = calculate_crc16(computed_checksum, (uint8_t *)&gen, 1);
+        }
+
+        start_bytes += 1;
+    }
+
+    eeprom_read_bytes(dest, start_bytes, size);
+
+    if ( flags & EEPFS_FLAGS_CHECKSUM )
+    {
+        computed_checksum = calculate_crc16(computed_checksum, (uint8_t *)dest, size);
+        if ( computed_checksum != checksum )
+        {
+            return EEPFS_CORRUPTED;
+        }
+    }
+
+    return EEPFS_ESUCCESS;
+}
+
+static uint8_t file_get_start(const eepfs_file_t * file, size_t * main_start_bytes, size_t * backup_start_bytes)
+{
+    size_t csize = file->flags & EEPFS_FLAGS_CHECKSUM ? 2 : 0;
+    size_t start1_bytes = file->start_block * EEPROM_BLOCK_SIZE;
+    size_t start2_bytes = 0;
+    uint8_t gen1 = 0, gen2 = 0;
+
+    if ( file->flags & EEPFS_FLAGS_BACKUP )
+    {
+        start2_bytes = start1_bytes + file->num_bytes + csize + 1;
+        start2_bytes = ROUND_UP(start2_bytes, EEPROM_BLOCK_SIZE);
+
+        // Read the generation counts
+        eeprom_read_bytes(&gen1, start1_bytes + csize, 1);
+        eeprom_read_bytes(&gen2, start2_bytes + csize, 1);
+
+        if ( (int8_t)(gen1 - gen2) < 0 )
+        {
+            SWAP(start1_bytes, start2_bytes);
+            SWAP(gen1, gen2);
+        }
+    }
+
+    *main_start_bytes = start1_bytes;
+    *backup_start_bytes = start2_bytes;
+    return gen1 + 1;
 }
 
 int eepfs_read(const char * path, void * dest, size_t size)
@@ -315,10 +410,19 @@ int eepfs_read(const char * path, void * dest, size_t size)
         return EEPFS_EBADINPUT;
     }
 
-    const size_t start_bytes = file->start_block * EEPROM_BLOCK_SIZE;
-    eeprom_read_bytes(dest, start_bytes, file->num_bytes);
+    /* Get the start bytes for the main and backup copies */
+    size_t main_start_bytes, backup_start_bytes;
+    file_get_start(file, &main_start_bytes, &backup_start_bytes);
 
-    return EEPFS_ESUCCESS;
+    /* Read the main copy */
+    if ( read_file(main_start_bytes, dest, size, file->flags) == EEPFS_ESUCCESS )
+        return EEPFS_ESUCCESS;
+    /* Read the backup copy if it exists */
+    if ( backup_start_bytes != 0 && read_file(backup_start_bytes, dest, size, file->flags) == EEPFS_ESUCCESS )
+        return EEPFS_ESUCCESS;
+
+    /* If both copies are corrupted, return an error */
+    return EEPFS_CORRUPTED;
 }
 
 int eepfs_write(const char * path, const void * src, size_t size)
@@ -337,8 +441,31 @@ int eepfs_write(const char * path, const void * src, size_t size)
         return EEPFS_EBADINPUT;
     }
 
-    const size_t start_bytes = file->start_block * EEPROM_BLOCK_SIZE;
-    eeprom_write_bytes(src, start_bytes, file->num_bytes);
+    /* Get the start bytes for the main and backup copies */
+    size_t main_start_bytes, backup_start_bytes;
+    uint8_t next_gen = file_get_start(file, &main_start_bytes, &backup_start_bytes);
+
+    if (backup_start_bytes == 0)
+        backup_start_bytes = main_start_bytes;
+    
+    /* Prepare the header bytes */
+    uint8_t header_bytes[3]; int header_count = 0;
+
+    if (file->flags & EEPFS_FLAGS_CHECKSUM)
+    {
+        uint16_t checksum = CRC16_INIT;
+        if ( file->flags & EEPFS_FLAGS_BACKUP )
+            checksum = calculate_crc16(checksum, (uint8_t *)&next_gen, 1);
+        checksum = calculate_crc16(checksum, (uint8_t *)src, size);
+        header_bytes[header_count++] = (uint8_t)(checksum >> 8);
+        header_bytes[header_count++] = (uint8_t)(checksum & 0xFF);
+    }
+
+    if (file->flags & EEPFS_FLAGS_BACKUP)
+        header_bytes[header_count++] = next_gen;
+
+    eeprom_write_bytes(src, backup_start_bytes + header_count, file->num_bytes);
+    eeprom_write_bytes(header_bytes, backup_start_bytes, header_count);
 
     return EEPFS_ESUCCESS;
 }
@@ -352,6 +479,17 @@ int eepfs_erase(const char * path)
     {
         /* File does not exist, return error code */
         return EEPFS_ENOFILE;
+    }
+
+    /* Calculate the total number of blocks to erase */
+    int num_bytes = file->num_bytes;
+    if (file->flags & EEPFS_FLAGS_CHECKSUM)
+        num_bytes += 2;
+    if (file->flags & EEPFS_FLAGS_BACKUP)
+    {
+        num_bytes += 1;
+        num_bytes = ROUND_UP(num_bytes, EEPROM_BLOCK_SIZE);
+        num_bytes *= 2;
     }
 
     const size_t num_blocks = DIVIDE_CEIL(file->num_bytes, EEPROM_BLOCK_SIZE);


### PR DESCRIPTION
This PR implements:

* An eventual consistency implementation for the EEPROM API. The eeprom module now stores an internal cache of EEPROM contents (which is lazily populated). Reads are returned from the cache; writes update the cache and then start an asynchronous write to persist them. The API behaves just like a blocking API, so it's not changed, and is still quite fast even with new Ares with real eeprom timings. From an UX perspective, it's important to inform the user when a save is in progress to prevent an accidental shutdown. This can be done with the new `eeprom_is_busy` API.
* Fixes an hideous bug in EEPFS signature generation that caused the filesystem to report corrupted/invalid eeprom contents after minor random changes to the ROM.
* Adds two opt-in features to increase EEPFS integrity: 
  * Checksum: automatically calculate a checksum of each file on the filesystem on reads and writes, reporting errors in case of failure.
  * Backup: keep two copies of each file on the fileystem, alternating the one being written. In case of accidental corruption, the other copy will likely still be valid and not too old.

Fixes #841 