### PR TITLE
Fix missing stdlib.h include

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -9,6 +9,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This fixes an error I was getting when trying to build pyrite64 on linux:
```
libdragon/include/debug.h:284:17: error: ‘abort’ was not declared in this scope
```