### PR TITLE
asset/dlfcn: caller-provided allocator for asset payloads and DSO images

### DIFF
--- a/include/asset.h
+++ b/include/asset.h
@@ -129,8 +129,42 @@ extern void __asset_init_compression_lvl3(void);
 void *asset_load(const char *fn, int *sz);
 
 /**
+ * @brief Custom allocator for the buffer returned by #asset_load_ex
+ *
+ * Lets a caller place the (decompressed) asset payload in memory of its
+ * choosing — e.g. a pre-reserved region — instead of the default heap.
+ * Only the returned payload buffer is governed by this allocator; on N64
+ * the full-file path decompresses in place into that same buffer, so it is
+ * the only allocation #asset_load_ex performs. The matching @c free must be
+ * used to release the buffer (do not call the C @c free() on it).
+ */
+typedef struct {
+    /** @brief Allocate @p size bytes aligned to at least @p align. */
+    void *(*alloc)(void *ctx, size_t size, size_t align);
+    /** @brief Free a buffer previously returned by @c alloc. */
+    void  (*free)(void *ctx, void *ptr);
+    /** @brief Opaque context passed through to both callbacks. */
+    void  *ctx;
+} asset_allocator_t;
+
+/**
+ * @brief Load an asset file with a caller-provided allocator
+ *
+ * Identical to #asset_load, but the returned payload buffer is allocated via
+ * @p allocator (when non-NULL) instead of the default heap. Pass NULL to get
+ * exactly #asset_load behaviour. Free the result with @c allocator->free
+ * (or @c free() when @p allocator was NULL).
+ *
+ * @param fn            Filename to load (including filesystem prefix)
+ * @param sz            If not NULL, filled with the uncompressed size
+ * @param allocator     Custom payload allocator, or NULL for the default heap
+ * @return void*        Pointer to the loaded file
+ */
+void *asset_load_ex(const char *fn, int *sz, const asset_allocator_t *allocator);
+
+/**
  * @brief Load an asset file (possibly uncompressing it)
- * 
+ *
  * This function loads an asset embedded within a larger file. It requires in
  * input an open file pointer, seeked to the beginning of the asset, and the
  * size of the asset itself. If the asset is compressed, it is transparently

--- a/include/scratch.h
+++ b/include/scratch.h
@@ -94,15 +94,62 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by #scratch_malloc(), #scratch_calloc(), or
-  * #scratch_realloc().
+  * Releases a block previously returned by any scratch allocator —
+  * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
+  * #scratch_memalign(), or #scratch_malloc_uncached(). The single
+  * entry point transparently handles cached vs uncached pointer views
+  * and direct vs aligned allocations; callers don't need to track
+  * which allocator produced the pointer.
   *
   * Passing NULL is allowed and has no effect.
   *
   * @param ptr          Pointer to the scratch allocation to free, or NULL.
   */
  void scratch_free(void *ptr);
+
+ /**
+  * @brief Allocate uncached memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns an uncached
+  * (KSEG1) mapping of the buffer. This mirrors #malloc_uncached() and is
+  * intended for short-lived buffers shared between CPU and RSP/RDP DMA paths
+  * (decoder workspaces, staging surfaces, etc.) where the coherency cost of
+  * cached access would otherwise force manual flushes around every transfer.
+  *
+  * The underlying allocation is 16-byte aligned and the size is rounded up to
+  * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
+  * cannot suffer false sharing with neighbouring allocations.
+  *
+  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * transparently.
+  *
+  * @param size         Number of bytes to allocate.
+  * @return Uncached pointer to the allocated memory, or NULL if there is not
+  *         enough memory.
+  *
+  * @note Memory returned by this function is uninitialized.
+  *
+  * @see scratch_free
+  * @see malloc_uncached
+  */
+ void *scratch_malloc_uncached(size_t size);
  
