### PR TITLE
[preview] Deprecate `debug_init_isviewer`, rename to `debug_init_emulog` and move `emux_exception_set_mask` to inspector global constructor

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -407,7 +407,7 @@ enum Page page_song(void) {
 }
 
 int main(void) {
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 	joypad_init();
 

--- a/examples/biosensortest/biosensortest.c
+++ b/examples/biosensortest/biosensortest.c
@@ -21,7 +21,7 @@ int main(void)
 
     timer_init();
     joypad_init();
-    debug_init_isviewer();
+    debug_init_emulog();
 
     console_init();
     console_set_render_mode(RENDER_MANUAL);

--- a/examples/brew-volley/main.c
+++ b/examples/brew-volley/main.c
@@ -449,7 +449,7 @@ void render(int cur_frame)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     display_init(RESOLUTION_640x480, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DEDITHER);

--- a/examples/compression/compression.c
+++ b/examples/compression/compression.c
@@ -127,7 +127,7 @@ int file_size(const char *fn) {
 
 int main(void) {
     debug_init_usblog();
-    debug_init_isviewer();
+    debug_init_emulog();
 
     console_init();
     console_set_debug(true);

--- a/examples/controllertest/controllertest.c
+++ b/examples/controllertest/controllertest.c
@@ -55,7 +55,7 @@ int main(void)
 {
     timer_init();
     controller_init();
-    debug_init_isviewer();
+    debug_init_emulog();
     console_init();
     console_set_render_mode(RENDER_MANUAL);
     console_set_debug(false);

--- a/examples/coroutine/coroutine.cpp
+++ b/examples/coroutine/coroutine.cpp
@@ -24,7 +24,7 @@ void worker(void* arg) {
 
 int main()
 {
-  debug_init_isviewer();
+  debug_init_emulog();
   debug_init_usblog();
   console_init();
   console_set_render_mode(RENDER_MANUAL);

--- a/examples/cpptest/cpptest.cpp
+++ b/examples/cpptest/cpptest.cpp
@@ -47,7 +47,7 @@ TestClass globalClass;
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/examples/eepromfstest/eepromfstest.c
+++ b/examples/eepromfstest/eepromfstest.c
@@ -452,7 +452,7 @@ static int validate_eeprom(eeprom_type_t eeprom_type)
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     /* Initialize peripherals */

--- a/examples/fontdemo/fontdemo.c
+++ b/examples/fontdemo/fontdemo.c
@@ -80,7 +80,7 @@ void run_benchmark(void)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/examples/fontgallery/fontgallery.c
+++ b/examples/fontgallery/fontgallery.c
@@ -594,7 +594,7 @@ void font_atlas_render(font_atlas *atlas, int x, int y)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/examples/gldemo/gldemo.c
+++ b/examples/gldemo/gldemo.c
@@ -230,7 +230,7 @@ void render()
 
 int main()
 {
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
     
     dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/joypadtest/joypadtest.c
+++ b/examples/joypadtest/joypadtest.c
@@ -85,7 +85,7 @@ int main(void)
     int cpak_num_banks[4] = {0, 0, 0, 0};
     int b_hold_time[4] = {0, 0, 0, 0};
 
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     console_init();
     console_set_render_mode(RENDER_MANUAL);

--- a/examples/meshviewer/meshviewer.c
+++ b/examples/meshviewer/meshviewer.c
@@ -251,7 +251,7 @@ static void setup_gl(void)
 
 static void init(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/micro-ui/micro-ui.c
+++ b/examples/micro-ui/micro-ui.c
@@ -213,7 +213,7 @@ void game_draw()
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     
     joypad_init();

--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -7,7 +7,7 @@
 
 int main(void) {
 	debug_init_usblog();
-	debug_init_isviewer();
+	debug_init_emulog();
 	joypad_init();
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
 

--- a/examples/overlays/actor/overlays_actor.c
+++ b/examples/overlays/actor/overlays_actor.c
@@ -97,7 +97,7 @@ int main()
     float scr_width;
     float scr_height;
     //Init debug log
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);

--- a/examples/overlays/scene/overlays_scene.cpp
+++ b/examples/overlays/scene/overlays_scene.cpp
@@ -4,7 +4,7 @@
 int main()
 {
     //Init debug log
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     //Init rendering
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_DISABLED);

--- a/examples/ovldemo/ovldemo.c
+++ b/examples/ovldemo/ovldemo.c
@@ -6,7 +6,7 @@ typedef void (*print_func)(int time);
 int main(void)
 {
     //Initialize debugging output
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     //Initialize joypad/controller
     joypad_init();

--- a/examples/pixelshader/pixelshader.c
+++ b/examples/pixelshader/pixelshader.c
@@ -60,7 +60,7 @@ void rsp_blend_process_line(surface_t *dest, int x0, int y0, int numlines) {
 }
 
 int main(void) {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     display_init(RESOLUTION_640x480, DEPTH_16_BPP, 2, GAMMA_NONE, FILTERS_DISABLED);
     dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/rdpqdemo/rdpqdemo.c
+++ b/examples/rdpqdemo/rdpqdemo.c
@@ -98,7 +98,7 @@ void render(int cur_frame)
 
 int main()
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     display_init(RESOLUTION_320x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);

--- a/examples/rspqdemo/rspqdemo.c
+++ b/examples/rspqdemo/rspqdemo.c
@@ -40,7 +40,7 @@ int main()
     // Initialize systems
     console_init();
     console_set_debug(true);
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 
     // Initialize the "vec" library that this example is based on (see vec.h)

--- a/examples/rtctest/rtctest.c
+++ b/examples/rtctest/rtctest.c
@@ -19,7 +19,7 @@ static void update_joystick_directions( void );
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     display_init( RESOLUTION_320x240, DEPTH_32_BPP, 2, GAMMA_NONE, FILTERS_DISABLED );

--- a/examples/spriteanim/spriteanim.c
+++ b/examples/spriteanim/spriteanim.c
@@ -65,7 +65,7 @@ void update(void)
 int main()
 {
     //Init logging
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     
     //Init display

--- a/examples/videoplayer/videoplayer.c
+++ b/examples/videoplayer/videoplayer.c
@@ -29,7 +29,7 @@ const char *colorspace_name(yuv_colorspace_t *cs) {
 int main(void)
 {
 	joypad_init();
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 
 	dfs_init(DFS_DEFAULT_LOCATION);

--- a/examples/vifx/vifx.c
+++ b/examples/vifx/vifx.c
@@ -5,7 +5,7 @@
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
     joypad_init();
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -42,7 +42,10 @@ extern "C" {
 #define DEBUG_FEATURE_LOG_USB       (1 << 0)
 
 /** 
- * @brief Flag to activate the ISViewer logging channel.
+ * @brief Flag to activate the logging channel in emulators.
+ *
+ * The logging is done using @ref emux if available,
+ * or through ISViewer otherwise if available.
  *
  * ISViewer was a real development cartridge that was used in the 90s
  * to debug N64 development. It is emulated by a few emulators to ease
@@ -54,13 +57,13 @@ extern "C" {
  *
  * Supported emulators:
  *
- *   * cen64 (https://github.com/n64dev/cen64) - run with -is-viewer command line flag
- *   * Ares (https://ares-emulator.github.io)
- *   * simple64 (https://simple64.github.io)
- *   * dgb-n64 (https://github.com/Dillonb/n64)
+ *   * cen64 (https://github.com/n64dev/cen64) - ISViewer only. Run with -is-viewer command line flag
+ *   * Ares (https://ares-emulator.github.io) - emux and ISViewer
+ *   * Gopher64 (https://loganmc10.itch.io/gopher64) - ISViewer only
+ *   * dgb-n64 (https://github.com/Dillonb/n64) - ISViewer only
  *
  */
-#define DEBUG_FEATURE_LOG_ISVIEWER  (1 << 1)
+#define DEBUG_FEATURE_LOG_EMU       (1 << 1)
 
 /** 
  * @brief Flag to activate the logging on CompactFlash/SD card.
@@ -132,6 +135,16 @@ extern "C" {
 #define DEBUG_FEATURE_ALL           0xFF
 
 
+/**
+ * @deprecated Use #DEBUG_FEATURE_LOG_EMU instead.
+ */
+#define DEBUG_FEATURE_LOG_ISVIEWER DEBUG_FEATURE_LOG_EMU
+/**
+ * @deprecated Use #debug_init_emulog instead.
+ */
+#define debug_init_isviewer debug_init_emulog
+
+
 #ifndef NDEBUG
 	/** 
 	 * @brief Initialize USB logging. 
@@ -151,7 +164,7 @@ extern "C" {
 	 *
 	 * @return true if the ISViewer logging channel was initialized successfully, false otherwise
 	 */
-	bool debug_init_isviewer(void);
+	bool debug_init_emulog(void);
 	/** @brief Initialize SD logging. */
 	bool debug_init_sdlog(const char *fn, const char *openfmt);
 	/** @brief Initialize SD filesystem */
@@ -176,8 +189,8 @@ extern "C" {
 		bool ok = false; 
 		if (features & DEBUG_FEATURE_LOG_USB)
 			ok = debug_init_usblog() || ok;
-		if (features & DEBUG_FEATURE_LOG_ISVIEWER)
-			ok = debug_init_isviewer() || ok;
+		if (features & DEBUG_FEATURE_LOG_EMU)
+			ok = debug_init_emulog() || ok;
 		if (features & DEBUG_FEATURE_FILE_SD)
 			ok = debug_init_sdfs("sd:/", -1) || ok;
 		if (features & DEBUG_FEATURE_LOG_SD)
@@ -222,7 +235,7 @@ extern "C" {
 #else
 	#define debug_init(ch)             ((void)(false), false)
 	#define debug_init_usblog()        ((void)(false), false)
-	#define debug_init_isviewer()      ((void)(false), false)
+	#define debug_init_emulog()        ((void)(false), false)
 	#define debug_init_sdlog(fn,fmt)   ((void)(false), false)
 	#define debug_init_sdfs(prefix,np) ((void)(false), false)
 	#define debugf(msg, ...)           ({ })

--- a/include/debugcpp.h
+++ b/include/debugcpp.h
@@ -19,7 +19,7 @@
     #define joypad_init() ({ __debug_init_cpp(); joypad_init(); })
     #define timer_init() ({ __debug_init_cpp(); timer_init(); })
     #define display_init(a,b,c,d,e) ({ __debug_init_cpp(); display_init(a,b,c,d,e); })
-    #define debug_init_isviewer() ({ __debug_init_cpp(); debug_init_isviewer(); })
+    #define debug_init_emulog() ({ __debug_init_cpp(); debug_init_emulog(); })
     #define debug_init_usblog() ({ __debug_init_cpp(); debug_init_usblog(); })
     ///@endcond
 #endif

--- a/include/emux.h
+++ b/include/emux.h
@@ -2,6 +2,8 @@
  * @file emux.h
  * @author Giovanni Bajo <giovannibajo@gmail.com>
  * @brief Implementation of the N64 emulator extensions
+ * @ingroup emux
+ * @defgroup emux emux
  * 
  * EMUX is an open spec for emulators to provide extensions to the emulated
  * N64 system, allowing advanced profiling and debugging features.

--- a/src/debug.c
+++ b/src/debug.c
@@ -308,12 +308,6 @@ bool debug_init_usblog(void)
 
 bool debug_init_emulog(void)
 {
-	if (emux_detect(1) & EMUX_FEAT1_EXCEPTION)
-	{
-		// Activate exceptions on console freeze
-		emux_exception_set_mask(EMUX_EXCEPTION_ERR_MASK);
-	}
-
 	if (emux_detect(1) & EMUX_FEAT1_LOG)
 	{
 		hook_init_once();

--- a/src/debug.c
+++ b/src/debug.c
@@ -45,7 +45,7 @@
  *    developer to inspect the application while it is running and
  *    afterwards. Logging can be performed through the USB channel
  *    of a supported cartridge (#DEBUG_FEATURE_LOG_USB), or through
- *    N64 emulators on PC (#DEBUG_FEATURE_LOG_ISVIEWER), or even
+ *    N64 emulators on PC (#DEBUG_FEATURE_LOG_EMU), or even
  *    redirected to a file on a SD card inserted into the development
  *    cartridge (#DEBUG_FEATURE_LOG_SD).
  *    On N64, logging can simply be performed by writing to stderr,
@@ -306,7 +306,7 @@ bool debug_init_usblog(void)
 	return true;
 }
 
-bool debug_init_isviewer(void)
+bool debug_init_emulog(void)
 {
 	if (emux_detect(1) & EMUX_FEAT1_EXCEPTION)
 	{

--- a/src/inspector.c
+++ b/src/inspector.c
@@ -20,6 +20,7 @@
 #include "cop0.h"
 #include "n64sys.h"
 #include "mi.h"
+#include "emux.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -851,5 +852,11 @@ void __inspector_init(void) {
         if (code == 2) inspector(ex, MODE_CPP_EXCEPTION);
     }
     register_syscall_handler(handler, 0x00001, 0x00002);
+
+	if (emux_detect(1) & EMUX_FEAT1_EXCEPTION)
+	{
+		// Activate exceptions on console freeze
+		emux_exception_set_mask(EMUX_EXCEPTION_ERR_MASK);
+	}
 }
 #endif

--- a/tests/test_h264.c
+++ b/tests/test_h264.c
@@ -1213,7 +1213,7 @@ bool exhaustive_decoderesidual_test(int numtests, int verbose) {
 
 int main(void)
 {
-    debug_init_isviewer();
+    debug_init_emulog();
     debug_init_usblog();
 
     timer_init();

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -430,7 +430,7 @@ static const struct Testsuite
 int main() {
 	console_init();
 	console_set_debug(false);
-	debug_init_isviewer();
+	debug_init_emulog();
 	debug_init_usblog();
 	emux_ioctl_fast(); // ask emulator to run as fast as possible
 


### PR DESCRIPTION
Supersedes #873

Companion trunk PR: #875
this contains changes from #875 plus accounts for emux in documentation, as well as moving `emux_exception_set_mask` initialization to the inspector