### PR TITLE
Implement workarounds for 8BitDo Retro Receiver v1.00 firmware

### DIFF
--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -85,13 +85,12 @@ int main(void)
     int cpak_num_banks[4] = {0, 0, 0, 0};
     int b_hold_time[4] = {0, 0, 0, 0};
 
-    timer_init();
-    joypad_init();
     debug_init_isviewer();
     debug_init_usblog();
     console_init();
     console_set_render_mode(RENDER_MANUAL);
     console_set_debug(false);
+    joypad_init();
 
     while (1)
     {

--- a/src/joybus/joypad.c
+++ b/src/joybus/joypad.c
@@ -348,9 +348,17 @@ static void joypad_accessory_polled(int port, uint8_t new_status)
     uint8_t prev_accessory_status = accessory->status;
     uint8_t accessory_status = new_status & JOYBUS_IDENTIFY_STATUS_ACCESSORY_MASK;
     // Work-around third-party controllers that don't correctly report accessory status
-    bool accessory_absent = (
-        accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT ||
-        accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED
+    bool accessory_disconnected = (
+        accessory_status != prev_accessory_status &&
+        (
+            accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_ABSENT ||
+            (
+                accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED &&
+                // Ignore 8BitDo receiver buggy Rumble Pak mode accessory status:
+                // Only the initial identify status is correct: subsequent identify status will incorrectly be unsupported.
+                prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT
+            )
+        )
     );
     bool accessory_changed = (
         accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_CHANGED ||
@@ -358,18 +366,25 @@ static void joypad_accessory_polled(int port, uint8_t new_status)
             accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
             prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
             prev_accessory_status != JOYBUS_IDENTIFY_STATUS_ACCESSORY_CHANGED
+        ) ||
+        (
+            // Handle 8BitDo receiver buggy switching from Rumble Pak to Controller Pak mode
+            accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT &&
+            prev_accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED
+        ) ||
+        (
+            // Handle 8BitDo receiver buggy switching from Controller Pak to Rumble Pak mode
+            accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_UNSUPPORTED &&
+            prev_accessory_status == JOYBUS_IDENTIFY_STATUS_ACCESSORY_PRESENT
         )
     );
-    if (accessory_absent || accessory_changed)
-    {
-        accessory->state = JOYPAD_ACCESSORY_STATE_IDLE;
-        accessory->type = JOYPAD_ACCESSORY_TYPE_NONE;
-        device->rumble_method = JOYPAD_RUMBLE_METHOD_NONE;
-        device->rumble_active = false;
-    }
     if (accessory_changed)
     {
         joypad_accessory_detect_async(port);
+    }
+    else if (accessory_disconnected)
+    {
+        joypad_accessory_reset(port);
     }
     accessory->status = accessory_status;
 }

