### PR TITLE
wav64: optional custom allocator hook for streaming heap blocks

### DIFF
--- a/include/scratch.h
+++ b/include/scratch.h
@@ -94,15 +94,62 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by #scratch_malloc(), #scratch_calloc(), or
-  * #scratch_realloc().
+  * Releases a block previously returned by any scratch allocator —
+  * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
+  * #scratch_memalign(), or #scratch_malloc_uncached(). The single
+  * entry point transparently handles cached vs uncached pointer views
+  * and direct vs aligned allocations; callers don't need to track
+  * which allocator produced the pointer.
   *
   * Passing NULL is allowed and has no effect.
   *
   * @param ptr          Pointer to the scratch allocation to free, or NULL.
   */
  void scratch_free(void *ptr);
+
+ /**
+  * @brief Allocate uncached memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns an uncached
+  * (KSEG1) mapping of the buffer. This mirrors #malloc_uncached() and is
+  * intended for short-lived buffers shared between CPU and RSP/RDP DMA paths
+  * (decoder workspaces, staging surfaces, etc.) where the coherency cost of
+  * cached access would otherwise force manual flushes around every transfer.
+  *
+  * The underlying allocation is 16-byte aligned and the size is rounded up to
+  * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
+  * cannot suffer false sharing with neighbouring allocations.
+  *
+  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * transparently.
+  *
+  * @param size         Number of bytes to allocate.
+  * @return Uncached pointer to the allocated memory, or NULL if there is not
+  *         enough memory.
+  *
+  * @note Memory returned by this function is uninitialized.
+  *
+  * @see scratch_free
+  * @see malloc_uncached
+  */
+ void *scratch_malloc_uncached(size_t size);
  
+ /**
+  * @brief Allocate aligned memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns a pointer
+  * aligned to @p alignment bytes. @p alignment must be a power of two and
+  * at least the natural scratch alignment (16 bytes); requests smaller than
+  * 16 are clamped up.
+  *
+  * Free with #scratch_free().
+  *
+  * @param alignment    Required alignment in bytes (power of two, >= 16).
+  * @param size         Number of bytes to allocate.
+  * @return Pointer to the aligned allocation, or NULL on failure.
+  */
+ void *scratch_memalign(size_t alignment, size_t size);
+
  /**
   * @brief Check internal consistency of the scratch heap.
   *
@@ -139,6 +186,22 @@ void scratch_get_stats(scratch_stats_t *stats);
   * @return true if there are no live scratch allocations, false otherwise.
   */
  bool scratch_empty(void);
+
+ /**
+  * @brief Check whether a pointer was allocated by the scratch allocator.
+  *
+  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
+  * / #scratch_realloc, false otherwise. The cached and uncached views of
+  * the same scratch address are both recognised.
+  *
+  * Intended for code paths that don't know up-front which allocator owns a
+  * pointer (e.g. fallbacks between scratch and the main heap) and need to
+  * dispatch to the correct deallocator.
+  *
+  * @param ptr Pointer to test.
+  * @return true if owned by scratch, false otherwise (including NULL).
+  */
+ bool scratch_owns(const void *ptr);
  
  #ifdef __cplusplus
  }

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -102,6 +102,29 @@ static int wav64_none_get_bitrate(wav64_t *wav) {
 	return wav->wave.frequency * wav->wave.channels * wav->wave.bits;
 }
 
