### PR TITLE
lspr3: caller-provided allocator for the transient mbStorage buffer

### DIFF
--- a/include/lspr3.h
+++ b/include/lspr3.h
@@ -27,9 +27,108 @@
 #ifndef __LIBDRAGON_LSPR3_H
 #define __LIBDRAGON_LSPR3_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef struct sprite_s sprite_t;
+
+/**
+ * @brief Optional parameters for advanced lspr3 decoding.
+ *
+ * Pass a pointer to one of these into #lspr3_load_buf_ex to override the
+ * default decode behaviour used by #sprite_load. Each field defaults to
+ * "use the standard behaviour" when zero, so a zero-initialised
+ * `(lspr3_load_parms_t){}` is equivalent to passing NULL.
+ */
+typedef struct lspr3_load_parms_s {
+    /**
+     * @brief Custom output-buffer allocator.
+     *
+     * When non-NULL, lspr3 invokes this instead of `memalign` for the
+     * decoded sprite buffer. The callback receives the size in bytes,
+     * the required alignment (in bytes — at least 16, typically 64 for
+     * RDP color-image use), and the @ref alloc_ctx opaque pointer.
+     *
+     * The caller owns the matching `free` — the returned sprite must NOT
+     * be passed to #sprite_free, because that path always calls libc
+     * `free()`. Pair `alloc` with your own destructor (e.g.
+     * `scratch_free` if you allocated from the scratch heap).
+     */
+    void *(*alloc)(void *ctx, size_t size, size_t alignment);
+
+    /** @brief Opaque pointer passed to @ref alloc. */
+    void *alloc_ctx;
+
+    /**
+     * @brief Output horizontal divisor.
+     *
+     * 0 or 1 = native source width (default).
+     * 2 = decode to a half-width sprite. The RDP YUV combiner performs
+     * the horizontal downsample during the YUV→RGB conversion using its
+     * bilinear filter, so no separate downsample pass runs. Useful when
+     * the destination framebuffer is narrower than the encoded source
+     * (or memory pressure rules out a full-width copy).
+     */
+    int output_x_divisor;
+
+    /**
+     * @brief Output vertical divisor.
+     *
+     * 0 or 1 = native source height (default).
+     * 2 = decode to a half-height sprite. As with @ref output_x_divisor
+     * the RDP bilinear filter handles the downsample during the YUV→RGB
+     * blit. The two divisors are independent — set both to 2 for a
+     * quarter-area sprite, or only one for an anisotropic downscale.
+     */
+    int output_y_divisor;
+
+    /**
+     * @brief Optional allocator for the transient mb-storage buffer.
+     *
+     * When non-NULL, lspr3 invokes this instead of `calloc` for the
+     * per-slice mbStorage_t array (sized `mb_count * sizeof(mbStorage_t)`,
+     * worst case ~110 KiB for a 640x240 source). The callback receives
+     * the total byte size and the @ref mb_alloc_ctx opaque pointer, and
+     * must return zero-initialised memory (the decoder relies on it).
+     *
+     * If set, @ref mb_free must also be set; lspr3 calls it on the
+     * returned pointer before #lspr3_load_buf_ex returns.
+     *
+     * Useful when the main heap is fragmented enough that a single
+     * 100+ KiB chunk can't be satisfied — callers can route this
+     * allocation to a dedicated reserve or to scratch.
+     */
+    void *(*mb_alloc)(void *ctx, size_t size);
+
+    /** @brief Matching deallocator for @ref mb_alloc. Required if @ref mb_alloc is set. */
+    void (*mb_free)(void *ctx, void *ptr);
+
+    /** @brief Opaque pointer passed to @ref mb_alloc and @ref mb_free. */
+    void *mb_alloc_ctx;
+} lspr3_load_parms_t;
+
+/**
+ * @brief Decode an H264I-encoded sprite from memory, with options.
+ *
+ * Lower-level decode entry point exposed for advanced callers. The
+ * #sprite_load path uses #lspr3_load_buf_ex with NULL @p parms, matching
+ * the historical behaviour (memalign-allocated output, native source
+ * dimensions).
+ *
+ * Callers passing custom @p parms.alloc are responsible for freeing the
+ * returned sprite via the matching deallocator — #sprite_free always
+ * calls libc `free()` and is not suitable for custom-allocated sprites.
+ *
+ * @param encoded_buf  Pointer to the H264I-encoded sprite payload.
+ * @param encoded_sz   Size of @p encoded_buf in bytes.
+ * @param parms        Optional decode parameters; pass NULL for defaults.
+ * @return The decoded sprite, or aborts via #assertf on failure.
+ */
+sprite_t *lspr3_load_buf_ex(const void *encoded_buf, int encoded_sz,
+                            const lspr3_load_parms_t *parms);
 
 /**
  * @brief Register the H264I (Lossy-sprite Level 3) decoder with the sprite loader.

--- a/include/lspr3.h
+++ b/include/lspr3.h
@@ -108,6 +108,25 @@ typedef struct lspr3_load_parms_s {
 
     /** @brief Opaque pointer passed to @ref mb_alloc and @ref mb_free. */
     void *mb_alloc_ctx;
+
+    /**
+     * @brief Decode in horizontal bands to cap the transient YUV footprint.
+     *
+     * When > 0, the frame is reconstructed in bands of this many MB-rows into a
+     * small windowed scratch buffer (`band_rows`+2 MB-rows) and each band is
+     * converted into the output sprite as it completes, so the peak transient
+     * YUV is ~`(band_rows+2)/mb_height` of the full-frame YUV instead of the
+     * whole frame. Output is bit-identical to the full-frame path: intra
+     * prediction's cross-band top-neighbours are carried, and each band decodes
+     * one row ahead so its bottom-row chroma upsample has its real neighbour (no
+     * seam at band boundaries). Costs a few % more decode time (extra per-band
+     * RSP/RDP syncs), so it is intended for callers trading a little speed for a
+     * smaller transient working set.
+     *
+     * 0 (default) = decode the whole frame at once (fastest; needs the full
+     * frame's worth of transient YUV).
+     */
+    int band_rows;
 } lspr3_load_parms_t;
 
 /**

--- a/include/scratch.h
+++ b/include/scratch.h
@@ -94,15 +94,62 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by #scratch_malloc(), #scratch_calloc(), or
-  * #scratch_realloc().
+  * Releases a block previously returned by any scratch allocator —
+  * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
+  * #scratch_memalign(), or #scratch_malloc_uncached(). The single
+  * entry point transparently handles cached vs uncached pointer views
+  * and direct vs aligned allocations; callers don't need to track
+  * which allocator produced the pointer.
   *
   * Passing NULL is allowed and has no effect.
   *
   * @param ptr          Pointer to the scratch allocation to free, or NULL.
   */
  void scratch_free(void *ptr);
