### PR TITLE
Fix Blit Transform Order

### DIFF
--- a/include/rdpq_tex.h
+++ b/include/rdpq_tex.h
@@ -330,8 +330,8 @@ typedef struct rdpq_blitparms_s {
 
     int cx;             ///< Transformation center (aka "hotspot") X coordinate, relative to (s0, t0). Used for all transformations
     int cy;             ///< Transformation center (aka "hotspot") X coordinate, relative to (s0, t0). Used for all transformations
-    float scale_x;      ///< Horizontal scale factor to apply to the surface. This scaling is applied along the X axis after rotation. If 0, no scaling is performed (the same as 1.0f). If negative, horizontal flipping is applied
-    float scale_y;      ///< Vertical scale factor to apply to the surface. This scaling is applied along the Y axis after rotation. If 0, no scaling is performed (the same as 1.0f). If negative, vertical flipping is applied
+    float scale_x;      ///< Horizontal scale factor to apply to the surface. This scaling is applied along the X axis before rotation. If 0, no scaling is performed (the same as 1.0f). If negative, horizontal flipping is applied
+    float scale_y;      ///< Vertical scale factor to apply to the surface. This scaling is applied along the Y axis before rotation. If 0, no scaling is performed (the same as 1.0f). If negative, vertical flipping is applied
     float theta;        ///< Counter-clockwise rotation angle in radians
     
     bool allow_xform;   ///< True if blit should be affected by transforms applied by rdpq_xform

--- a/src/rdpq/rdpq_tex.c
+++ b/src/rdpq/rdpq_tex.c
@@ -604,10 +604,10 @@ static void tex_xblit(const surface_t *surf, float x0, float y0, const rdpq_blit
     fm_sincosf(parms->theta, &sin_theta, &cos_theta);
 
     float mtx[3][2] = {
-        { cos_theta * scalex, -sin_theta * scaley },
-        { sin_theta * scalex, cos_theta * scaley },
-        { x0 - cx * cos_theta * scalex - cy * sin_theta * scaley,
-          y0 + cx * sin_theta * scalex - cy * cos_theta * scaley }
+        { cos_theta * scalex, sin_theta * scalex },
+        { -sin_theta * scaley, cos_theta * scaley },
+        { x0-((cx*(cos_theta*scalex))+(cy*(-sin_theta*scaley))),
+        y0-((cx*(sin_theta*scalex))+(cy*(cos_theta*scaley)))}
     };
 
     void draw_cb(rdpq_tile_t tile, int s0, int t0, int s1, int t1)
@@ -655,7 +655,7 @@ static void tex_xblit_xform(const surface_t *surf, float x0, float y0, const rdp
     float scalex = parms->scale_x == 0 ? 1.0f : parms->scale_x;
     float scaley = parms->scale_y == 0 ? 1.0f : parms->scale_y;
     rdpq_xform_push();
-    rdpq_xform_mult_rst(x0, y0, parms->theta, scalex, scaley);
+    rdpq_xform_mult_srt(x0, y0, parms->theta, scalex, scaley);
     
     void draw_cb(rdpq_tile_t tile, int s0, int t0, int s1, int t1)
     {

--- a/src/rdpq/rdpq_tex.c
+++ b/src/rdpq/rdpq_tex.c
@@ -604,10 +604,10 @@ static void tex_xblit(const surface_t *surf, float x0, float y0, const rdpq_blit
     fm_sincosf(parms->theta, &sin_theta, &cos_theta);
 
     float mtx[3][2] = {
-        { cos_theta * scalex, sin_theta * scalex },
-        { -sin_theta * scaley, cos_theta * scaley },
-        { x0-((cx*(cos_theta*scalex))+(cy*(-sin_theta*scaley))),
-        y0-((cx*(sin_theta*scalex))+(cy*(cos_theta*scaley)))}
+        { cos_theta * scalex, -sin_theta * scalex },
+        { sin_theta * scaley, cos_theta * scaley },
+        { x0-((cx*(cos_theta*scalex))+(cy*(sin_theta*scaley))),
+        y0-((cx*(-sin_theta*scalex))+(cy*(cos_theta*scaley)))}
     };
 
     void draw_cb(rdpq_tile_t tile, int s0, int t0, int s1, int t1)


### PR DESCRIPTION
Now does scaling before rotation rather than after rotation which is a more standard order. Also fixed bug with center offset when using non-uniform scaling and rotation.