### PR TITLE
Fix apultra safe_dist under-reporting for multi-block inputs

### DIFF
--- a/tools/common/apultra/shrink.c
+++ b/tools/common/apultra/shrink.c
@@ -1058,7 +1058,7 @@ static int apultra_reduce_commands(apultra_compressor *pCompressor, const unsign
  *
  * @return size of compressed data in output buffer, or -1 if the data is uncompressible
  */
-static int apultra_write_block(apultra_compressor *pCompressor, const apultra_final_match *pBestMatch, const unsigned char *pInWindow, const int nStartOffset, const int nEndOffset, unsigned char *pOutData, const int nMaxOutDataSize, int *nCurBitsOffset, int *nCurBitShift, int *nFollowsLiteral, int *nCurRepMatchOffset, const int nBlockFlags) {
+static int apultra_write_block(apultra_compressor *pCompressor, const apultra_final_match *pBestMatch, const unsigned char *pInWindow, const int nStartOffset, const int nEndOffset, unsigned char *pOutData, const int nMaxOutDataSize, int *nCurBitsOffset, int *nCurBitShift, int *nFollowsLiteral, int *nCurRepMatchOffset, const int nBlockFlags, const int nPriorDelta) {
    int i;
    int nRepMatchOffset = *nCurRepMatchOffset;
    int nCurFollowsLiteral = *nFollowsLiteral;
@@ -1203,7 +1203,7 @@ static int apultra_write_block(apultra_compressor *pCompressor, const apultra_fi
          nCurFollowsLiteral = 1;
       }
 
-      const int nCurSafeDist = (i - nStartOffset) - nOutOffset;
+      const int nCurSafeDist = nPriorDelta + (i - nStartOffset) - nOutOffset;
       if (nCurSafeDist >= 0 && pCompressor->stats.safe_dist < nCurSafeDist)
          pCompressor->stats.safe_dist = nCurSafeDist;
    }
@@ -1219,7 +1219,7 @@ static int apultra_write_block(apultra_compressor *pCompressor, const apultra_fi
       pCompressor->stats.num_eod++;
       pCompressor->stats.commands_divisor++;
 
-      const int nCurSafeDist = (i - nStartOffset) - nOutOffset;
+      const int nCurSafeDist = nPriorDelta + (i - nStartOffset) - nOutOffset;
       if (nCurSafeDist >= 0 && pCompressor->stats.safe_dist < nCurSafeDist)
          pCompressor->stats.safe_dist = nCurSafeDist;
    }
@@ -1247,7 +1247,7 @@ static int apultra_write_block(apultra_compressor *pCompressor, const apultra_fi
  *
  * @return size of compressed data in output buffer, or -1 if the data is uncompressible
  */
-static int apultra_optimize_and_write_block(apultra_compressor *pCompressor, const unsigned char *pInWindow, const int nPreviousBlockSize, const int nInDataSize, unsigned char *pOutData, const int nMaxOutDataSize, int *nCurBitsOffset, int *nCurBitShift, int *nCurFollowsLiteral, int *nCurRepMatchOffset, const int nBlockFlags) {
+static int apultra_optimize_and_write_block(apultra_compressor *pCompressor, const unsigned char *pInWindow, const int nPreviousBlockSize, const int nInDataSize, unsigned char *pOutData, const int nMaxOutDataSize, int *nCurBitsOffset, int *nCurBitShift, int *nCurFollowsLiteral, int *nCurRepMatchOffset, const int nBlockFlags, const int nPriorDelta) {
    const int nEndOffset = nPreviousBlockSize + nInDataSize;
    const int nArrivalsPerPosition = pCompressor->max_arrivals;
    int *rle_len = (int*)pCompressor->intervals /* reuse */;
@@ -1441,7 +1441,7 @@ static int apultra_optimize_and_write_block(apultra_compressor *pCompressor, con
 
    /* Write compressed block */
 
-   return apultra_write_block(pCompressor, pCompressor->best_match - nPreviousBlockSize, pInWindow, nPreviousBlockSize, nEndOffset, pOutData, nMaxOutDataSize, nCurBitsOffset, nCurBitShift, nCurFollowsLiteral, nCurRepMatchOffset, nBlockFlags);
+   return apultra_write_block(pCompressor, pCompressor->best_match - nPreviousBlockSize, pInWindow, nPreviousBlockSize, nEndOffset, pOutData, nMaxOutDataSize, nCurBitsOffset, nCurBitShift, nCurFollowsLiteral, nCurRepMatchOffset, nBlockFlags, nPriorDelta);
 }
 
 /* Forward declaration */
@@ -1615,7 +1615,7 @@ static void apultra_compressor_destroy(apultra_compressor *pCompressor) {
  *
  * @return size of compressed data in output buffer, or -1 if the data is uncompressible
  */
-static int apultra_compressor_shrink_block(apultra_compressor *pCompressor, const unsigned char *pInWindow, const int nPreviousBlockSize, const int nInDataSize, unsigned char *pOutData, const int nMaxOutDataSize, int *nCurBitsOffset, int *nCurBitShift, int *nCurFollowsLiteral, int *nCurRepMatchOffset, const int nBlockFlags) {
+static int apultra_compressor_shrink_block(apultra_compressor *pCompressor, const unsigned char *pInWindow, const int nPreviousBlockSize, const int nInDataSize, unsigned char *pOutData, const int nMaxOutDataSize, int *nCurBitsOffset, int *nCurBitShift, int *nCurFollowsLiteral, int *nCurRepMatchOffset, const int nBlockFlags, const int nPriorDelta) {
    int nCompressedSize;
 
    if (apultra_build_suffix_array(pCompressor, pInWindow, nPreviousBlockSize + nInDataSize))
@@ -1626,7 +1626,7 @@ static int apultra_compressor_shrink_block(apultra_compressor *pCompressor, cons
       }
       apultra_find_all_matches(pCompressor, NMATCHES_PER_INDEX, nPreviousBlockSize, nPreviousBlockSize + nInDataSize, nBlockFlags);
 
-      nCompressedSize = apultra_optimize_and_write_block(pCompressor, pInWindow, nPreviousBlockSize, nInDataSize, pOutData, nMaxOutDataSize, nCurBitsOffset, nCurBitShift, nCurFollowsLiteral, nCurRepMatchOffset, nBlockFlags);
+      nCompressedSize = apultra_optimize_and_write_block(pCompressor, pInWindow, nPreviousBlockSize, nInDataSize, pOutData, nMaxOutDataSize, nCurBitsOffset, nCurBitShift, nCurFollowsLiteral, nCurRepMatchOffset, nBlockFlags, nPriorDelta);
    }
 
    return nCompressedSize;
@@ -1716,8 +1716,14 @@ size_t apultra_compress(const unsigned char *pInputData, unsigned char *pOutBuff
 
          if ((nOriginalSize + nInDataSize) >= nInputSize)
             nBlockFlags |= 2;
+         /* Prior cumulative (decoder-output − decoder-input) at the start
+          * of this block. Used by safe_dist accounting so it sees the
+          * GLOBAL output-vs-input lead, not just the per-block local delta.
+          * Dictionary bytes are not emitted by the decoder, so they're
+          * excluded from the input side. */
+         const int nPriorDelta = (nOriginalSize - (int)nDictionarySize) - nCompressedSize;
          nOutDataSize = apultra_compressor_shrink_block(&compressor, pInputData + nOriginalSize - nPreviousBlockSize, nPreviousBlockSize, nInDataSize, pOutBuffer + nCompressedSize, nOutDataEnd,
-            &nCurBitsOffset, &nCurBitShift, &nCurFollowsLiteral, &nCurRepMatchOffset, nBlockFlags);
+            &nCurBitsOffset, &nCurBitShift, &nCurFollowsLiteral, &nCurRepMatchOffset, nBlockFlags, nPriorDelta);
          nBlockFlags &= (~1);
 
          if (nOutDataSize >= 0) {


### PR DESCRIPTION
### Problem

For inputs larger than `BLOCK_SIZE` (1 MiB), `apultra_compress` can write a `stats.safe_dist` that is too small for safe in-place decompression. Consumers that size their in-place buffer from `safe_dist` (e.g., `bufsize = orig_size + (safe_dist + cmp_size - orig_size)`) will see the decoder's output pointer overtake the unread compressed input, corrupting subsequent reads.

The bitstream itself is valid — streaming/non-in-place decoders decode correctly. Only in-place decoders are affected, and only on multi-block inputs.

### Symptom

libdragon's `mkasset -c 2` (vendored apultra) on a 2,282,582-byte input produced `cmp_size = 1,621,797`, `safe_dist = 660,785` (i.e. emitted `inplace_margin = 0`). libdragon's in-place asm decoder returned at byte 1,619,454 (premature accidental EOS in corrupted-input territory). Traced byte-exact decode showed the actual worst-case (`output_pos − input_pos`) reached ~672,860  (`safe_dist` was under-reported by ~12 KB).

### Root cause

In apultra_write_block:
```c
const int nCurSafeDist = (i - nStartOffset) - nOutOffset;
if (nCurSafeDist >= 0 && pCompressor->stats.safe_dist < nCurSafeDist)
   pCompressor->stats.safe_dist = nCurSafeDist;
```

- `i - nStartOffset` is bytes consumed from the current block's input.
- `nOutOffset` is bytes written to the current block's output (reset to 0 at the top of `apultra_write_block`; `pOutData` is already advanced by the caller).

So `nCurSafeDist` measures the per-block local lead of output over input. For a single-block compression the local lead equals the global lead and the bug is invisible. For multi-block compression the local lead resets to 0 at each block boundary but the global lead, which is what an in-place decoder actually experiences, does not. The accumulated lead from earlier blocks is lost.

Concretely, if block 0 finishes with `delta_0_end = block_0_input − block_0_output` bytes of lead, then during block 1 the actual global_delta is `delta_0_end + local_block_1_delta`. `stats.safe_dist` misses the `delta_0_end` term and any later additions.

### Fix

Thread nPriorDelta — the cumulative (decoder-output − decoder-input) at block start — through `apultra_compressor_shrink_block` → `apultra_optimize_and_write_block` → `apultra_write_block`, and add it to `nCurSafeDist`. The top-level loop in `apultra_compress` already has the cumulative `nOriginalSize` and `nCompressedSize`, so the value is just:
```c
const int nPriorDelta = (nOriginalSize - (int)nDictionarySize) - nCompressedSize;
```
Dictionary bytes are not emitted by the decoder, so they're excluded from the input side.

Also submitted upstream as https://github.com/emmanuel-marty/apultra/pull/26