### PR TITLE
Adjust VI_TIMING_MPAL preset values

### DIFF
--- a/src/vi.c
+++ b/src/vi.c
@@ -51,8 +51,8 @@ const vi_timing_preset_t VI_TIMING_PAL = {
 };
 
 const vi_timing_preset_t VI_TIMING_MPAL = {
-    .vi_h_total = VI_H_TOTAL_SET(0b00000, 772.25),
-    .vi_h_total_leap = VI_H_TOTAL_LEAP_SET(775.25, 775.25),
+    .vi_h_total = VI_H_TOTAL_SET(0b00000, 772.75),
+    .vi_h_total_leap = VI_H_TOTAL_LEAP_SET(774.50, 774.50), ///< (774.00, 774.00) is slightly more stable for interlaced over composite
     .vi_v_total = VI_V_TOTAL_SET(526),
     .vi_burst = VI_BURST_SET(70, 5, 30, 57),
     .vi_v_burst = VI_V_BURST_SET(14, 516),


### PR DESCRIPTION
Updated MPAL VI timing preset values for better chroma subcarrier phase alignment (practically: improved dot crawl stability over composite). Derived from adjusting video timing parameters and comparing various values on an MPAL N64 over composite video to an MPAL-compatible CRT.

Discord conversations: 
https://discord.com/channels/205520502922543113/763114214688555039/1506423098998788257 https://discord.com/channels/205520502922543113/763114214688555039/1506503691102847097 https://discord.com/channels/205520502922543113/1501711398118494259

H_TOTAL=772.75, LEAP_A=774.50 observed to be optimal for MPAL progressive. Observed optimal interlaced leap value (774.00) added as comment for reference.

Addresses https://github.com/DragonMinded/libdragon/issues/884