### PR TITLE
mkmaterial: add combiner.reg.* properties

### DIFF
--- a/tools/mkmaterial/combexpr.cpp
+++ b/tools/mkmaterial/combexpr.cpp
@@ -15,6 +15,7 @@
 #include <cctype>
 #include <map>
 #include <unordered_set>
+#include <array>
 #include <assert.h>
 
 namespace combexpr {
@@ -143,11 +144,14 @@ enum UniformId {
     UNIFORM_PRIM_LOD_FRAC,
     UNIFORM_ENV,
     UNIFORM_PRIM,
+    UNIFORM_COUNT
 };
+
+typedef std::array<float, 3> UniformValue;
 
 struct Uniform {
     UniformId id;
-    float value;
+    UniformValue value;
     bool forbidden;     // true if explicitly used by in the expression, so can't be used as uniform
     bool used;          // true if already allocated as uniform
 
@@ -178,6 +182,11 @@ struct Uniform {
     }
 
     void set(float v) {
+        value = {v, v, v};
+        used = true;
+    }
+
+    void set(UniformValue v) {
         value = v;
         used = true;
     }
@@ -292,7 +301,7 @@ struct CombinerExpr {
                 // Search if there's already an uniform with this value
                 bool found = false;
                 for (int k=0; k<uniforms.size(); k++) {
-                    if (uniforms[k].used && uniforms[k].value == v) {
+                    if (uniforms[k].used && uniforms[k].value[0] == v) {
                         value = uniforms[k].to_slot();
                         found = true;
                         break;
@@ -449,8 +458,8 @@ struct CombinerExprFull {
         auto k5 = channels[RGB].find_uniform(internal::UNIFORM_K5);
         if (k4 || k5) {
             uint32_t value = 0;
-            if (k4) value |= (int)(k4->value * 255 + 0.5f) << 8;
-            if (k5) value |= (int)(k5->value * 255 + 0.5f) << 0;
+            if (k4) value |= (int)(k4->value[0] * 255 + 0.5f) << 8;
+            if (k5) value |= (int)(k5->value[0] * 255 + 0.5f) << 0;
             res[UNIFORM_K4K5] = value;
         }
 
@@ -459,8 +468,8 @@ struct CombinerExprFull {
         auto keyscale  = channels[RGB].find_uniform(internal::UNIFORM_KEYSCALE);
         if (keycenter || keyscale) {
             uint32_t value = 0;
-            if (keycenter) value |= (int)(keycenter->value * 255 + 0.5f) << 8;
-            if (keyscale)  value |= (int)(keyscale->value * 255 + 0.5f) << 0;
+            if (keycenter) value |= (int)(keycenter->value[0] * 255 + 0.5f) << 8;
+            if (keyscale)  value |= (int)(keyscale->value[0] * 255 + 0.5f) << 0;
             res[UNIFORM_CHROMAKEY] = value;
         }
 
@@ -468,7 +477,7 @@ struct CombinerExprFull {
         // there by allocate_uniforms() even if it's just used in the alpha channel
         auto prim_lod_frac = channels[RGB].find_uniform(internal::UNIFORM_PRIM_LOD_FRAC);
         if (prim_lod_frac) {
-            res[UNIFORM_PRIM_LOD_FRAC] = (int)(prim_lod_frac->value * 255 + 0.5f);
+            res[UNIFORM_PRIM_LOD_FRAC] = (int)(prim_lod_frac->value[0] * 255 + 0.5f);
         }
 
         // Prim/Env
@@ -480,13 +489,12 @@ struct CombinerExprFull {
             if (rgb || alpha) {
                 uint32_t value = 0;
                 if (rgb) {
-                    int v = rgb->value * 255 + 0.5f;
-                    value |= v << 24;
-                    value |= v << 16;
-                    value |= v << 8;
+                    value |= (int)(rgb->value[0] * 255 + 0.5f) << 24;
+                    value |= (int)(rgb->value[1] * 255 + 0.5f) << 16;
+                    value |= (int)(rgb->value[2] * 255 + 0.5f) << 8;
                 }
                 if (alpha) {
-                    value |= (int)(alpha->value * 255 + 0.5f) << 0;
+                    value |= (int)(alpha->value[0] * 255 + 0.5f) << 0;
                 }
                 res[udesc.second] = value;
             }

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -96,10 +96,21 @@ struct RenderModes {
     void parse_attr(std::string key, std::string value);
 };
 
+typedef std::array<float, 4> Vec4;
+
+struct CombinerRegister {
+    Vec4 value;
+    bool is_set;
+
+    void parse_float(std::string value);
+    void parse_color(std::string value);
+};
+
 struct Combiner {
     combexpr::CombinerExpr rgb{combexpr::CombinerChannel::RGB, "0", "0", "0", "tex0"};
     combexpr::CombinerExpr alpha{combexpr::CombinerChannel::ALPHA, "0", "0", "0", "tex0"};
     combexpr::CombinerExprFull full;
+    CombinerRegister registers[combexpr::internal::UNIFORM_COUNT];
 
     void parse_attr(std::string key, std::string value);
     uint64_t to_rdpq_mode_arg(void);

--- a/tools/mkmaterial/mkmaterial_export.cpp
+++ b/tools/mkmaterial/mkmaterial_export.cpp
@@ -149,10 +149,26 @@ void texconvert(Texture &tex)
     free(sprite_outfn);
 }
 
+void normalize_combiner(Combiner &cc)
+{
+    for (size_t ch = 0; ch < 2; ch++) {
+        for (auto &uniform : cc.full.channels[ch].uniforms) {
+            if (!cc.registers[uniform.id].is_set) continue;
+            auto& v = cc.registers[uniform.id].value;
+            if (ch == combexpr::RGB) {
+                uniform.set({v[0], v[1], v[2]});
+            } else if (ch == combexpr::ALPHA) {
+                uniform.set(v[3]);
+            }
+        }
+    }
+}
+
 void mat_convert(Material &mat)
 {
     if (mat.tex[0]) texconvert(mat.tex[0]);
     if (mat.tex[1]) texconvert(mat.tex[1]);
+    normalize_combiner(mat.cc);
 }
 
 void Material::write(FILE *f)

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -74,6 +74,36 @@ int parse_int(std::string value, int min, int max)
     }
 }
 
+std::vector<std::string> split_string(std::string str, char delimiter) {
+    std::vector<std::string> tokens;
+    size_t start = 0;
+    size_t end = str.find(delimiter);
+    
+    while (end != std::string::npos) {
+        tokens.push_back(str.substr(start, end - start));
+        start = end + 1;
+        end = str.find(delimiter, start);
+    }
+    tokens.push_back(str.substr(start));
+    return tokens;
+}
+
+Vec4 parse_color(std::string value)
+{
+    std::vector<std::string> tokens = split_string(value, ',');
+    if (tokens.size() != 3 && tokens.size() != 4) {
+        throw std::runtime_error("invalid color value: " + value);
+    }
+    Vec4 color{};
+    for (size_t i = 0; i < tokens.size(); i++) {
+        color[i] = parse_float(tokens[i], 0, 1);
+    }
+    if (tokens.size() < 4) {
+        color[3] = 1;
+    }
+    return color;
+}
+
 std::string parse_enum(std::string value, const std::vector<std::string> &enums)
 {
     for (size_t i = 0; i < enums.size(); i++) {
@@ -86,6 +116,19 @@ std::string parse_enum(std::string value, const std::vector<std::string> &enums)
         if (i < enums.size() - 1) error += ", ";
     }
     throw std::runtime_error(error);
+}
+
+void CombinerRegister::parse_float(std::string value)
+{
+    float v = ::parse_float(value, 0, 1);
+    this->value = {v, v, v, v};
+    is_set = true;
+}
+
+void CombinerRegister::parse_color(std::string value)
+{
+    this->value = ::parse_color(value);
+    is_set = true;
 }
 
 void Combiner::parse_attr(std::string key, std::string value)
@@ -130,6 +173,20 @@ void Combiner::parse_attr(std::string key, std::string value)
         } else {
             throw std::runtime_error("invalid alpha.raw combiner expression: must be in format \"(a,b,c,d)\"");
         }
+    } else if (key == "reg.k4") {
+        registers[combexpr::internal::UNIFORM_K4].parse_float(value);
+    } else if (key == "reg.k5") {
+        registers[combexpr::internal::UNIFORM_K5].parse_float(value);
+    } else if (key == "reg.keyscale") {
+        registers[combexpr::internal::UNIFORM_KEYSCALE].parse_float(value);
+    } else if (key == "reg.keycenter") {
+        registers[combexpr::internal::UNIFORM_KEYCENTER].parse_float(value);
+    } else if (key == "reg.prim_lod_frac") {
+        registers[combexpr::internal::UNIFORM_PRIM_LOD_FRAC].parse_float(value);
+    } else if (key == "reg.env") {
+        registers[combexpr::internal::UNIFORM_ENV].parse_color(value);
+    } else if (key == "reg.prim") {
+        registers[combexpr::internal::UNIFORM_PRIM].parse_color(value);
     } else {
         throw std::runtime_error("Unknown combiner key: " + key);
     }


### PR DESCRIPTION
These new properties allow setting various RDP registers directly, bypassing the combiner expression.
This is especially useful in combination with the raw combiner properties.