### PR TITLE
scratch: add memalign, uncached alloc, and scratch_owns

### DIFF
--- a/include/scratch.h
+++ b/include/scratch.h
@@ -31,8 +31,8 @@
  /**
   * @brief Allocate memory from the scratch heap.
   *
- * Allocates @p size bytes from the scratch allocator.
- * The returned pointer is suitably aligned for normal C object access.
+  * Allocates @p size bytes from the scratch allocator.
+  * The returned pointer is suitably aligned for normal C object access.
   *
   * @param size         Number of bytes to allocate.
   * @return Pointer to the allocated memory, or NULL if there is not enough
@@ -94,7 +94,7 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by any scratch allocator —
+  * Releases a block previously returned by any scratch allocator:
   * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
   * #scratch_memalign(), or #scratch_malloc_uncached(). The single
   * entry point transparently handles cached vs uncached pointer views
@@ -120,7 +120,7 @@
   * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
   * cannot suffer false sharing with neighbouring allocations.
   *
-  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * Free with the standard #scratch_free(); it handles cached/uncached views
   * transparently.
   *
   * @param size         Number of bytes to allocate.
@@ -188,18 +188,18 @@ void scratch_get_stats(scratch_stats_t *stats);
  bool scratch_empty(void);
 
  /**
-  * @brief Check whether a pointer was allocated by the scratch allocator.
+  * @brief Check whether an address belongs to the scratch heap.
   *
-  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
-  * / #scratch_realloc, false otherwise. The cached and uncached views of
-  * the same scratch address are both recognised.
+  * Returns true if @p ptr falls inside the scratch heap reservation. The cached
+  * and uncached views of the same scratch address are both recognised.
   *
   * Intended for code paths that don't know up-front which allocator owns a
   * pointer (e.g. fallbacks between scratch and the main heap) and need to
   * dispatch to the correct deallocator.
   *
   * @param ptr Pointer to test.
-  * @return true if owned by scratch, false otherwise (including NULL).
+  * @return true if the address is inside the scratch heap, false otherwise
+  *         (including NULL).
   */
  bool scratch_owns(const void *ptr);
  

--- a/include/scratch.h
+++ b/include/scratch.h
@@ -94,15 +94,62 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by #scratch_malloc(), #scratch_calloc(), or
-  * #scratch_realloc().
+  * Releases a block previously returned by any scratch allocator —
+  * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
+  * #scratch_memalign(), or #scratch_malloc_uncached(). The single
+  * entry point transparently handles cached vs uncached pointer views
+  * and direct vs aligned allocations; callers don't need to track
+  * which allocator produced the pointer.
   *
   * Passing NULL is allowed and has no effect.
   *
   * @param ptr          Pointer to the scratch allocation to free, or NULL.
   */
  void scratch_free(void *ptr);
+
+ /**
+  * @brief Allocate uncached memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns an uncached
+  * (KSEG1) mapping of the buffer. This mirrors #malloc_uncached() and is
+  * intended for short-lived buffers shared between CPU and RSP/RDP DMA paths
+  * (decoder workspaces, staging surfaces, etc.) where the coherency cost of
+  * cached access would otherwise force manual flushes around every transfer.
+  *
+  * The underlying allocation is 16-byte aligned and the size is rounded up to
+  * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
+  * cannot suffer false sharing with neighbouring allocations.
+  *
+  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * transparently.
+  *
+  * @param size         Number of bytes to allocate.
+  * @return Uncached pointer to the allocated memory, or NULL if there is not
+  *         enough memory.
+  *
+  * @note Memory returned by this function is uninitialized.
+  *
+  * @see scratch_free
+  * @see malloc_uncached
+  */
+ void *scratch_malloc_uncached(size_t size);
  
+ /**
+  * @brief Allocate aligned memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns a pointer
+  * aligned to @p alignment bytes. @p alignment must be a power of two and
+  * at least the natural scratch alignment (16 bytes); requests smaller than
+  * 16 are clamped up.
+  *
+  * Free with #scratch_free().
+  *
+  * @param alignment    Required alignment in bytes (power of two, >= 16).
+  * @param size         Number of bytes to allocate.
+  * @return Pointer to the aligned allocation, or NULL on failure.
+  */
+ void *scratch_memalign(size_t alignment, size_t size);
+
  /**
   * @brief Check internal consistency of the scratch heap.
   *
@@ -139,6 +186,22 @@ void scratch_get_stats(scratch_stats_t *stats);
   * @return true if there are no live scratch allocations, false otherwise.
   */
  bool scratch_empty(void);
