### PR TITLE
Workaround/fix -Wextra warnings

### DIFF
--- a/include/audio.h
+++ b/include/audio.h
@@ -106,7 +106,7 @@ void audio_pause(bool pause);
  * write data to.  If all buffers are full, wait until the AI has played back
  * the next buffer in its queue and try writing again.
  */
-volatile int audio_can_write();
+int audio_can_write();
 
 /**
  * @brief Write a chunk of silence

--- a/include/dma.h
+++ b/include/dma.h
@@ -229,7 +229,7 @@ void io_write(pi_addr_t pi_address, uint32_t data);
 bool io_accessible(pi_addr_t pi_address);
 
 __attribute__((deprecated("use dma_wait instead"))) 
-volatile int dma_busy(void);
+int dma_busy(void);
 
 
 #ifdef __cplusplus

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -142,7 +142,10 @@ inline uint16_t color_to_packed16(color_t c) {
 
 /** @brief Convert a #color_t to the 32-bit packed format used by a #FMT_RGBA32 surface (RGBA 8888) */
 inline uint32_t color_to_packed32(color_t c) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     return *(uint32_t*)&c;
+#pragma GCC diagnostic pop
 }
 /** @brief Create a #color_t from the 16-bit packed format used by a #FMT_RGBA16 surface (RGBA 5551) */
 inline color_t color_from_packed16(uint16_t c) {

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -142,10 +142,7 @@ inline uint16_t color_to_packed16(color_t c) {
 
 /** @brief Convert a #color_t to the 32-bit packed format used by a #FMT_RGBA32 surface (RGBA 8888) */
 inline uint32_t color_to_packed32(color_t c) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-    return *(uint32_t*)&c;
-#pragma GCC diagnostic pop
+    return (c.r << 24) | (c.g << 16) | (c.b << 8) | (c.a << 0);
 }
 /** @brief Create a #color_t from the 16-bit packed format used by a #FMT_RGBA16 surface (RGBA 5551) */
 inline color_t color_from_packed16(uint16_t c) {

--- a/include/n64sys.h
+++ b/include/n64sys.h
@@ -777,7 +777,7 @@ void* sys_hw_memset64(void *ptr, uint64_t value, size_t len);
 
 /* Deprecated version of get_ticks */
 __attribute__((deprecated("use get_ticks instead")))
-static inline volatile unsigned long read_count(void) {
+static inline unsigned long read_count(void) {
     return get_ticks();
 }
 /** @endcond */

--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -680,7 +680,6 @@ inline void rdpq_load_tlut_raw(rdpq_tile_t tile, int color_idx, int num_colors)
  */
 inline void rdpq_set_tile_size_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t s1, uint16_t t1)
 {
-    assertf((s0) >= 0 && (t0) >= 0 && (s1) >= 0 && (t1) >= 0, "texture coordinates must be positive");
     assertf((s0) <= 1024*4 && (t0) <= 1024*4 && (s1) <= 1024*4 && (t1) <= 1024*4, "texture coordinates must be smaller than 1024");
 
     extern void __rdpq_write8_syncchange(uint32_t, uint32_t, uint32_t, uint32_t);
@@ -1013,7 +1012,7 @@ inline void rdpq_set_prim_color(color_t color)
 inline void rdpq_set_detail_factor(float value)
 {
     // NOTE: this does not require a pipe sync
-    int8_t conv = (1.0 - value) * 31;
+    int8_t conv = (1.0f - value) * 31;
     extern void __rdpq_fixup_write8_syncchange(uint32_t, uint32_t, uint32_t, uint32_t);
     __rdpq_fixup_write8_syncchange(RDPQ_CMD_SET_PRIM_COLOR_COMPONENT, ((conv & 0x1F) << 8) | (2<<16), 0, 0);
 }

--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -680,6 +680,7 @@ inline void rdpq_load_tlut_raw(rdpq_tile_t tile, int color_idx, int num_colors)
  */
 inline void rdpq_set_tile_size_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t s1, uint16_t t1)
 {
+    assertf((s0) >= 0 && (t0) >= 0 && (s1) >= 0 && (t1) >= 0, "texture coordinates must be positive");
     assertf((s0) <= 1024*4 && (t0) <= 1024*4 && (s1) <= 1024*4 && (t1) <= 1024*4, "texture coordinates must be smaller than 1024");
 
     extern void __rdpq_write8_syncchange(uint32_t, uint32_t, uint32_t, uint32_t);

--- a/src/GL/gl_internal.h
+++ b/src/GL/gl_internal.h
@@ -18,7 +18,7 @@
 #include "../rdpq/rdpq_internal.h"
 #include "rdpq_tri.h"
 
-#define RADIANS(x) ((x) * M_PI / 180.0f)
+#define RADIANS(x) ((x) * (float)M_PI / 180.0f)
 
 #define CLAMP01(x) CLAMP((x), 0, 1)
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -252,7 +252,7 @@ void mixer_ch_set_freq(int ch, float frequency) {
 	assertf(frequency >= 0, "cannot set negative frequency on channel %d: %f", ch, frequency);
 	// Check if the frequency is within the configured limit. Allow for a 1% margin because of rounding errors
 	// for default maximum frequency being the output sample rate converted from fixed point.
-	assertf(frequency <= Mixer.limits[ch].max_frequency*1.01, "frequency %.1f exceeds configured limit %.1f on channel %d; use mixer_ch_set_limit to change the limit for this channel", frequency, Mixer.limits[ch].max_frequency, ch);
+	assertf(frequency <= Mixer.limits[ch].max_frequency*1.01f, "frequency %.1f exceeds configured limit %.1f on channel %d; use mixer_ch_set_limit to change the limit for this channel", frequency, Mixer.limits[ch].max_frequency, ch);
 	c->step = MIXER_FX64(frequency / (float)Mixer.sample_rate) << (c->flags & CH_FLAGS_BPS_SHIFT);
 }
 

--- a/src/audio/opus/fixed_generic.h
+++ b/src/audio/opus/fixed_generic.h
@@ -72,10 +72,10 @@
 #endif
 
 /** Compile-time conversion of float constant to 16-bit value */
-#define QCONST16(x,bits) ((opus_val16)(.5+(x)*(((opus_val32)1)<<(bits))))
+#define QCONST16(x,bits) ((opus_val16)(.5f+(x)*(((opus_val32)1)<<(bits))))
 
 /** Compile-time conversion of float constant to 32-bit value */
-#define QCONST32(x,bits) ((opus_val32)(.5+(x)*(((opus_val32)1)<<(bits))))
+#define QCONST32(x,bits) ((opus_val32)(.5f+(x)*(((opus_val32)1)<<(bits))))
 
 /** Negate a 16-bit value */
 #define NEG16(x) (-(x))

--- a/src/profile.c
+++ b/src/profile.c
@@ -173,7 +173,7 @@ void profile_dump(void) {
 		strcpy(n, slots[i].name);
 		
 		uint32_t mean = slots[i].ticks / frames;
-	    float partial_avg = (float)mean * 100.0 / (float)frame_avg_wall;
+	    float partial_avg = (float)mean * 100.0f / (float)frame_avg_wall;
 		int cache_misses = slots[i].cache_misses / frames;
 		float cache_miss_rate = 0.0f;
 		if (slots[i].cache_hits + slots[i].cache_misses > 0) {

--- a/src/rdpq/rdpq_tri.c
+++ b/src/rdpq/rdpq_tri.c
@@ -508,10 +508,10 @@ void rdpq_triangle_rsp(const rdpq_trifmt_t *fmt, const float *v1, const float *v
         int32_t rgba = 0;
         if (fmt->shade_offset >= 0) {
             const float *v_shade = fmt->shade_flat ? v1 : v;
-            uint32_t r = v_shade[fmt->shade_offset+0] * 255.0;
-            uint32_t g = v_shade[fmt->shade_offset+1] * 255.0;
-            uint32_t b = v_shade[fmt->shade_offset+2] * 255.0;
-            uint32_t a = v_shade[fmt->shade_offset+3] * 255.0;
+            uint32_t r = v_shade[fmt->shade_offset+0] * 255.0f;
+            uint32_t g = v_shade[fmt->shade_offset+1] * 255.0f;
+            uint32_t b = v_shade[fmt->shade_offset+2] * 255.0f;
+            uint32_t a = v_shade[fmt->shade_offset+3] * 255.0f;
             rgba = (r << 24) | (g << 16) | (b << 8) | a;
         }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,7 +28,10 @@
 /** @brief Round n down to the previous multiple of d */
 #define ROUND_DOWN(n, d) ({ \
     typeof(n) _n = n; typeof(d) _d = d; \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wtype-limits\"") \
     ((_n >= 0) ? ((_n) / (_d) * (_d)) : -(((-_n + (_d) - 1) / (_d)) * (_d))); \
+    _Pragma("GCC diagnostic pop") \
 })
 
 /** @brief Return the ceil of n/d */

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,10 +28,7 @@
 /** @brief Round n down to the previous multiple of d */
 #define ROUND_DOWN(n, d) ({ \
     typeof(n) _n = n; typeof(d) _d = d; \
-    _Pragma("GCC diagnostic push") \
-    _Pragma("GCC diagnostic ignored \"-Wtype-limits\"") \
     ((_n >= 0) ? ((_n) / (_d) * (_d)) : -(((-_n + (_d) - 1) / (_d)) * (_d))); \
-    _Pragma("GCC diagnostic pop") \
 })
 
 /** @brief Return the ceil of n/d */


### PR DESCRIPTION
Most changes are required for me to build tiny3d, which uses `-Wextra -Wdouble-promotion`
https://discord.com/channels/205520502922543113/1262534624689651832/1503307355197280337

Note I'm using an older toolchain. I assume recent toolchains don't exhibit this problem

The changes in .c files were not required, but while I was at it...

I will point out the debatable changes in a self-review. But something should be picked between
- merging this PR to libdragon
- removing `-Wextra -Wdouble-promotion` from tiny3d and fixing `-Wstrict-aliasing` in `color_to_packed32`
- not supporting older toolchains