+// Custom allocator for wav64 heap blocks (see wav64_set_allocator). Default
+// {NULL,NULL} => memalign/free.
+static wav64_allocator_t s_wav64_allocator = {0};
+
+// Number of live handles allocated through the custom allocator. wav64_close()
+// frees an arena-owned block through the currently-installed allocator, so the
+// allocator must not be swapped or cleared while any such block is outstanding.
+static int s_wav64_arena_blocks = 0;
+
+void wav64_set_allocator(const wav64_allocator_t *allocator)
+{
+	// Changing the allocator while it still owns open handles would free those
+	// handles through the wrong path in wav64_close(). Install it before the
+	// first streaming load and clear it only after those handles are closed.
+	assertf(s_wav64_arena_blocks == 0,
+		"wav64_set_allocator: cannot change the allocator while %d arena-owned "
+		"handle(s) are still open (wav64_close them first)", s_wav64_arena_blocks);
+	if (allocator && allocator->alloc && allocator->free)
+		s_wav64_allocator = *allocator;
+	else
+		s_wav64_allocator = (wav64_allocator_t){0};
+}
+
 static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_name, wav64_loadparms_t *parms)
 {
 	wav64_loadparms_t default_parms = {0};
@@ -167,9 +190,20 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 	int heap_off_ext = heap_size;
 	heap_size += ROUND_UP(ext_size, 16);							// Extended header data
 	
-	// Allocate heap memory
+	// Allocate heap memory. A custom allocator (wav64_set_allocator) lets the
+	// caller pool these blocks in a contiguous arena instead of scattering them
+	// across the main heap. The preload path below reallocs this block, which a
+	// bump-style arena can't satisfy — so the custom allocator is only honored
+	// for streaming loads (where the block is never realloc'd).
 	assert(heap_size % 16 == 0);
-	void *heap = memalign(16, heap_size);
+	bool heap_from_arena = false;
+	void *heap = NULL;
+	if (s_wav64_allocator.alloc && !preload) {
+		heap = s_wav64_allocator.alloc(heap_size, 16);
+		heap_from_arena = (heap != NULL);
+	}
+	if (!heap)
+		heap = memalign(16, heap_size);
 	assertf(heap, "Out of memory");
 	if (!wav) wav = heap + heap_off_waveform;
 	wav->st = heap;
@@ -195,7 +229,9 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 	wav->st->format = head.format;
 	wav->st->current_fd = file_handle;
 	wav->st->base_offset = head.start_offset + start_offset;
-	wav->st->flags = owned_fd ? WAV64_FLAG_OWNED_FD : 0;
+	wav->st->flags = (owned_fd ? WAV64_FLAG_OWNED_FD : 0)
+	               | (heap_from_arena ? WAV64_FLAG_ARENA_OWNED : 0);
+	if (heap_from_arena) s_wav64_arena_blocks++;
 
 	// Initialize the compression algorithm
 	algos[wav->st->format].init(wav, head.state_size);
@@ -219,6 +255,9 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 		if (algos[wav->st->format].close)
 			algos[wav->st->format].close(wav);
 
+		// realloc() can't act on a custom-arena block; the arena path is gated
+		// to !preload above, so this is only ever reached for memalign blocks.
+		assertf(!heap_from_arena, "wav64: preload reached on an arena-owned block");
 		wav->st = realloc(wav->st, heap_off_preload_end);
 		wav->st->ext = NULL;
 
@@ -295,6 +334,11 @@ void wav64_close(wav64_t *wav)
 	if (!heap)
 		return;
 
+	// Remember how the heap block was allocated before the memset below wipes
+	// wav->st (and thus the flags). Arena-owned blocks are released through the
+	// custom allocator; the rest via free().
+	const bool heap_from_arena = (wav->st->flags & WAV64_FLAG_ARENA_OWNED) != 0;
+
 	// Stop playing the waveform on all channels
 	for (int i=0; i<MIXER_MAX_CHANNELS; i++) {
 		if (mixer_ch_playing_waveform(i) == &wav->wave)
@@ -311,8 +355,16 @@ void wav64_close(wav64_t *wav)
 
 	memset(wav, 0, sizeof(wav64_t));
 
-	// Free the heap allocation (that might or might not include the wav64_t instance)
-	free(heap);
+	// Free the heap allocation (that might or might not include the wav64_t
+	// instance). Arena-owned blocks go back through the custom allocator; the
+	// set_allocator assert guarantees it is still the one that produced them.
+	if (heap_from_arena) {
+		assertf(s_wav64_allocator.free,
+			"wav64_close: arena-owned handle freed with no allocator installed");
+		s_wav64_allocator.free(heap);
+		s_wav64_arena_blocks--;
+	} else
+		free(heap);
 }
 
 /** @brief Initialize wav64 compression level 3 */

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -5,6 +5,12 @@
 #ifndef __LIBDRAGON_WAV64_INTERNAL_H
 #define __LIBDRAGON_WAV64_INTERNAL_H
 
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define WAV64_ID            "WV64"    ///< WAV64 file identifier
 #define WAV64_FORMAT_RAW    0         ///< Raw audio format
 #define WAV64_FORMAT_VADPCM 1         ///< VADPCM compressed format
@@ -12,6 +18,7 @@
 #define WAV64_NUM_FORMATS   4         ///< Number of supported formats
 
 #define WAV64_FLAG_OWNED_FD (1 << 0)  ///< Flag indicating the file descriptor is owned by the wav64 structure
+#define WAV64_FLAG_ARENA_OWNED (1 << 1) ///< Heap block came from the custom allocator (wav64_set_allocator); free via it
 
 /// @cond
 typedef struct wav64_s wav64_t;
@@ -64,8 +71,39 @@ typedef struct {
 } wav64_compression_t;
 
 /**
+ * @brief Custom allocator for the wav64 heap block.
+ *
+ * By default each wav64_load() allocates its single heap block (the wav64_state_t
+ * plus, for streaming, just the small handle) via memalign(16, ...). Install a
+ * custom allocator to source those blocks from a caller-owned region (e.g. a
+ * contiguous per-bank arena) so many small streaming handles don't fragment the
+ * main heap. The matching free() is called from wav64_close() for blocks that
+ * were allocated while a custom allocator was installed.
+ *
+ * @param alloc  Returns @p sz bytes aligned to @p align (>= 16), or NULL on failure.
+ * @param free   Releases a block previously returned by @p alloc.
+ */
+typedef struct wav64_allocator_s {
+	void* (*alloc)(size_t sz, size_t align);
+	void  (*free)(void* p);
+} wav64_allocator_t;
+
+/**
+ * @brief Install (or clear) the custom allocator used for wav64 heap blocks.
+ *
+ * Pass NULL to restore the default memalign/free. The allocator only affects
+ * loads made while it is installed; each handle remembers how it was allocated
+ * (WAV64_FLAG_ARENA_OWNED) and is freed accordingly in wav64_close().
+ */
+void wav64_set_allocator(const wav64_allocator_t *allocator);
+
+/**
  * Similar to #wav64_load, but uses a file descriptor instead of a filename.
  */
 wav64_t *wav64_loadfd(int fd, const char *debug_file_name, wav64_loadparms_t *parms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "debug.h"
+#include "n64sys.h"
 #include "scratch.h"
 #include "system_internal.h"
 #include "utils.h"
@@ -149,9 +150,9 @@ void *scratch_malloc(size_t size) {
     return block_user_ptr(b);
 }
 
-void scratch_free(void *ptr) {
-    if (!ptr) return;
-
+/* Release the chunk that ptr is the user-data of. Caller guarantees ptr is
+ * a valid direct-allocated scratch chunk's user pointer. */
+static void scratch_free_chunk(void *ptr) {
     block_t *b = block_from_user_ptr(ptr);
     assert(ptr_in_heap(b));
     assert(!block_is_free(b));
@@ -164,6 +165,66 @@ void scratch_free(void *ptr) {
     block_mark_free(b);
     if (b == sh_head) trim_head();
 }
+
+void scratch_free(void *ptr) {
+    if (!ptr) return;
+
+    /* scratch_free is the single-entry deallocator for any pointer
+     * returned by any scratch_* allocation. It transparently handles:
+     *   - cached vs uncached views (both refer to the same physical chunk)
+     *   - direct allocations (scratch_malloc / scratch_calloc) where the
+     *     pointer is at user_ptr_offset within the chunk
+     *   - aligned allocations (scratch_memalign) where the pointer is
+     *     offset further into the chunk and the chunk's raw user pointer
+     *     is stored in a back-slot at (ptr - sizeof(void*))
+     * Callers don't need to track which allocator produced the pointer or
+     * which view (cached/uncached) they hold. */
+    void *cached = CachedAddr(ptr);
+
+    /* First try the direct interpretation: assume `cached` is the user
+     * pointer of a scratch chunk and check the header for the USED magic.
+     * If the magic matches, we're done — release this chunk. */
+    block_t *b_direct = block_from_user_ptr(cached);
+    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
+        scratch_free_chunk(cached);
+        return;
+    }
+
+    /* Otherwise this must be a memalign'd pointer: the back-slot before
+     * `cached` holds the raw chunk's user pointer. Validate and release. */
+    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
+    void *raw = *back_slot;
+    block_t *b_raw = block_from_user_ptr(raw);
+    /* Validate with a real runtime check, not just an assert: under NDEBUG
+     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
+     * stale back-slot holds garbage) must fail safely rather than free an
+     * arbitrary address (there is no MMU to catch it). Require the raw block to
+     * be a live scratch chunk that actually contains this aligned alias. */
+    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
+        (uintptr_t)cached >= (uintptr_t)raw &&
+        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
+    if (!valid) {
+        assertf(false,
+            "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
+        return;
+    }
+    scratch_free_chunk(raw);
+}
+
+void *scratch_malloc_uncached(size_t size) {
+    // Round the size up to a full cacheline so the uncached buffer can never
+    // false-share with a neighbouring allocation (mirrors malloc_uncached).
+    size = ROUND_UP(size, 16);
+    void *p = scratch_malloc(size);
+    if (!p) return NULL;
+
+    // The memory may have been in the data cache from a prior cached use of
+    // the same block; invalidate so a future writeback can't clobber RSP/RDP
+    // writes.
+    data_cache_hit_invalidate(p, size);
+    return UncachedAddr(p);
+}
+
 
 void *scratch_calloc(size_t count, size_t size) {
     if (count && size > ((size_t)-1) / count) return NULL;
@@ -199,6 +260,27 @@ void *scratch_realloc(void *ptr, size_t size) {
     memcpy(q, ptr, old_requested < size ? old_requested : size);
     scratch_free(ptr);
     return q;
+}
+
+void *scratch_memalign(size_t alignment, size_t size) {
+    if (alignment < SCRATCH_ALIGN) alignment = SCRATCH_ALIGN;
+    /* Power-of-two check matches POSIX memalign semantics. */
+    assertf((alignment & (alignment - 1)) == 0,
+        "scratch_memalign: alignment must be a power of two");
+
+    /* Over-allocate by (alignment + sizeof(void*)) so we can both align the
+     * returned pointer and stash a back-pointer to the raw block in the
+     * gap before it. Guard the addition against wrap (mirrors scratch_calloc):
+     * a wrapped size would under-allocate and let the caller overrun the heap. */
+    if (size > (size_t)-1 - alignment - sizeof(void *)) return NULL;
+    size_t padded = size + alignment + sizeof(void *);
+    void *raw = scratch_malloc(padded);
+    if (!raw) return NULL;
+
+    uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + (alignment - 1)) & ~(alignment - 1);
+    void **back_slot = (void **)(aligned_addr - sizeof(void *));
+    *back_slot = raw;
+    return (void *)aligned_addr;
 }
 
 void scratch_check(void) {
@@ -254,4 +336,11 @@ void scratch_get_stats(scratch_stats_t *stats) {
 
 bool scratch_empty(void) {
     return sh_live_blocks == 0;
+}
+
+bool scratch_owns(const void *ptr) {
+    if (!ptr) return false;
+    /* Accept either the cached or uncached view of a scratch address. */
+    const void *cached = CachedAddr(ptr);
+    return ptr_in_heap(cached);
 }


### PR DESCRIPTION
Stacked on top of #927 

Add wav64_set_allocator so a caller can pool the small per-load streaming handles into a contiguous arena instead of scattering individual memalign blocks across the main heap. Only honored for streaming loads (the preload path reallocs its block, which a bump arena can't satisfy); each handle records WAV64_FLAG_ARENA_OWNED so wav64_close releases it through the matching free.

Declared in wav64_internal.h since it is not a stable public API.