+ /**
+  * @brief Allocate aligned memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns a pointer
+  * aligned to @p alignment bytes. @p alignment must be a power of two and
+  * at least the natural scratch alignment (16 bytes); requests smaller than
+  * 16 are clamped up.
+  *
+  * Free with #scratch_free().
+  *
+  * @param alignment    Required alignment in bytes (power of two, >= 16).
+  * @param size         Number of bytes to allocate.
+  * @return Pointer to the aligned allocation, or NULL on failure.
+  */
+ void *scratch_memalign(size_t alignment, size_t size);
+
  /**
   * @brief Check internal consistency of the scratch heap.
   *
@@ -139,6 +186,22 @@ void scratch_get_stats(scratch_stats_t *stats);
   * @return true if there are no live scratch allocations, false otherwise.
   */
  bool scratch_empty(void);
+
+ /**
+  * @brief Check whether a pointer was allocated by the scratch allocator.
+  *
+  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
+  * / #scratch_realloc, false otherwise. The cached and uncached views of
+  * the same scratch address are both recognised.
+  *
+  * Intended for code paths that don't know up-front which allocator owns a
+  * pointer (e.g. fallbacks between scratch and the main heap) and need to
+  * dispatch to the correct deallocator.
+  *
+  * @param ptr Pointer to test.
+  * @return true if owned by scratch, false otherwise (including NULL).
+  */
+ bool scratch_owns(const void *ptr);
  
  #ifdef __cplusplus
  }

--- a/src/asset.c
+++ b/src/asset.c
@@ -305,7 +305,7 @@ void *asset_loadf(FILE *f, int *sz)
     return asset_loadfd(fd, sz);
 }
 
-void *asset_load(const char *fn, int *sz)
+void *asset_load_ex(const char *fn, int *sz, const asset_allocator_t *allocator)
 {
     void *buf = NULL; int buf_size = 0;
     int size;
@@ -315,12 +315,20 @@ void *asset_load(const char *fn, int *sz)
     size = stat.st_size;
     asset_parsed_header_t header;
     buf_size = asset_read_header(fd, &header, &size);
-    buf = memalign(ASSET_ALIGNMENT, buf_size);
+    if (allocator && allocator->alloc)
+        buf = allocator->alloc(allocator->ctx, buf_size, ASSET_ALIGNMENT);
+    else
+        buf = memalign(ASSET_ALIGNMENT, buf_size);
     assertf(buf, "Out of memory");
     asset_read(fd, &header, &size, buf, &buf_size);
     if (sz) *sz = size;
     close(fd);
     return buf;
+}
+
+void *asset_load(const char *fn, int *sz)
+{
+    return asset_load_ex(fn, sz, NULL);
 }
 
 #ifdef N64

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -102,6 +102,12 @@ dl_module_t *__dl_list_head;
 dl_module_t *__dl_list_tail;
 /** @brief Number of loaded modules */
 size_t __dl_num_loaded_modules;
+/** @brief Custom module-image allocator (see dl_set_module_allocator) */
+static dl_module_alloc_t module_alloc_func;
+/** @brief Matching module-image deallocator */
+static dl_module_free_t module_free_func;
+/** @brief Context passed to the module allocator callbacks */
+static void *module_alloc_ctx;
 /** @brief String of last error */
 static char error_string[256];
 /** @brief Whether an error is present */
@@ -504,7 +510,16 @@ void *dlopen(const char *filename, int mode)
         //Increment use count
         handle->ref_count++;
     } else {
-        handle = asset_load(filename, NULL);
+        if(module_alloc_func) {
+            asset_allocator_t allocator = {
+                .alloc = module_alloc_func,
+                .free = module_free_func,
+                .ctx = module_alloc_ctx,
+            };
+            handle = asset_load_ex(filename, NULL, &allocator);
+        } else {
+            handle = asset_load(filename, NULL);
+        }
         assertf(handle->magic == DSO_MAGIC, "Invalid DSO file");
         link_module(handle, filename);
         handle->mode = mode;
@@ -636,7 +651,26 @@ static void close_module(dl_module_t *module)
     end_module(module);
     //Remove module from memory
     __dl_remove_module(module);
-    free(module);
+    //Release the module image via the same allocator that produced it.
+    if(module_free_func) {
+        module_free_func(module_alloc_ctx, module);
+    } else {
+        free(module);
+    }
+}
+
+void dl_set_module_allocator(dl_module_alloc_t alloc, dl_module_free_t dealloc, void *ctx)
+{
+    // dlclose() frees each module image through the currently-installed free
+    // callback — module origin is not tracked per-module — so the allocator may
+    // only be changed while no modules are loaded. Install it before the first
+    // dlopen() and clear it only after every module has been dlclose()d.
+    assertf(__dl_num_loaded_modules == 0,
+        "dl_set_module_allocator: cannot change the allocator while %u module(s) "
+        "are still loaded (dlclose them first)", (unsigned)__dl_num_loaded_modules);
+    module_alloc_func = alloc;
+    module_free_func = dealloc;
+    module_alloc_ctx = ctx;
 }
 
 static void close_unused_modules()

