### PR TITLE
Fix fm_mat[34]_scale

### DIFF
--- a/include/fgeom.h
+++ b/include/fgeom.h
@@ -341,9 +341,9 @@ inline void fm_mat4_identity(fm_mat4_t *out)
  */
 inline void fm_mat4_scale(fm_mat4_t *out, const fm_vec3_t *scale)
 {
-    for (int i=0; i<4; i++) out->m[0][i] *= scale->x;
-    for (int i=0; i<4; i++) out->m[1][i] *= scale->y;
-    for (int i=0; i<4; i++) out->m[2][i] *= scale->z;
+    for (int i=0; i<4; i++) out->m[i][0] *= scale->x;
+    for (int i=0; i<4; i++) out->m[i][1] *= scale->y;
+    for (int i=0; i<4; i++) out->m[i][2] *= scale->z;
 }
 
 /**

--- a/include/fgeom2d.h
+++ b/include/fgeom2d.h
@@ -177,8 +177,8 @@ inline void fm_mat3_identity(fm_mat3_t *out)
  */
 inline void fm_mat3_scale(fm_mat3_t *out, const fm_vec2_t *scale)
 {
-    for (int i=0; i<3; i++) out->m[0][i] *= scale->x;
-    for (int i=0; i<3; i++) out->m[1][i] *= scale->y;
+    for (int i=0; i<3; i++) out->m[i][0] *= scale->x;
+    for (int i=0; i<3; i++) out->m[i][1] *= scale->y;
 }
 
 /**


### PR DESCRIPTION
This brings the matrix _scale functions behavior in line with other functions:
All functions apply transformations to the input matrix in a way that is equivalent to multiplying the elementary transform matrix to the left of the input matrix.

If you're not convinced you can try this code which exhibits the bug:

<details>

```c
#include "fgeom2d.h"
#include <libdragon.h>

char buf[1024];

char *mat3_str(fm_mat3_t *mat) {
  sprintf(buf,
          "%f %f %f\n"
          "%f %f %f\n"
          "%f %f %f\n",
          mat->m[0][0], mat->m[1][0], mat->m[2][0], mat->m[0][1], mat->m[1][1],
          mat->m[2][1], mat->m[0][2], mat->m[1][2], mat->m[2][2]);
  return buf;
}

inline void fm_mat3_scale_fixed(fm_mat3_t *out, const fm_vec2_t *scale)
{
    for (int i=0; i<3; i++) out->m[i][0] *= scale->x;
    for (int i=0; i<3; i++) out->m[i][1] *= scale->y;
}

int main() {
  debug_init_emulog();

  fm_vec2_t scale = {{2.0f, 4.0f}};
  float rotation = 0.1f;
  fm_vec2_t translate = {{10.0f, 100.0f}};
  fm_mat3_t mtx_ini, srt, s, r, t, srt_mul, srt_stack, srt_stack_fixed;

  fm_mat3_identity(&mtx_ini);
  fm_mat3_from_rotation(&mtx_ini, 0.2f);

  fm_mat3_from_srt(&srt, &scale, rotation, &translate);
  fm_mat3_mul(&srt, &srt, &mtx_ini);

  fm_mat3_from_scale(&s, &scale);
  fm_mat3_from_rotation(&r, rotation);
  fm_mat3_from_translation(&t, &translate);

  srt_mul = mtx_ini;
  fm_mat3_mul(&srt_mul, &s, &srt_mul);
  fm_mat3_mul(&srt_mul, &r, &srt_mul);
  fm_mat3_mul(&srt_mul, &t, &srt_mul);

  srt_stack = mtx_ini;
  fm_mat3_scale(&srt_stack, &scale);
  fm_mat3_rotate(&srt_stack, rotation);
  fm_mat3_translate(&srt_stack, &translate);

  srt_stack_fixed = mtx_ini;
  fm_mat3_scale_fixed(&srt_stack_fixed, &scale);
  fm_mat3_rotate(&srt_stack_fixed, rotation);
  fm_mat3_translate(&srt_stack_fixed, &translate);

  debugf("srt =\n%s\n", mat3_str(&srt));
  debugf("s =\n%s\n", mat3_str(&s));
  debugf("r =\n%s\n", mat3_str(&r));
  debugf("t =\n%s\n", mat3_str(&t));
  debugf("srt_mul =\n%s\n", mat3_str(&srt_mul));
  debugf("srt_stack =\n%s\n", mat3_str(&srt_stack));
  debugf("srt_stack_fixed =\n%s\n", mat3_str(&srt_stack_fixed));
}
```

Output:

```
srt =
1.871005 0.786727 10.000000
-0.986394 3.861014 100.000000
0.000000 0.000000 1.000000

s =
2.000000 0.000000 0.000000
0.000000 4.000000 0.000000
0.000000 0.000000 1.000000

r =
0.995004 0.099833 0.000000
-0.099833 0.995004 0.000000
0.000000 0.000000 1.000000

t =
1.000000 0.000000 10.000000
0.000000 1.000000 100.000000
0.000000 0.000000 1.000000

srt_mul =
1.871005 0.786727 10.000000
-0.986394 3.861014 100.000000
0.000000 0.000000 1.000000

srt_stack =
1.910673 1.182081 10.000000
-0.591040 3.821346 100.000000
0.000000 0.000000 1.000000

srt_stack_fixed =
1.871005 0.786727 10.000000
-0.986394 3.861014 100.000000
0.000000 0.000000 1.000000
```

</details>

notice how srt_stack is wrong compared to both srt and srt_mul, and how it's correct with using `fm_mat3_scale_fixed`