### PR TITLE
[preview] Tend to GHA workflows

### DIFF
--- a/.github/actions/path-diff/action.yml
+++ b/.github/actions/path-diff/action.yml
@@ -10,7 +10,7 @@ inputs:
   paths:
     description: "Paths to compare"
     required: false
-    default: ./Dockerfile ./tools/build-toolchain.sh
+    default: ./Dockerfile ./tools/build-toolchain.sh ./tools/build-gdb.sh
 outputs:
   changed:
     value: ${{ steps.path_change.outputs.exitCode }}

--- a/.github/actions/path-diff/action.yml
+++ b/.github/actions/path-diff/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -22,7 +22,7 @@ jobs:
             unzip
           update: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 
@@ -45,7 +45,7 @@ jobs:
           N64_INST=$(pwd)/gcc-toolchain-mips64 make ${{ matrix.build }}
 
       - name: "Upload ${{ matrix.build }} executables"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}-${{ matrix.build }}
           path: ${{ github.workspace }}/**/tools/**/*.exe

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Using a full fetch so that the diff action can run.
 
@@ -51,12 +51,12 @@ jobs:
       # use from registry o/w
       - name: Set up Docker Build
         if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         if: ${{ steps.path_diff.outputs.changed == 1 }}
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ steps.vars.outputs.repository_name }}
           # latest tag is handled separately
@@ -65,7 +65,7 @@ jobs:
 
       - name: Log in to the container registry
         if: ${{ steps.path_diff.outputs.changed == 1 }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and push image
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           # Only push image if this is a push event. Otherwise it will fail because
           # of permission issues on PRs. Also see https://github.com/DragonMinded/libdragon/issues/230
@@ -91,7 +91,7 @@ jobs:
       # cached, it should not take long to build.
       - name: Load image for libdragon build
         if: ${{ steps.path_diff.outputs.changed == 1}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           # Do not push the image yet, we also want to make sure libdragon builds
           # with the fresh image.
@@ -113,7 +113,7 @@ jobs:
           ./build.sh --test
 
       - name: "Upload built ROMs to artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roms
           path: |
@@ -125,7 +125,7 @@ jobs:
       # build with this freshly built image.
       - name: Push latest image
         if: ${{ steps.path_diff.outputs.changed == 1 && github.ref == steps.vars.outputs.default_ref }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ghcr.io/${{ steps.vars.outputs.repository_name }}:latest

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -173,7 +173,7 @@ jobs:
           Package_Rpm_Architecture: ${{ matrix.rpm-architecture }}
           Package_License: GPL
           Package_Description: MIPS GCC toolchain for the N64
-          Package_Url: https://n64brew.com
+          Package_Url: https://github.com/DragonMinded/libdragon
           Package_Maintainer: N64 Brew Community
 
       - name: Publish Windows-x86_64 Build Artifact

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -74,13 +74,13 @@ jobs:
           fpm --version
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1 # we only require the last check-in, unless we want to create a changelog.
 
       # Cache and restore dependencies instead of downloading them to increase build speed.
       # Expires after 7 days.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           path: |
@@ -178,7 +178,7 @@ jobs:
 
       - name: Publish Windows-x86_64 Build Artifact
         if: ${{ matrix.target-platform == 'Windows-x86_64' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gcc-toolchain-mips64-${{ matrix.target-platform }}
           path: |
@@ -186,7 +186,7 @@ jobs:
 
       - name: Publish Linux-x86_64 Build Artifacts
         if: ${{ matrix.target-platform == 'Linux-x86_64' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gcc-toolchain-mips64-${{ matrix.target-platform }}
           path: |
@@ -195,7 +195,7 @@ jobs:
 
       - name: Publish Linux-aarch64 Build Artifacts
         if: ${{ matrix.target-platform == 'Linux-aarch64' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gcc-toolchain-mips64-${{ matrix.target-platform }}
           path: |
@@ -207,25 +207,25 @@ jobs:
     needs: Build-Toolchain
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Download Windows-x86_64 artifact
         id: download-windows-x86_64-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gcc-toolchain-mips64-Windows-x86_64
           path: ${{ runner.temp }}/gcc-toolchain-mips64-Windows-x86_64
 
       - name: Download Linux-x86_64 artifact
         id: download-linux-x86_64-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gcc-toolchain-mips64-Linux-x86_64
           path: ${{ runner.temp }}/gcc-toolchain-mips64-Linux-x86_64
 
       - name: Download Linux-aarch64 artifact
         id: download-linux-arm64-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gcc-toolchain-mips64-Linux-aarch64
           path: ${{ runner.temp }}/gcc-toolchain-mips64-Linux-aarch64
@@ -268,7 +268,7 @@ jobs:
 
       - name: Generate Release
         if: github.ref == 'refs/heads/trunk'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: false
           prerelease: false


### PR DESCRIPTION
Note these changes should be backported to trunk.

Two fixups, and mostly updating action versions for Node 24 as Node 20 is going away very soon https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Unfortunately the peaceiris/actions-gh-pages action has not been updated by its maintainer to Node 24, maybe it will happen later or we will have to replace it.