+
+ /**
+  * @brief Allocate uncached memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns an uncached
+  * (KSEG1) mapping of the buffer. This mirrors #malloc_uncached() and is
+  * intended for short-lived buffers shared between CPU and RSP/RDP DMA paths
+  * (decoder workspaces, staging surfaces, etc.) where the coherency cost of
+  * cached access would otherwise force manual flushes around every transfer.
+  *
+  * The underlying allocation is 16-byte aligned and the size is rounded up to
+  * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
+  * cannot suffer false sharing with neighbouring allocations.
+  *
+  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * transparently.
+  *
+  * @param size         Number of bytes to allocate.
+  * @return Uncached pointer to the allocated memory, or NULL if there is not
+  *         enough memory.
+  *
+  * @note Memory returned by this function is uninitialized.
+  *
+  * @see scratch_free
+  * @see malloc_uncached
+  */
+ void *scratch_malloc_uncached(size_t size);
  
+ /**
+  * @brief Allocate aligned memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns a pointer
+  * aligned to @p alignment bytes. @p alignment must be a power of two and
+  * at least the natural scratch alignment (16 bytes); requests smaller than
+  * 16 are clamped up.
+  *
+  * Free with #scratch_free().
+  *
+  * @param alignment    Required alignment in bytes (power of two, >= 16).
+  * @param size         Number of bytes to allocate.
+  * @return Pointer to the aligned allocation, or NULL on failure.
+  */
+ void *scratch_memalign(size_t alignment, size_t size);
+
  /**
   * @brief Check internal consistency of the scratch heap.
   *
@@ -139,6 +186,22 @@ void scratch_get_stats(scratch_stats_t *stats);
   * @return true if there are no live scratch allocations, false otherwise.
   */
  bool scratch_empty(void);
+
+ /**
+  * @brief Check whether a pointer was allocated by the scratch allocator.
+  *
+  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
+  * / #scratch_realloc, false otherwise. The cached and uncached views of
+  * the same scratch address are both recognised.
+  *
+  * Intended for code paths that don't know up-front which allocator owns a
+  * pointer (e.g. fallbacks between scratch and the main heap) and need to
+  * dispatch to the correct deallocator.
+  *
+  * @param ptr Pointer to test.
+  * @return true if owned by scratch, false otherwise (including NULL).
+  */
+ bool scratch_owns(const void *ptr);
  
  #ifdef __cplusplus
  }

--- a/src/lspr3.c
+++ b/src/lspr3.c
@@ -26,6 +26,7 @@
 #include "sprite.h"
 #include "sprite_internal.h"
 #include "n64sys.h"
+#include "scratch.h"
 #include "surface.h"
 #include "utils.h"
 #include "yuv.h"
@@ -48,6 +49,16 @@
 
 /** @brief Required alignment of the decoded sprite buffer. */
 #define H264I_BUF_ALIGN 64
