### PR TITLE
yuv: caller-provided allocator for the chroma interleave buffer

### DIFF
--- a/include/scratch.h
+++ b/include/scratch.h
@@ -94,15 +94,62 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by #scratch_malloc(), #scratch_calloc(), or
-  * #scratch_realloc().
+  * Releases a block previously returned by any scratch allocator —
+  * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
+  * #scratch_memalign(), or #scratch_malloc_uncached(). The single
+  * entry point transparently handles cached vs uncached pointer views
+  * and direct vs aligned allocations; callers don't need to track
+  * which allocator produced the pointer.
   *
   * Passing NULL is allowed and has no effect.
   *
   * @param ptr          Pointer to the scratch allocation to free, or NULL.
   */
  void scratch_free(void *ptr);
+
+ /**
+  * @brief Allocate uncached memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns an uncached
+  * (KSEG1) mapping of the buffer. This mirrors #malloc_uncached() and is
+  * intended for short-lived buffers shared between CPU and RSP/RDP DMA paths
+  * (decoder workspaces, staging surfaces, etc.) where the coherency cost of
+  * cached access would otherwise force manual flushes around every transfer.
+  *
+  * The underlying allocation is 16-byte aligned and the size is rounded up to
+  * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
+  * cannot suffer false sharing with neighbouring allocations.
+  *
+  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * transparently.
+  *
+  * @param size         Number of bytes to allocate.
+  * @return Uncached pointer to the allocated memory, or NULL if there is not
+  *         enough memory.
+  *
+  * @note Memory returned by this function is uninitialized.
+  *
+  * @see scratch_free
+  * @see malloc_uncached
+  */
+ void *scratch_malloc_uncached(size_t size);
  
+ /**
+  * @brief Allocate aligned memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns a pointer
+  * aligned to @p alignment bytes. @p alignment must be a power of two and
+  * at least the natural scratch alignment (16 bytes); requests smaller than
+  * 16 are clamped up.
+  *
+  * Free with #scratch_free().
+  *
+  * @param alignment    Required alignment in bytes (power of two, >= 16).
+  * @param size         Number of bytes to allocate.
+  * @return Pointer to the aligned allocation, or NULL on failure.
+  */
+ void *scratch_memalign(size_t alignment, size_t size);
+
  /**
   * @brief Check internal consistency of the scratch heap.
   *
@@ -139,6 +186,22 @@ void scratch_get_stats(scratch_stats_t *stats);
   * @return true if there are no live scratch allocations, false otherwise.
   */
  bool scratch_empty(void);
+
+ /**
+  * @brief Check whether a pointer was allocated by the scratch allocator.
+  *
+  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
+  * / #scratch_realloc, false otherwise. The cached and uncached views of
+  * the same scratch address are both recognised.
+  *
+  * Intended for code paths that don't know up-front which allocator owns a
+  * pointer (e.g. fallbacks between scratch and the main heap) and need to
+  * dispatch to the correct deallocator.
+  *
+  * @param ptr Pointer to test.
+  * @return true if owned by scratch, false otherwise (including NULL).
+  */
+ bool scratch_owns(const void *ptr);
  
  #ifdef __cplusplus
  }

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "debug.h"
+#include "n64sys.h"
 #include "scratch.h"
 #include "system_internal.h"
 #include "utils.h"
@@ -149,9 +150,9 @@ void *scratch_malloc(size_t size) {
     return block_user_ptr(b);
 }
 
