### PR TITLE
allow bypassing the rsp to prevent overlay switching when using other overlays

### DIFF
--- a/include/coroutine.h
+++ b/include/coroutine.h
@@ -61,7 +61,7 @@ void coro_yield(void);
  * try to execute the function via coro_resume.
  * 
  * This function should be preferred over spin-waiting inside the coroutine,
- * since it avoids a context switch alltogether if the time has not passed yet.
+ * since it avoids a context switch altogether if the time has not passed yet.
  * 
  * @param ticks minimum time to wait in ticks
  */

--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -1464,9 +1464,9 @@ inline void rdpq_set_other_modes_raw(uint64_t mode)
  * This function enqueues a command directly to the RDP to set the other modes register.
  * 
  * Like rdpq_set_other_modes_raw this function requires a good knowledge of the
- * RDP. Calls that modify values stored in other modes wiil undo changes made
+ * RDP. Calls that modify values stored in other modes will undo changes made
  * using this function as the rdpq overlay will not be aware of calls made to 
- * this function becuase it skips the RSP alltogether
+ * this function because it skips the RSP alltogether
  * 
  * @note If possible, prefer using the RDPQ mode API (defined in rdpq_mode.h),
  * that expose a higher level API for changing the RDP modes

--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -1267,9 +1267,10 @@ inline void rdpq_set_texture_image_raw(uint8_t index, uint32_t offset, tex_forma
     assertf(height <= 1024, "Texture height out of range [1,1024]: %d", height);
     assertf(index <= 15, "Lookup address index out of range [0,15]: %d", index);
     extern void __rdpq_fixup_write8_syncchange(uint32_t, uint32_t, uint32_t, uint32_t);
+    extern void __rdpq_write8_syncchange(uint32_t cmd_id, uint32_t arg0, uint32_t arg1, uint32_t autosync);
     // NOTE: we also encode the texture height in the command (split in two halves...)
     // to help the validator to a better job. The RDP hardware ignores those bits.
-    __rdpq_fixup_write8_syncchange(RDPQ_CMD_SET_TEXTURE_IMAGE,
+    (index == 0 ? __rdpq_write8_syncchange : __rdpq_fixup_write8_syncchange)(RDPQ_CMD_SET_TEXTURE_IMAGE,
         _carg(format, 0x1F, 19) | _carg(width-1, 0x3FF, 0) | _carg(height-1, 0x1FF, 10),
         _carg(index, 0xF, 26) | (offset & 0x1FFFFFF) | _carg((height-1)>>9, 0x1, 31),
         AUTOSYNC_PIPE);
@@ -1455,6 +1456,29 @@ inline void rdpq_set_other_modes_raw(uint64_t mode)
     __rdpq_set_other_modes(
         (mode >> 32) & 0x00FFFFFF,
         mode & 0xFFFFFFFF);
+}
+
+/**
+ * @brief Directly set the other modes register in the RDP.
+ * 
+ * This function enqueues a command directly to the RDP to set the other modes register.
+ * 
+ * Like rdpq_set_other_modes_raw this function requires a good knowledge of the
+ * RDP. Calls that modify values stored in other modes wiil undo changes made
+ * using this function as the rdpq overlay will not be aware of calls made to 
+ * this function becuase it skips the RSP alltogether
+ * 
+ * @note If possible, prefer using the RDPQ mode API (defined in rdpq_mode.h),
+ * that expose a higher level API for changing the RDP modes
+ * 
+ * @param      mode     The new render mode. See the RDP_RM
+ */
+inline void rdpq_set_other_modes_unsafe(uint64_t mode) {
+    extern void __rdpq_write8_syncchange(uint32_t cmd_id, uint32_t arg0, uint32_t arg1, uint32_t autosync);
+    __rdpq_write8_syncchange(RDPQ_CMD_SET_OTHER_MODES,
+        (mode >> 32) & 0x00FFFFFF,
+        mode & 0xFFFFFFFF,
+        AUTOSYNC_PIPE);   
 }
 
 /**

--- a/include/rdpq.h
+++ b/include/rdpq.h
@@ -1466,7 +1466,7 @@ inline void rdpq_set_other_modes_raw(uint64_t mode)
  * Like rdpq_set_other_modes_raw this function requires a good knowledge of the
  * RDP. Calls that modify values stored in other modes will undo changes made
  * using this function as the rdpq overlay will not be aware of calls made to 
- * this function because it skips the RSP alltogether
+ * this function because it skips the RSP altogether
  * 
  * @note If possible, prefer using the RDPQ mode API (defined in rdpq_mode.h),
  * that expose a higher level API for changing the RDP modes

--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -1259,6 +1259,7 @@ extern inline void rdpq_load_block_linear(int32_t offset, void *buffer, uint16_t
 extern inline void rdpq_load_tile_fx(rdpq_tile_t tile, uint16_t s0, uint16_t t0, uint16_t s1, uint16_t t1);
 extern inline void rdpq_set_combiner_raw(uint64_t cc);
 extern inline void rdpq_set_other_modes_raw(uint64_t mode);
+extern inline void rdpq_set_other_modes_unsafe(uint64_t mode);
 extern inline void rdpq_change_other_modes_raw(uint64_t mask, uint64_t val);
 extern inline void rdpq_set_color_image_raw(uint8_t index, uint32_t offset, tex_format_t format, uint32_t width, uint32_t height, uint32_t stride);
 extern inline void rdpq_set_z_image_raw(uint8_t index, uint32_t offset);


### PR DESCRIPTION
It is costly to switch overlays anytime you need to change a register in the rdp when using an overlay like tiny3d. If a material edit requires changing the other modes, such as blending mode changes, zmode changes, ect. It would require switching to the rdpq overlay to make that change. rdpq would also get invovled to change the image texture even if you arent using placeholders. This change aims to fix both of these by providing

rdpq_set_other_modes_unsafe - to directly modify the other modes register bypassing the rsp rdpq_set_texture_image_raw - modify it so if index 0 is used, it bypasses the rsp

These two changes open up the possibility for more effecient material changes to be implemented when using libdragon