### PR TITLE
fix: set CC_FOR_TARGET in newlib configure to fix macOS build

### DIFF
--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -298,7 +298,9 @@ popd
 # Compile newlib for target.
 mkdir -p newlib_compile_target
 pushd newlib_compile_target
-CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" ../"newlib-$NEWLIB_V"/configure \
+CC_FOR_TARGET="${N64_TARGET}-gcc" \
+CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" \
+../"newlib-$NEWLIB_V"/configure \
     --prefix="$CROSS_PREFIX" \
     --target="$N64_TARGET" \
     --with-cpu=mips64vr4300 \
@@ -364,7 +366,9 @@ else
     # Compile newlib for target.
     mkdir -p newlib_compile
     pushd newlib_compile
-    CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" ../"newlib-$NEWLIB_V"/configure \
+    CC_FOR_TARGET="${N64_TARGET}-gcc" \
+    CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" \
+    ../"newlib-$NEWLIB_V"/configure \
         --prefix="$INSTALL_PATH" \
         --target="$N64_TARGET" \
         --with-cpu=mips64vr4300 \


### PR DESCRIPTION
## Summary

On macOS (Sequoia 15.x with Xcode), the newlib/libgloss configure step falls back to the host compiler (Apple Clang) for test compilations. Clang rejects cross-compilation flags:

```
clang: error: unsupported option '-mabi=' for target 'x86_64-apple-macosx15.0.0'
configure: error: cannot compute suffix of object files: cannot compile
```

## Fix

Explicitly set `CC_FOR_TARGET="${N64_TARGET}-gcc"` before both newlib configure invocations in `build-toolchain.sh`. This ensures configure uses the cross-compiler for all test compilations instead of falling back to the host toolchain.

## Changes

- `tools/build-toolchain.sh`: Added `CC_FOR_TARGET` to both newlib configure calls (standard build line 301 + Canadian cross line 369)

## Test plan

- [x] Verified the cross-compiler path is correct (`mips64-elf-gcc` is in PATH after GCC pass 1)
- [ ] Needs testing on macOS Sequoia (I built successfully on Linux)

Fixes #818