### PR TITLE
Add mixer support for folding stereo into mono

### DIFF
--- a/examples/mixertest/mixertest.c
+++ b/examples/mixertest/mixertest.c
@@ -34,6 +34,7 @@ int main(void) {
 	wav64_set_loop(sfx_monosample, true);
 
 	bool music = false;
+	bool force_mono = false;
 	int music_frequency = sfx_monosample->wave.frequency;
 
 	while (1) {
@@ -45,6 +46,9 @@ int main(void) {
 		graphics_draw_text(disp, 50, 70, "B - Play laser (keep pressed)");
 		graphics_draw_text(disp, 50, 80, "Z - Start / stop background music");
 		graphics_draw_text(disp, 70, 90, "L/R - Change music frequency");
+		graphics_draw_text(disp, 50, 100, "C-Left / C-Right - Cannon panned hard L/R");
+		graphics_draw_text(disp, 50, 110, "C-Up - Toggle force mono");
+		graphics_draw_text(disp, 50, 120, force_mono ? "Output: MONO" : "Output: STEREO");
 		graphics_draw_text(disp, 50, 140, "Music courtesy of MishtaLu / indiegamemusic.com");
 		display_show(disp);
 
@@ -53,10 +57,32 @@ int main(void) {
 
 		if (ckeys.a) {
 			wav64_play(sfx_cannon, CHANNEL_SFX1);
+			// Restore centered vol — C-Left/C-Right leave SFX1's
+			// stored vol hard-panned, and mixer_ch_play does not
+			// reset it.
+			mixer_ch_set_vol(CHANNEL_SFX1, 1.0f, 1.0f);
 		}
 		if (ckeys.b) {
 			wav64_play(sfx_laser, CHANNEL_SFX2);
 			mixer_ch_set_vol(CHANNEL_SFX2, 0.25f, 0.25f);
+		}
+		if (ckeys.c_left) {
+			// Hard-pan to the left so the force-mono toggle has an audible
+			// effect: with it off, the cannon only hits the left speaker;
+			// with it on, it splits across both at half amplitude.
+			wav64_play(sfx_cannon, CHANNEL_SFX1);
+			mixer_ch_set_vol(CHANNEL_SFX1, 1.0f, 0.0f);
+		}
+		if (ckeys.c_right) {
+			wav64_play(sfx_cannon, CHANNEL_SFX1);
+			mixer_ch_set_vol(CHANNEL_SFX1, 0.0f, 1.0f);
+		}
+		if (ckeys.c_up) {
+			force_mono = !force_mono;
+			// Global toggle: re-applies the flag across every channel
+			// the mixer currently owns. Voices already playing pick
+			// up the change at the next mixer_poll without restart.
+			mixer_set_force_mono(force_mono);
 		}
 		if (ckeys.z) {
 			music = !music;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -169,6 +169,36 @@ void mixer_ch_set_vol_dolby(int ch, float fl, float fr,
 	float c, float sl, float sr);
 
 /**
+ * @brief Enable or disable mono-fold on a single channel.
+ *
+ * When enabled, the channel's output is folded equally onto both output buses
+ * regardless of its panning or stereo routing:
+ *  - Mono channel: both buses receive (lvol + rvol) / 2 of the sample.
+ *  - Stereo waveform (owner + sub pair): L and R sample streams are each
+ *    routed at half amplitude to both buses, yielding
+ *    L_out = R_out = 0.5 * (L*lvol + R*rvol).
+ *
+ * Set the flag on the OWNER channel of a stereo pair; the SUB inherits.
+ *
+ * @param[in]   ch              Channel index
+ * @param[in]   enable          true to fold, false to restore stereo routing
+ */
+void mixer_ch_set_mono_fold(int ch, bool enable);
+
+/**
+ * @brief Query the mono-fold flag for a channel.
+ */
+bool mixer_ch_get_mono_fold(int ch);
+
+/**
+ * @brief Enable or disable mono-fold on every channel at once.
+ *
+ * Convenience wrapper for a global "Mono" output preference. Applies the
+ * flag to all currently-allocated channels.
+ */
+void mixer_set_mono_fold(bool enable);
+
+/**
  * @brief Start playing the specified waveform on the specified channel.
  * 
  * This function immediately begins playing the waveform, interrupting any

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -169,7 +169,7 @@ void mixer_ch_set_vol_dolby(int ch, float fl, float fr,
 	float c, float sl, float sr);
 
 /**
- * @brief Enable or disable mono-fold on a single channel.
+ * @brief Enable or disable force-mono on a single channel.
  *
  * When enabled, the channel's output is folded equally onto both output buses
  * regardless of its panning or stereo routing:
@@ -183,20 +183,20 @@ void mixer_ch_set_vol_dolby(int ch, float fl, float fr,
  * @param[in]   ch              Channel index
  * @param[in]   enable          true to fold, false to restore stereo routing
  */
-void mixer_ch_set_mono_fold(int ch, bool enable);
+void mixer_ch_set_force_mono(int ch, bool enable);
 
 /**
- * @brief Query the mono-fold flag for a channel.
+ * @brief Query the force-mono flag for a channel.
  */
-bool mixer_ch_get_mono_fold(int ch);
+bool mixer_ch_get_force_mono(int ch);
 
 /**
- * @brief Enable or disable mono-fold on every channel at once.
+ * @brief Enable or disable force-mono on every channel at once.
  *
  * Convenience wrapper for a global "Mono" output preference. Applies the
  * flag to all currently-allocated channels.
  */
-void mixer_set_mono_fold(bool enable);
+void mixer_set_force_mono(bool enable);
 
 /**
  * @brief Start playing the specified waveform on the specified channel.

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -67,6 +67,7 @@ DEFINE_RSP_UCODE(rsp_mixer);
 #define CH_FLAGS_STEREO     	(1<<3)   ///< Set if the channel is stereo (left)
 #define CH_FLAGS_STEREO_SUB 	(1<<4)   ///< The channel is the second half of a stereo (right)
 #define CH_FLAGS_STEREO_ALLOC	(1<<5)   ///< The channel has a buffer sized for stereo
+#define CH_FLAGS_MONO_FOLD  	(1<<6)   ///< Fold this channel's output to both buses (mono downmix). CPU-side only; RSP ucode ignores this bit.
 
 /// @brief Fixed point value used in waveform position calculations.
 /// This is a signed 64-bit integer with the fractional part using
@@ -265,6 +266,23 @@ void mixer_ch_set_vol(int ch, float lvol, float rvol) {
 
 void mixer_ch_set_vol_pan(int ch, float vol, float pan) {
 	mixer_ch_set_vol(ch, vol * (1.f - pan), vol * pan);
+}
+
+void mixer_ch_set_mono_fold(int ch, bool enable) {
+	assert(ch < Mixer.num_channels);
+	if (enable) Mixer.channels[ch].flags |=  CH_FLAGS_MONO_FOLD;
+	else        Mixer.channels[ch].flags &= ~CH_FLAGS_MONO_FOLD;
+}
+
+bool mixer_ch_get_mono_fold(int ch) {
+	assert(ch < Mixer.num_channels);
+	return (Mixer.channels[ch].flags & CH_FLAGS_MONO_FOLD) != 0;
+}
+
+void mixer_set_mono_fold(bool enable) {
+	for (int i = 0; i < Mixer.num_channels; i++) {
+		mixer_ch_set_mono_fold(i, enable);
+	}
 }
 
 void mixer_ch_set_vol_dolby(int ch, float fl, float fr,
@@ -651,11 +669,19 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		mixer_channel_t *c = &Mixer.channels[ch];
 
 		// Stereo sub-channel. Will be ignored by RSP but we need to configure
-		// volume correctly.
+		// volume correctly. The mono-fold flag lives on the OWNER channel
+		// (ch-1), since it's a property of the voice — check there.
 		if (c->flags & CH_FLAGS_STEREO_SUB) {
 			rsp_wv[ch].ptr = 0;
-			settings->lvol[ch] = 0;
-			settings->rvol[ch] = Mixer.rvol[ch-1];
+			if (Mixer.channels[ch-1].flags & CH_FLAGS_MONO_FOLD) {
+				// R sample stream → half-amplitude to both buses.
+				mixer_fx15_t v = Mixer.rvol[ch-1] >> 1;
+				settings->lvol[ch] = v;
+				settings->rvol[ch] = v;
+			} else {
+				settings->lvol[ch] = 0;
+				settings->rvol[ch] = Mixer.rvol[ch-1];
+			}
 			continue;
 		}
 
@@ -696,11 +722,29 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		}
 
 		if (c->flags & CH_FLAGS_STEREO) {
-			settings->lvol[ch] = Mixer.lvol[ch];
-			settings->rvol[ch] = 0;
+			if (c->flags & CH_FLAGS_MONO_FOLD) {
+				// L sample stream → half-amplitude to both buses.
+				// Combined with the SUB branch above, this folds a stereo
+				// voice to mono: L_out = R_out = 0.5*(L*lvol + R*rvol).
+				mixer_fx15_t v = Mixer.lvol[ch] >> 1;
+				settings->lvol[ch] = v;
+				settings->rvol[ch] = v;
+			} else {
+				settings->lvol[ch] = Mixer.lvol[ch];
+				settings->rvol[ch] = 0;
+			}
 		} else {
-			settings->lvol[ch] = Mixer.lvol[ch];
-			settings->rvol[ch] = Mixer.rvol[ch];
+			if (c->flags & CH_FLAGS_MONO_FOLD) {
+				// Mono source: average the pan and write to both buses.
+				// A hard-panned source loses its panning and -6 dB; a
+				// centered source (lvol==rvol) is unaffected.
+				mixer_fx15_t v = (Mixer.lvol[ch] + Mixer.rvol[ch]) >> 1;
+				settings->lvol[ch] = v;
+				settings->rvol[ch] = v;
+			} else {
+				settings->lvol[ch] = Mixer.lvol[ch];
+				settings->rvol[ch] = Mixer.rvol[ch];
+			}
 		}
 	}
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -67,7 +67,7 @@ DEFINE_RSP_UCODE(rsp_mixer);
 #define CH_FLAGS_STEREO     	(1<<3)   ///< Set if the channel is stereo (left)
 #define CH_FLAGS_STEREO_SUB 	(1<<4)   ///< The channel is the second half of a stereo (right)
 #define CH_FLAGS_STEREO_ALLOC	(1<<5)   ///< The channel has a buffer sized for stereo
-#define CH_FLAGS_MONO_FOLD  	(1<<6)   ///< Fold this channel's output to both buses (mono downmix). CPU-side only; RSP ucode ignores this bit.
+#define CH_FLAGS_FORCE_MONO  	(1<<6)   ///< Fold this channel's output to both buses (mono downmix). CPU-side only; RSP ucode ignores this bit.
 
 /// @brief Fixed point value used in waveform position calculations.
 /// This is a signed 64-bit integer with the fractional part using
@@ -268,20 +268,20 @@ void mixer_ch_set_vol_pan(int ch, float vol, float pan) {
 	mixer_ch_set_vol(ch, vol * (1.f - pan), vol * pan);
 }
 
-void mixer_ch_set_mono_fold(int ch, bool enable) {
+void mixer_ch_set_force_mono(int ch, bool enable) {
 	assert(ch < Mixer.num_channels);
-	if (enable) Mixer.channels[ch].flags |=  CH_FLAGS_MONO_FOLD;
-	else        Mixer.channels[ch].flags &= ~CH_FLAGS_MONO_FOLD;
+	if (enable) Mixer.channels[ch].flags |=  CH_FLAGS_FORCE_MONO;
+	else        Mixer.channels[ch].flags &= ~CH_FLAGS_FORCE_MONO;
 }
 
-bool mixer_ch_get_mono_fold(int ch) {
+bool mixer_ch_get_force_mono(int ch) {
 	assert(ch < Mixer.num_channels);
-	return (Mixer.channels[ch].flags & CH_FLAGS_MONO_FOLD) != 0;
+	return (Mixer.channels[ch].flags & CH_FLAGS_FORCE_MONO) != 0;
 }
 
-void mixer_set_mono_fold(bool enable) {
+void mixer_set_force_mono(bool enable) {
 	for (int i = 0; i < Mixer.num_channels; i++) {
-		mixer_ch_set_mono_fold(i, enable);
+		mixer_ch_set_force_mono(i, enable);
 	}
 }
 
@@ -669,11 +669,11 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		mixer_channel_t *c = &Mixer.channels[ch];
 
 		// Stereo sub-channel. Will be ignored by RSP but we need to configure
-		// volume correctly. The mono-fold flag lives on the OWNER channel
+		// volume correctly. The force-mono flag lives on the OWNER channel
 		// (ch-1), since it's a property of the voice — check there.
 		if (c->flags & CH_FLAGS_STEREO_SUB) {
 			rsp_wv[ch].ptr = 0;
-			if (Mixer.channels[ch-1].flags & CH_FLAGS_MONO_FOLD) {
+			if (Mixer.channels[ch-1].flags & CH_FLAGS_FORCE_MONO) {
 				// R sample stream → half-amplitude to both buses.
 				mixer_fx15_t v = Mixer.rvol[ch-1] >> 1;
 				settings->lvol[ch] = v;
@@ -722,7 +722,7 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		}
 
 		if (c->flags & CH_FLAGS_STEREO) {
-			if (c->flags & CH_FLAGS_MONO_FOLD) {
+			if (c->flags & CH_FLAGS_FORCE_MONO) {
 				// L sample stream → half-amplitude to both buses.
 				// Combined with the SUB branch above, this folds a stereo
 				// voice to mono: L_out = R_out = 0.5*(L*lvol + R*rvol).
@@ -734,7 +734,7 @@ static void mixer_exec(int32_t *out, int num_samples) {
 				settings->rvol[ch] = 0;
 			}
 		} else {
-			if (c->flags & CH_FLAGS_MONO_FOLD) {
+			if (c->flags & CH_FLAGS_FORCE_MONO) {
 				// Mono source: average the pan and write to both buses.
 				// A hard-panned source loses its panning and -6 dB; a
 				// centered source (lvol==rvol) is unaffected.


### PR DESCRIPTION
Allows for games to use stereo waveforms and easily collapse them for mono output. Particularly useful for FMVs that use `CH_FLAGS_STEREO_SUB`, which do not currently support setting stereo pan with `mixer_ch_set_vol_pan`. But also just generally useful for having a single toggle of "Stereo" or "Mono" without having to figure out panning.

Example ROM:
[mixertest.z64.zip](https://github.com/user-attachments/files/28771458/mixertest.z64.zip)

<img width="752" height="644" alt="image" src="https://github.com/user-attachments/assets/0b3f8401-b44f-4553-ae61-ae2302e56587" />
