### PR TITLE
Fix mkasset --help for -w long option

### DIFF
--- a/tools/mkasset/mkasset.c
+++ b/tools/mkasset/mkasset.c
@@ -35,7 +35,7 @@ void print_args(char * name)
     fprintf(stderr, "   -v/--verbose            Verbose output\n");
     fprintf(stderr, "   -o/--output <dir>       Specify output directory (default: .)\n");
     fprintf(stderr, "   -c/--compress <algo>    Compression level 0-%d (default: %d)\n", MAX_COMPRESSION, DEFAULT_COMPRESSION);
-    fprintf(stderr, "   -w/--winsize <window>   Maximum size of the matching window in KiB. (default: %d)\n", DEFAULT_WINSIZE_STREAMING/1024);
+    fprintf(stderr, "   -w/--window <window>    Maximum size of the matching window in KiB. (default: %d)\n", DEFAULT_WINSIZE_STREAMING/1024);
     fprintf(stderr, "\nSupported window sizes: 2, 4, 8, 16, 32, 64, 128, 256\n");
     fprintf(stderr, "The window size affects the memory used by asset_fopen() only.\n");
     fprintf(stderr, "If you only use asset_load(), use the biggest window (256 KiB) to improve ratio.\n");


### PR DESCRIPTION
The implementation expects `--window`, not `--winsize`