### PR TITLE
Prefer brew's python3 in build-gdb on macOS

### DIFF
--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -73,14 +73,14 @@ test -d "$BUILD_PATH/gdb-$GDB_V"           || tar -xzf "$DOWNLOAD_PATH/gdb-$GDB_
 
 # Resolve dependencies on macOS via homebrew
 if [[ $OSTYPE == 'darwin'* ]]; then
-    # Tell GDB configure to use Homebrew's GMP, MPFR, MPC, and Zlib.
+    # Tell GDB configure to use Homebrew's Python, GMP, MPFR, MPC, and Zlib.
     # These should have already been installed by build-toolchain.sh
     GDB_CONFIGURE_ARGS=(
         "--with-gmp=$(brew --prefix gmp)"
         "--with-mpfr=$(brew --prefix mpfr)"
         "--with-mpc=$(brew --prefix libmpc)"
         "--with-isl=$(brew --prefix isl)"
-        "--with-python=python3"
+        "--with-python=$(brew --prefix python3)/bin/python3"
         "--with-system-zlib"
     )
 elif [ "$N64_HOST" == "x86_64-w64-mingw32" ]; then


### PR DESCRIPTION
Fixes an issue where build-gdb.sh fails to find python3 in some cases ([as reported in #libdragon-dev Discord chat](https://discord.com/channels/205520502922543113/974342113850445874/1509224246482833659))

Since we already install python3 with brew in build-toolchain.sh, and we already point the other dependencies at brew-prefixed paths, this just puts python3 in line with the others.