--- a/src/dlfcn_internal.h
+++ b/src/dlfcn_internal.h
@@ -46,4 +46,38 @@ extern dl_module_t *__dl_list_tail;
 /** @brief Number of loaded modules */
 extern size_t __dl_num_loaded_modules;
 
+/**
+ * @brief Allocate the buffer holding a DSO module image (see #dl_set_module_allocator)
+ */
+typedef void *(*dl_module_alloc_t)(void *ctx, size_t size, size_t align);
+
+/**
+ * @brief Free a DSO module image buffer (see #dl_set_module_allocator)
+ */
+typedef void  (*dl_module_free_t)(void *ctx, void *ptr);
+
+/**
+ * @brief Install a custom allocator for DSO module images
+ *
+ * By default #dlopen allocates the (decompressed) module image on the heap
+ * and #dlclose frees it with @c free(). This installs a custom allocator
+ * used for every subsequent #dlopen, so the image can be placed in memory of
+ * the caller's choosing (e.g. a pre-reserved region to control heap layout).
+ *
+ * The installed allocator must remain in place for the whole lifetime of any
+ * module loaded while it was active, because #dlclose uses the installed
+ * @p free to release the image. Pass NULL callbacks to restore the default
+ * (@c malloc / @c free) behaviour.
+ *
+ * @note Internal/advanced API: deliberately not declared in the public
+ * <dlfcn.h>. The allocator-lifetime coupling above is a sharp edge not yet
+ * fit for general use; declared here for opt-in by code embedding libdragon
+ * that needs to control DSO image placement.
+ *
+ * @param alloc     Allocator callback, or NULL to restore the default
+ * @param free      Matching deallocator callback, or NULL for the default
+ * @param ctx       Opaque context passed through to both callbacks
+ */
+void dl_set_module_allocator(dl_module_alloc_t alloc, dl_module_free_t free, void *ctx);
+
 #endif

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "debug.h"
+#include "n64sys.h"
 #include "scratch.h"
 #include "system_internal.h"
 #include "utils.h"
@@ -149,9 +150,9 @@ void *scratch_malloc(size_t size) {
     return block_user_ptr(b);
 }
 