+
+/** @brief Set to 1 to enable per-allocation heap/scratch trace dumps for
+ *  diagnosing memory pressure during cam decodes. Off in production. */
+#define LSPR3_TRACE_MEM 0
+
+#if LSPR3_TRACE_MEM
+static void lspr3_memdump(const char *tag);
+#else
+#define lspr3_memdump(tag) ((void)0)
+#endif
 
 /**
  * @brief Header structure for H264I-encoded files.
@@ -86,11 +97,16 @@ static bool lspr3_is_encoded(const void *buf, int sz) {
     return memcmp(hdr->magic, H264I_FILE_MAGIC, H264I_FILE_MAGIC_SIZE) == 0;
 }
 
-static size_t lspr3_decoded_size_buf(const void *encoded_buf, int encoded_sz) {
+static size_t lspr3_decoded_size_buf(const void *encoded_buf, int encoded_sz,
+                                     int x_divisor, int y_divisor) {
     if (!lspr3_is_encoded(encoded_buf, encoded_sz)) return 0;
+    if (x_divisor < 1) x_divisor = 1;
+    if (y_divisor < 1) y_divisor = 1;
     const lspr3_header_t *hdr = (const lspr3_header_t *)encoded_buf;
     assertf(hdr->version == H264I_VERSION, "Invalid lossy sprite version (H264I version %d, expected %d)\nPlease regenerate your asset files", hdr->version, H264I_VERSION);
-    size_t pixel_bytes = hdr->orig_width * hdr->orig_height * 2;
+    size_t out_w = hdr->orig_width / x_divisor;
+    size_t out_h = hdr->orig_height / y_divisor;
+    size_t pixel_bytes = out_w * out_h * 2;
     size_t header_bytes = sizeof(sprite_t) + sizeof(sprite_ext_t);
     return ROUND_UP(header_bytes, 64) + ROUND_UP(pixel_bytes, 16);
 }
@@ -103,7 +119,8 @@ static void lspr3_decode_intra_slice(
     uint8_t pic_init_qp,
     int8_t chroma_qp_index_offset,
     uint8_t **out_yuv,
-    size_t *out_yuv_size
+    size_t *out_yuv_size,
+    const lspr3_load_parms_t *parms
 ) {
     assertf(payload_size >= 2, "H264I: payload too small");
 
@@ -119,8 +136,10 @@ static void lspr3_decode_intra_slice(
     int mb_h = (height + 15) / 16;
     u32 pic_size_in_mbs = (u32)(mb_w * mb_h);
     size_t yuv_size = (size_t)pic_size_in_mbs * 256 + (size_t)pic_size_in_mbs * 64 * 2;
-    uint8_t *yuv = (uint8_t*)malloc_uncached(yuv_size);
-    assertf(yuv, "H264I: out of memory");
+    lspr3_memdump("pre-yuv");
+    uint8_t *yuv = (uint8_t*)scratch_malloc_uncached(yuv_size);
+    assertf(yuv, "H264I: out of memory (yuv %u)", (unsigned)yuv_size);
+    lspr3_memdump("post-yuv");
     image_t image = { .data = yuv, .width = (u32)mb_w, .height = (u32)mb_h };
 
     seqParamSet_t sps = {
@@ -167,8 +186,26 @@ static void lspr3_decode_intra_slice(
     assertf(slice.firstMbInSlice == 0, "H264I: first_mb_in_slice != 0");
     assertf(slice.picParameterSetId == 0, "H264I: unexpected PPS id");
 
-    mbStorage_t *mb = (mbStorage_t*)calloc(pic_size_in_mbs, sizeof(mbStorage_t));
-    assertf(mb, "H264I: out of memory");
+    lspr3_memdump("pre-mb");
+    // mb storage is transient — allocated here, freed at the end of
+    // this function. Default routes to the main heap to avoid stacking
+    // on scratch's peak alongside the longer-lived yuv + output sprite
+    // buffers (the three together would otherwise need a contiguous
+    // scratch window large enough to hold all of them simultaneously).
+    // Callers facing main-heap fragmentation can override via
+    // parms->mb_alloc to route this elsewhere (e.g. a dedicated reserve
+    // sized for the worst-case mb count).
+    size_t mb_bytes = (size_t)pic_size_in_mbs * sizeof(mbStorage_t);
+    mbStorage_t *mb;
+    if (parms && parms->mb_alloc) {
+        mb = (mbStorage_t*)parms->mb_alloc(parms->mb_alloc_ctx, mb_bytes);
+    } else {
+        mb = (mbStorage_t*)calloc(pic_size_in_mbs, sizeof(mbStorage_t));
+    }
+    assertf(mb, "H264I: out of memory (mb %u = %u x %u)",
+        (unsigned)mb_bytes,
+        (unsigned)sizeof(mbStorage_t), (unsigned)pic_size_in_mbs);
+    lspr3_memdump("post-mb");
     h264bsdInitMbNeighbours(mb, (u32)mb_w, pic_size_in_mbs);
 
     i32 qpY = (i32)pps.picInitQp + slice.sliceQpDelta;
@@ -225,7 +262,11 @@ static void lspr3_decode_intra_slice(
     // before the memory is released.
     rsph264_sync();
     assertf(currMbAddr == pic_size_in_mbs, "H264I: incomplete slice");
-    free(mb);
+    if (parms && parms->mb_alloc) {
+        parms->mb_free(parms->mb_alloc_ctx, mb);
+    } else {
+        free(mb);  // matches the calloc above (main heap, not scratch)
+    }
 
     *out_yuv = yuv;
     *out_yuv_size = yuv_size;
@@ -234,17 +275,23 @@ static void lspr3_decode_intra_slice(
 // Build the FMT_RGBA16 sprite from the I420 reconstruction. The RDP YUV
 // combiner does the YUV→RGB conversion on the fly (BT.709 full range, hard
 // coded to match the encoder's rgba_to_i420), with bilinear chroma upsample
-// as a side benefit.
+// as a side benefit. If x_divisor and/or y_divisor are > 1 the source is
+// also downsampled in that axis by the RDP's bilinear filter during the blit.
 static void lspr3_build_rgba16_sprite(
     sprite_t *sprite, const uint8_t *pic,
     uint16_t orig_w, uint16_t orig_h,
-    int stride, int luma_h
+    int stride, int luma_h,
+    int x_divisor, int y_divisor
 ) {
+    if (x_divisor < 1) x_divisor = 1;
+    if (y_divisor < 1) y_divisor = 1;
+    uint16_t out_w = orig_w / x_divisor;
+    uint16_t out_h = orig_h / y_divisor;
     uint8_t preserved_flags = sprite->flags & SPRITE_FLAGS_OWNEDBUFFER;
     size_t header_bytes = ROUND_UP(sizeof(sprite_t) + sizeof(sprite_ext_t), 64);
     sys_hw_memset(sprite, 0, header_bytes);
-    sprite->width = orig_w;
-    sprite->height = orig_h;
+    sprite->width = out_w;
+    sprite->height = out_h;
     sprite->flags = preserved_flags | SPRITE_FLAGS_NODATA | SPRITE_FLAGS_EXT | FMT_RGBA16;
     sprite->hslices = 1;
     sprite->vslices = 1;
@@ -271,10 +318,10 @@ static void lspr3_build_rgba16_sprite(
     // The RDP writes through to RAM bypassing the CPU cache. Discard
     // any (possibly speculative) cached lines for the destination so a
     // future read of `dst` doesn't return stale data.
-    size_t pixel_bytes = (size_t)orig_w * orig_h * 2;
+    size_t pixel_bytes = (size_t)out_w * out_h * 2;
     size_t pixel_bytes_aligned = ROUND_UP(pixel_bytes, 16);
     data_cache_hit_writeback_invalidate(dst, pixel_bytes_aligned);
-    surface_t target_surf = surface_make_linear(dst, FMT_RGBA16, orig_w, orig_h);
+    surface_t target_surf = surface_make_linear(dst, FMT_RGBA16, out_w, out_h);
 
     yuv_init();
     {
@@ -286,7 +333,20 @@ static void lspr3_build_rgba16_sprite(
             // pixels until the caller next sets a render mode.
             rdpq_mode_push();
             {
-                yuv_tex_blit(&frame, 0, 0, NULL, &YUV_BT709_FULL);
+                if (x_divisor > 1 || y_divisor > 1) {
+                    // Downsample during the blit. The RDP bilinear filter
+                    // handles sub-pixel sampling, so a 0.5x scale produces
+                    // a clean downsample (chroma is naturally 2x2 upsampled
+                    // before the combiner so the chroma plane's sample
+                    // density is preserved through the downscale).
+                    rdpq_blitparms_t bp = {
+                        .scale_x = 1.0f / (float)x_divisor,
+                        .scale_y = 1.0f / (float)y_divisor,
+                    };
+                    yuv_tex_blit(&frame, 0, 0, &bp, &YUV_BT709_FULL);
+                } else {
+                    yuv_tex_blit(&frame, 0, 0, NULL, &YUV_BT709_FULL);
+                }
             }
             rdpq_mode_pop();
         }
@@ -319,19 +379,55 @@ static void lspr3_apply_alpha1(uint16_t *dst, uint16_t w, uint16_t h,
     data_cache_hit_writeback(dst, ROUND_UP((size_t)w * h * 2, 16));
 }
 
-static sprite_t *lspr3_load_buf(const void *encoded_buf, int encoded_sz) {
-    // Allocate the buffer for the decoded sprite.
-    size_t decoded_sz = lspr3_decoded_size_buf(encoded_buf, encoded_sz);
-    assertf(decoded_sz > 0, "Invalid H264I buffer");
-    sprite_t *sprite = (sprite_t *)memalign(H264I_BUF_ALIGN, decoded_sz);
-    assertf(sprite, "Out of memory");
-    sprite->flags = SPRITE_FLAGS_OWNEDBUFFER;
+#if LSPR3_TRACE_MEM
+static void lspr3_memdump(const char *tag) {
+    struct mallinfo mi = mallinfo();
+    scratch_stats_t ss;
+    scratch_get_stats(&ss);
+    debugf("n64: MEMF [%s] heap.uord=%u ford=%u keep=%u | scratch.live=%u resv=%u\n",
+        tag,
+        (unsigned)mi.uordblks, (unsigned)mi.fordblks, (unsigned)mi.keepcost,
+        (unsigned)ss.live_bytes, (unsigned)ss.reserved_bytes);
+}
+#endif
 
-    // Decode the H264I bitstream into YUV planes. When a 1-bit alpha bitmap is
-    // present it is appended after the H.264 payload, so the payload itself is
-    // shorter than the whole buffer by alpha_size bytes.
+sprite_t *lspr3_load_buf_ex(const void *encoded_buf, int encoded_sz,
+                            const lspr3_load_parms_t *parms)
+{
+    lspr3_memdump("lspr3-entry");
+    int x_divisor = (parms && parms->output_x_divisor > 0) ? parms->output_x_divisor : 1;
+    int y_divisor = (parms && parms->output_y_divisor > 0) ? parms->output_y_divisor : 1;
+
+    // Allocate the buffer for the decoded sprite. Default path uses memalign
+    // with H264I_BUF_ALIGN so the post-header pixel area lands on a 64-byte
+    // boundary (required by rdpq_set_color_image when the pixel area is
+    // used as a YUV blit target). A caller-provided allocator is responsible
+    // for satisfying the same alignment — typically by passing the
+    // alignment through to its own aligned allocator.
+    size_t decoded_sz = lspr3_decoded_size_buf(encoded_buf, encoded_sz, x_divisor, y_divisor);
+    assertf(decoded_sz > 0, "Invalid H264I buffer");
+    sprite_t *sprite;
+    if (parms && parms->alloc) {
+        sprite = (sprite_t *)parms->alloc(parms->alloc_ctx, decoded_sz, H264I_BUF_ALIGN);
+    } else {
+        sprite = (sprite_t *)memalign(H264I_BUF_ALIGN, decoded_sz);
+    }
+    assertf(sprite, "H264I: out of memory (sprite %u)", (unsigned)decoded_sz);
+    sprite->flags = SPRITE_FLAGS_OWNEDBUFFER;
+    lspr3_memdump("post-sprite-alloc");
+
+    // Decode the H264I bitstream into YUV planes. The transient yuv +
+    // macroblock-storage buffers always go through scratch — they're
+    // short-lived and stack cleanly with no fragmentation impact on the
+    // caller's heap. When a 1-bit alpha bitmap is present it is appended
+    // after the H.264 payload, so the payload is shorter than the whole
+    // buffer by alpha_size bytes.
     const lspr3_header_t *hdr = (const lspr3_header_t *)encoded_buf;
     size_t alpha_size = (hdr->flags & LSPR3_FLAG_ALPHA1) ? hdr->alpha_size : 0;
+    // 1-bit alpha is authored at the source resolution; it can't be applied to
+    // a divisor-downsampled buffer. Fail loudly rather than corrupt memory.
+    assertf(!(alpha_size && (x_divisor > 1 || y_divisor > 1)),
+        "H264I: 1-bit alpha is not supported together with output divisors");
     assertf((size_t)encoded_sz >= sizeof(lspr3_header_t) + alpha_size,
         "H264I buffer truncated (sz=%d, alpha_size=%zu)", encoded_sz, alpha_size);
     size_t payload_size = (size_t)encoded_sz - sizeof(lspr3_header_t) - alpha_size;
@@ -341,7 +437,7 @@ static sprite_t *lspr3_load_buf(const void *encoded_buf, int encoded_sz) {
         hdr->payload, payload_size,
         hdr->width, hdr->height,
         hdr->pic_init_qp, hdr->chroma_qp_index_offset,
-        &pic, &pic_size
+        &pic, &pic_size, parms
     );
 
     // Convert the YUV planes into the final RGBA16 sprite
@@ -352,9 +448,10 @@ static sprite_t *lspr3_load_buf(const void *encoded_buf, int encoded_sz) {
     lspr3_build_rgba16_sprite(
         sprite, pic,
         hdr->orig_width, hdr->orig_height,
-        stride, luma_h
+        stride, luma_h,
+        x_divisor, y_divisor
     );
-    free_uncached(pic);
+    scratch_free(pic);
 
     // Re-apply the lossless 1-bit alpha mask (if any) on top of the RGBA5551
     // pixels the RDP just produced (the YUV combiner writes alpha=1 everywhere).
@@ -366,6 +463,13 @@ static sprite_t *lspr3_load_buf(const void *encoded_buf, int encoded_sz) {
     }
 
     return sprite;
+}
+
+// Default decoder callback registered with sprite_load_buf: uses memalign
+// for the output (callers that go through sprite_load / sprite_load_buf
+// can pass the result to sprite_free unchanged).
+static sprite_t *lspr3_load_buf(const void *encoded_buf, int encoded_sz) {
+    return lspr3_load_buf_ex(encoded_buf, encoded_sz, NULL);
 }
 
 static int lspr3_init_refcount = 0;

--- a/src/lspr3.c
+++ b/src/lspr3.c
@@ -54,6 +54,12 @@
  *  diagnosing memory pressure during cam decodes. Off in production. */
 #define LSPR3_TRACE_MEM 0
 
