### PR TITLE
Add `DEBUG_FEATURE_LOG_EMULATOR_BEST` as an alias to ISViewer logging

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -397,7 +397,7 @@ enum Page page_song(void) {
 
 int main(void) {
 	joypad_init();
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -47,7 +47,7 @@ TestClass globalClass;
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/examples/fontdemo/fontdemo.c
+++ b/examples/fontdemo/fontdemo.c
@@ -80,7 +80,7 @@ void run_benchmark(void)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/examples/fontgallery/fontgallery.c
+++ b/examples/fontgallery/fontgallery.c
@@ -594,7 +594,7 @@ void font_atlas_render(font_atlas *atlas, int x, int y)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -86,7 +86,7 @@ int main(void)
 
     timer_init();
     joypad_init();
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     console_init();
     console_set_render_mode(RENDER_MANUAL);
     console_set_debug(false);

--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -7,7 +7,7 @@
 
 int main(void) {
 	debug_init_usblog();
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	joypad_init();
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -97,7 +97,7 @@ int main()
     float scr_width;
     float scr_height;
     //Init debug log
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -4,7 +4,7 @@
 int main()
 {
     //Init debug log
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -98,7 +98,7 @@ void render(int cur_frame)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/rspqdemo/rspqdemo.c
+++ b/examples/rspqdemo/rspqdemo.c
@@ -40,7 +40,7 @@ int main()
     // Initialize systems
     console_init();
     console_set_debug(true);
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 
     // Initialize the "vec" library that this example is based on (see vec.h)

--- a/examples/spriteanim/spriteanim.c
+++ b/examples/spriteanim/spriteanim.c
@@ -65,7 +65,7 @@ void update(void)
 int main()
 {
     //Init logging
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     
     //Init display

--- a/include/debug.h
+++ b/include/debug.h
@@ -60,6 +60,11 @@ extern "C" {
  */
 #define DEBUG_FEATURE_LOG_ISVIEWER  (1 << 1)
 
+/**
+ * @brief Activate the best available logging channel for in-emulator development.
+ */
+#define DEBUG_FEATURE_LOG_EMULATOR_BEST DEBUG_FEATURE_LOG_ISVIEWER
+
 /** 
  * @brief Flag to activate the logging on CompactFlash/SD card.
  *

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -335,7 +335,7 @@ static const struct Testsuite
 int main() {
 	console_init();
 	console_set_debug(false);
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 
 	if (dfs_init( DFS_DEFAULT_LOCATION ) != DFS_ESUCCESS) {


### PR DESCRIPTION
The plan being that trunk-based codebases can do
```diff
-debug_init_isviewer();
+debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
```
now, and in the future we expand DEBUG_FEATURE_LOG_EMULATOR_BEST to also activate emux based logging if available