### PR TITLE
Fix errors appearing with GCC 17

### DIFF
--- a/include/joyframe.h
+++ b/include/joyframe.h
@@ -170,7 +170,7 @@ typedef uint8_t joyframe_t[64] __attribute__((aligned(8)));
     uint8_t *send_ptr = &pkt[idx]; \
     pkt[63] = idx + send_len + recv_len - 1; \
     assertf(pkt[63] < 64, "joybus frame overflow"); \
-    (send_len || recv_len) ? send_ptr : NULL; \
+    (send_len | recv_len) ? send_ptr : NULL; \
 })
 
 /**

--- a/src/rdpq/rdpq_debug.c
+++ b/src/rdpq/rdpq_debug.c
@@ -1508,7 +1508,7 @@ void rdpq_validate(uint64_t *buf, uint32_t flags, int *r_errs, int *r_warns)
                 tex_fmt_name[rdp.col.fmt], size, size); break;
         }
         uint32_t addr = BITS(buf[0], 0, 24);
-        if (RDPQ_VALIDATE_DETACH_ADDR && addr == RDPQ_VALIDATE_DETACH_ADDR) {
+        if ((RDPQ_VALIDATE_DETACH_ADDR & addr) == RDPQ_VALIDATE_DETACH_ADDR) {
             // special case for libdragon: if the address is 0x800000, then it means
             // that the developer requested to detach the framebuffer. Treat it as
             // if SET_COLOR_IMAGE was never sent.
@@ -1527,7 +1527,7 @@ void rdpq_validate(uint64_t *buf, uint32_t flags, int *r_errs, int *r_warns)
         validate_busy_pipe();
         VALIDATE_ERR(BITS(buf[0], 0, 5) == 0, "Z image must be aligned to 64 bytes");
         uint32_t addr = BITS(buf[0], 0, 24);
-        if (RDPQ_VALIDATE_DETACH_ADDR && addr == RDPQ_VALIDATE_DETACH_ADDR) {
+        if ((RDPQ_VALIDATE_DETACH_ADDR & addr) == RDPQ_VALIDATE_DETACH_ADDR) {
             // special case for libdragon: if the address is 0x800000, then it means
             // that the developer requested to detach the Z buffer. Treat it as
             // if SET_Z_IMAGE was never sent.

--- a/src/rdpq/rdpq_tri.c
+++ b/src/rdpq/rdpq_tri.c
@@ -344,7 +344,7 @@ static inline void __rdpq_write_tex_coeffs(rspq_write_t *w, rdpq_tri_edge_data_t
     rspq_write_arg(w, (DwDy_fixed&0xffff0000));
     rspq_write_arg(w, (DsDe_fixed<<16) | (DtDe_fixed&0xffff));
     rspq_write_arg(w, (DwDe_fixed<<16));
-    rspq_write_arg(w, (DsDy_fixed<<16) | (DtDy_fixed&&0xffff));
+    rspq_write_arg(w, (DsDy_fixed<<16) | (DtDy_fixed&0xffff));
     rspq_write_arg(w, (DwDy_fixed<<16));
 
     tracef("invw1-mul: %f (%08lx)\n", invw1, (int32_t)(invw1*65536));


### PR DESCRIPTION
I'm using a snapshot of GCC 17 (`mips64-elf-gcc (GCC) 17.0.0 20260524 (experimental)`) and I've noticed that libdragon fails to compile due to specific errors:

* `error: use of logical '&&' with constant operand`
* `error: use of logical '||' with constant operand`