--- a/src/joybus/joypad_accessory.c
+++ b/src/joybus/joypad_accessory.c
@@ -150,6 +150,13 @@ static bool joypad_accessory_check_write_crc_error(
         }
         case JOYBUS_ACCESSORY_IO_STATUS_BAD_CRC:
         {
+            if (accessory->ignore_write_crc)
+            {
+                // Special case: some buggy accessories always return an invalid data CRC.
+                // Ignore the CRC error and treat the write operation as successful.
+                accessory->error = JOYPAD_ACCESSORY_ERROR_NONE;
+                return false;
+            }
             size_t retries = accessory->retries;
             if (retries < JOYPAD_ACCESSORY_RETRY_LIMIT)
             {
@@ -590,6 +597,14 @@ static void joypad_accessory_detect_write_callback(uint64_t *out_dwords, void *c
 
     const joybus_cmd_n64_accessory_write_port_t *cmdw =
         (void *)&out_bytes[port + JOYBUS_COMMAND_METADATA_SIZE];
+
+    if (cmdw->recv.data_crc == 0x00 && joybus_accessory_calculate_data_crc(cmdw->send.data) != 0x00)
+    {
+        // Special case: some accessories (notably 8BitDo receivers on old firmware) always return an invalid data CRC of 0x00.
+        // If this buggy behavior is detected, ignore all write CRC errors for this device from now on.
+        joypad_accessories_hot[port].ignore_write_crc = true;
+    }
+
     joybus_callback_t retry_callback = joypad_accessory_detect_write_callback;
     if (joypad_accessory_check_write_crc_error(port, cmdw, retry_callback, ctx))
         return; // Accessory communication error!
@@ -608,8 +623,12 @@ void joypad_accessory_detect_async(joypad_port_t port)
     {
         joypad_transfer_pak_wait_timer_init(port);
     }
+
     // Create a random label for the Controller Pak probe
-    __rand((uint8_t *)accessory->cpak_probe_label, sizeof(accessory->cpak_probe_label));
+    // Avoid generating a probe label with a data CRC of 0x00
+    do { __rand((uint8_t *)accessory->cpak_probe_label, sizeof(accessory->cpak_probe_label)); }
+    while (joybus_accessory_calculate_data_crc((uint8_t *)accessory->cpak_probe_label) == 0x00);
+     
     // Don't interrupt other accessory operations if they are still running
     if (accessory->state == JOYPAD_ACCESSORY_STATE_IDLE)
     {

--- a/src/joybus/joypad_accessory.h
+++ b/src/joybus/joypad_accessory.h
@@ -154,6 +154,7 @@ typedef struct joypad_accessory_s
     joypad_accessory_state_t state;
     joypad_accessory_error_t error;
     unsigned retries;
+    bool ignore_write_crc;      ///< Should write CRC errors be ignored?
     uint8_t cpak_label_backup[JOYBUS_ACCESSORY_DATA_SIZE];
     uint8_t cpak_probe_label[JOYBUS_ACCESSORY_DATA_SIZE];
     bool cpak_bankswitching;    ///< Does Controller Pak support bankswitching?


### PR DESCRIPTION
[Discord thread](https://discord.com/channels/205520502922543113/1485671114737979453)

We have received reports that LibDragon does not work correctly with 8BitDo N64 Retro Receiver and N64 2.4G Wireless Controller Adapter running certain firmware versions.

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/ea3960c1-e79b-4c9d-b14b-7971ccfc4dd3" />


Despite 8bitdo's firmware update log claiming that the N64 Retro Receiver firmware v1.08 is the "Factory firmware", some devices are shipping with a v1.0 firmware which incorrectly implements Joybus accessory behavior. This causes accessory detection to fail in LibDragon.

<img width="1750" height="586" alt="image" src="https://github.com/user-attachments/assets/a660ddda-b26c-45a4-85b6-380b18224315" />

### Known issues with buggy 8BitDo receiver firmware:

* Joybus Identify accessory status behavior is non-standard:
  * Rumble Pak mode initially reports as `0x01` "Accessory Present" but all subsequent identify statuses will be `0x00` "Accessory Unsupported"
  * Switching Rumble Pak and Controller Pak mode transitions between `0x00` "Accessory Unsupported" and `0x01` "Accessory Present" status
* Accessory Write command data CRC responses is always `0x00`

These issues have been fixed in later versions, so the "best" solution here is to [update your receiver's firmware using the 8BitDo Ultimate Software V2](https://app.8bitdo.com/Ultimate-Software-V2/) but this PR attempts to provide a working experience for receivers running the outdated firmware.

### Mitigations

* Gracefully handle these specific nonsensical Joybus Identify status transitions
* During accessory detection, if an invalid data CRC of 0x00 is found, set a bit to ignore all write CRC errors for the device.
* Adjust randomly-generated CPak Probe Label so that its data CRC will never be `0x00`
* Improve handling of accessory disconnect to cancel pending read/write operations

**Test ROM:** [joypadtest.z64.zip](https://github.com/user-attachments/files/26522813/joypadtest.z64.zip)