### PR TITLE
RDP validator: warn on combined rgb passed to mul with (potential) overflow

### DIFF
--- a/include/rdpq_macros.h
+++ b/include/rdpq_macros.h
@@ -914,7 +914,7 @@ typedef uint32_t rdpq_blender_t;
  */
 #define ZBUF_MAX        0xFFFC 
 
-#if !defined(__ASSEMBLER__) && defined(N64)
+#ifndef __ASSEMBLER__
 
 ///@cond
 extern uint16_t __rdpq_zfp14(float f);

--- a/include/rdpq_macros.h
+++ b/include/rdpq_macros.h
@@ -914,7 +914,7 @@ typedef uint32_t rdpq_blender_t;
  */
 #define ZBUF_MAX        0xFFFC 
 
-#ifndef __ASSEMBLER__
+#if !defined(__ASSEMBLER__) && defined(N64)
 
 ///@cond
 extern uint16_t __rdpq_zfp14(float f);

--- a/src/rdpq/rdpq_debug.c
+++ b/src/rdpq/rdpq_debug.c
@@ -6,7 +6,6 @@
  */
 #include "rdpq_debug.h"
 #include "rdpq_debug_internal.h"
-#include "rdpq_macros.h"
 #ifdef N64
 #include "rdpq.h"
 #include "rspq.h"
