### PR TITLE
version bump and GCC snapshot support

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -50,6 +50,10 @@ jobs:
           sudo apt-get install texinfo
           sudo apt-get install libmpc-dev
           sudo apt-get install squashfs-tools
+          sudo apt-get install liblzma-dev
+          sudo apt-get install xz-utils
+          sudo apt-get install xzdec
+
           # If there are other dependencies, we should add them here and make sure the documentation is updated!
 
       - name: Install x-compile system build dependencies
@@ -85,6 +89,7 @@ jobs:
         with:
           path: |
             ./tools/**/*.tar.gz
+            ./tools/**/*.tar.xz
             ./tools/**/*.tar.bz2
           key: ${{ runner.os }}-dependency-downloads # TODO: concurrency errors may currently occur due to matrix, but they are the same files.
 
@@ -92,7 +97,7 @@ jobs:
         id: gcc-version-generator
         run: |
           echo "BINUTILS_VERSION=$(grep -Po 'BINUTILS_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
-          echo "GCC_VERSION=$(grep -Po 'GCC_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
+          echo "GCC_VERSION=$(grep -Po -m 1 'GCC_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
           echo "NEWLIB_VERSION=$(grep -Po 'NEWLIB_V=\K[^"]*' ./tools/build-toolchain.sh)" >> $GITHUB_OUTPUT
           echo "GDB_VERSION=$(grep -Po 'GDB_V=\K[^"]*' ./tools/build-gdb.sh)" >> $GITHUB_OUTPUT
 

--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -24,7 +24,7 @@ exec > >(tee "$BUILD_PATH/build-gdb.log") 2>&1
 echo "Build started at: $(date)"
 
 # Dependency source libs (Versions)
-GDB_V=16.2
+GDB_V=17.2
 
 # Defines the build system variables to allow cross compilation.
 N64_HOST=${N64_HOST:-""}

--- a/tools/build-mikmod.sh
+++ b/tools/build-mikmod.sh
@@ -26,13 +26,16 @@ JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN)}"
 JOBS="${JOBS:-1}" # If getconf returned nothing, default to 1
 
 # Specify where to get libmikmod from and where to put it
+
+#LIBMIKMOD_REPO=https://github.com/sezero/mikmod.git
 LIBMIKMOD_REPO=https://github.com/networkfusion/libmikmod.git
 LIBMIKMOD_COMMIT=738b1e8b11b470360b1b919680d1d88429d9d174
-LIBMIKMOD_DIR=/tmp/libmikmod
+LIBMIKMOD_DIR=toolchain/libmikmod
+
+#git clone --recurse-submodules --recursive $LIBMIKMOD_REPO $LIBMIKMOD_DIR
 
 # Remove the cloned libmikmod repo if it already exists
 [ -d "$LIBMIKMOD_DIR" ] && rm -Rf $LIBMIKMOD_DIR
-# Clone, compile, and install libmikmod
 git clone $LIBMIKMOD_REPO $LIBMIKMOD_DIR
 pushd $LIBMIKMOD_DIR/n64
 git checkout $LIBMIKMOD_COMMIT

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -42,12 +42,12 @@ BINUTILS_CONFIGURE_ARGS=()
 GCC_CONFIGURE_ARGS=()
 
 # Dependency source libs (Versions)
-BINUTILS_V=2.44
-GCC_V=14.2.0
-NEWLIB_V=4.4.0.20231231
+BINUTILS_V=2.46.1
+GCC_V=16
+NEWLIB_V=4.5.0.20241231
 GMP_V=6.3.0
-MPC_V=1.3.1
-MPFR_V=4.2.1
+MPC_V=1.4.1
+MPFR_V=4.2.2
 ZLIB_V=${ZLIB_V:-""}
 MAKE_V=${MAKE_V:-""}
 
@@ -124,26 +124,30 @@ else
 fi
 
 # Dependency downloads and unpack
-test -f "$DOWNLOAD_PATH/binutils-$BINUTILS_V.tar.gz" || download "https://ftpmirror.gnu.org/gnu/binutils/binutils-$BINUTILS_V.tar.gz"
-test -d "$BUILD_PATH/binutils-$BINUTILS_V"           || tar -xzf "$DOWNLOAD_PATH/binutils-$BINUTILS_V.tar.gz" -C "$BUILD_PATH"
+test -f "$DOWNLOAD_PATH/binutils-with-gold-$BINUTILS_V.tar.gz" || download "https://ftpmirror.gnu.org/gnu/binutils/binutils-with-gold-$BINUTILS_V.tar.gz"
+test -d "$BUILD_PATH/binutils-with-gold-$BINUTILS_V"           || tar -xzpf "$DOWNLOAD_PATH/binutils-with-gold-$BINUTILS_V.tar.gz" -C "$BUILD_PATH"
 
