### PR TITLE
emux v1.1: remove dashes from instruction names

### DIFF
--- a/include/emux.h
+++ b/include/emux.h
@@ -34,13 +34,13 @@
 #define EMUX_XDETECT(rd, code)          EMUX_OP(0x20,   rd,      0,  code)  ///< Detect EMUX presence
 #define EMUX_XBREAK()                   EMUX_OP(0x21,    0,      0, 0x000)  ///< Trigger a breakpoint
 #define EMUX_XBREAKPOINT(addr, op)      EMUX_OP(0x22, addr,      0,    op)  ///< Configure a breakpoint/watchpoint
-#define EMUX_XTRACE_START(count)        EMUX_OP(0x23,    0,      0, count)  ///< Start tracing
-#define EMUX_XTRACE_STOP()              EMUX_OP(0x24,    0,      0, 0x000)  ///< Stop tracing
+#define EMUX_XTRACESTART(count)         EMUX_OP(0x23,    0,      0, count)  ///< Start tracing
+#define EMUX_XTRACESTOP()               EMUX_OP(0x24,    0,      0, 0x000)  ///< Stop tracing
 #define EMUX_XLOG(addr, len, code)      EMUX_OP(0x25, addr,    len,  code)  ///< Log a string
 #define EMUX_XLOGREGS(mask, code)       EMUX_OP(0x26, mask,      0,  code)  ///< Log registers
 #define EMUX_XHEXDUMP(addr, len)        EMUX_OP(0x27, addr,    len, 0x000)  ///< Hexdump memory region
 #define EMUX_XPROF(slot, code)          EMUX_OP(0x28, slot,      0,  code)  ///< Control profiler
-#define EMUX_XPROF_READ(slot, metric)   EMUX_OP(0x29, slot, metric, 0x000)  ///< Read profiler metric
+#define EMUX_XPROFREAD(slot, metric)    EMUX_OP(0x29, slot, metric, 0x000)  ///< Read profiler metric
 #define EMUX_XEXCEPTION(mask)           EMUX_OP(0x2A,    0,   mask, 0x000)  ///< Set exception mask
 #define EMUX_XIOCTL(code)               EMUX_OP(0x2C,    0,      0,  code)  ///< Modify emulator behavior
 /** @} */
@@ -392,7 +392,7 @@ inline uint64_t emux_prof_read(int slot, uint32_t metric)
 
     __asm__ __volatile__(
         " .word %2\n"
-        : "+r"(__metric) : "r"(__slot), "i"(EMUX_XPROF_READ(REG_T0, REG_T1)) : "memory"
+        : "+r"(__metric) : "r"(__slot), "i"(EMUX_XPROFREAD(REG_T0, REG_T1)) : "memory"
     );
 
     return __metric;

--- a/include/emux.inc
+++ b/include/emux.inc
@@ -17,16 +17,12 @@
     .word EMUX_XBREAKPOINT(\rd, \op)
 .endm
 
-.macro xtrace_start
-    .word EMUX_XTRACE_START(0)
+.macro xtracestart num_insn=0
+    .word EMUX_XTRACESTART(\num_insn)
 .endm
 
-.macro xtrace_count num_insn
-    .word EMUX_XTRACE_START(\num_insn)
-.endm
-
-.macro xtrace_stop
-    .word EMUX_XTRACE_STOP()
+.macro xtracestop
+    .word EMUX_XTRACESTOP()
 .endm
 
 .macro xlog_string str

--- a/include/rsp_rdpq.inc
+++ b/include/rsp_rdpq.inc
@@ -888,7 +888,7 @@ RDPQ_Triangle:
 
 #if 0
     mfc0 fp, COP0_DP_CLOCK
-    xtrace_start
+    xtracestart
 #endif
 
     j half_swap
@@ -1342,7 +1342,7 @@ no_texture:
     addi s3, 0x10
 
 #if 0
-    xtrace_stop
+    xtracestop
 
     mfc0 t0, COP0_DP_CLOCK
     sub t0, t0, fp

--- a/include/rsp_rdpq_tri.inc
+++ b/include/rsp_rdpq_tri.inc
@@ -195,7 +195,7 @@ RDPQ_Triangle_Send_Async:
 
 #if RDPQ_TRIANGLE_PROFILE
     mfc0 fp, COP0_DP_CLOCK
-    xtrace_start
+    xtracestart
 #endif
 
     #define vall1    $v01
@@ -638,7 +638,7 @@ rdpq_triangle_change_buffer_done:
                                                     sdv vzout1.e0, 0x00,z_dmem
 
 #if RDPQ_TRIANGLE_PROFILE
-    xtrace_stop
+    xtracestop
     mfc0 t0, COP0_DP_CLOCK
     sub t0, t0, fp
     xlog_string "RDPQ_Triangle:  "


### PR DESCRIPTION
New emux spec location, for reference: https://n64brew.dev/wiki/Emux

As discussed on discord
I left `xlog_string` alone as it's a utility macro wrapping `xlog`
Companion ares PR: https://github.com/ares-emulator/ares/pull/2518