@@ -1272,19 +1271,19 @@ static void validate_draw_cmd(bool use_colors, bool use_tex, bool use_z, bool us
     // Warn if that may be the case, as rgb.mul starts overflowing from 256 onwards.
     if (rdp.som.cycle_type == 1) { // 2cyc
         struct cc_cycle_s *ccA = &rdp.cc.cyc[0];
-        if (rdp.cc.cyc[1].rgb.mul == _RDPQ_COMB2B_RGB_MUL_COMBINED) {
-            if (ccA->rgb.mul == _RDPQ_COMB2A_RGB_MUL_ZERO) {
-                if (ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_ONE) {
+        if (rdp.cc.cyc[1].rgb.mul == 0) { // combined
+            if (ccA->rgb.mul >= 16 && ccA->rgb.mul <= 31) { // zero
+                if (ccA->rgb.add == 6) { // one
                     VALIDATE_WARN_CC(0, "combined rgb passed to mul input and evaluating to 1, overflow will occur");
                 }
             } else {
                 // Detect a lerp (where subb == add)
-                if ((ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_TEX0 && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_TEX0)
-                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_TEX1 && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_TEX1)
-                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_PRIM && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_PRIM)
-                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_SHADE && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_SHADE)
-                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_ENV && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_ENV)
-                    || (ccA->rgb.subb >= 8 /* ZERO */ && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_ZERO)) {
+                if ((ccA->rgb.subb == 1 && ccA->rgb.add == 1) // tex0
+                    || (ccA->rgb.subb == 2 && ccA->rgb.add == 2) // tex1
+                    || (ccA->rgb.subb == 3 && ccA->rgb.add == 3) // prim
+                    || (ccA->rgb.subb == 4 && ccA->rgb.add == 4) // shade
+                    || (ccA->rgb.subb == 5 && ccA->rgb.add == 5) // env
+                    || (ccA->rgb.subb >= 8 && ccA->rgb.add == 7)) { // zero
                     // Lerps would only be problematic if subb == add == ONE, but subb cannot take the ONE input so lerps are always fine.
                 } else {
                     VALIDATE_WARN_CC(0, "combined rgb passed to mul input and exotic combiner detected, be mindful of overflow");

--- a/src/rdpq/rdpq_debug.c
+++ b/src/rdpq/rdpq_debug.c
@@ -6,6 +6,7 @@
  */
 #include "rdpq_debug.h"
 #include "rdpq_debug_internal.h"
+#include "rdpq_macros.h"
 #ifdef N64
 #include "rdpq.h"
 #include "rspq.h"
@@ -1264,6 +1265,32 @@ static void validate_draw_cmd(bool use_colors, bool use_tex, bool use_z, bool us
         }
 
     }   break;
+    }
+
+    // In 2-cycle mode, check for rgb.mul being set to COMBINED and receiving a 1 (or greater) input.
+    // Note "1" corresponds to a 256 value in the combiner unit (and not 255).
+    // Warn if that may be the case, as rgb.mul starts overflowing from 256 onwards.
+    if (rdp.som.cycle_type == 1) { // 2cyc
+        struct cc_cycle_s *ccA = &rdp.cc.cyc[0];
+        if (rdp.cc.cyc[1].rgb.mul == _RDPQ_COMB2B_RGB_MUL_COMBINED) {
+            if (ccA->rgb.mul == _RDPQ_COMB2A_RGB_MUL_ZERO) {
+                if (ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_ONE) {
+                    VALIDATE_WARN_CC(0, "combined rgb passed to mul input and evaluating to 1, overflow will occur");
+                }
+            } else {
+                // Detect a lerp (where subb == add)
+                if ((ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_TEX0 && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_TEX0)
+                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_TEX1 && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_TEX1)
+                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_PRIM && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_PRIM)
+                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_SHADE && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_SHADE)
+                    || (ccA->rgb.subb == _RDPQ_COMB2A_RGB_SUBB_ENV && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_ENV)
+                    || (ccA->rgb.subb >= 8 /* ZERO */ && ccA->rgb.add == _RDPQ_COMB2A_RGB_ADD_ZERO)) {
+                    // Lerps would only be problematic if subb == add == ONE, but subb cannot take the ONE input so lerps are always fine.
+                } else {
+                    VALIDATE_WARN_CC(0, "combined rgb passed to mul input and exotic combiner detected, be mindful of overflow");
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Based on the discussion sparked by HTD in the N64Brew discord at https://discord.com/channels/205520502922543113/974342113850445874/1487434018344403047

This adds a warning to the RDP validator, when COMBINED is used for mul in the second cycle, and a (potential) overflow is detected.

This chooses to warn always when an "exotic" first cycle combiner formula is used (exotic = not a lerp), as non-lerps are very rarely used in practice

----------

Testing: I expanded upon HTD's example

https://github.com/Dragorn421/n64homebrew/blob/main/cc_mul_overflow_validate_test/main.c

<img width="660" height="336" alt="image" src="https://github.com/user-attachments/assets/f9473a70-8880-40dd-832a-cb42dbc36068" />

The first full red one `0 0 0 1 -> mul=COMBINED` and cyan one `1 0 ENV PRIM -> mul=COMBINED` are demonstrating overflow, and warn as expected

The second full red one `0 0 ENV 1 -> mul=COMBINED` also overflows, but uses "exotic" combiner formula `(0-0*env)+1` (so warns as "mind overflow")

Finally the bottom right one `0 0 ENV PRIM -> mul=COMBINED` doesn't overflow but still warns as it uses an "exotic" first cycle formula.

The other rectangles don't overflow and don't warn

<details>

<summary>rdpq log</summary>

 (empty lines added for convenience)

```
[0xa00cf120] fe00000000800000    SET_Z_IMAGE      <detach>
[0xa00cf128] ff1bbd3f00082c40    SET_COLOR_IMAGE  dram=00082c40 w=320 h=240 rgba32
[0xa00cf130] f700000000000000    SET_FILL_COLOR   rgba16=(0,0,0,0) rgba32=(0,0,0,0)
[0xa00cf138] ed000000005003c0    SET_SCISSOR      xy=(0.00,0.00)-(320.00,240.00)
[0xa00cf140] ed000000004ff3c0    SET_SCISSOR      xy=(0.00,0.00)-(319.75,240.00)
[0xa00cf148] ef30000000000000    SET_OTHER_MODES  fill
[0xa00cf150] f7000000326432ff    SET_FILL_COLOR   rgba16=(6,11,31,1) rgba32=(50,100,50,255)
[0xa00cf158] f64fc3bc00000000    FILL_RECT        xy=(0.00,0.00)-(319.00,239.00)
[0xa00cf160] e700000000000000    SYNC_PIPE
[0xa00cf168] ed000000005003c0    SET_SCISSOR      xy=(0.00,0.00)-(320.00,240.00)
[0xa00cf170] fc00000000000000    SET_COMBINE_MODE cyc0=[(comb-comb)*comb+comb, (comb-comb)*lod_frac+comb], cyc1=[<passthrough>]
[0xa00cf178] ef00000000000200    SET_OTHER_MODES  1cyc tex=[yuv0 yuv1] dither=[square,pat] cvg=[zap]
[0xa00cf180] fc887f1088fcf279    SET_COMBINE_MODE cyc0=[(0-0)*0+tex0, (0-0)*0+tex0], cyc1=[(0-0)*0+tex1, (0-0)*0+tex1]
[0xa00cf188] ef000cf000000200    SET_OTHER_MODES  1cyc cvg=[zap]
[0xa00cf190] fc887f1088fcf279    SET_COMBINE_MODE cyc0=[(0-0)*0+tex0, (0-0)*0+tex0], cyc1=[(0-0)*0+tex1, (0-0)*0+tex1]
[0xa00cf198] ef000cf000000200    SET_OTHER_MODES  1cyc cvg=[zap]
[0xa00cf1a0] fa000000ff8040ff    SET_PRIM_COLOR   rgba32=(255,128,64,255)
[0xa00cf1a8] fb000000ffffffff    SET_ENV_COLOR    rgba32=(255,255,255,255)

[0xa00cf1b0] f102000000029ba8    RDPQ_MESSAGE     genuine
[0xa00cf1b8] fc887e6a88ff7dfe    SET_COMBINE_MODE cyc0=[(0-0)*0+1, (0-0)*0+1], cyc1=[(prim-0)*prim.a+0, (0-0)*0+1]
[0xa00cf1c0] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf1c8] f60a80a800028028    FILL_RECT        xy=(10.00,10.00)-(42.00,42.00)

[0xa00cf1d0] f102000000029bb0    RDPQ_MESSAGE     0 0 0 1 -> mul=COMBINED
[0xa00cf1d8] e700000000000000    SYNC_PIPE
[0xa00cf1e0] fc887e6088ff7dfe    SET_COMBINE_MODE cyc0=[(0-0)*0+1, (0-0)*0+1], cyc1=[(prim-0)*comb+0, (0-0)*0+1]
[0xa00cf1e8] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf1f0] f61480a8000c8028    FILL_RECT        xy=(50.00,10.00)-(82.00,42.00)
[RDPQ_VALIDATION] WARN:  combined rgb passed to mul input and evaluating to 1, overflow will occur
[RDPQ_VALIDATION]        SET_COMBINE_MODE last sent at 0xa00cf1e0

[0xa00cf1f8] f102000000029bc8    RDPQ_MESSAGE     0 0 0 1 -> suba=COMBINED
[0xa00cf200] e700000000000000    SYNC_PIPE
[0xa00cf208] fc887e0388ff7dfe    SET_COMBINE_MODE cyc0=[(0-0)*0+1, (0-0)*0+1], cyc1=[(comb-0)*prim+0, (0-0)*0+1]
[0xa00cf210] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf218] f61e80a800168028    FILL_RECT        xy=(90.00,10.00)-(122.00,42.00)

[0xa00cf220] f102000000029be8    RDPQ_MESSAGE     1 0 PRIM 0 -> mul=COMBINED
[0xa00cf228] e700000000000000    SYNC_PIPE
[0xa00cf230] fc61fec088fffdfe    SET_COMBINE_MODE cyc0=[(1-0)*prim+0, (0-0)*0+1], cyc1=[(1-0)*comb+0, (0-0)*0+1]
[0xa00cf238] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf240] f62880a800208028    FILL_RECT        xy=(130.00,10.00)-(162.00,42.00)

[0xa00cf248] f102000000029c08    RDPQ_MESSAGE     1 PRIM ENV PRIM -> mul=COMBINED
[0xa00cf250] e700000000000000    SYNC_PIPE
[0xa00cf258] fc62fec038fdfdfe    SET_COMBINE_MODE cyc0=[(1-prim)*env+prim, (0-0)*0+1], cyc1=[(1-0)*comb+0, (0-0)*0+1]
[0xa00cf260] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf268] f60a8148000280c8    FILL_RECT        xy=(10.00,50.00)-(42.00,82.00)

[0xa00cf270] f102000000029c28    RDPQ_MESSAGE     1 0 ENV PRIM -> mul=COMBINED
[0xa00cf278] e700000000000000    SYNC_PIPE
[0xa00cf280] fc62fec088fdfdfe    SET_COMBINE_MODE cyc0=[(1-0)*env+prim, (0-0)*0+1], cyc1=[(1-0)*comb+0, (0-0)*0+1]
[0xa00cf288] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf290] f6148148000c80c8    FILL_RECT        xy=(50.00,50.00)-(82.00,82.00)
[RDPQ_VALIDATION] WARN:  combined rgb passed to mul input and exotic combiner detected, be mindful of overflow
[RDPQ_VALIDATION]        SET_COMBINE_MODE last sent at 0xa00cf280

[0xa00cf298] f102000000029c48    RDPQ_MESSAGE     0 0 ENV 1 -> mul=COMBINED
[0xa00cf2a0] e700000000000000    SYNC_PIPE
[0xa00cf2a8] fc82fe6088ff7dfe    SET_COMBINE_MODE cyc0=[(0-0)*env+1, (0-0)*0+1], cyc1=[(prim-0)*comb+0, (0-0)*0+1]
[0xa00cf2b0] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf2b8] f61e8148001680c8    FILL_RECT        xy=(90.00,50.00)-(122.00,82.00)
[RDPQ_VALIDATION] WARN:  combined rgb passed to mul input and exotic combiner detected, be mindful of overflow
[RDPQ_VALIDATION]        SET_COMBINE_MODE last sent at 0xa00cf2a8

[0xa00cf2c0] f102000000029c68    RDPQ_MESSAGE     0 0 ENV PRIM -> mul=COMBINED
[0xa00cf2c8] e700000000000000    SYNC_PIPE
[0xa00cf2d0] fc82fec088fdfdfe    SET_COMBINE_MODE cyc0=[(0-0)*env+prim, (0-0)*0+1], cyc1=[(1-0)*comb+0, (0-0)*0+1]
[0xa00cf2d8] ef100cf000000200    SET_OTHER_MODES  2cyc cvg=[zap]
[0xa00cf2e0] f6288148002080c8    FILL_RECT        xy=(130.00,50.00)-(162.00,82.00)
[RDPQ_VALIDATION] WARN:  combined rgb passed to mul input and exotic combiner detected, be mindful of overflow
[RDPQ_VALIDATION]        SET_COMBINE_MODE last sent at 0xa00cf2d0

[0xa00cf2e8] e90111c080037bb4    SYNC_FULL
```

</details>

-----------

Note I added `rdpq_macros.h` to the rdpq_debug.c includes so that I could use e.g. `_RDPQ_COMB2A_RGB_SUBB_TEX0`. If that's preferred I can switch to raw magic int literals

----------

If accepted, this probably should be backported to trunk