-test -f "$DOWNLOAD_PATH/gcc-$GCC_V.tar.gz"           || download "https://ftpmirror.gnu.org/gnu/gcc/gcc-$GCC_V/gcc-$GCC_V.tar.gz"
-test -d "$BUILD_PATH/gcc-$GCC_V"                     || tar -xzf "$DOWNLOAD_PATH/gcc-$GCC_V.tar.gz" -C "$BUILD_PATH"
+test -f "$DOWNLOAD_PATH/index.html"                  || download "https://gcc.gnu.org/pub/gcc/snapshots/LATEST-${GCC_V:0:2}/index.html"
+GCC_V=`cat "$DOWNLOAD_PATH/index.html" | grep "<title>GCC ${GCC_V:0:2}-" | cut -f2 -d\ `
+
+test -f "$DOWNLOAD_PATH/gcc-$GCC_V.tar.xz"           || download "https://gcc.gnu.org/pub/gcc/snapshots/LATEST-${GCC_V:0:2}/gcc-$GCC_V.tar.xz"
+test -d "$BUILD_PATH/gcc-$GCC_V"                     || tar -xJpf "$DOWNLOAD_PATH/gcc-$GCC_V.tar.xz" -C "$BUILD_PATH"
+
 
 test -f "$DOWNLOAD_PATH/newlib-$NEWLIB_V.tar.gz"     || download "https://sourceware.org/pub/newlib/newlib-$NEWLIB_V.tar.gz"
-test -d "$BUILD_PATH/newlib-$NEWLIB_V"               || tar -xzf "$DOWNLOAD_PATH/newlib-$NEWLIB_V.tar.gz" -C "$BUILD_PATH"
+test -d "$BUILD_PATH/newlib-$NEWLIB_V"               || tar -xzpf "$DOWNLOAD_PATH/newlib-$NEWLIB_V.tar.gz" -C "$BUILD_PATH"
 
 if [ "$GMP_V" != "" ]; then
-    test -f "$DOWNLOAD_PATH/gmp-$GMP_V.tar.bz2"      || download "https://ftpmirror.gnu.org/gnu/gmp/gmp-$GMP_V.tar.bz2"
-    test -d "$BUILD_PATH/gmp-$GMP_V"                 || tar -xf "$DOWNLOAD_PATH/gmp-$GMP_V.tar.bz2" -C "$BUILD_PATH" # note: no .gz download file currently available
+    test -f "$DOWNLOAD_PATH/gmp-$GMP_V.tar.gz"      || download "https://ftpmirror.gnu.org/gnu/gmp/gmp-$GMP_V.tar.gz"
+    test -d "$BUILD_PATH/gmp-$GMP_V"                 || tar -xzpf "$DOWNLOAD_PATH/gmp-$GMP_V.tar.gz" -C "$BUILD_PATH" # note: no .gz download file currently available
     pushd "$BUILD_PATH/gcc-$GCC_V"
     ln -sf ../"gmp-$GMP_V" "gmp"
     popd
 fi
 
 if [ "$MPC_V" != "" ]; then
-    test -f "$DOWNLOAD_PATH/mpc-$MPC_V.tar.gz"       || download "https://ftpmirror.gnu.org/gnu/mpc/mpc-$MPC_V.tar.gz"
-    test -d "$BUILD_PATH/mpc-$MPC_V"                 || tar -xzf "$DOWNLOAD_PATH/mpc-$MPC_V.tar.gz" -C "$BUILD_PATH"
+    test -f "$DOWNLOAD_PATH/mpc-$MPC_V.tar.xz"       || download "https://ftpmirror.gnu.org/gnu/mpc/mpc-$MPC_V.tar.xz"
+    test -d "$BUILD_PATH/mpc-$MPC_V"                 || tar -xJpf "$DOWNLOAD_PATH/mpc-$MPC_V.tar.xz" -C "$BUILD_PATH"
     pushd "$BUILD_PATH/gcc-$GCC_V"
     ln -sf ../"mpc-$MPC_V" "mpc"
     popd
@@ -151,7 +155,7 @@ fi
 
 if [ "$MPFR_V" != "" ]; then
     test -f "$DOWNLOAD_PATH/mpfr-$MPFR_V.tar.gz"     || download "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-$MPFR_V.tar.gz"
