### PR TITLE
tools: Fix polyfill.h build on MSYS2 update from 2026-04-13

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,1 +1,2 @@
 toolchain/
+common/msys2_age.h

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -41,13 +41,15 @@ ifeq ($(OS),Windows_NT)
 	ifeq ($(CHECK_CXX),fail)
 		$(error "CXX is not set to a mingw compiler: ${CXX}")
 	endif
+
+	MSYS2_AGE_HEADER := common/msys2_age.h
 endif
 
 # Decomment to rebuild tools with ASAN
 #C_CXX_FLAGS += -O0 -g -fsanitize=address
 #LDFLAGS += -g -fsanitize=address
 
-all:
+all: $(MSYS2_AGE_HEADER)
 
 %.o: %.c
 	@echo "    [CC] $@"
@@ -59,6 +61,13 @@ all:
 	@echo "    [AR] $@"
 	rm -f $@
 	$(AR) rcs $@ $^
+
+# Dump an estimate of the MSYS2 environment's age into a header so that we can check it for compatibility reasons.
+common/msys2_age.h:
+	@echo "Generating MSYS2 age header..."
+	@date_str=$$(pacman -Qi msys2-runtime | sed -n 's/^Install Date *: *//p'); \
+	age=$$(date -d "$$date_str" +%Y%m%d); \
+	echo "#define MSYS2_RUNTIME_PACMAN_AGE $$age" > $@
 
 # Avoid many warnings for vendored code that we don't intend to ever modify
 common/shrinkler_compress.o: 	   CFLAGS += -Wno-all -Wno-error

--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -40,7 +40,7 @@ extern "C" {
 // if typedef doesn't exist (msvc, blah)
 typedef intptr_t ssize_t;
 
-/* Fetched from: https://stackoverflow.com/a/47229318 */
+/* Implementation of 'getline' fetched from: https://stackoverflow.com/a/47229318 */
 /* The original code is public domain -- Will Hartung 4/9/09 */
 /* Modifications, public domain as well, by Antti Haapala, 11/10/17
    - Switched to getc on 5/23/19 */

--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -31,6 +31,8 @@
 #include <fcntl.h>
 #include <time.h>
 
+#include "msys2_age.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -90,6 +92,25 @@ static ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
     (*lineptr)[pos] = '\0';
     return pos;
 }
+
+// Provide implementation of strndup for MSYS2 environments that are missing it (before April 13 2026).
+#if defined(MSYS2_RUNTIME_PACMAN_AGE) && MSYS2_RUNTIME_PACMAN_AGE <= 20260413
+__attribute__((used))
+static char *msys2_fallback_strndup(const char *s, size_t n)
+{
+    size_t len = strnlen(s, n);
+    char *ret = (char*)malloc(len + 1);
+    if (!ret) return NULL;
+    memcpy(ret, s, len);
+    ret[len] = '\0';
+    return ret;
+}
+
+    #ifdef strndup
+    #undef strndup
+    #endif
+    #define strndup   msys2_fallback_strndup
+#endif
 
 #if defined(__MSVCRT_VERSION__) && __MSVCRT_VERSION__ >= 0xE00
     // UCRT is being used so we can use runtime-provided tmpfile() implementation

--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -91,24 +91,16 @@ static ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
     return pos;
 }
 
-/* This function is original code in libdragon */
-__attribute__((used))
-static char *strndup(const char *s, size_t n)
-{
-  size_t len = strnlen(s, n);
-  char *ret = (char*)malloc(len + 1);
-  if (!ret) return NULL;
-  memcpy(ret, s, len);
-  ret[len] = '\0';
-  return ret;
-}
-
-// tmpfile in mingw is broken (it uses msvcrt that tries to
-// create a file in C:\, which is non-writable nowadays)
-#ifdef tmpfile
-#undef tmpfile
+#if defined(__MSVCRT_VERSION__) && __MSVCRT_VERSION__ >= 0xE00
+    // UCRT is being used so we can use runtime-provided tmpfile() implementation
+#else
+    // tmpfile() in MINGW64 is broken for use (it uses MSVCRT that tries to
+    // create a file in C:\, which is non-writable nowadays)
+    #ifdef tmpfile
+    #undef tmpfile
+    #endif
+    #define tmpfile()   mingw_tmpfile()
 #endif
-#define tmpfile()   mingw_tmpfile()
 
 typedef void* HANDLE;
 typedef const char* LPCSTR;


### PR DESCRIPTION
Update to MSYS2 headers from 2026-04-13 improved conformance with C23 and POSIX which means users building libdragon now get `strndup` provided by the environment. This affects both MINGW64 and UCRT64. This caused a compilation issue because `polyfill.h` defines its own implementation since it was previously missing. I removed the custom implementation to fix the issue.

> [!WARNING]
> People using MSYS2 installation older than 2026-04-13 will need to update their environments by running `pacman -Syu` from an MSYS2 terminal.

I also added a preprocessor guard around custom implementation of `tmpfile` so that when building with UCRT64, the standard implementation is used instead.