### PR TITLE
Fix memory leak when looping H264 video

### DIFF
--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -88,6 +88,7 @@ int main(void)
 	}
 
 	fmv_play("rom:/caminandes.h264", &(fmv_parms_t){
+		.loop = true,
 		.osd_callback = osd_callback,
 	});
 }

--- a/src/video/h264.c
+++ b/src/video/h264.c
@@ -140,10 +140,15 @@ static void h264_rewind(video_t *v) {
     player->idx = 0;
     player->buf_len = 0;
     player->in_frame_decoding = false;
-    
-    // Reset decoder
-    h264bsdInit(&player->s, 0);
-    h264bsdSetNumBufferedPics(&player->s, (u32)player->max_buffered_pics);
+
+    if (player->s.dpb->buffer) {
+        // Rewind: reset decoder state, keep existing allocations
+        h264bsdRewindStorage(&player->s);
+    } else {
+        // First open: initialize from scratch
+        h264bsdInit(&player->s, 0);
+        h264bsdSetNumBufferedPics(&player->s, (u32)player->max_buffered_pics);
+    }
 
     rsph264_begin_frame();
     while (1) {
@@ -152,6 +157,11 @@ static void h264_rewind(video_t *v) {
             case H264BSD_RDY:
                 continue;
             case H264BSD_HDRS_RDY:
+                // First open: SPS activated for the first time
+                player->in_frame_decoding = true;
+                return;
+            case H264BSD_PIC_RDY:
+                // Rewind: SPS unchanged, first IDR decoded immediately
                 player->in_frame_decoding = true;
                 return;
             default:

--- a/src/video/h264_decoder/h264bsd_dpb.c
+++ b/src/video/h264_decoder/h264bsd_dpb.c
@@ -1627,6 +1627,64 @@ void h264bsdFlushDpb(dpbStorage_t *dpb)
 
 /*------------------------------------------------------------------------------
 
+    Function: h264bsdClearDpb
+
+        Functional description:
+            Function to reset DPB logical state without freeing allocated
+            buffers. All picture slots are marked unused and counters are
+            reset. Pixel data allocations and DPB configuration (dpbSize,
+            maxRefFrames, etc.) are preserved. Intended for use during
+            video rewind/loop.
+
+------------------------------------------------------------------------------*/
+
+void h264bsdClearDpb(dpbStorage_t *dpb)
+{
+
+/* Variables */
+
+    u32 i;
+
+/* Code */
+
+    ASSERT(dpb);
+
+    if (dpb->buffer)
+    {
+        for (i = 0; i < dpb->dpbSize + 1; i++)
+        {
+            /* keep data and pAllocatedData pointers intact */
+            dpb->buffer[i].picNum = 0;
+            dpb->buffer[i].frameNum = 0;
+            dpb->buffer[i].picOrderCnt = 0;
+            dpb->buffer[i].status = UNUSED;
+            dpb->buffer[i].toBeDisplayed = 0;
+            dpb->buffer[i].inOutputBuf = 0;
+            dpb->buffer[i].picId = 0;
+            dpb->buffer[i].numErrMbs = 0;
+            dpb->buffer[i].isIdr = 0;
+        }
+    }
+
+    dpb->currentOut = NULL;
+    dpb->numOut = 0;
+    dpb->outIndex = 0;
+    dpb->numRefFrames = 0;
+    dpb->fullness = 0;
+    dpb->prevRefFrameNum = 0;
+    dpb->lastContainsMmco5 = 0;
+    dpb->flushed = 0;
+    dpb->maxLongTermFrameIdx = NO_LONG_TERM_FRAME_INDICES;
+
+    if (dpb->list)
+    {
+        H264SwDecMemset(dpb->list, 0,
+            (MAX_NUM_REF_IDX_L0_ACTIVE + 1) * sizeof(dpbPicture_t*));
+    }
+}
+
+/*------------------------------------------------------------------------------
+
     Function: h264bsdFreeDpb
 
         Functional description:

--- a/src/video/h264_decoder/h264bsd_dpb.h
+++ b/src/video/h264_decoder/h264bsd_dpb.h
@@ -151,6 +151,8 @@ void h264bsdDpbReleasePicture(dpbStorage_t *dpb, const u8 *data);
 
 void h264bsdFlushDpb(dpbStorage_t *dpb);
 
+void h264bsdClearDpb(dpbStorage_t *dpb);
+
 void h264bsdFreeDpb(dpbStorage_t *dpb);
 
 #endif /* #ifdef H264SWDEC_DPB_H */

--- a/src/video/h264_decoder/h264bsd_storage.c
+++ b/src/video/h264_decoder/h264bsd_storage.c
@@ -466,6 +466,85 @@ void h264bsdResetStorage(storage_t *pStorage)
 
 /*------------------------------------------------------------------------------
 
+    Function: h264bsdRewindStorage
+
+        Functional description:
+            Reset decoder state for video rewind/loop without freeing any
+            allocated memory. Parameter sets (SPS/PPS), macroblock storage,
+            slice group map, and DPB pixel buffers are preserved. Per-frame
+            state (slice, POC, AUB, stream pointers, etc.) is reset so the
+            decoder can re-parse the stream from the beginning.
+
+        Inputs:
+            pStorage    pointer to storage structure
+
+        Outputs:
+            pStorage    state fields reset, allocations preserved
+
+        Returns:
+            none
+
+------------------------------------------------------------------------------*/
+
+void h264bsdRewindStorage(storage_t *pStorage)
+{
+
+/* Variables */
+
+    u32 i;
+
+/* Code */
+
+    ASSERT(pStorage);
+
+    /* reset slice state */
+    pStorage->slice->numDecodedMbs = 0;
+    pStorage->slice->sliceId = 0;
+
+    /* reset per-frame flags */
+    pStorage->skipRedundantSlices = 0;
+    pStorage->picStarted = 0;
+    pStorage->validSliceInAccessUnit = 0;
+    pStorage->numConcealedMbs = 0;
+    pStorage->currentPicId = 0;
+    pStorage->pendingActivation = 0;
+    pStorage->mbLayerIdx = 0;
+
+    /* reset stream pointers */
+    pStorage->prevBufNotFinished = 0;
+    pStorage->prevBufPointer = NULL;
+    pStorage->prevBytesConsumed = 0;
+    H264SwDecMemset(pStorage->strm, 0, sizeof(strmData_t));
+
+    /* reset POC, AUB, NAL unit, and slice header state */
+    H264SwDecMemset(pStorage->poc, 0, sizeof(pocStorage_t));
+    H264SwDecMemset(pStorage->aub, 0, sizeof(aubCheck_t));
+    pStorage->aub->firstCallFlag = HANTRO_TRUE;
+    H264SwDecMemset(pStorage->prevNalUnit, 0, sizeof(nalUnit_t));
+    H264SwDecMemset(pStorage->sliceHeader, 0, 2 * sizeof(sliceHeader_t));
+
+    /* reset current image data pointer (will be reassigned by
+     * h264bsdAllocateDpbImage during decode) */
+    pStorage->currImage->data = NULL;
+
+    /* reset macroblock slice state (same as h264bsdResetStorage) */
+    if (pStorage->mb)
+    {
+        for (i = 0; i < pStorage->picSizeInMbs; i++)
+        {
+            pStorage->mb[i].sliceId = 0;
+#ifndef OPTIMIZE_NO_DECODED_FLAG
+            pStorage->mb[i].decoded = 0;
+#endif
+        }
+    }
+
+    /* clear DPB state, keeping allocated buffers */
+    h264bsdClearDpb(pStorage->dpb);
+}
+
+/*------------------------------------------------------------------------------
+
     Function: h264bsdIsStartOfPicture
 
         Functional description:

--- a/src/video/h264_decoder/h264bsd_storage.h
+++ b/src/video/h264_decoder/h264bsd_storage.h
@@ -167,6 +167,7 @@ typedef struct
 
 void h264bsdInitStorage(storage_t *pStorage);
 void h264bsdResetStorage(storage_t *pStorage);
+void h264bsdRewindStorage(storage_t *pStorage);
 u32 h264bsdIsStartOfPicture(storage_t *pStorage);
 u32 h264bsdIsEndOfPicture(storage_t *pStorage);
 u32 h264bsdStoreSeqParamSet(storage_t *pStorage, seqParamSet_t *pSeqParamSet);


### PR DESCRIPTION
`h264_rewind` resets the H.264 decoder by calling `h264bsdInit` → `h264bsdInitStorage`, which does `memset(pStorage, 0, sizeof(storage_t))`. This zeros all pointers in the storage struct without freeing them.

The fix is to "rewind" the storage struct if it already has buffers so that we reset the decoder state but keep existing allocations.