### PR TITLE
[trunk] Deprecate `debug_init_isviewer`, rename to `debug_init_emulog`

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -397,7 +397,7 @@ enum Page page_song(void) {
 
 int main(void) {
 	joypad_init();
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -47,7 +47,7 @@ TestClass globalClass;
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/examples/fontdemo/fontdemo.c
+++ b/examples/fontdemo/fontdemo.c
@@ -80,7 +80,7 @@ void run_benchmark(void)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/examples/fontgallery/fontgallery.c
+++ b/examples/fontgallery/fontgallery.c
@@ -594,7 +594,7 @@ void font_atlas_render(font_atlas *atlas, int x, int y)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -86,7 +86,7 @@ int main(void)
 
     timer_init();
     joypad_init();
-    debug_init_isviewer();
+    debug_init_emulog();
     console_init();
     console_set_render_mode(RENDER_MANUAL);
     console_set_debug(false);

--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -7,7 +7,7 @@
 
 int main(void) {
 	debug_init_usblog();
-	debug_init_isviewer();
+	debug_init_emulog();
 	joypad_init();
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -97,7 +97,7 @@ int main()
     float scr_width;
     float scr_height;
     //Init debug log
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -4,7 +4,7 @@
 int main()
 {
     //Init debug log
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -98,7 +98,7 @@ void render(int cur_frame)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/rspqdemo/rspqdemo.c
+++ b/examples/rspqdemo/rspqdemo.c
@@ -40,7 +40,7 @@ int main()
     // Initialize systems
     console_init();
     console_set_debug(true);
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 
     // Initialize the "vec" library that this example is based on (see vec.h)

--- a/examples/spriteanim/spriteanim.c
+++ b/examples/spriteanim/spriteanim.c
@@ -65,7 +65,7 @@ void update(void)
 int main()
 {
     //Init logging
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     
     //Init display

--- a/include/debug.h
+++ b/include/debug.h
@@ -40,8 +40,9 @@ extern "C" {
 #define DEBUG_FEATURE_LOG_USB       (1 << 0)
 
 /** 
- * @brief Flag to activate the ISViewer logging channel.
+ * @brief Flag to activate the logging channel in emulators.
  *
+ * Currently relies on ISViewer support from the emulator.
  * ISViewer was a real development cartridge that was used in the 90s
  * to debug N64 development. It is emulated by a few emulators to ease
  * the work of homebrew developers.
@@ -58,7 +59,7 @@ extern "C" {
  *   * dgb-n64 (https://github.com/Dillonb/n64)
  *
  */
-#define DEBUG_FEATURE_LOG_ISVIEWER  (1 << 1)
+#define DEBUG_FEATURE_LOG_EMU       (1 << 1)
 
 /** 
  * @brief Flag to activate the logging on CompactFlash/SD card.
@@ -130,11 +131,21 @@ extern "C" {
 #define DEBUG_FEATURE_ALL           0xFF
 
 
+/**
+ * @deprecated Use #DEBUG_FEATURE_LOG_EMU instead.
+ */
+#define DEBUG_FEATURE_LOG_ISVIEWER DEBUG_FEATURE_LOG_EMU
+/**
+ * @deprecated Use #debug_init_emulog instead.
+ */
+#define debug_init_isviewer debug_init_emulog
+
+
 #ifndef NDEBUG
 	/** @brief Initialize USB logging. */
 	bool debug_init_usblog(void);
-	/** @brief Initialize ISViewer logging. */
-	bool debug_init_isviewer(void);
+	/** @brief Initialize emulator logging. */
+	bool debug_init_emulog(void);
 	/** @brief Initialize SD logging. */
 	bool debug_init_sdlog(const char *fn, const char *openfmt);
 	/** @brief Initialize SD filesystem */
@@ -159,8 +170,8 @@ extern "C" {
 		bool ok = false; 
 		if (features & DEBUG_FEATURE_LOG_USB)
 			ok = debug_init_usblog() || ok;
-		if (features & DEBUG_FEATURE_LOG_ISVIEWER)
-			ok = debug_init_isviewer() || ok;
+		if (features & DEBUG_FEATURE_LOG_EMU)
+			ok = debug_init_emulog() || ok;
 		if (features & DEBUG_FEATURE_FILE_SD)
 			ok = debug_init_sdfs("sd:/", -1) || ok;
 		if (features & DEBUG_FEATURE_LOG_SD)
@@ -200,7 +211,7 @@ extern "C" {
 #else
 	#define debug_init(ch)             ({ false; })
 	#define debug_init_usblog()        ({ false; })
-	#define debug_init_isviewer()      ({ false; })
+	#define debug_init_emulog()        ({ false; })
 	#define debug_init_sdlog(fn,fmt)   ({ false; })
 	#define debug_init_sdfs(prefix,np) ({ false; })
 	#define debugf(msg, ...)           ({ })

--- a/include/debugcpp.h
+++ b/include/debugcpp.h
@@ -19,7 +19,7 @@
     #define joypad_init() ({ __debug_init_cpp(); joypad_init(); })
     #define timer_init() ({ __debug_init_cpp(); timer_init(); })
     #define display_init(a,b,c,d,e) ({ __debug_init_cpp(); display_init(a,b,c,d,e); })
-    #define debug_init_isviewer() ({ __debug_init_cpp(); debug_init_isviewer(); })
+    #define debug_init_emulog() ({ __debug_init_cpp(); debug_init_emulog(); })
     #define debug_init_usblog() ({ __debug_init_cpp(); debug_init_usblog(); })
     ///@endcond
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -44,7 +44,7 @@
  *    developer to inspect the application while it is running and
  *    afterwards. Logging can be performed through the USB channel
  *    of a supported cartridge (#DEBUG_FEATURE_LOG_USB), or through
- *    N64 emulators on PC (#DEBUG_FEATURE_LOG_ISVIEWER), or even
+ *    N64 emulators on PC (#DEBUG_FEATURE_LOG_EMU), or even
  *    redirected to a file on a SD card inserted into the development
  *    cartridge (#DEBUG_FEATURE_LOG_SD).
  *    On N64, logging can simply be performed by writing to stderr,
@@ -577,7 +577,7 @@ bool debug_init_usblog(void)
 	return true;
 }
 
-bool debug_init_isviewer(void)
+bool debug_init_emulog(void)
 {
 	if (!isviewer_init())
 		return false;

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -335,7 +335,7 @@ static const struct Testsuite
 int main() {
 	console_init();
 	console_set_debug(false);
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 
 	if (dfs_init( DFS_DEFAULT_LOCATION ) != DFS_ESUCCESS) {


### PR DESCRIPTION
Supersedes #872

The plan is that trunk-based codebases can do
```diff
-debug_init_isviewer();
+debug_init_emulog();
```
now (or just keep using the now deprecated alias `debug_init_isviewer`),
and in the future we expand `debug_init_emulog` to also activate emux based logging if available