### PR TITLE
Fix H264 luma overflow issue

### DIFF
--- a/src/video/rsph264.c
+++ b/src/video/rsph264.c
@@ -15,7 +15,11 @@ static uint32_t rsph264_intra_ovl_id = 0;
 enum {
     // Tasks in rsph264_inter
     TASK_OMX_DEQUANT_TRANSFORM_RESIDUAL        = 0,
-    TASK_OMX_TRANSFORM_DEQUANT_LUMADC          = 1,
+    // Slot 1 was OMX_TransformDequantLumaDC; moved to the intra overlay
+    // because TransformDequantLumaDC needs full 32-bit signed math (~324
+    // bytes of IMEM) that this overlay can't spare. The slot is held as
+    // an RSPQ_Loop placeholder so the remaining inter command IDs don't
+    // shift.
     TASK_OMX_TRANSFORM_DEQUANT_CHROMADC        = 2,
     TASK_PROCESS_LUMA_INTER_RESIDUAL           = 3,
     TASK_PROCESS_CHROMA_RESIDUAL               = 4,
@@ -32,6 +36,7 @@ enum {
     TASK_OMX_INTRAPREDICT_CHROMA_8             = 2,
     TASK_PROCESS_LUMA_INTRA4_RESIDUAL          = 3,
     TASK_PROCESS_LUMA_INTRA16_RESIDUAL         = 4,
+    TASK_OMX_TRANSFORM_DEQUANT_LUMADC          = 5,
 
     TASK_SET_PACKED_DELTA_BUFFER               = 15,
 };
@@ -342,17 +347,9 @@ inline void rsph264_queue_transform_dequant_lumadc(
         fast_data_cache_hit_writeback_invalidate(dst, 32);
     }
 
-    rspq_write(rsph264_inter_ovl_id, TASK_OMX_TRANSFORM_DEQUANT_LUMADC,
+    rspq_write(rsph264_intra_ovl_id, TASK_OMX_TRANSFORM_DEQUANT_LUMADC,
         0, PhysicalAddr(dst),
         ((qp / 6) << 8) | (qp % 6));
-
-    // check_overlay(TASK_OMX_TRANSFORM_DEQUANT_LUMADC);
-    // uint32_t *q = queue_push_begin();
-    // q[0] = (uint32_t)TASK_OMX_TRANSFORM_DEQUANT_LUMADC & MASK_TASKID;
-    // q[1] = (uint32_t)0;      // FIXME: remove, not needed anymore
-    // q[2] = (uint32_t)dst;
-    // q[3] = (uint32_t)((qp / 6) << 8) | (qp % 6);
-    // queue_push_end();
 }
 
 inline void rsph264_queue_transform_dequant_chromadc(

--- a/src/video/rsph264_common.inc
+++ b/src/video/rsph264_common.inc
@@ -822,11 +822,15 @@ TransformResidual4x4IDCT:
 ####################################################################
 # TransformDequantLumaDC
 #
-# Reconstruct a 4x4 Luma DC block from a packed block of coefficients. 
+# Reconstruct a 4x4 Luma DC block from a packed block of coefficients.
 # Do a 4x4 inverse Hadamard transformation, followed by a quantization
 # step.
 #
-# This is exposed as OMX_TransformDequantLumaDC.
+# Only assembled when RSPH264_INCLUDE_TDLDC is defined (intra overlay
+# only). The inter overlay used to expose this as OMX_TransformDequantLumaDC
+# but that path is dead — the only live caller is the intra-bundled
+# Task_ProcessLumaIntra16x16Residual. Excluding it from inter saves
+# ~324 bytes of IMEM there.
 ####################################################################
 # ARGS:
 #   $v00/$v01: 4x4 coefficient matrix
@@ -835,6 +839,7 @@ TransformResidual4x4IDCT:
 #   s4: address of destination buffer in DMEM
 #
 
+#ifdef RSPH264_INCLUDE_TDLDC
     .func TransformDequantLumaDC
 TransformDequantLumaDC:
     # Apply a IHT 4X4 transformation. This is quite similar to 
@@ -887,42 +892,78 @@ TransformDequantLumaDC:
     vmacf $v01, $v04, $v13,6
     vmacf $v01, $v05, $v13,7
 
-    # Dequantize using only first multiplication factor ($v27[e8]) calculated
-    # by CalcDequantFactors. 
-    vmudn $v00, $v00, $v27,8
-    vmudn $v01, $v01, $v27,8
-
-    # Now we need to apply scale. The scale factor in QP is used after being
-    # subtracted by 2, so for instance QP=5 -> <<3; QP=1 -> <<-1 -> >>1.
-    # In case of right shift, a rounding is also necessary.
-    # So we can't just use the scale factor calculated by CalcDequantFactors.
+    # Dequantize: scale T (post-IHT coefficients) by the QP-derived
+    # multiplication factor LS = $v27[e8]. The full operation is:
+    #   qp/6 == 0 (LumaDCScaleDown2): result = (T*LS + 2) >> 2
+    #   qp/6 == 1 (LumaDCScaleDown1): result = (T*LS + 1) >> 1
+    #   qp/6 >= 2:                   result = (T*LS) << (qp/6 - 2)
+    #
+    # IMPORTANT: T*LS may exceed s16 range for low QPs (where T after IHT
+    # can be near ±32767 and LS up to 29 → |product| up to ~950k). The
+    # right-shift paths must compute T*LS as a full 32-bit signed value
+    # via vmudh + vsar(ACC_HI/MD), or the sign wraps when truncated to 16
+    # bits and the result comes out wrong-signed (this caused the camera
+    # blowout bug — MB output saturating to 0xff instead of dark). The
+    # shift-left path is fine with truncating vmudn because shift-left
+    # discards high bits regardless.
     srl t0, t1, 8
-    beqz t0, LumaDCScaleDown2    # >>2
+    beqz t0, LumaDCScaleDown2
     addi t0, -1
-    beqz t0, LumaDCScaleDown1    # >>1
+    beqz t0, LumaDCScaleDown1
     nop
 
-    # Shift the dequant scale factor itself by 2, so that we can then apply
-    # to our coefficients.
+    # qp/6 >= 2: shift left by (qp/6 - 2). 16-bit truncation is OK.
+    vmudn $v00, $v00, $v27,8
+    vmudn $v01, $v01, $v27,8
     vsrl $v06, $v29, 2
     vmudn $v00, $v00, $v06,8
     j LumaDCEnd
     vmudn $v01, $v01, $v06,8
 
 LumaDCScaleDown1:
-    # Right-shift by 1, after adding 1 (from shift register vshift[e15])
-    vaddc $v00, $v00, vshift,15
-    vaddc $v01, $v01, vshift,15
-    vsra $v00, $v00, 1
+    # (T*LS + 1) >> 1 with full 32-bit signed precision.
+    # We can't use the vzero alias ($v00) because $v00 holds T; build a
+    # zero in $v04 for the carry-propagation vadd.
+    vxor $v04, $v04, $v04
+    vmudh $v06, $v00, $v27,8      # ACC = T*LS (signed*signed); ACC_LO=0
+    vsar $v05, COP2_ACC_HI        # v05 = high 16 of T*LS (sign-extended)
+    vsar $v06, COP2_ACC_MD        # v06 = low 16 of T*LS (raw bits)
+    vaddc $v06, $v06, vshift,15   # low += 1; VCC = unsigned carry-out
+    vadd $v05, $v05, $v04         # high += 0 + carry
+    vsrl $v06, $v06, 1            # low >>= 1 (logical)
+    vsll8 $v05, $v05, 15          # low bit of high → bit 15 of result
+    vor $v00, $v06, $v05
+
+    vmudh $v06, $v01, $v27,8
+    vsar $v05, COP2_ACC_HI
+    vsar $v06, COP2_ACC_MD
+    vaddc $v06, $v06, vshift,15
+    vadd $v05, $v05, $v04
+    vsrl $v06, $v06, 1
+    vsll8 $v05, $v05, 15
     j LumaDCEnd
-    vsra $v01, $v01, 1
+    vor $v01, $v06, $v05
 
 LumaDCScaleDown2:
-    # Right-shift by 2, after adding 2 (from shift register vshift[e14])
-    vaddc $v00, $v00, vshift,14
-    vaddc $v01, $v01, vshift,14
-    vsra $v00, $v00, 2
-    vsra $v01, $v01, 2
+    # (T*LS + 2) >> 2 with full 32-bit signed precision.
+    vxor $v04, $v04, $v04
+    vmudh $v06, $v00, $v27,8
+    vsar $v05, COP2_ACC_HI
+    vsar $v06, COP2_ACC_MD
+    vaddc $v06, $v06, vshift,14   # +2
+    vadd $v05, $v05, $v04
+    vsrl $v06, $v06, 2
+    vsll8 $v05, $v05, 14          # low 2 bits of high → bits 14..15 of result
+    vor $v00, $v06, $v05
+
+    vmudh $v06, $v01, $v27,8
+    vsar $v05, COP2_ACC_HI
+    vsar $v06, COP2_ACC_MD
+    vaddc $v06, $v06, vshift,14
+    vadd $v05, $v05, $v04
+    vsrl $v06, $v06, 2
+    vsll8 $v05, $v05, 14
+    vor $v01, $v06, $v05
 
 LumaDCEnd:
     sqv $v00,0, 0*16,s4
@@ -930,6 +971,7 @@ LumaDCEnd:
     sqv $v01,0, 1*16,s4
 
     .endfunc
+#endif  /* RSPH264_INCLUDE_TDLDC */
 
 #if 0
 TEXT_OVERLAY_START:

--- a/src/video/rsph264_inter.S
+++ b/src/video/rsph264_inter.S
@@ -9,7 +9,13 @@
 
     RSPQ_BeginOverlayHeader
         RSPQ_DefineCommand OMX_DequantTransformResidual,         28
-        RSPQ_DefineCommand OMX_TransformDequantLumaDC,           12
+        # OMX_TransformDequantLumaDC moved to the intra overlay:
+        # TransformDequantLumaDC needs ~324 bytes of IMEM that this
+        # overlay can't spare. rsph264_queue_transform_dequant_lumadc
+        # now dispatches to the intra overlay (slot 5). 
+        # Slot kept as a no-op placeholder so the existing
+        # command IDs don't shift.
+        RSPQ_DefineCommand RSPQ_Loop,                             4
         RSPQ_DefineCommand OMX_TransformDequantChromaDC,         12
         RSPQ_DefineCommand Task_ProcessLumaInterResidual,        28
         RSPQ_DefineCommand Task_ProcessChromaResidual,           28
@@ -1395,26 +1401,12 @@ TransformOnly:
     .endfunc
 
 ####################################################################
-# OMX_TransformDequantLumaDC
-#
-# Reconstruct the 4x4 Luma DC block from packed delta buffer. Save
-# it within the internal LUMA_DC structure, and DMA back into RDRAM.
+# OMX_TransformDequantLumaDC: removed (dead code, see header table).
+# TransformDequantLumaDC is no longer assembled into this overlay.
 ####################################################################
-# ARGS
-#  a0: <unused>
-#  a1: dst
-#  a2: qp
 
 #define dcdmasize  t8
 #define dcfunc     t9
-
-    .func OMX_TransformDequantLumaDC
-OMX_TransformDequantLumaDC:
-    li s4, %lo(LUMA_DC)
-    li dcdmasize, DMA_SIZE(32,1)
-    j TransformDequantAnyDC
-    li dcfunc, %lo(TransformDequantLumaDC)
-    .endfunc
 
 ####################################################################
 # OMX_TransformDequantChromaDC

--- a/src/video/rsph264_intra.S
+++ b/src/video/rsph264_intra.S
@@ -13,7 +13,7 @@
         RSPQ_DefineCommand OMX_IntraPredictChroma8x8,            32
         RSPQ_DefineCommand Task_ProcessLumaIntra4x4Residual,     40
         RSPQ_DefineCommand Task_ProcessLumaIntra16x16Residual,   32
-        RSPQ_DefineCommand RSPQ_Loop,                             4
+        RSPQ_DefineCommand OMX_TransformDequantLumaDC,           12
         RSPQ_DefineCommand RSPQ_Loop,                             4
         RSPQ_DefineCommand RSPQ_Loop,                             4
         RSPQ_DefineCommand RSPQ_Loop,                             4
@@ -38,6 +38,10 @@ DECLARE_OMXDL_TABLE(
 )
 #endif
 
+# Pull in TransformDequantLumaDC from common.inc — only the intra overlay
+# uses it (via Task_ProcessLumaIntra16x16Residual), and the function is
+# fat enough that including it in inter blows the IMEM budget.
+#define RSPH264_INCLUDE_TDLDC
 #include "rsph264_common.inc"
 
     .data
@@ -1536,6 +1540,35 @@ Intra4Res_CopyLoop:
     #define npart t8
     #define qp    t9
     #define tcmask s5
+
+####################################################################
+# OMX_TransformDequantLumaDC
+#
+# Reconstruct the 4x4 LumaDC block from packed delta buffer, run the
+# Hadamard inverse transform + dequantization, and DMA the result back
+# to RDRAM. Lives in the intra overlay because TransformDequantLumaDC
+# is only assembled there (inter overlay can't spare the IMEM).
+#
+#  a0: <unused>
+#  a1: dst (RDRAM, 8-byte aligned, 32 bytes)
+#  a2: qp = ((qpY/6) << 8) | (qpY%6)
+####################################################################
+    .func OMX_TransformDequantLumaDC
+OMX_TransformDequantLumaDC:
+    jal CalcDequantFactors
+    move t0, a2                  # qp (delay slot)
+
+    jal UnpackNextDeltaBlock
+    li s4, %lo(LUMA_DC)          # delay slot
+
+    jal TransformDequantLumaDC
+    move t1, a2                  # qp (delay slot)
+
+    li t0, DMA_SIZE(32, 1)
+    move s0, a1                  # dst RDRAM addr
+    jal_and_j DMAOut, RSPQ_Loop
+    .endfunc
+
 
     .func Task_ProcessLumaIntra16x16Residual
 Task_ProcessLumaIntra16x16Residual:

--- a/tests/test_h264.c
+++ b/tests/test_h264.c
@@ -931,6 +931,77 @@ bool exhaustive_dequant_test(BufferTest *buf, int func, int numtests, int verbos
     return true;
 }
 
+// Regression test for the TransformDequantLumaDC s16-overflow bug.
+//
+// exhaustive_dequant_test masks OMX_LUMADC_4x4 coefficients to ±256, so
+// the post-IHT operand T stays well inside ±s16/Scale and never crosses
+// the boundary where the old vmudn-based code truncated T*Scale to its
+// low 16 bits and flipped the sign. This test pokes that boundary
+// directly: a 1-coefficient packed delta places value T at position 0,
+// the inverse Hadamard fans it to all 16 lanes, and the RSP output is
+// compared against the OMX C reference for each (qp%6, qp/6).
+static const uint8_t LumaDC_VMatrix[6] = { 10, 11, 13, 14, 16, 18 };
+
+static bool lumadc_overflow_one(int16_t T, int qp, int verbose) {
+    static uint8_t  delta_buf[16] __attribute__((aligned(8)));
+    static int16_t  dc_rsp[16]    __attribute__((aligned(8)));
+    static int16_t  dc_ref[16]    __attribute__((aligned(8)));
+
+    memset(delta_buf, 0, sizeof(delta_buf));
+    delta_buf[0] = 0x10 | 0x20;            // 16-bit | last | position 0
+    delta_buf[1] = (uint8_t)(T & 0xFF);
+    delta_buf[2] = (uint8_t)((T >> 8) & 0xFF);
+
+    for (int i = 0; i < 16; i++)
+        dc_rsp[i] = dc_ref[i] = (int16_t)0xDEAD;
+
+    data_cache_hit_writeback_invalidate(delta_buf, sizeof(delta_buf));
+
+    rsph264_queue_set_packed_delta_buffer(0, delta_buf);
+    rsph264_queue_transform_dequant_lumadc(0, dc_rsp, qp);
+    rsph264_sync();
+
+    const uint8_t *p = delta_buf;
+    OMXResult err = omxVCM4P10_TransformDequantLumaDCFromPair(&p, dc_ref, qp);
+    assert(err == OMX_Sts_NoErr);
+
+    for (int i = 0; i < 16; i++) {
+        if (dc_rsp[i] != dc_ref[i]) {
+            if (verbose >= 1) {
+                printf("FAILED qp=%d T=%d lane=%d: rsp=%d ref=%d\n",
+                    qp, T, i, (int)dc_rsp[i], (int)dc_ref[i]);
+            }
+            return false;
+        }
+    }
+    return true;
+}
+
+bool lumadc_overflow_test(int verbose) {
+    // Right-shift paths (qp/6 ∈ {0,1}): only paths where the old
+    // vmudn-based code's s16 truncation flipped T*Scale's sign. One
+    // value past the boundary per qp triggers the bug — that's the
+    // exact failure the symptom report describes (qp=5, Scale=18 →
+    // T=-1821 saturates I_16x16 MBs to luma 0xFF).
+    for (int qp = 0; qp < 12; qp++) {
+        int Scale = LumaDC_VMatrix[qp % 6];
+        int16_t T = -(32767 / Scale) - 1;
+        if (!lumadc_overflow_one(T, qp, verbose)) {
+            printf("FAILED LumaDC overflow case: qp=%d T=%d\n", qp, T);
+            return false;
+        }
+    }
+
+    // Shift-left paths (qp/6 ≥ 2): unaffected by the bug, but the
+    // common.inc rewrite churned surrounding code — one sanity case
+    // per bucket guards against future regressions. T=128 keeps
+    // T*Scale << shift inside s16 for every Scale and shift up to 3.
+    if (!lumadc_overflow_one(128, 12, verbose)) return false; // shift 0
+    if (!lumadc_overflow_one(128, 30, verbose)) return false; // shift 3
+
+    return true;
+}
+
 uint8_t* coeff_buf_decode(uint8_t *src, int16_t *dst) {
     uint8_t flg;
     do {
@@ -1287,6 +1358,13 @@ int main(void)
 
     printf("OMX_TransformDequantLumaDC... "); fflush(stdout);
     exhaustive_dequant_test(&buftest, OMX_LUMADC_4x4, 4*1024, verbose);
+    printf("OK\n");
+
+    printf("OMX_TransformDequantLumaDC overflow boundary... "); fflush(stdout);
+    if (!lumadc_overflow_test(verbose)) {
+        printf("FAILED\n");
+        while(1) {}
+    }
     printf("OK\n");
 
     printf("OMX_TransformDequantChromaDC... "); fflush(stdout);


### PR DESCRIPTION
### Symptom
Some H.264-encoded `lossysprite` images render with luma blown out to 0xFF (white) in macroblocks coded as `Intra_16x16` (mbType 7-30), while neighboring `Intra_4x4` MBs render correctly. Reproduces with low picture-init QPs — anything where `qpY < 12` after slice/MB deltas. The encoded bitstream is correct; this is a decoder bug.

See the new `lumadc_overflow_test` test case in tests/test_h264.c

### Analysis

`TransformDequantLumaDC` in `src/video/rsph264_common.inc` does the post-IHT dequantization step `T*LS [+ round] >> shift` with a 16-bit-truncating multiply:

```asm
vmudn $v00, $v00, $v27,8       # T * LS — truncates product to low 16 bits
...
LumaDCScaleDown1:                # qpY/6 == 1: result = (T*LS + 1) >> 1
    vaddc $v00, $v00, vshift,15
    vsra  $v00, $v00, 1
LumaDCScaleDown2:                # qpY/6 == 0: result = (T*LS + 2) >> 2
    vaddc $v00, $v00, vshift,14
    vsra  $v00, $v00, 2
```

For an I_16x16 DC-mode MB with QP=5 and a single non-zero DC coefficient, the inverse Hadamard fans the value out to all 16 lanes uniformly. With T = -1821 and LS = 18, the product is -32778 — one past INT16_MIN. `vmudn` returns the low 16 bits as +0x7FF6 (= +32758), inverting the sign. The subsequent `+2 >> 2` yields +8190 instead of -8194, which the per-block IDCT then turns into pixels of 0xFF instead of 0x00. The shift-left path (`qpY/6 >= 2`) is unaffected because shift-left preserves the low 16 bits regardless of overflow.

### Proposed fix
Compute `T*LS + round` in full 32-bit signed precision via `vmudh` + `vsar(ACC_HI/MD)`, propagate the carry from the round add into the high half, then repack the low half of the shifted 32-bit result:

```asm
LumaDCScaleDown2:                          # (T*LS + 2) >> 2 in 32-bit
    vxor  $v04, $v04, $v04                 # zero for carry-add
    vmudh $v06, $v00, $v27,8               # ACC = T*LS (signed*signed)
    vsar  $v05, COP2_ACC_HI                # high 16 of product (sign-ext)
    vsar  $v06, COP2_ACC_MD                # low 16 of product
    vaddc $v06, $v06, vshift,14            # low += 2; VCC = unsigned carry
    vadd  $v05, $v05, $v04                 # high += 0 + carry
    vsrl  $v06, $v06, 2                    # low >>= 2 (logical)
    vsll8 $v05, $v05, 14                   # high << (16-2) into low half
    vor   $v00, $v06, $v05                 # repack to 16-bit
```

Same shape for `LumaDCScaleDown1` with shift 1 / round 1. The shift-left path keeps using `vmudn`.