+
+ /**
+  * @brief Check whether a pointer was allocated by the scratch allocator.
+  *
+  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
+  * / #scratch_realloc, false otherwise. The cached and uncached views of
+  * the same scratch address are both recognised.
+  *
+  * Intended for code paths that don't know up-front which allocator owns a
+  * pointer (e.g. fallbacks between scratch and the main heap) and need to
+  * dispatch to the correct deallocator.
+  *
+  * @param ptr Pointer to test.
+  * @return true if owned by scratch, false otherwise (including NULL).
+  */
+ bool scratch_owns(const void *ptr);
  
  #ifdef __cplusplus
  }

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -166,6 +166,39 @@ static void scratch_free_chunk(void *ptr) {
     if (b == sh_head) trim_head();
 }
 
+static bool block_matches_user_ptr(block_t *b, const void *ptr) {
+    return ptr_in_heap(b) && !block_is_free(b) &&
+        b->magic == MAGIC_USED && block_user_ptr(b) == ptr;
+}
+
+static void *scratch_resolve_ptr(const void *ptr) {
+    if (!ptr) return NULL;
+
+    void *cached = CachedAddr(ptr);
+    if (!ptr_in_heap(cached)) return NULL;
+
+    /* Fast path: normal scratch_malloc/calloc/realloc pointers point exactly
+     * at the user area that follows the block header. */
+    block_t *b = block_from_user_ptr(cached);
+    if (block_matches_user_ptr(b, cached))
+        return cached;
+
+    /* scratch_memalign returns an aligned alias inside a normal scratch block.
+     * The original user pointer is stored immediately before the alias. */
+    void *raw = *(void **)(cached - 4);
+    b = block_from_user_ptr(raw);
+    if (!block_matches_user_ptr(b, raw))
+        return NULL;
+
+    /* Accept the alias only if it still points inside the raw block payload. */
+    if ((uintptr_t)cached < (uintptr_t)raw)
+        return NULL;
+    if ((uintptr_t)cached >= (uintptr_t)raw + (block_size(b) - header_size()))
+        return NULL;
+
+    return raw;
+}
+
 void scratch_free(void *ptr) {
     if (!ptr) return;
 
@@ -179,35 +212,13 @@ void scratch_free(void *ptr) {
      *     is stored in a back-slot at (ptr - sizeof(void*))
      * Callers don't need to track which allocator produced the pointer or
      * which view (cached/uncached) they hold. */
-    void *cached = CachedAddr(ptr);
-
-    /* First try the direct interpretation: assume `cached` is the user
-     * pointer of a scratch chunk and check the header for the USED magic.
-     * If the magic matches, we're done — release this chunk. */
-    block_t *b_direct = block_from_user_ptr(cached);
-    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
-        scratch_free_chunk(cached);
-        return;
-    }
-
-    /* Otherwise this must be a memalign'd pointer: the back-slot before
-     * `cached` holds the raw chunk's user pointer. Validate and release. */
-    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
-    void *raw = *back_slot;
-    block_t *b_raw = block_from_user_ptr(raw);
-    /* Validate with a real runtime check, not just an assert: under NDEBUG
-     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
-     * stale back-slot holds garbage) must fail safely rather than free an
-     * arbitrary address (there is no MMU to catch it). Require the raw block to
-     * be a live scratch chunk that actually contains this aligned alias. */
-    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
-        (uintptr_t)cached >= (uintptr_t)raw &&
-        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
-    if (!valid) {
+    void *raw = scratch_resolve_ptr(ptr);
+    if (!raw) {
         assertf(false,
             "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
         return;
     }
+
     scratch_free_chunk(raw);
 }
 

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "debug.h"
+#include "n64sys.h"
 #include "scratch.h"
 #include "system_internal.h"
 #include "utils.h"
@@ -149,9 +150,9 @@ void *scratch_malloc(size_t size) {
     return block_user_ptr(b);
 }
 
-void scratch_free(void *ptr) {
-    if (!ptr) return;
-
+/* Release the chunk that ptr is the user-data of. Caller guarantees ptr is
+ * a valid direct-allocated scratch chunk's user pointer. */
+static void scratch_free_chunk(void *ptr) {
     block_t *b = block_from_user_ptr(ptr);
     assert(ptr_in_heap(b));
     assert(!block_is_free(b));
@@ -164,6 +165,66 @@ void scratch_free(void *ptr) {
     block_mark_free(b);
     if (b == sh_head) trim_head();
 }
+
+void scratch_free(void *ptr) {
+    if (!ptr) return;
+
+    /* scratch_free is the single-entry deallocator for any pointer
+     * returned by any scratch_* allocation. It transparently handles:
+     *   - cached vs uncached views (both refer to the same physical chunk)
+     *   - direct allocations (scratch_malloc / scratch_calloc) where the
+     *     pointer is at user_ptr_offset within the chunk
+     *   - aligned allocations (scratch_memalign) where the pointer is
+     *     offset further into the chunk and the chunk's raw user pointer
+     *     is stored in a back-slot at (ptr - sizeof(void*))
+     * Callers don't need to track which allocator produced the pointer or
+     * which view (cached/uncached) they hold. */
+    void *cached = CachedAddr(ptr);
+
+    /* First try the direct interpretation: assume `cached` is the user
+     * pointer of a scratch chunk and check the header for the USED magic.
+     * If the magic matches, we're done — release this chunk. */
+    block_t *b_direct = block_from_user_ptr(cached);
+    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
+        scratch_free_chunk(cached);
+        return;
+    }
+
+    /* Otherwise this must be a memalign'd pointer: the back-slot before
+     * `cached` holds the raw chunk's user pointer. Validate and release. */
+    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
+    void *raw = *back_slot;
+    block_t *b_raw = block_from_user_ptr(raw);
+    /* Validate with a real runtime check, not just an assert: under NDEBUG
+     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
+     * stale back-slot holds garbage) must fail safely rather than free an
+     * arbitrary address (there is no MMU to catch it). Require the raw block to
+     * be a live scratch chunk that actually contains this aligned alias. */
+    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
+        (uintptr_t)cached >= (uintptr_t)raw &&
+        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
+    if (!valid) {
+        assertf(false,
+            "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
+        return;
+    }
+    scratch_free_chunk(raw);
+}
+
+void *scratch_malloc_uncached(size_t size) {
+    // Round the size up to a full cacheline so the uncached buffer can never
+    // false-share with a neighbouring allocation (mirrors malloc_uncached).
+    size = ROUND_UP(size, 16);
+    void *p = scratch_malloc(size);
+    if (!p) return NULL;
+
+    // The memory may have been in the data cache from a prior cached use of
+    // the same block; invalidate so a future writeback can't clobber RSP/RDP
+    // writes.
+    data_cache_hit_invalidate(p, size);
+    return UncachedAddr(p);
+}
+
 
 void *scratch_calloc(size_t count, size_t size) {
     if (count && size > ((size_t)-1) / count) return NULL;
@@ -199,6 +260,27 @@ void *scratch_realloc(void *ptr, size_t size) {
     memcpy(q, ptr, old_requested < size ? old_requested : size);
     scratch_free(ptr);
     return q;
+}
+
+void *scratch_memalign(size_t alignment, size_t size) {
+    if (alignment < SCRATCH_ALIGN) alignment = SCRATCH_ALIGN;
+    /* Power-of-two check matches POSIX memalign semantics. */
+    assertf((alignment & (alignment - 1)) == 0,
+        "scratch_memalign: alignment must be a power of two");
+
+    /* Over-allocate by (alignment + sizeof(void*)) so we can both align the
+     * returned pointer and stash a back-pointer to the raw block in the
+     * gap before it. Guard the addition against wrap (mirrors scratch_calloc):
+     * a wrapped size would under-allocate and let the caller overrun the heap. */
+    if (size > (size_t)-1 - alignment - sizeof(void *)) return NULL;
+    size_t padded = size + alignment + sizeof(void *);
+    void *raw = scratch_malloc(padded);
+    if (!raw) return NULL;
+
+    uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + (alignment - 1)) & ~(alignment - 1);
+    void **back_slot = (void **)(aligned_addr - sizeof(void *));
+    *back_slot = raw;
+    return (void *)aligned_addr;
 }
 
 void scratch_check(void) {
@@ -254,4 +336,11 @@ void scratch_get_stats(scratch_stats_t *stats) {
 
 bool scratch_empty(void) {
     return sh_live_blocks == 0;
+}
+
+bool scratch_owns(const void *ptr) {
+    if (!ptr) return false;
+    /* Accept either the cached or uncached view of a scratch address. */
+    const void *cached = CachedAddr(ptr);
+    return ptr_in_heap(cached);
 }


### PR DESCRIPTION
Adds `scratch_malloc_uncached` (KSEG1 view with cache invalidated, mirrors `malloc_uncached`), `scratch_memalign` (arbitrary power-of-two alignment via a back-slot to the raw chunk), and `scratch_owns` (membership test recognizing both cached and uncached views). `scratch_free` becomes the single deallocator for every scratch pointer, dispatching on the chunk magic so callers no longer track which sub-allocator or view produced a pointer.