-    test -d "$BUILD_PATH/mpfr-$MPFR_V"               || tar -xzf "$DOWNLOAD_PATH/mpfr-$MPFR_V.tar.gz" -C "$BUILD_PATH"
+    test -d "$BUILD_PATH/mpfr-$MPFR_V"               || tar -xzpf "$DOWNLOAD_PATH/mpfr-$MPFR_V.tar.gz" -C "$BUILD_PATH"
     pushd "$BUILD_PATH/gcc-$GCC_V"
     ln -sf ../"mpfr-$MPFR_V" "mpfr"
     popd
@@ -159,12 +163,12 @@ fi
 
 if [ "$MAKE_V" != "" ]; then
     test -f "$DOWNLOAD_PATH/make-$MAKE_V.tar.gz"     || download "https://ftpmirror.gnu.org/gnu/make/make-$MAKE_V.tar.gz"
-    test -d "$BUILD_PATH/make-$MAKE_V"               || tar -xzf "$DOWNLOAD_PATH/make-$MAKE_V.tar.gz" -C "$BUILD_PATH"
+    test -d "$BUILD_PATH/make-$MAKE_V"               || tar -xzpf "$DOWNLOAD_PATH/make-$MAKE_V.tar.gz" -C "$BUILD_PATH"
 fi
 
 if [ "$ZLIB_V" != "" ]; then
     test -f "$DOWNLOAD_PATH/zlib-$ZLIB_V.tar.gz"     || download "https://zlib.net/fossils/zlib-$ZLIB_V.tar.gz"
-    test -d "$BUILD_PATH/zlib-$ZLIB_V"               || tar -xzf "$DOWNLOAD_PATH/zlib-$ZLIB_V.tar.gz" -C "$BUILD_PATH"
+    test -d "$BUILD_PATH/zlib-$ZLIB_V"               || tar -xzpf "$DOWNLOAD_PATH/zlib-$ZLIB_V.tar.gz" -C "$BUILD_PATH"
 fi
 
 cd "$BUILD_PATH"
@@ -172,7 +176,7 @@ cd "$BUILD_PATH"
 # Deduce build triplet using config.guess (if not specified)
 # This is by the definition the current system so it should be OK.
 if [ "$N64_BUILD" == "" ]; then
-    N64_BUILD=$("binutils-$BINUTILS_V"/config.guess)
+    N64_BUILD=$("binutils-with-gold-$BINUTILS_V"/config.guess)
 fi
 
 if [ "$N64_HOST" == "" ]; then
@@ -263,7 +267,7 @@ fi
 # Compile BUILD->TARGET binutils
 mkdir -p binutils_compile_target
 pushd binutils_compile_target
-../"binutils-$BINUTILS_V"/configure ${BINUTILS_CONFIGURE_ARGS[@]} \
+../"binutils-with-gold-$BINUTILS_V"/configure ${BINUTILS_CONFIGURE_ARGS[@]} \
     --prefix="$CROSS_PREFIX" \
     --target="$N64_TARGET" \
     --with-cpu=mips64vr4300 \
@@ -328,10 +332,10 @@ else
     # with this commit: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=2952f10cd79af4645222f124f28c7928287d8113
     # This is due to the fact that pkg-config is used to activate compilation with msgpack
     # but that it is not correct in the case of a canadian cross.
-    echo "Compiling binutils-$BINUTILS_V for foreign host"
+    echo "Compiling binutils-with-gold-$BINUTILS_V for foreign host"
     mkdir -p binutils_compile_host
     pushd binutils_compile_host
-    ../"binutils-$BINUTILS_V"/configure \
+    ../"binutils-with-gold-$BINUTILS_V"/configure \
         --prefix="$INSTALL_PATH" \
         --build="$N64_BUILD" \
         --host="$N64_HOST" \
@@ -412,7 +416,7 @@ TOOLCHAIN_VERSION_FILE="$INSTALL_PATH/$N64_TARGET/include/toolchain.version"
 
 VERSION_CONTENT="{
   \"host\": \"$N64_HOST\",
-  \"binutils\": \"$BINUTILS_V\",
+  \"binutils-with-gold\": \"$BINUTILS_V\",
   \"gcc\": \"$GCC_V\",
   \"newlib\": \"$NEWLIB_V\"
 }"


### PR DESCRIPTION
- Use gcc mirror with snapshots and get latest version from index.html
- Switch to binutils-with-gold
- Update all other packages versions to latest working release
- Use newlib-4.5.0.20241231
- Add permissions to decompress flags
- Add xz to install workflow

**Changes**
- GCC_V has to be initialized with major version number for snapshots.

**Status**
- [x] GCC 16 snapshots
- [x] binutils-with-gold
- [ ] #850
- [ ] #918 

**Outdated**
- #851
- #855
- #709 