+/** @brief Set to 1 to verify the banded intra decoder bit-for-bit against the
+ *  full-frame path on every decode (needs a 2nd full YUV, so run on 8 MiB).
+ *  Off in production. */
+#define LSPR3_VERIFY_BANDING 0
+#define LSPR3_VERIFY_BAND_ROWS 5
+
 #if LSPR3_TRACE_MEM
 static void lspr3_memdump(const char *tag);
 #else
@@ -272,6 +278,231 @@ static void lspr3_decode_intra_slice(
     *out_yuv_size = yuv_size;
 }
 
+static uint8_t *lspr3_setup_rgba16_sprite_header(sprite_t *sprite, uint16_t out_w, uint16_t out_h);
+
+// Banded variant: reconstruct the frame in horizontal bands of `band_rows`
+// MB-rows into a small windowed scratch buffer, so the peak transient YUV is a
+// fraction of the full-frame path. Each completed band is either assembled into
+// the full-frame `out_yuv` (verification: lets a harness diff against the
+// full-frame reconstruction) OR converted directly into `out_sprite` (shipping:
+// no full YUV ever resident). Exactly one of out_yuv / out_sprite is non-NULL.
+// For out_sprite, x_div/y_div carry the same output downsample as the full-frame
+// path.
+//
+// The window is `band_rows`+2 MB-rows: the band's content occupies window rows
+// 1..band_rows, with one extra "lookahead" row below it (row band_rows+1) and an
+// unused padding row above it (row 0, an artefact of the window addressing's +1
+// offset). The lookahead row matters for two reasons:
+//   1. Chroma seam: the YUV->RGB bilinear chroma upsample at the band's bottom
+//      row needs the next row's chroma. Decoding one row ahead and including it
+//      in the blit feeds that upsample its real neighbour, so band boundaries are
+//      seam-free. The lookahead row's OWN output (its bottom edge clamps) lands
+//      on the next band's first output rows and is overwritten by that band.
+//   2. Continuity: the lookahead row IS the next band's first content row, and it
+//      was decoded with its top intra-pred neighbour in-window, so it is carried
+//      forward (to window row 1) rather than re-decoded. Because that row is never
+//      re-decoded, the next band's first DECODED row sits at window row 2 and
+//      reads window row 1 as its top neighbour — window row 0 is never read.
+// Output is bit-identical to the full-frame path.
+static void lspr3_decode_intra_slice_banded(
+    const uint8_t *payload, size_t payload_size,
+    uint16_t width, uint16_t height,
+    uint16_t orig_w, uint16_t orig_h,
+    uint8_t pic_init_qp, int8_t chroma_qp_index_offset,
+    uint8_t *out_yuv, sprite_t *out_sprite, int band_rows,
+    int x_div, int y_div,
+    const lspr3_load_parms_t *parms
+) {
+    assertf(payload_size >= 2, "H264I-band: payload too small");
+    uint8_t nal_hdr = payload[0];
+    nalUnit_t nal = {
+        .nalUnitType = (nalUnitType_e)(nal_hdr & 0x1F),
+        .nalRefIdc = (nal_hdr >> 5) & 3,
+    };
+
+    int mb_w = (width + 15) / 16;
+    int mb_h = (height + 15) / 16;
+    u32 pic_size_in_mbs = (u32)(mb_w * mb_h);
+    if (band_rows <= 0 || band_rows > mb_h) band_rows = mb_h;
+    int win_rows = band_rows + 2;   // content (1..band_rows) + lookahead + pad row 0
+
+    size_t win_yuv_size = (size_t)(win_rows * mb_w) * 256 + (size_t)(win_rows * mb_w) * 64 * 2;
+    uint8_t *win = (uint8_t*)scratch_malloc_uncached(win_yuv_size);
+    assertf(win, "H264I-band: out of memory (yuv-window %u)", (unsigned)win_yuv_size);
+    image_t image = { .data = win, .width = (u32)mb_w, .height = (u32)mb_h };
+
+    seqParamSet_t sps = {
+        .profileIdc = 66, .levelIdc = 22, .seqParameterSetId = 0,
+        .maxFrameNum = 1 << 4, .picOrderCntType = 2, .numRefFrames = 1,
+        .picWidthInMbs = (u32)mb_w, .picHeightInMbs = (u32)mb_h,
+    };
+    picParamSet_t pps = {
+        .picParameterSetId = 0, .seqParameterSetId = 0, .picOrderPresentFlag = 0,
+        .numSliceGroups = 1, .sliceGroupMapType = 0, .picSizeInMapUnits = (u32)pic_size_in_mbs,
+        .numRefIdxL0Active = 1, .picInitQp = pic_init_qp, .chromaQpIndexOffset = chroma_qp_index_offset,
+        .deblockingFilterControlPresentFlag = 1, .constrainedIntraPredFlag = 0,
+        .redundantPicCntPresentFlag = 0,
+    };
+
+    uint8_t *rbsp = (uint8_t *)(payload + 1);
+    size_t rbsp_size = payload_size - 1;
+    strmData_t strm = {0};
+    strm.pStart = rbsp;
+    strm.pCurr = ((u64)(uintptr_t)rbsp) << 3;
+    strm.pEnd = ((u64)(uintptr_t)(rbsp + rbsp_size)) << 3;
+
+    rsph264_begin_frame();
+
+    sliceHeader_t slice = {0};
+    u32 slice_status = h264bsdDecodeSliceHeader(&strm, &slice, &sps, &pps, &nal);
+    assertf(slice_status == HANTRO_OK, "H264I-band: slice header decode failed");
+
+    size_t mb_bytes = (size_t)pic_size_in_mbs * sizeof(mbStorage_t);
+    mbStorage_t *mb;
+    if (parms && parms->mb_alloc) mb = (mbStorage_t*)parms->mb_alloc(parms->mb_alloc_ctx, mb_bytes);
+    else                          mb = (mbStorage_t*)calloc(pic_size_in_mbs, sizeof(mbStorage_t));
+    assertf(mb, "H264I-band: out of memory (mb %u)", (unsigned)mb_bytes);
+    h264bsdInitMbNeighbours(mb, (u32)mb_w, pic_size_in_mbs);
+
+    i32 qpY = (i32)pps.picInitQp + slice.sliceQpDelta;
+    macroblockLayer_t mbLayers[H264I_MB_RING] = {0};
+    rspq_syncpoint_t slot_sync[H264I_MB_RING] = {0};
+
+    // Plane offsets (window vs full-frame). One MB-row = mb_w*256 (luma) /
+    // mb_w*64 (each chroma) bytes.
+    const size_t win_luma_plane = (size_t)(win_rows * mb_w) * 256;
+    const size_t win_cb_plane   = (size_t)(win_rows * mb_w) * 64;
+    const size_t full_luma_plane = (size_t)pic_size_in_mbs * 256;
+    const size_t full_cb_plane   = (size_t)pic_size_in_mbs * 64;
+    const size_t row_luma = (size_t)mb_w * 256;
+    const size_t row_cb   = (size_t)mb_w * 64;
+    const int stride = mb_w * 16;          /* luma plane width (px) */
+    const int uv_stride = stride / 2;
+
+    // Convert-mode setup: build the sprite header and the RDP YUV→RGB session
+    // once; each band is blitted into its slice of the output sprite below.
+    surface_t target = {0};
+    if (out_sprite) {
+        uint16_t out_w = orig_w / x_div;
+        uint16_t out_h = orig_h / y_div;
+        uint8_t *dst = lspr3_setup_rgba16_sprite_header(out_sprite, out_w, out_h);
+        size_t pixel_bytes_aligned = ROUND_UP((size_t)out_w * out_h * 2, 16);
+        data_cache_hit_writeback_invalidate(dst, pixel_bytes_aligned);
+        target = surface_make_linear(dst, FMT_RGBA16, out_w, out_h);
+        yuv_init();
+    }
+
+    u32 currMbAddr = 0;
+    for (int bandStart = 0; bandStart < mb_h; bandStart += band_rows) {
+        int nrows = (bandStart + band_rows <= mb_h) ? band_rows : (mb_h - bandStart);
+        int contentEnd = bandStart + nrows;
+        int hasLA = (contentEnd < mb_h);   // a lookahead MB-row exists below this band
+        h264bsdSetImageWindow((u32)bandStart, (u32)win_rows);
+
+        // Decode this band's content rows plus one lookahead row (if any). For
+        // bands after the first the band's first content row was already decoded
+        // as the previous band's lookahead and carried into window row 1, so
+        // currMbAddr already sits past it (at window row 2's global address).
+        u32 bandEndMb = (u32)((hasLA ? contentEnd + 1 : contentEnd) * mb_w);
+        while (currMbAddr < bandEndMb) {
+            u32 slot = currMbAddr % H264I_MB_RING;
+            if (slot_sync[slot]) rspq_syncpoint_wait(slot_sync[slot]);
+            macroblockLayer_t *mbLayer = &mbLayers[slot];
+            mbStorage_t *pMb = mb + currMbAddr;
+            pMb->sliceId = 1;
+            pMb->disableDeblockingFilterIdc = slice.disableDeblockingFilterIdc;
+            pMb->filterOffsetA = slice.sliceAlphaC0Offset;
+            pMb->filterOffsetB = slice.sliceBetaOffset;
+            pMb->chromaQpIndexOffset = pps.chromaQpIndexOffset;
+            u32 s1 = h264bsdDecodeMacroblockLayer(&strm, mbLayer, mb + currMbAddr,
+                                                  slice.sliceType, slice.numRefIdxL0Active);
+            assertf(s1 == HANTRO_OK, "H264I-band: mb-layer fail at %lu", (unsigned long)currMbAddr);
+            u32 s2 = h264bsdDecodeMacroblock(mb + currMbAddr, mbLayer, &image, NULL,
+                                             &qpY, currMbAddr, pps.constrainedIntraPredFlag, &slice);
+            assertf(s2 == HANTRO_OK, "H264I-band: mb decode fail at %lu", (unsigned long)currMbAddr);
+            slot_sync[slot] = rspq_syncpoint_new();
+            currMbAddr++;
+        }
+        rsph264_sync();   // RSP has written this band's MBs into the window
+
+        if (out_yuv) {
+            // Verification: assemble window rows [1..nrows] -> full-frame rows.
+            memcpy(out_yuv + (size_t)bandStart * row_luma,
+                   win + 1 * row_luma, (size_t)nrows * row_luma);
+            memcpy(out_yuv + full_luma_plane + (size_t)bandStart * row_cb,
+                   win + win_luma_plane + 1 * row_cb, (size_t)nrows * row_cb);
+            memcpy(out_yuv + full_luma_plane + full_cb_plane + (size_t)bandStart * row_cb,
+                   win + win_luma_plane + win_cb_plane + 1 * row_cb, (size_t)nrows * row_cb);
+        } else {
+            // Shipping: convert window rows [1..nrows] — plus the lookahead row
+            // (row nrows+1) when present — straight into the output sprite. The
+            // lookahead row in the blit gives the band's bottom content row its
+            // real next chroma row, so the YUV->RGB upsample has no edge-clamp
+            // seam at the boundary. The lookahead row's own output lands on the
+            // next band's first rows and is overwritten by that band's blit, so
+            // only the seam-free content survives.
+            int blit_rows = nrows + (hasLA ? 1 : 0);
+            yuv_frame_t bf = {
+                .y = surface_make_linear(win + 1 * row_luma, FMT_I8, stride, blit_rows * 16),
+                .u = surface_make_linear(win + win_luma_plane + 1 * row_cb, FMT_I8, uv_stride, blit_rows * 8),
+                .v = surface_make_linear(win + win_luma_plane + win_cb_plane + 1 * row_cb, FMT_I8, uv_stride, blit_rows * 8),
+            };
+            rdpq_attach(&target, NULL);
+            rdpq_mode_push();
+            if (x_div > 1 || y_div > 1) {
+                rdpq_blitparms_t bp = { .scale_x = 1.0f / x_div, .scale_y = 1.0f / y_div };
+                yuv_tex_blit(&bf, 0, (bandStart * 16) / y_div, &bp, &YUV_BT709_FULL);
+            } else {
+                yuv_tex_blit(&bf, 0, bandStart * 16, NULL, &YUV_BT709_FULL);
+            }
+            rdpq_mode_pop();
+            rdpq_detach_wait();   // RDP done reading the window -> safe to reuse it
+        }
+
+        if (hasLA) {
+            // The lookahead row (window row nrows+1) IS the next band's first
+            // content row, already decoded. Carry it to window row 1 so the next
+            // band continues from it without re-decoding; the next band's first
+            // decoded row then sits at window row 2 and reads this as its top
+            // neighbour. Window is uncached -> the copy is visible to the RSP
+            // immediately. (Window row 0 is unused padding; nothing reads it.)
+            memcpy(win + 1 * row_luma, win + (size_t)(nrows + 1) * row_luma, row_luma);
+            memcpy(win + win_luma_plane + 1 * row_cb,
+                   win + win_luma_plane + (size_t)(nrows + 1) * row_cb, row_cb);
+            memcpy(win + win_luma_plane + win_cb_plane + 1 * row_cb,
+                   win + win_luma_plane + win_cb_plane + (size_t)(nrows + 1) * row_cb, row_cb);
+        }
+    }
+    h264bsdSetImageWindow(0, 0);   // restore full-frame addressing for FMV path
+    rsph264_sync();
+    if (out_sprite) yuv_close();
+    assertf(currMbAddr == pic_size_in_mbs, "H264I-band: incomplete slice");
+    if (parms && parms->mb_alloc) parms->mb_free(parms->mb_alloc_ctx, mb);
+    else                          free(mb);
+    scratch_free(win);
+}
+
+// Initialise the RGBA16 sprite header (no pixel data) and return a pointer to
+// the sprite's pixel area. Shared by the full-frame and banded converters so
+// both produce an identically-laid-out sprite.
+static uint8_t *lspr3_setup_rgba16_sprite_header(sprite_t *sprite, uint16_t out_w, uint16_t out_h)
+{
+    uint8_t preserved_flags = sprite->flags & SPRITE_FLAGS_OWNEDBUFFER;
+    size_t header_bytes = ROUND_UP(sizeof(sprite_t) + sizeof(sprite_ext_t), 64);
+    sys_hw_memset(sprite, 0, header_bytes);
+    sprite->width = out_w;
+    sprite->height = out_h;
+    sprite->flags = preserved_flags | SPRITE_FLAGS_NODATA | SPRITE_FLAGS_EXT | FMT_RGBA16;
+    sprite->hslices = 1;
+    sprite->vslices = 1;
+
+    sprite_ext_t *sx = (sprite_ext_t*)sprite->data;
+    sx->size = sizeof(sprite_ext_t);
+    sx->version = SPRITE_EXT_VERSION;
+    sx->data_ptr = (uint32_t)header_bytes;
+    return (uint8_t*)sprite + header_bytes;
+}
+
 // Build the FMT_RGBA16 sprite from the I420 reconstruction. The RDP YUV
 // combiner does the YUV→RGB conversion on the fly (BT.709 full range, hard
 // coded to match the encoder's rgba_to_i420), with bilinear chroma upsample
