### PR TITLE
tools: Fix MSYS2 assert being able to return (theoretically)

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -43,13 +43,15 @@ ifeq ($(OS),Windows_NT)
 	endif
 
 # Define a macro with an estimate of the MSYS2 environment's age so that we can check it for compatibility reasons.
-	MSYS2_AGE := $(shell date -d "$$(pacman -Qi msys2-runtime | sed -n 's/^Install Date *: *//p')" +%Y%m%d)
-	ifeq ($(MSYS2_AGE),)
-		$(error "Failed to determine MSYS2 age. Please make sure that pacman, date, and sed are in PATH and that msys2-runtime is installed.")
-	else
-		CFLAGS += -DMSYS2_RUNTIME_PACMAN_AGE=$(MSYS2_AGE)
-		CXXFLAGS += -DMSYS2_RUNTIME_PACMAN_AGE=$(MSYS2_AGE)
-	endif
+    MSYS2_AGE := $(shell date -d "$$(pacman -Qi msys2-runtime | sed -n 's/^Install Date *: *//p')" +%Y%m%d)
+    
+    ifeq ($(MSYS2_AGE),)
+        $(error Failed to determine MSYS2 age. Please make sure that pacman, date, and sed are in PATH and that msys2-runtime is installed.)
+    else
+        $(info MSYS2 age determined as: $(MSYS2_AGE))
+        CFLAGS += -DMSYS2_RUNTIME_PACMAN_AGE=$(MSYS2_AGE)
+        CXXFLAGS += -DMSYS2_RUNTIME_PACMAN_AGE=$(MSYS2_AGE)
+    endif
 else
 # When cross-building, set a default value for MSYS2_RUNTIME_PACMAN_AGE
 	CFLAGS += -DMSYS2_RUNTIME_PACMAN_AGE=0

--- a/tools/common/aplib_compress.c
+++ b/tools/common/aplib_compress.c
@@ -1,3 +1,4 @@
+#include "../common/polyfill.h"
 // apultra
 #include "apultra/matchfinder.c"
 #include "apultra/shrink.c"

--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -21,9 +21,16 @@
 #ifdef __cplusplus
 #include <cstdio>
 #endif
+// NOTE: include both assert.h and cassert because we need to make sure
+// _assert and _wassert are declared properly before we mess with them later.
+#include <assert.h>
+#ifdef __cplusplus
+#include <cassert>
+#endif
 #include <stdlib.h>
 #include <errno.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <process.h>
 #include <share.h>
@@ -108,6 +115,38 @@ static char *msys2_fallback_strndup(const char *s, size_t n)
     #undef strndup
     #endif
     #define strndup   msys2_fallback_strndup
+#endif
+
+// Replace 'assert' so that it has 'noreturn' behaviour on Windows.
+// (soft reverts this MSYS2 commit: https://sourceforge.net/p/mingw-w64/mingw-w64/ci/ecf2328a328d11dec7044b40b2b5e93b5b2b9d9e/)
+#if defined(MSYS2_RUNTIME_PACMAN_AGE) && MSYS2_RUNTIME_PACMAN_AGE >= 20260611 && !defined(NDEBUG)
+
+    #if defined(_UNICODE) || defined(UNICODE)
+
+__attribute__((used)) __attribute__((noreturn))
+static void msys2_wassert_fix(const wchar_t* _Message, const wchar_t* _File, unsigned _Line)
+{
+    _wassert(_Message, _File, _Line);
+    abort();
+    __builtin_unreachable();
+}
+
+#define _wassert(a,b,c) msys2_wassert_fix(a,b,c)
+
+    #else
+
+__attribute__((used)) __attribute__((noreturn))
+static void msys2_assert_fix(const char* _Message, const char* _File, unsigned _Line)
+{
+    _assert(_Message, _File, _Line);
+    abort();
+    __builtin_unreachable();
+}
+
+#define _assert(a,b,c) msys2_assert_fix(a,b,c)
+
+    #endif // defined(_UNICODE) || defined(UNICODE)
+
 #endif
 
 #if defined(__MSVCRT_VERSION__) && __MSVCRT_VERSION__ >= 0xE00

--- a/tools/cpaktool/cpaklib.c
+++ b/tools/cpaktool/cpaklib.c
@@ -19,6 +19,7 @@
 #include "../../include/joypad.h"
 #include "../../include/system.h"
 #include "../../include/dir.h"
+#include "../common/polyfill.h"
 
 
 #define __randn(n)  (\


### PR DESCRIPTION
On 16/06/2026, MSYS2 team merged this commit (https://sourceforge.net/p/mingw-w64/mingw-w64/ci/ecf2328a328d11dec7044b40b2b5e93b5b2b9d9e/) which removed `__attribute__((noreturn))` from the declaration of assert functions `_assert` and `_wassert`.

The motivation behind this change was to avoid UB in the case when these functions returned while marked as noreturn. This is possible because of Microsoft's implementation of `assert` - when the destination of the diagnostic message is set to a MessageBox (which is the default in window-based applications), the MessageBox displayed has (for ungodly reasons) an Ignore button which the user can select. If they do, the failed assert is passed through and execution continues. For more details, see Microsoft's documentation: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/assert-macro-assert-wassert?view=msvc-170

Unfortunately, this change broke GCC diagnostics for code that assumes a sensible implementation of `assert` and therefore uses `assert` as a check for requirements and a dependable termination point that's communicated to the compiler. This PR overrides calls to `_assert` and `_wassert` to restore previous behaviour. Going forward, all calls to `assert` should work reliably on Windows as long as `polyfill.h` is included.