### PR TITLE
toolchain: Remove Texinfo dependency

### DIFF
--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Install native system build dependencies
         run: |
           sudo apt-get install libmpfr-dev
-          sudo apt-get install texinfo
           sudo apt-get install libmpc-dev
           sudo apt-get install squashfs-tools
           # If there are other dependencies, we should add them here and make sure the documentation is updated!

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         libmpc-dev \
         libmpfr-dev \
         make \
-        texinfo \
         wget \
         zlib1g-dev \
     && apt autoremove -yq

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -84,7 +84,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     # Install required dependencies. gsed is really required, the others are optionals
     # and just speed up build.
     # zlib is part of the base OS, and doesn't need to be installed here.
-    brew install -q gmp mpfr libmpc gsed isl make python3 texinfo
+    brew install -q gmp mpfr libmpc gsed isl make python3
 
     # FIXME: we could avoid download/symlink GMP and friends for a cross-compiler
     # but we need to symlink them for the canadian compiler.
@@ -308,8 +308,10 @@ CFLAGS_FOR_TARGET="-DHAVE_ASSERT_FUNC -O2 -fpermissive" \
     --disable-werror \
     --enable-newlib-multithread \
     --enable-newlib-retargetable-locking
-make -j "$JOBS"
-make install || sudo env PATH="$PATH" make install || su -c "env PATH=\"$PATH\" make install"
+make MAKEINFO=true -j "$JOBS"
+make MAKEINFO=true install || \
+    sudo env PATH="$PATH" make MAKEINFO=true install || \
+    su -c "env PATH=\"$PATH\" make MAKEINFO=true install"
 popd
 
 # For a standard cross-compiler, the only thing left is to finish compiling the target libraries
@@ -376,8 +378,10 @@ else
         --disable-werror \
         --enable-newlib-multithread \
         --enable-newlib-retargetable-locking
-    make -j "$JOBS"
-    make install || sudo env PATH="$PATH" make install || su -c "env PATH=\"$PATH\" make install"
+    make MAKEINFO=true -j "$JOBS"
+    make MAKEINFO=true install || \
+        sudo env PATH="$PATH" make MAKEINFO=true install || \
+        su -c "env PATH=\"$PATH\" make MAKEINFO=true install"
     popd
 
     # Finish compiling GCC


### PR DESCRIPTION
Minimal patch to install the currently pinned toolchain components without Texinfo/`makeinfo`. Release tarballs are intended to build without Texinfo, but missing or outdated `.info` files can still trigger `makeinfo` invocations.

`MAKEINFO=true` is passed as a Make argument because the `MAKEINFO` assignment generated by `configure` (typically the `missing` wrapper) takes precedence over an environment variable.

Previous Binutils versions have [triggered `makeinfo` invocations](https://github.com/DragonMinded/libdragon/issues/353), so version updates should continue being tested without Texinfo.

After merging, `texinfo` can be removed as a dependency on the [installation wiki](https://github.com/DragonMinded/libdragon/wiki/Installing-libdragon#option-3-compile-and-install-the-toolchain-from-sources).