@@ -287,19 +518,7 @@ static void lspr3_build_rgba16_sprite(
     if (y_divisor < 1) y_divisor = 1;
     uint16_t out_w = orig_w / x_divisor;
     uint16_t out_h = orig_h / y_divisor;
-    uint8_t preserved_flags = sprite->flags & SPRITE_FLAGS_OWNEDBUFFER;
-    size_t header_bytes = ROUND_UP(sizeof(sprite_t) + sizeof(sprite_ext_t), 64);
-    sys_hw_memset(sprite, 0, header_bytes);
-    sprite->width = out_w;
-    sprite->height = out_h;
-    sprite->flags = preserved_flags | SPRITE_FLAGS_NODATA | SPRITE_FLAGS_EXT | FMT_RGBA16;
-    sprite->hslices = 1;
-    sprite->vslices = 1;
-
-    sprite_ext_t *sx = (sprite_ext_t*)sprite->data;
-    sx->size = sizeof(sprite_ext_t);
-    sx->version = SPRITE_EXT_VERSION;
-    sx->data_ptr = (uint32_t)header_bytes;
+    uint8_t *dst = lspr3_setup_rgba16_sprite_header(sprite, out_w, out_h);
 
     int uv_stride = stride / 2;
     size_t y_bytes  = (size_t)stride * luma_h;
@@ -307,7 +526,6 @@ static void lspr3_build_rgba16_sprite(
     const uint8_t *y_plane = pic;
     const uint8_t *u_plane = pic + y_bytes;
     const uint8_t *v_plane = u_plane + uv_bytes;
-    uint8_t *dst = (uint8_t*)sprite + header_bytes;
 
     yuv_frame_t frame = {
         .y = surface_make_linear((void*)y_plane, FMT_I8, stride,    luma_h),
@@ -431,30 +649,84 @@ sprite_t *lspr3_load_buf_ex(const void *encoded_buf, int encoded_sz,
     assertf((size_t)encoded_sz >= sizeof(lspr3_header_t) + alpha_size,
         "H264I buffer truncated (sz=%d, alpha_size=%zu)", encoded_sz, alpha_size);
     size_t payload_size = (size_t)encoded_sz - sizeof(lspr3_header_t) - alpha_size;
-    uint8_t *pic = NULL;
-    size_t pic_size = 0;
-    lspr3_decode_intra_slice(
-        hdr->payload, payload_size,
-        hdr->width, hdr->height,
-        hdr->pic_init_qp, hdr->chroma_qp_index_offset,
-        &pic, &pic_size, parms
-    );
+    const int mb_w = (hdr->width + 15) / 16;
+    const int mb_h = (hdr->height + 15) / 16;
+    const int stride = mb_w * 16;
+    const int luma_h = mb_h * 16;
+    const int band_rows = (parms && parms->band_rows > 0) ? parms->band_rows : 0;
 
-    // Convert the YUV planes into the final RGBA16 sprite
-    int mb_w = (hdr->width + 15) / 16;
-    int mb_h = (hdr->height + 15) / 16;
-    int stride = mb_w * 16;
-    int luma_h = mb_h * 16;
-    lspr3_build_rgba16_sprite(
-        sprite, pic,
-        hdr->orig_width, hdr->orig_height,
-        stride, luma_h,
-        x_divisor, y_divisor
-    );
-    scratch_free(pic);
+    if (band_rows > 0) {
+        // Banded: reconstruct + convert band-by-band straight into the sprite;
+        // no full-frame YUV is ever resident (the memory win).
+        lspr3_decode_intra_slice_banded(
+            hdr->payload, payload_size, hdr->width, hdr->height,
+            hdr->orig_width, hdr->orig_height,
+            hdr->pic_init_qp, hdr->chroma_qp_index_offset,
+            NULL, sprite, band_rows, x_divisor, y_divisor, parms);
+    } else {
+        // Full-frame: decode the whole frame, then convert in one pass.
+        uint8_t *pic = NULL;
+        size_t pic_size = 0;
+        lspr3_decode_intra_slice(
+            hdr->payload, payload_size, hdr->width, hdr->height,
+            hdr->pic_init_qp, hdr->chroma_qp_index_offset, &pic, &pic_size, parms);
+        lspr3_build_rgba16_sprite(sprite, pic, hdr->orig_width, hdr->orig_height,
+                                  stride, luma_h, x_divisor, y_divisor);
+        scratch_free(pic);
+    }
+
+#if LSPR3_VERIFY_BANDING
+    // Produce the sprite the OTHER way and diff the pixel areas. Needs a 2nd
+    // sprite-sized scratch buffer -> run this on 8 MiB. The full-frame and
+    // banded converts should be identical except possibly the chroma-upsample
+    // rows at band seams, so the report includes the diff count + first row.
+    {
+        sprite_t *spr2 = (parms && parms->alloc)
+            ? (sprite_t*)parms->alloc(parms->alloc_ctx, decoded_sz, H264I_BUF_ALIGN)
+            : (sprite_t*)memalign(H264I_BUF_ALIGN, decoded_sz);
+        if (spr2) {
+            spr2->flags = SPRITE_FLAGS_OWNEDBUFFER;
+            const int vbr = (band_rows > 0) ? 0 : LSPR3_VERIFY_BAND_ROWS;
+            uint32_t tv0 = TICKS_READ();
+            if (vbr > 0) {
+                lspr3_decode_intra_slice_banded(
+                    hdr->payload, payload_size, hdr->width, hdr->height,
+                    hdr->orig_width, hdr->orig_height,
+                    hdr->pic_init_qp, hdr->chroma_qp_index_offset,
+                    NULL, spr2, vbr, x_divisor, y_divisor, parms);
+            } else {
+                uint8_t *p2 = NULL; size_t ps2 = 0;
+                lspr3_decode_intra_slice(hdr->payload, payload_size, hdr->width, hdr->height,
+                    hdr->pic_init_qp, hdr->chroma_qp_index_offset, &p2, &ps2, parms);
+                lspr3_build_rgba16_sprite(spr2, p2, hdr->orig_width, hdr->orig_height,
+                                          stride, luma_h, x_divisor, y_divisor);
+                scratch_free(p2);
+            }
+            unsigned us = (unsigned)TICKS_TO_US(TICKS_READ() - tv0);
+            const size_t hdr_bytes = ROUND_UP(sizeof(sprite_t) + sizeof(sprite_ext_t), 64);
+            const size_t px = (size_t)sprite->width * sprite->height * 2;
+            const uint8_t *a = (const uint8_t*)sprite + hdr_bytes;
+            const uint8_t *b = (const uint8_t*)spr2 + hdr_bytes;
+            size_t first = 0, ndiff = 0;
+            for (size_t k = 0; k < px; k++) { if (a[k] != b[k]) { if (!ndiff) first = k; ndiff++; } }
+            if (ndiff) {
+                debugf("n64: *** SPRITE DIFF brPrimary=%d vbr=%d first@%u row=%u ndiff=%u/%u (%.2f%%) ***\n",
+                    band_rows, vbr, (unsigned)first, (unsigned)(first / (sprite->width * 2)),
+                    (unsigned)ndiff, (unsigned)px, 100.0 * (double)ndiff / (double)px);
+            } else {
+                debugf("n64: SPRITE OK vbr=%d (%u px-bytes identical, %uus)\n", vbr, (unsigned)px, us);
+            }
+            if (parms && parms->alloc) scratch_free(spr2); else free(spr2);
+        } else {
+            debugf("n64: sprite-verify SKIP (no scratch for 2nd sprite; need 8 MiB)\n");
+        }
+    }
+#endif
 
     // Re-apply the lossless 1-bit alpha mask (if any) on top of the RGBA5551
     // pixels the RDP just produced (the YUV combiner writes alpha=1 everywhere).
+    // The mask is applied at source resolution to the final sprite, so it works
+    // for both the full-frame and banded paths (divisors are ruled out above).
     if (alpha_size) {
         size_t header_bytes = ROUND_UP(sizeof(sprite_t) + sizeof(sprite_ext_t), 64);
         uint16_t *dst = (uint16_t *)((uint8_t *)sprite + header_bytes);

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "debug.h"
+#include "n64sys.h"
 #include "scratch.h"
 #include "system_internal.h"
 #include "utils.h"
@@ -149,9 +150,9 @@ void *scratch_malloc(size_t size) {
     return block_user_ptr(b);
 }
 
-void scratch_free(void *ptr) {
-    if (!ptr) return;
-
+/* Release the chunk that ptr is the user-data of. Caller guarantees ptr is
+ * a valid direct-allocated scratch chunk's user pointer. */
+static void scratch_free_chunk(void *ptr) {
     block_t *b = block_from_user_ptr(ptr);
     assert(ptr_in_heap(b));
     assert(!block_is_free(b));
@@ -164,6 +165,66 @@ void scratch_free(void *ptr) {
     block_mark_free(b);
     if (b == sh_head) trim_head();
 }
+
+void scratch_free(void *ptr) {
+    if (!ptr) return;
+
+    /* scratch_free is the single-entry deallocator for any pointer
+     * returned by any scratch_* allocation. It transparently handles:
+     *   - cached vs uncached views (both refer to the same physical chunk)
+     *   - direct allocations (scratch_malloc / scratch_calloc) where the
+     *     pointer is at user_ptr_offset within the chunk
+     *   - aligned allocations (scratch_memalign) where the pointer is
+     *     offset further into the chunk and the chunk's raw user pointer
+     *     is stored in a back-slot at (ptr - sizeof(void*))
+     * Callers don't need to track which allocator produced the pointer or
+     * which view (cached/uncached) they hold. */
+    void *cached = CachedAddr(ptr);
+
+    /* First try the direct interpretation: assume `cached` is the user
+     * pointer of a scratch chunk and check the header for the USED magic.
+     * If the magic matches, we're done — release this chunk. */
+    block_t *b_direct = block_from_user_ptr(cached);
+    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
+        scratch_free_chunk(cached);
+        return;
+    }
+
+    /* Otherwise this must be a memalign'd pointer: the back-slot before
+     * `cached` holds the raw chunk's user pointer. Validate and release. */
+    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
+    void *raw = *back_slot;
+    block_t *b_raw = block_from_user_ptr(raw);
+    /* Validate with a real runtime check, not just an assert: under NDEBUG
+     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
+     * stale back-slot holds garbage) must fail safely rather than free an
+     * arbitrary address (there is no MMU to catch it). Require the raw block to
+     * be a live scratch chunk that actually contains this aligned alias. */
+    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
+        (uintptr_t)cached >= (uintptr_t)raw &&
+        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
+    if (!valid) {
+        assertf(false,
+            "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
+        return;
+    }
+    scratch_free_chunk(raw);
+}
+
+void *scratch_malloc_uncached(size_t size) {
+    // Round the size up to a full cacheline so the uncached buffer can never
+    // false-share with a neighbouring allocation (mirrors malloc_uncached).
+    size = ROUND_UP(size, 16);
+    void *p = scratch_malloc(size);
+    if (!p) return NULL;
+
+    // The memory may have been in the data cache from a prior cached use of
+    // the same block; invalidate so a future writeback can't clobber RSP/RDP
+    // writes.
+    data_cache_hit_invalidate(p, size);
+    return UncachedAddr(p);
+}
+
 
 void *scratch_calloc(size_t count, size_t size) {
     if (count && size > ((size_t)-1) / count) return NULL;
@@ -199,6 +260,27 @@ void *scratch_realloc(void *ptr, size_t size) {
     memcpy(q, ptr, old_requested < size ? old_requested : size);
     scratch_free(ptr);
     return q;
+}
+
+void *scratch_memalign(size_t alignment, size_t size) {
+    if (alignment < SCRATCH_ALIGN) alignment = SCRATCH_ALIGN;
+    /* Power-of-two check matches POSIX memalign semantics. */
+    assertf((alignment & (alignment - 1)) == 0,
+        "scratch_memalign: alignment must be a power of two");
+
+    /* Over-allocate by (alignment + sizeof(void*)) so we can both align the
+     * returned pointer and stash a back-pointer to the raw block in the
+     * gap before it. Guard the addition against wrap (mirrors scratch_calloc):
+     * a wrapped size would under-allocate and let the caller overrun the heap. */
+    if (size > (size_t)-1 - alignment - sizeof(void *)) return NULL;
+    size_t padded = size + alignment + sizeof(void *);
+    void *raw = scratch_malloc(padded);
+    if (!raw) return NULL;
+
+    uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + (alignment - 1)) & ~(alignment - 1);
+    void **back_slot = (void **)(aligned_addr - sizeof(void *));
+    *back_slot = raw;
+    return (void *)aligned_addr;
 }
 
 void scratch_check(void) {
@@ -254,4 +336,11 @@ void scratch_get_stats(scratch_stats_t *stats) {
 
 bool scratch_empty(void) {
     return sh_live_blocks == 0;
+}
+
+bool scratch_owns(const void *ptr) {
+    if (!ptr) return false;
+    /* Accept either the cached or uncached view of a scratch address. */
+    const void *cached = CachedAddr(ptr);
+    return ptr_in_heap(cached);
 }

--- a/src/video/h264_decoder/h264bsd_util.c
+++ b/src/video/h264_decoder/h264bsd_util.c
@@ -272,24 +272,53 @@ u32 h264bsdNextMbAddress(u32 *pSliceGroupMap, u32 picSizeInMbs, u32 currMbAddr)
         Returns:
             none
 ------------------------------------------------------------------------------*/
+/* Optional windowed-decode-target params (default 0 = full-frame). When
+ * s_imgWinHeightMbs != 0, the image data buffer is treated as a sliding window
+ * of s_imgWinHeightMbs MB-rows whose row 0 corresponds to global MB-row
+ * s_imgWinBaseRow, so a decoder (lspr3) can reconstruct into a small scratch
+ * buffer instead of the full frame. Set/reset by h264bsdSetImageWindow around a
+ * banded decode; the full h264bsd/FMV path never touches these so its addressing
+ * is byte-identical to before. Single-threaded decode only. */
+static u32 s_imgWinBaseRow = 0;
+static u32 s_imgWinHeightMbs = 0;
+
+void h264bsdSetImageWindow(u32 baseRow, u32 heightMbs)
+{
+    s_imgWinBaseRow = baseRow;
+    s_imgWinHeightMbs = heightMbs;
+}
+
 void h264bsdSetCurrImageMbPointers(image_t *image, u32 mbNum)
 {
-    u32 width, height;
-    u32 picSize;
+    u32 width;
+    u32 winPicSize;
     u32 row, col;
     u32 tmp;
+    u32 winHeight;
 
     width = image->width;
-    height = image->height;
     row = mbNum / width;
     col = mbNum % width;
 
-    tmp = row * width;
-    picSize = width * height;
+    if (s_imgWinHeightMbs)
+    {
+        /* Windowed: window has s_imgWinHeightMbs MB-rows; row 0 is the carried
+         * top-boundary context, the band's content occupies rows 1..N. The
+         * band's first global row (s_imgWinBaseRow) maps to window row 1. */
+        winHeight = s_imgWinHeightMbs;
+        tmp = ((row - s_imgWinBaseRow) + 1) * width;
+    }
+    else
+    {
+        /* Full-frame: identical to the original addressing. */
+        winHeight = image->height;
+        tmp = row * width;
+    }
+    winPicSize = width * winHeight;
 
     image->luma = (u8*)(image->data + col * 16 + tmp * 256);
-    image->cb = (u8*)(image->data + picSize * 256 + tmp * 64 + col * 8);
-    image->cr = (u8*)(image->cb + picSize * 64);
+    image->cb = (u8*)(image->data + winPicSize * 256 + tmp * 64 + col * 8);
+    image->cr = (u8*)(image->cb + winPicSize * 64);
 }
 
 

--- a/src/video/h264_decoder/h264bsd_util.h
+++ b/src/video/h264_decoder/h264bsd_util.h
@@ -200,6 +200,11 @@ u32 h264bsdNextMbAddress(u32 *pSliceGroupMap, u32 picSizeInMbs, u32 currMbAddr);
 
 void h264bsdSetCurrImageMbPointers(image_t *image, u32 mbNum);
 
+/* Set/reset the windowed-decode-target params used by
+ * h264bsdSetCurrImageMbPointers. heightMbs==0 restores full-frame addressing.
+ * Used by lspr3's banded intra decode; the full decoder never calls this. */
+void h264bsdSetImageWindow(u32 baseRow, u32 heightMbs);
+
 void h264bsdWriteSliceMbData(image_t *image, u32 firstMbNum, u32 lastMbNum, u32* pData);
 
 #endif /* #ifdef H264SWDEC_UTIL_H */


### PR DESCRIPTION
Stacked on top of #927 

Add load_buf_ex plus an mb_alloc/mb_free hook so the large transient mbStorage buffer can be sourced from a caller-controlled heap (e.g. a reserved region) instead of churning the system heap mid-session and fragmenting it. Default behaviour is unchanged.

Additionally, allow decoding intra frames in horizontal row bands (with a one-row chroma lookahead for seamless joins) instead of allocating a full-frame YUV scratch, capping the transient working set on memory-constrained targets. band_rows is tunable; full-frame decode remains available.