### PR TITLE
examples: Make sure all examples' Makefiles clean up their DFS files

### DIFF
--- a/examples/audioplayer/Makefile
+++ b/examples/audioplayer/Makefile
@@ -48,7 +48,7 @@ audioplayer.z64: N64_ROM_TITLE="Audio Player"
 audioplayer.z64: $(BUILD_DIR)/audioplayer.dfs
 
 clean:
-	rm -rf $(BUILD_DIR) audioplayer.z64
+	rm -rf $(BUILD_DIR) audioplayer.z64 filesystem
 
 -include $(wildcard $(BUILD_DIR)/*.d)
 

--- a/examples/customfont/Makefile
+++ b/examples/customfont/Makefile
@@ -20,7 +20,7 @@ $(BUILD_DIR)/customfont.dfs: filesystem/libdragon-font.sprite
 $(BUILD_DIR)/customfont.elf: $(OBJS)
 
 clean:
-	rm -rf $(BUILD_DIR) *.z64
+	rm -rf $(BUILD_DIR) *.z64 filesystem
 .PHONY: clean
 
 -include $(DEPS)

--- a/examples/rdpqdemo/Makefile
+++ b/examples/rdpqdemo/Makefile
@@ -33,7 +33,7 @@ rdpqdemo.z64: N64_ROM_TITLE="RSPQ Demo"
 rdpqdemo.z64: $(BUILD_DIR)/rdpqdemo.dfs 
 
 clean:
-	rm -rf $(BUILD_DIR) rdpqdemo.z64
+	rm -rf $(BUILD_DIR) rdpqdemo.z64 filesystem
 
 -include $(wildcard $(BUILD_DIR)/*.d)
 

--- a/examples/spriteanim/Makefile
+++ b/examples/spriteanim/Makefile
@@ -24,7 +24,7 @@ spriteanim.z64: N64_ROM_TITLE="Sprite Anim Demo"
 spriteanim.z64: $(BUILD_DIR)/spriteanim.dfs 
 
 clean:
-	rm -rf $(BUILD_DIR) spriteanim.z64
+	rm -rf $(BUILD_DIR) spriteanim.z64 filesystem
 
 -include $(wildcard $(BUILD_DIR)/*.d)
 

--- a/examples/videoplayer/Makefile
+++ b/examples/videoplayer/Makefile
@@ -3,7 +3,7 @@ include $(N64_INST)/include/n64.mk
 
 MOVIE_FILE=caminandes.ogv
 MOVIE_URL=https://archive.org/download/CaminandesLlamigos/Caminandes_%20Llamigos-1080p.ogv
-DFS_FILES=filesystem/caminandes.h264
+DFS_FILES=filesystem/caminandes.h264 filesystem/caminandes.wav64 filesystem/caminandes.seek
 
 src = videoplayer.c
 
@@ -52,6 +52,8 @@ filesystem/caminandes.h264: $(MOVIE_FILE)
 		touch "$@" ; \
 	fi
 
+filesystem/caminandes.wav64: filesystem/caminandes.h264
+filesystem/caminandes.seek: filesystem/caminandes.h264
 
 # Download the movie file if wget or curl is available and it isn't already downloaded
 $(MOVIE_FILE):

--- a/examples/vifx/Makefile
+++ b/examples/vifx/Makefile
@@ -19,7 +19,7 @@ $(BUILD_DIR)/vifx.dfs: $(assets_conv)
 $(BUILD_DIR)/vifx.elf: $(OBJS)
 
 clean:
-	rm -rf $(BUILD_DIR) *.z64
+	rm -rf $(BUILD_DIR) *.z64 filesystem
 .PHONY: clean
 
 -include $(wildcard $(BUILD_DIR)/*.d)


### PR DESCRIPTION
Currently some of the examples do not delete converted files in their `filesystem` directories when you run `make clean`. This can cause problems because of stale assets built with old tool versions in your local libdragon copy if you've built the examples a long time ago. Here's a small PR to fix that.