-void scratch_free(void *ptr) {
-    if (!ptr) return;
-
+/* Release the chunk that ptr is the user-data of. Caller guarantees ptr is
+ * a valid direct-allocated scratch chunk's user pointer. */
+static void scratch_free_chunk(void *ptr) {
     block_t *b = block_from_user_ptr(ptr);
     assert(ptr_in_heap(b));
     assert(!block_is_free(b));
@@ -164,6 +165,66 @@ void scratch_free(void *ptr) {
     block_mark_free(b);
     if (b == sh_head) trim_head();
 }
+
+void scratch_free(void *ptr) {
+    if (!ptr) return;
+
+    /* scratch_free is the single-entry deallocator for any pointer
+     * returned by any scratch_* allocation. It transparently handles:
+     *   - cached vs uncached views (both refer to the same physical chunk)
+     *   - direct allocations (scratch_malloc / scratch_calloc) where the
+     *     pointer is at user_ptr_offset within the chunk
+     *   - aligned allocations (scratch_memalign) where the pointer is
+     *     offset further into the chunk and the chunk's raw user pointer
+     *     is stored in a back-slot at (ptr - sizeof(void*))
+     * Callers don't need to track which allocator produced the pointer or
+     * which view (cached/uncached) they hold. */
+    void *cached = CachedAddr(ptr);
+
+    /* First try the direct interpretation: assume `cached` is the user
+     * pointer of a scratch chunk and check the header for the USED magic.
+     * If the magic matches, we're done — release this chunk. */
+    block_t *b_direct = block_from_user_ptr(cached);
+    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
+        scratch_free_chunk(cached);
+        return;
+    }
+
+    /* Otherwise this must be a memalign'd pointer: the back-slot before
+     * `cached` holds the raw chunk's user pointer. Validate and release. */
+    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
+    void *raw = *back_slot;
+    block_t *b_raw = block_from_user_ptr(raw);
+    /* Validate with a real runtime check, not just an assert: under NDEBUG
+     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
+     * stale back-slot holds garbage) must fail safely rather than free an
+     * arbitrary address (there is no MMU to catch it). Require the raw block to
+     * be a live scratch chunk that actually contains this aligned alias. */
+    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
+        (uintptr_t)cached >= (uintptr_t)raw &&
+        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
+    if (!valid) {
+        assertf(false,
+            "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
+        return;
+    }
+    scratch_free_chunk(raw);
+}
+
+void *scratch_malloc_uncached(size_t size) {
+    // Round the size up to a full cacheline so the uncached buffer can never
+    // false-share with a neighbouring allocation (mirrors malloc_uncached).
+    size = ROUND_UP(size, 16);
+    void *p = scratch_malloc(size);
+    if (!p) return NULL;
+
+    // The memory may have been in the data cache from a prior cached use of
+    // the same block; invalidate so a future writeback can't clobber RSP/RDP
+    // writes.
+    data_cache_hit_invalidate(p, size);
+    return UncachedAddr(p);
+}
+
 
 void *scratch_calloc(size_t count, size_t size) {
     if (count && size > ((size_t)-1) / count) return NULL;
@@ -199,6 +260,27 @@ void *scratch_realloc(void *ptr, size_t size) {
     memcpy(q, ptr, old_requested < size ? old_requested : size);
     scratch_free(ptr);
     return q;
+}
+
+void *scratch_memalign(size_t alignment, size_t size) {
+    if (alignment < SCRATCH_ALIGN) alignment = SCRATCH_ALIGN;
+    /* Power-of-two check matches POSIX memalign semantics. */
+    assertf((alignment & (alignment - 1)) == 0,
+        "scratch_memalign: alignment must be a power of two");
+
+    /* Over-allocate by (alignment + sizeof(void*)) so we can both align the
+     * returned pointer and stash a back-pointer to the raw block in the
+     * gap before it. Guard the addition against wrap (mirrors scratch_calloc):
+     * a wrapped size would under-allocate and let the caller overrun the heap. */
+    if (size > (size_t)-1 - alignment - sizeof(void *)) return NULL;
+    size_t padded = size + alignment + sizeof(void *);
+    void *raw = scratch_malloc(padded);
+    if (!raw) return NULL;
+
+    uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + (alignment - 1)) & ~(alignment - 1);
+    void **back_slot = (void **)(aligned_addr - sizeof(void *));
+    *back_slot = raw;
+    return (void *)aligned_addr;
 }
 
 void scratch_check(void) {
@@ -254,4 +336,11 @@ void scratch_get_stats(scratch_stats_t *stats) {
 
 bool scratch_empty(void) {
     return sh_live_blocks == 0;
+}
+
+bool scratch_owns(const void *ptr) {
+    if (!ptr) return false;
+    /* Accept either the cached or uncached view of a scratch address. */
+    const void *cached = CachedAddr(ptr);
+    return ptr_in_heap(cached);
 }

--- a/src/video/yuv.c
+++ b/src/video/yuv.c
@@ -23,6 +23,48 @@
 /** @brief Internal buffer used to interleave U and V components */
 static surface_t internal_buffer;
 
+/** @brief Optional caller-provided allocator for the interleave buffer.
+ *
+ * By default the internal buffer is allocated with surface_alloc() (the system
+ * heap). On memory-constrained targets the system heap can fragment such that
+ * this allocation fails mid-session; a failed alloc would leave a NULL buffer
+ * that rsp_yuv would then DMA to physical 0, corrupting low RDRAM. Callers can
+ * install an allocator (e.g. backed by a scratch/transient heap) to source the
+ * buffer from contiguous memory instead. See yuv_set_internal_allocator(). */
+static yuv_allocator_t internal_allocator;
+/** @brief True when internal_buffer.buffer came from internal_allocator. */
+static bool internal_buffer_custom;
+
+static void internal_buffer_release(void)
+{
+    if (internal_buffer.buffer && internal_buffer_custom)
+        internal_allocator.free(internal_allocator.ctx, internal_buffer.buffer);
+    else
+        surface_free(&internal_buffer);
+    internal_buffer = (surface_t){0};
+    internal_buffer_custom = false;
+}
+
+void yuv_set_internal_allocator(const yuv_allocator_t *allocator)
+{
+    // Changing the allocator while it still owns the live interleave buffer
+    // would strand that buffer on the old allocator (its eventual release would
+    // route through whichever allocator is installed then). Install the
+    // allocator up front — before any blit allocates the buffer — and clear it
+    // only once the buffer has been released (e.g. after the final yuv_close()).
+    assertf(!internal_buffer_custom,
+        "yuv_set_internal_allocator: cannot change the allocator while its "
+        "interleave buffer is still live (change it before the first blit or "
+        "after yuv_close())");
+    // Drop any default-heap buffer so the next resize_internal_buffer()
+    // re-allocates it through the new allocator.
+    internal_buffer_release();
+    if (allocator && allocator->alloc && allocator->free)
+        internal_allocator = *allocator;
+    else
+        internal_allocator = (yuv_allocator_t){0};
+}
+
 // Calculated with: yuv_new_colorspace(0.299, 0.114, 16, 219, 224);
 const yuv_colorspace_t YUV_BT601_TV = {
     .c0=1.16895, .c1=1.60229, .c2=-0.393299, .c3=-0.816156, .c4=2.02514, .y0=16,
@@ -51,8 +93,19 @@ const yuv_colorspace_t YUV_BT709_FULL = {
 static void resize_internal_buffer(int w, int h)
 {
     if (internal_buffer.width != w || internal_buffer.height != h) {
-        surface_free(&internal_buffer);
-        internal_buffer = surface_alloc(FMT_IA16, w, h);
+        internal_buffer_release();
+        if (internal_allocator.alloc) {
+            // Custom allocator: build a non-owning surface around its buffer so
+            // surface_free() won't touch it; we release it via the allocator.
+            size_t stride = TEX_FORMAT_PIX2BYTES(FMT_IA16, w);
+            void *buf = internal_allocator.alloc(internal_allocator.ctx, stride * h, 16);
+            internal_buffer = surface_make_linear(buf, FMT_IA16, w, h);
+            internal_buffer_custom = (buf != NULL);
+        } else {
+            internal_buffer = surface_alloc(FMT_IA16, w, h);
+        }
+        assertf(internal_buffer.buffer,
+            "yuv: out of memory allocating %dx%d internal interleave buffer", w, h);
     }
 }
 
@@ -98,7 +151,7 @@ void yuv_close(void)
     assert(yuv_initialized > 0);
     yuv_initialized--;
     if (yuv_initialized == 0) {
-        surface_free(&internal_buffer);
+        internal_buffer_release();
         rspq_overlay_unregister(ovl_yuv);
     }
 }
@@ -248,6 +301,11 @@ void rsp_yuv_set_input_buffer(uint8_t *y, uint8_t *cb, uint8_t *cr, int y_pitch)
 
 void rsp_yuv_set_output_buffer(uint8_t *out, int out_pitch)
 {
+    // Never let the RSP DMA to physical 0: a NULL output buffer (e.g. a failed
+    // surface_alloc under low memory) would otherwise interleave chroma straight
+    // into low RDRAM, silently smashing .text. Fail loudly instead.
+    assertf(out != NULL && PhysicalAddr(out) != 0,
+        "rsp_yuv: output buffer is NULL (out of memory?)");
     rspq_write(ovl_yuv, CMD_YUV_SET_OUTPUT,
         PhysicalAddr(out), out_pitch);
 }

--- a/src/video/yuv_internal.h
+++ b/src/video/yuv_internal.h
@@ -13,4 +13,62 @@
 #define BLOCK_W 32
 #define BLOCK_H 16
 
+// This header is also included by rsp_yuv.S for the macros above; keep the C
+// declarations below out of the assembler's view.
+#ifndef __ASSEMBLER__
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Allocator for the YUV library's internal interleave buffer.
+ *
+ * The blitter keeps a small internal buffer (used to interleave the U and V
+ * chroma planes before feeding them to the RDP). By default it is allocated
+ * from the system heap. On memory-constrained or long-running targets that heap
+ * can fragment to the point where this allocation fails mid-session; callers can
+ * install a custom allocator (e.g. backed by a contiguous scratch/transient
+ * heap) to source it from elsewhere. See #yuv_set_internal_allocator.
+ */
+typedef struct yuv_allocator_s {
+    /** @brief Allocate @p size bytes aligned to at least @p align. Must return
+     *         an uncached pointer (the RDP/RSP access the buffer directly), or
+     *         NULL on failure. */
+    void *(*alloc)(void *ctx, size_t size, int align);
+    /** @brief Free a pointer previously returned by alloc(). */
+    void  (*free)(void *ctx, void *ptr);
+    /** @brief Opaque context passed to alloc()/free(). */
+    void  *ctx;
+} yuv_allocator_t;
+
+/**
+ * @brief Install a custom allocator for the internal interleave buffer.
+ *
+ * Pass NULL to revert to the default (system-heap) allocator. Both @p alloc and
+ * @p free must be provided, otherwise the default allocator is used.
+ *
+ * The allocator must be installed up front, before the interleave buffer is
+ * first allocated (i.e. before the first blit), and cleared only once it has
+ * been released (e.g. after the final #yuv_close()): the buffer is freed through
+ * whichever allocator is installed at release time, so changing it while the
+ * buffer is live would strand it on the wrong allocator. This is asserted.
+ *
+ * @note Internal/advanced API: deliberately not declared in the public
+ * <yuv.h>. The allocator-lifetime coupling above is a sharp edge not yet fit
+ * for general use; declared here for opt-in by code embedding libdragon that
+ * needs to control the interleave buffer's placement.
+ *
+ * @param allocator   Allocator to install, or NULL for the default.
+ */
+void yuv_set_internal_allocator(const yuv_allocator_t *allocator);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !__ASSEMBLER__
+
 #endif


### PR DESCRIPTION
Stacked on top of #927 

The U/V interleave buffer was allocated from the system heap; under fragmentation that alloc could fail mid-session, and the resulting NULL buffer was DMA'd by the RSP to physical 0, silently corrupting low RDRAM.

Add yuv_set_internal_allocator so the buffer can come from contiguous memory, and assert in rsp_yuv_set_output_buffer against a NULL/physical-0 target so a failed alloc can never reach the RSP. Default unchanged.