-void scratch_free(void *ptr) {
-    if (!ptr) return;
-
+/* Release the chunk that ptr is the user-data of. Caller guarantees ptr is
+ * a valid direct-allocated scratch chunk's user pointer. */
+static void scratch_free_chunk(void *ptr) {
     block_t *b = block_from_user_ptr(ptr);
     assert(ptr_in_heap(b));
     assert(!block_is_free(b));
@@ -164,6 +165,66 @@ void scratch_free(void *ptr) {
     block_mark_free(b);
     if (b == sh_head) trim_head();
 }
+
+void scratch_free(void *ptr) {
+    if (!ptr) return;
+
+    /* scratch_free is the single-entry deallocator for any pointer
+     * returned by any scratch_* allocation. It transparently handles:
+     *   - cached vs uncached views (both refer to the same physical chunk)
+     *   - direct allocations (scratch_malloc / scratch_calloc) where the
+     *     pointer is at user_ptr_offset within the chunk
+     *   - aligned allocations (scratch_memalign) where the pointer is
+     *     offset further into the chunk and the chunk's raw user pointer
+     *     is stored in a back-slot at (ptr - sizeof(void*))
+     * Callers don't need to track which allocator produced the pointer or
+     * which view (cached/uncached) they hold. */
+    void *cached = CachedAddr(ptr);
+
+    /* First try the direct interpretation: assume `cached` is the user
+     * pointer of a scratch chunk and check the header for the USED magic.
+     * If the magic matches, we're done — release this chunk. */
+    block_t *b_direct = block_from_user_ptr(cached);
+    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
+        scratch_free_chunk(cached);
+        return;
+    }
+
+    /* Otherwise this must be a memalign'd pointer: the back-slot before
+     * `cached` holds the raw chunk's user pointer. Validate and release. */
+    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
+    void *raw = *back_slot;
+    block_t *b_raw = block_from_user_ptr(raw);
+    /* Validate with a real runtime check, not just an assert: under NDEBUG
+     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
+     * stale back-slot holds garbage) must fail safely rather than free an
+     * arbitrary address (there is no MMU to catch it). Require the raw block to
+     * be a live scratch chunk that actually contains this aligned alias. */
+    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
+        (uintptr_t)cached >= (uintptr_t)raw &&
+        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
+    if (!valid) {
+        assertf(false,
+            "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
+        return;
+    }
+    scratch_free_chunk(raw);
+}
+
+void *scratch_malloc_uncached(size_t size) {
+    // Round the size up to a full cacheline so the uncached buffer can never
+    // false-share with a neighbouring allocation (mirrors malloc_uncached).
+    size = ROUND_UP(size, 16);
+    void *p = scratch_malloc(size);
+    if (!p) return NULL;
+
+    // The memory may have been in the data cache from a prior cached use of
+    // the same block; invalidate so a future writeback can't clobber RSP/RDP
+    // writes.
+    data_cache_hit_invalidate(p, size);
+    return UncachedAddr(p);
+}
+
 
 void *scratch_calloc(size_t count, size_t size) {
     if (count && size > ((size_t)-1) / count) return NULL;
@@ -199,6 +260,27 @@ void *scratch_realloc(void *ptr, size_t size) {
     memcpy(q, ptr, old_requested < size ? old_requested : size);
     scratch_free(ptr);
     return q;
+}
+
+void *scratch_memalign(size_t alignment, size_t size) {
+    if (alignment < SCRATCH_ALIGN) alignment = SCRATCH_ALIGN;
+    /* Power-of-two check matches POSIX memalign semantics. */
+    assertf((alignment & (alignment - 1)) == 0,
+        "scratch_memalign: alignment must be a power of two");
+
+    /* Over-allocate by (alignment + sizeof(void*)) so we can both align the
+     * returned pointer and stash a back-pointer to the raw block in the
+     * gap before it. Guard the addition against wrap (mirrors scratch_calloc):
+     * a wrapped size would under-allocate and let the caller overrun the heap. */
+    if (size > (size_t)-1 - alignment - sizeof(void *)) return NULL;
+    size_t padded = size + alignment + sizeof(void *);
+    void *raw = scratch_malloc(padded);
+    if (!raw) return NULL;
+
+    uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + (alignment - 1)) & ~(alignment - 1);
+    void **back_slot = (void **)(aligned_addr - sizeof(void *));
+    *back_slot = raw;
+    return (void *)aligned_addr;
 }
 
 void scratch_check(void) {
@@ -254,4 +336,11 @@ void scratch_get_stats(scratch_stats_t *stats) {
 
 bool scratch_empty(void) {
     return sh_live_blocks == 0;
+}
+
+bool scratch_owns(const void *ptr) {
+    if (!ptr) return false;
+    /* Accept either the cached or uncached view of a scratch address. */
+    const void *cached = CachedAddr(ptr);
+    return ptr_in_heap(cached);
 }


### PR DESCRIPTION
Stacked on top of #927 

`asset_load_ex(fn, sz, allocator)` places the decompressed payload via a caller-supplied allocator.

`dl_set_module_allocator` routes DSO module images through it so a caller can place them in a reserved region to control heap layout.

Kept as an internal API (declared in dlfcn_internal.h) for now.