### PR TITLE
debug log: separate emux log from ISViewer

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -407,7 +407,7 @@ enum Page page_song(void) {
 }
 
 int main(void) {
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 	joypad_init();
 

--- a/examples/biosensortest/biosensortest.c
+++ b/examples/biosensortest/biosensortest.c
@@ -21,7 +21,7 @@ int main(void)
 
     timer_init();
     joypad_init();
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 
     console_init();
     console_set_render_mode(RENDER_MANUAL);

--- a/examples/brew-volley/main.c
+++ b/examples/brew-volley/main.c
@@ -449,7 +449,7 @@ void render(int cur_frame)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     display_init(RESOLUTION_640x480, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DEDITHER);

--- a/examples/compression/compression.c
+++ b/examples/compression/compression.c
@@ -127,7 +127,7 @@ int file_size(const char *fn) {
 
 int main(void) {
     debug_init_usblog();
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 
     console_init();
     console_set_debug(true);

--- a/examples/controllertest/controllertest.c
+++ b/examples/controllertest/controllertest.c
@@ -55,7 +55,7 @@ int main(void)
 {
     timer_init();
     controller_init();
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     console_init();
     console_set_render_mode(RENDER_MANUAL);
     console_set_debug(false);

--- a/examples/coroutine/coroutine.cpp
+++ b/examples/coroutine/coroutine.cpp
@@ -24,7 +24,7 @@ void worker(void* arg) {
 
 int main()
 {
-  debug_init_isviewer();
+  debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
   debug_init_usblog();
   console_init();
   console_set_render_mode(RENDER_MANUAL);

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -47,7 +47,7 @@ TestClass globalClass;
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -452,7 +452,7 @@ static int validate_eeprom(eeprom_type_t eeprom_type)
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     /* Initialize peripherals */

--- a/examples/fontdemo/fontdemo.c
+++ b/examples/fontdemo/fontdemo.c
@@ -80,7 +80,7 @@ void run_benchmark(void)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/examples/fontgallery/fontgallery.c
+++ b/examples/fontgallery/fontgallery.c
@@ -594,7 +594,7 @@ void font_atlas_render(font_atlas *atlas, int x, int y)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/examples/gldemo/gldemo.c
+++ b/examples/gldemo/gldemo.c
@@ -230,7 +230,7 @@ void render()
 
 int main()
 {
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
     
     dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -85,7 +85,7 @@ int main(void)
     int cpak_num_banks[4] = {0, 0, 0, 0};
     int b_hold_time[4] = {0, 0, 0, 0};
 
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     console_init();
     console_set_render_mode(RENDER_MANUAL);

--- a/examples/meshviewer/meshviewer.c
+++ b/examples/meshviewer/meshviewer.c
@@ -251,7 +251,7 @@ static void setup_gl(void)
 
 static void init(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/micro-ui/micro-ui.c
+++ b/examples/micro-ui/micro-ui.c
@@ -213,7 +213,7 @@ void game_draw()
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     
     joypad_init();

--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -7,7 +7,7 @@
 
 int main(void) {
 	debug_init_usblog();
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	joypad_init();
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -97,7 +97,7 @@ int main()
     float scr_width;
     float scr_height;
     //Init debug log
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -4,7 +4,7 @@
 int main()
 {
     //Init debug log
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);

--- a/examples/ovldemo/ovldemo.c
+++ b/examples/ovldemo/ovldemo.c
@@ -6,7 +6,7 @@ typedef void (*print_func)(int time);
 int main(void)
 {
     //Initialize debugging output
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     //Initialize joypad/controller
     joypad_init();

--- a/examples/pixelshader/pixelshader.c
+++ b/examples/pixelshader/pixelshader.c
@@ -60,7 +60,7 @@ void rsp_blend_process_line(surface_t *dest, int x0, int y0, int numlines) {
 }
 
 int main(void) {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_DISABLED);
     dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -98,7 +98,7 @@ void render(int cur_frame)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/rspqdemo/rspqdemo.c
+++ b/examples/rspqdemo/rspqdemo.c
@@ -40,7 +40,7 @@ int main()
     // Initialize systems
     console_init();
     console_set_debug(true);
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 
     // Initialize the "vec" library that this example is based on (see vec.h)

--- a/examples/rtctest/rtctest.c
+++ b/examples/rtctest/rtctest.c
@@ -19,7 +19,7 @@ static void update_joystick_directions( void );
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_DISABLED );

--- a/examples/spriteanim/spriteanim.c
+++ b/examples/spriteanim/spriteanim.c
@@ -65,7 +65,7 @@ void update(void)
 int main()
 {
     //Init logging
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     
     //Init display

--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -29,7 +29,7 @@ const char *colorspace_name(yuv_colorspace_t *cs) {
 int main(void)
 {
 	joypad_init();
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 
 	dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/vifx/vifx.c
+++ b/examples/vifx/vifx.c
@@ -5,7 +5,7 @@
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
     joypad_init();
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -62,6 +62,35 @@ extern "C" {
  */
 #define DEBUG_FEATURE_LOG_ISVIEWER  (1 << 1)
 
+/**
+ * @brief Flag to activate the emux logging channel.
+ *
+ * @ref emux is a set of N64 emulator extensions.
+ * Specifically, this makes use of the xlog extension.
+ *
+ * Logging can be done by writing to stderr. You can use the debugf()
+ * macro as a simple wrapper over fprintf(stderr) that can be
+ * disabled when building the final ROM through the NDEBUG macro.
+ *
+ * Supported emulators:
+ *
+ *   * Ares (https://ares-emulator.github.io)
+ *
+ */
+#define DEBUG_FEATURE_LOG_EMUX  (1 << 4)
+
+/**
+ * @brief Don't activate ISViewer if emux is available.
+ *
+ * @see #DEBUG_FEATURE_LOG_EMUX
+ */
+#define DEBUG_FEATURE_LOG_PREFER_EMUX_OVER_ISVIEWER (1 << 5)
+
+/**
+ * @brief Activate the best available logging channel for in-emulator development.
+ */
+#define DEBUG_FEATURE_LOG_EMULATOR_BEST (DEBUG_FEATURE_LOG_ISVIEWER | DEBUG_FEATURE_LOG_EMUX | DEBUG_FEATURE_LOG_PREFER_EMUX_OVER_ISVIEWER)
+
 /** 
  * @brief Flag to activate the logging on CompactFlash/SD card.
  *
@@ -118,6 +147,21 @@ extern "C" {
  */
 #define DEBUG_FEATURE_FILE_SD       (1 << 3)
 
+/**
+ * @brief Flag to enable emux exceptions
+ *
+ * @ref emux is a set of N64 emulator extensions.
+ * Specifically, this makes use of the xexception extension.
+ *
+ * This extension allows emulators to report hardware crashes using CPU exceptions.
+ *
+ * Supported emulators:
+ *
+ *   * Ares (https://ares-emulator.github.io)
+ *
+ */
+#define DEBUG_FEATURE_EMUX_EXCEPTIONS (1 << 6)
+
 
 /**
  * @brief Flag to activate all supported debugging features.
@@ -152,10 +196,21 @@ extern "C" {
 	 * @return true if the ISViewer logging channel was initialized successfully, false otherwise
 	 */
 	bool debug_init_isviewer(void);
+	/**
+	 * @brief Initialize emux logging.
+	 *
+	 * This function initializes the emux logging channel. It is used to log messages
+	 * to emulators that support it.
+	 *
+	 * @return true if the emux logging channel was initialized successfully, false otherwise
+	 */
+	bool debug_init_emux_log(void);
 	/** @brief Initialize SD logging. */
 	bool debug_init_sdlog(const char *fn, const char *openfmt);
 	/** @brief Initialize SD filesystem */
 	bool debug_init_sdfs(const char *prefix, int npart);
+	/** @brief Use emux exceptions */
+	bool debug_init_emux_exceptions(void);
 
 	/** @brief Shutdown SD filesystem. */
 	void debug_close_sdfs(void);
@@ -174,14 +229,21 @@ extern "C" {
 	static inline bool debug_init(int features)
 	{
 		bool ok = false; 
+		bool emux_log_ok = false;
 		if (features & DEBUG_FEATURE_LOG_USB)
 			ok = debug_init_usblog() || ok;
-		if (features & DEBUG_FEATURE_LOG_ISVIEWER)
+		if (features & DEBUG_FEATURE_LOG_EMUX)
+			ok = (emux_log_ok = debug_init_emux_log()) || ok;
+		if ((features & DEBUG_FEATURE_LOG_ISVIEWER)
+			&& ((features & DEBUG_FEATURE_LOG_PREFER_EMUX_OVER_ISVIEWER)
+					? !emux_log_ok : true))
 			ok = debug_init_isviewer() || ok;
 		if (features & DEBUG_FEATURE_FILE_SD)
 			ok = debug_init_sdfs("sd:/", -1) || ok;
 		if (features & DEBUG_FEATURE_LOG_SD)
 			ok = debug_init_sdlog("sd:/libdragon.log", "a");
+		if (features & DEBUG_FEATURE_EMUX_EXCEPTIONS)
+			ok = debug_init_emux_exceptions() || ok;
 		return ok;
 	}
 

--- a/include/emux.h
+++ b/include/emux.h
@@ -3,7 +3,7 @@
  * @author Giovanni Bajo <giovannibajo@gmail.com>
  * @brief Implementation of the N64 emulator extensions
  * @ingroup emux
- * @defgroup emux
+ * @defgroup emux emux
  * 
  * EMUX is an open spec for emulators to provide extensions to the emulated
  * N64 system, allowing advanced profiling and debugging features.

--- a/include/emux.h
+++ b/include/emux.h
@@ -2,6 +2,7 @@
  * @file emux.h
  * @author Giovanni Bajo <giovannibajo@gmail.com>
  * @brief Implementation of the N64 emulator extensions
+ * @ingroup emux
  * 
  * EMUX is an open spec for emulators to provide extensions to the emulated
  * N64 system, allowing advanced profiling and debugging features.

--- a/include/emux.h
+++ b/include/emux.h
@@ -3,6 +3,7 @@
  * @author Giovanni Bajo <giovannibajo@gmail.com>
  * @brief Implementation of the N64 emulator extensions
  * @ingroup emux
+ * @defgroup emux
  * 
  * EMUX is an open spec for emulators to provide extensions to the emulated
  * N64 system, allowing advanced profiling and debugging features.

--- a/src/debug.c
+++ b/src/debug.c
@@ -308,11 +308,17 @@ bool debug_init_usblog(void)
 
 bool debug_init_isviewer(void)
 {
-	if (emux_detect(1) & EMUX_FEAT1_EXCEPTION)
+	if (isviewer_init())
 	{
-		// Activate exceptions on console freeze
-		emux_exception_set_mask(EMUX_EXCEPTION_ERR_MASK);
+		hook_init_once();
+		debug_writer[1] = isviewer_write;
+		return true;
 	}
+	
+	return false;
+}
+
+bool debug_init_emux_log(void) {
 
 	if (emux_detect(1) & EMUX_FEAT1_LOG)
 	{
@@ -321,13 +327,6 @@ bool debug_init_isviewer(void)
 		return true;
 	}
 
-	if (isviewer_init())
-	{
-		hook_init_once();
-		debug_writer[1] = isviewer_write;
-		return true;
-	}
-	
 	return false;
 }
 
@@ -360,6 +359,17 @@ void debug_close_sdfs(void)
 		detach_filesystem(sdfs_prefix);
 		f_mount(NULL, sdfs_logic_drive, 0);
 	}
+}
+
+bool debug_init_emux_exceptions(void) {
+	if (emux_detect(1) & EMUX_FEAT1_EXCEPTION)
+	{
+		// Activate exceptions on console freeze
+		emux_exception_set_mask(EMUX_EXCEPTION_ERR_MASK);
+		return true;
+	}
+
+	return false;
 }
 
 static void debugfv(const char *msg, va_list args)

--- a/tests/test_h264.c
+++ b/tests/test_h264.c
@@ -1213,7 +1213,7 @@ bool exhaustive_decoderesidual_test(int numtests, int verbose) {
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
     debug_init_usblog();
 
     timer_init();

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -430,7 +430,7 @@ static const struct Testsuite
 int main() {
 	console_init();
 	console_set_debug(false);
-	debug_init_isviewer();
+	debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
 	debug_init_usblog();
 	emux_ioctl_fast(); // ask emulator to run as fast as possible
 


### PR DESCRIPTION
Currently (in preview) emux logging is silently enabled by calling `debug_init_isviewer`, in which case (if emux is available) ISViewer will also silently not be enabled

This was done for backwards compatiblity reasons, but I believe we can do better and expect users to update a single line of code

This PR removes the emux stuff from `debug_init_isviewer` and moves it to two new functions `debug_init_emux_log` and `debug_init_emux_exceptions`, called respectively behind debug feature flags `DEBUG_FEATURE_LOG_EMUX` and `DEBUG_FEATURE_EMUX_EXCEPTIONS`

Additionally the PR adds `DEBUG_FEATURE_LOG_PREFER_EMUX_OVER_ISVIEWER` which when passed to `debug_init` (including as part of `DEBUG_FEATURE_ALL`) means that emux and ISViewer logging won't be both active (which would lead to duplicate logging).

------------

The PR also adds `DEBUG_FEATURE_LOG_EMULATOR_BEST` as a combination of `DEBUG_FEATURE_LOG_{ISVIEWER,EMUX,PREFER_EMUX_OVER_ISVIEWER}`.
The point of this macro is to abstract the actual logging protocol away instead of hardcoding the logging method one uses,
and also I'm opening a PR to trunk ( #872 ) that defines `DEBUG_FEATURE_LOG_EMULATOR_BEST` to just `DEBUG_FEATURE_LOG_ISVIEWER` so that migrating can go like
```diff
-debug_init_isviewer();
+debug_init(DEBUG_FEATURE_LOG_EMULATOR_BEST);
```
and start even for trunk-based codebases, pending merge of emux things to trunk