### PR TITLE
h264: optional custom allocator hook for the player instance

### DIFF
--- a/include/fmv.h
+++ b/include/fmv.h
@@ -161,6 +161,15 @@ typedef struct fmv_parms_s {
      * @param info      Video metadata from the opened stream
      */
     yuv_blitter_t (*create_yuv_blitter)(void *osd_ctx, video_info_t *info);
+
+    /**
+     * @brief Number of decoded pictures to buffer in the DPB.
+     *
+     * If 0, defaults to 4 on a 4 MB N64 (8 on an Expansion Pak). Each
+     * buffered picture adds picSizeInMbs*384 bytes to the DPB. Set as low as
+     * 1 to minimize DPB size at the cost of frame-pacing smoothness.
+     */
+    int buffered_pics;
 } fmv_parms_t;
 
 

--- a/include/scratch.h
+++ b/include/scratch.h
@@ -94,15 +94,62 @@
  /**
   * @brief Free a scratch allocation.
   *
-  * Releases a block previously returned by #scratch_malloc(), #scratch_calloc(), or
-  * #scratch_realloc().
+  * Releases a block previously returned by any scratch allocator —
+  * #scratch_malloc(), #scratch_calloc(), #scratch_realloc(),
+  * #scratch_memalign(), or #scratch_malloc_uncached(). The single
+  * entry point transparently handles cached vs uncached pointer views
+  * and direct vs aligned allocations; callers don't need to track
+  * which allocator produced the pointer.
   *
   * Passing NULL is allowed and has no effect.
   *
   * @param ptr          Pointer to the scratch allocation to free, or NULL.
   */
  void scratch_free(void *ptr);
+
+ /**
+  * @brief Allocate uncached memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns an uncached
+  * (KSEG1) mapping of the buffer. This mirrors #malloc_uncached() and is
+  * intended for short-lived buffers shared between CPU and RSP/RDP DMA paths
+  * (decoder workspaces, staging surfaces, etc.) where the coherency cost of
+  * cached access would otherwise force manual flushes around every transfer.
+  *
+  * The underlying allocation is 16-byte aligned and the size is rounded up to
+  * a multiple of 16 bytes, so the buffer exclusively owns its cachelines and
+  * cannot suffer false sharing with neighbouring allocations.
+  *
+  * Free with the standard #scratch_free() — it handles cached/uncached views
+  * transparently.
+  *
+  * @param size         Number of bytes to allocate.
+  * @return Uncached pointer to the allocated memory, or NULL if there is not
+  *         enough memory.
+  *
+  * @note Memory returned by this function is uninitialized.
+  *
+  * @see scratch_free
+  * @see malloc_uncached
+  */
+ void *scratch_malloc_uncached(size_t size);
  
+ /**
+  * @brief Allocate aligned memory from the scratch heap.
+  *
+  * Allocates @p size bytes from the scratch allocator and returns a pointer
+  * aligned to @p alignment bytes. @p alignment must be a power of two and
+  * at least the natural scratch alignment (16 bytes); requests smaller than
+  * 16 are clamped up.
+  *
+  * Free with #scratch_free().
+  *
+  * @param alignment    Required alignment in bytes (power of two, >= 16).
+  * @param size         Number of bytes to allocate.
+  * @return Pointer to the aligned allocation, or NULL on failure.
+  */
+ void *scratch_memalign(size_t alignment, size_t size);
+
  /**
   * @brief Check internal consistency of the scratch heap.
   *
@@ -139,6 +186,22 @@ void scratch_get_stats(scratch_stats_t *stats);
   * @return true if there are no live scratch allocations, false otherwise.
   */
  bool scratch_empty(void);
+
+ /**
+  * @brief Check whether a pointer was allocated by the scratch allocator.
+  *
+  * Returns true if @p ptr was returned by #scratch_malloc / #scratch_calloc
+  * / #scratch_realloc, false otherwise. The cached and uncached views of
+  * the same scratch address are both recognised.
+  *
+  * Intended for code paths that don't know up-front which allocator owns a
+  * pointer (e.g. fallbacks between scratch and the main heap) and need to
+  * dispatch to the correct deallocator.
+  *
+  * @param ptr Pointer to test.
+  * @return true if owned by scratch, false otherwise (including NULL).
+  */
+ bool scratch_owns(const void *ptr);
  
  #ifdef __cplusplus
  }

--- a/src/scratch.c
+++ b/src/scratch.c
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "debug.h"
+#include "n64sys.h"
 #include "scratch.h"
 #include "system_internal.h"
 #include "utils.h"
@@ -149,9 +150,9 @@ void *scratch_malloc(size_t size) {
     return block_user_ptr(b);
 }
 
-void scratch_free(void *ptr) {
-    if (!ptr) return;
-
+/* Release the chunk that ptr is the user-data of. Caller guarantees ptr is
+ * a valid direct-allocated scratch chunk's user pointer. */
+static void scratch_free_chunk(void *ptr) {
     block_t *b = block_from_user_ptr(ptr);
     assert(ptr_in_heap(b));
     assert(!block_is_free(b));
@@ -164,6 +165,66 @@ void scratch_free(void *ptr) {
     block_mark_free(b);
     if (b == sh_head) trim_head();
 }
+
+void scratch_free(void *ptr) {
+    if (!ptr) return;
+
+    /* scratch_free is the single-entry deallocator for any pointer
+     * returned by any scratch_* allocation. It transparently handles:
+     *   - cached vs uncached views (both refer to the same physical chunk)
+     *   - direct allocations (scratch_malloc / scratch_calloc) where the
+     *     pointer is at user_ptr_offset within the chunk
+     *   - aligned allocations (scratch_memalign) where the pointer is
+     *     offset further into the chunk and the chunk's raw user pointer
+     *     is stored in a back-slot at (ptr - sizeof(void*))
+     * Callers don't need to track which allocator produced the pointer or
+     * which view (cached/uncached) they hold. */
+    void *cached = CachedAddr(ptr);
+
+    /* First try the direct interpretation: assume `cached` is the user
+     * pointer of a scratch chunk and check the header for the USED magic.
+     * If the magic matches, we're done — release this chunk. */
+    block_t *b_direct = block_from_user_ptr(cached);
+    if (ptr_in_heap(b_direct) && b_direct->magic == MAGIC_USED) {
+        scratch_free_chunk(cached);
+        return;
+    }
+
+    /* Otherwise this must be a memalign'd pointer: the back-slot before
+     * `cached` holds the raw chunk's user pointer. Validate and release. */
+    void **back_slot = (void **)((uintptr_t)cached - sizeof(void *));
+    void *raw = *back_slot;
+    block_t *b_raw = block_from_user_ptr(raw);
+    /* Validate with a real runtime check, not just an assert: under NDEBUG
+     * asserts are compiled out, and a bad pointer (e.g. a double-free, whose
+     * stale back-slot holds garbage) must fail safely rather than free an
+     * arbitrary address (there is no MMU to catch it). Require the raw block to
+     * be a live scratch chunk that actually contains this aligned alias. */
+    bool valid = ptr_in_heap(b_raw) && b_raw->magic == MAGIC_USED &&
+        (uintptr_t)cached >= (uintptr_t)raw &&
+        (uintptr_t)cached < (uintptr_t)raw + (block_size(b_raw) - header_size());
+    if (!valid) {
+        assertf(false,
+            "scratch_free: %p is neither a scratch chunk nor a memalign'd alias", ptr);
+        return;
+    }
+    scratch_free_chunk(raw);
+}
+
+void *scratch_malloc_uncached(size_t size) {
+    // Round the size up to a full cacheline so the uncached buffer can never
+    // false-share with a neighbouring allocation (mirrors malloc_uncached).
+    size = ROUND_UP(size, 16);
+    void *p = scratch_malloc(size);
+    if (!p) return NULL;
+
+    // The memory may have been in the data cache from a prior cached use of
+    // the same block; invalidate so a future writeback can't clobber RSP/RDP
+    // writes.
+    data_cache_hit_invalidate(p, size);
+    return UncachedAddr(p);
+}
+
 
 void *scratch_calloc(size_t count, size_t size) {
     if (count && size > ((size_t)-1) / count) return NULL;
@@ -199,6 +260,27 @@ void *scratch_realloc(void *ptr, size_t size) {
     memcpy(q, ptr, old_requested < size ? old_requested : size);
     scratch_free(ptr);
     return q;
+}
+
+void *scratch_memalign(size_t alignment, size_t size) {
+    if (alignment < SCRATCH_ALIGN) alignment = SCRATCH_ALIGN;
+    /* Power-of-two check matches POSIX memalign semantics. */
+    assertf((alignment & (alignment - 1)) == 0,
+        "scratch_memalign: alignment must be a power of two");
+
+    /* Over-allocate by (alignment + sizeof(void*)) so we can both align the
+     * returned pointer and stash a back-pointer to the raw block in the
+     * gap before it. Guard the addition against wrap (mirrors scratch_calloc):
+     * a wrapped size would under-allocate and let the caller overrun the heap. */
+    if (size > (size_t)-1 - alignment - sizeof(void *)) return NULL;
+    size_t padded = size + alignment + sizeof(void *);
+    void *raw = scratch_malloc(padded);
+    if (!raw) return NULL;
+
+    uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + (alignment - 1)) & ~(alignment - 1);
+    void **back_slot = (void **)(aligned_addr - sizeof(void *));
+    *back_slot = raw;
+    return (void *)aligned_addr;
 }
 
 void scratch_check(void) {
@@ -254,4 +336,11 @@ void scratch_get_stats(scratch_stats_t *stats) {
 
 bool scratch_empty(void) {
     return sh_live_blocks == 0;
+}
+
+bool scratch_owns(const void *ptr) {
+    if (!ptr) return false;
+    /* Accept either the cached or uncached view of a scratch address. */
+    const void *cached = CachedAddr(ptr);
+    return ptr_in_heap(cached);
 }

--- a/src/video/fmv.c
+++ b/src/video/fmv.c
@@ -20,7 +20,10 @@
 
 void fmv_play(const char *video_fn, const fmv_parms_t *parms)
 {
-    video_t *video = video_open(video_fn, &(video_parms_t){ .buffered_pics = 8 });
+    int buffered_pics = (parms && parms->buffered_pics)
+        ? parms->buffered_pics
+        : (is_memory_expanded() ? 8 : 4);
+    video_t *video = video_open(video_fn, &(video_parms_t){ .buffered_pics = buffered_pics });
     video_info_t info = video_get_info(video);
     if (!parms) {
         parms = alloca(sizeof(fmv_parms_t));

--- a/src/video/h264.c
+++ b/src/video/h264.c
@@ -5,6 +5,7 @@
  */
 
 #include "h264.h"
+#include "h264_internal.h"
 #include "h264_decoder.h"
 #include "rsph264_internal.h"
 #include "asset_internal.h"
@@ -39,6 +40,7 @@ typedef struct h264_s {
     uint32_t max_slice_size;            ///< Maximum size of a slice seen so far
     bool has_slice_metadata;            ///< True if the stream advertised max_slice_size
     int max_buffered_pics;              ///< Runtime-configured buffered pictures
+    bool from_custom_alloc;             ///< Player block came from h264_set_allocator (free via it)
     storage_t s;                        ///< H264 decoder main structure
     uint8_t buf[];                      ///< Internal buffered data
 } h264_t;
@@ -195,10 +197,45 @@ static void h264_rewind(video_t *v) {
     }
 }
 
+// Custom allocator for the h264_t player block (see h264_set_allocator).
+// Default {NULL,NULL} => malloc/free.
+static h264_allocator_t s_h264_allocator = {0};
+
+// Number of live players allocated through the custom allocator. h264_close()
+// frees a custom player through the currently-installed allocator, so it must
+// not be swapped or cleared while any such player is still open.
+static int s_h264_custom_players = 0;
+
+void h264_set_allocator(const h264_allocator_t *allocator)
+{
+    // Changing the allocator while it still owns open players would free those
+    // players through the wrong path in h264_close(). Install it before the
+    // first h264_open() and clear it only after those players are closed.
+    assertf(s_h264_custom_players == 0,
+        "h264_set_allocator: cannot change the allocator while %d custom-allocated "
+        "player(s) are still open (h264_close them first)", s_h264_custom_players);
+    if (allocator && allocator->alloc && allocator->free)
+        s_h264_allocator = *allocator;
+    else
+        s_h264_allocator = (h264_allocator_t){0};
+}
+
 static video_t* h264_open(const char *fn, const video_parms_t *parms) {
-    h264_t *player = malloc(sizeof(h264_t) + H264_BUF_SIZE);
+    const size_t player_size = sizeof(h264_t) + H264_BUF_SIZE;
+    // The player instance is large (~268 KiB). A custom allocator lets the
+    // caller source it from a dedicated region instead of the heap; fall back
+    // to malloc if none is installed or it declines.
+    bool from_custom = false;
+    h264_t *player = NULL;
+    if (s_h264_allocator.alloc) {
+        player = s_h264_allocator.alloc(player_size, 16);
+        from_custom = (player != NULL);
+    }
+    if (!player) player = malloc(player_size);
     assertf(player, "Out of memory");
-    sys_hw_memset(player, 0, sizeof(h264_t) + H264_BUF_SIZE);
+    sys_hw_memset(player, 0, player_size);
+    player->from_custom_alloc = from_custom;   // set AFTER the memset
+    if (from_custom) s_h264_custom_players++;
     player->fd = -1;
     if (parms && parms->buffered_pics)
         player->max_buffered_pics = parms->buffered_pics;
@@ -228,7 +265,17 @@ static void h264_close(video_t *v) {
         player->fd = -1;
     }
     h264bsdShutdown(&player->s);
-    free(player);
+    // Capture origin before free: route custom-allocated players back through
+    // the custom allocator, the rest via free(). The set_allocator assert
+    // guarantees the installed allocator is still the one that produced them.
+    const bool from_custom = player->from_custom_alloc;
+    if (from_custom) {
+        assertf(s_h264_allocator.free,
+            "h264_close: custom-allocated player freed with no allocator installed");
+        s_h264_allocator.free(player);
+        s_h264_custom_players--;
+    } else
+        free(player);
 }
 
 static const char* h264_status_str(int status) {

--- a/src/video/h264_decoder/h264bsd_dpb.c
+++ b/src/video/h264_decoder/h264bsd_dpb.c
@@ -59,6 +59,22 @@
 #include "h264bsd_image.h"
 #include "h264bsd_util.h"
 #include "basetype.h"
+#if H264BSD_N64
+#include "n64sys.h"
+#include "scratch.h"
+#include <malloc.h>
+
+/* Set to 1 to debugf DPB allocation request size, heap/scratch state, and
+ * which allocator served each frame in the per-frame fallback. Off in
+ * production; the MEMORY_ALLOCATION_ERROR return is enough signal for
+ * normal use. */
+#define H264BSD_TRACE_DPB 0
+#if H264BSD_TRACE_DPB
+#define dpb_tracef(fmt, ...) debugf(fmt, ##__VA_ARGS__)
+#else
+#define dpb_tracef(fmt, ...) ((void)0)
+#endif
+#endif
 
 /*------------------------------------------------------------------------------
     2. External compiler flags
@@ -1044,6 +1060,107 @@ u32 h264bsdInitDpb(
         return(MEMORY_ALLOCATION_ERROR);
     H264SwDecMemset(dpb->buffer, 0,
             (dpb->dpbSize + 1)*sizeof(dpbPicture_t));
+#if H264BSD_N64
+    {
+        /* N64: Allocate all frame buffers as one contiguous block. Prefer
+         * the scratch heap (backed by sbrk_top, growing downward from the
+         * top of RDRAM) because that keeps the DPB out of the regular
+         * malloc heap and avoids fragmenting the wilderness. If the
+         * scratch heap doesn't have enough contiguous headroom (small
+         * persistent allocations near the top can shrink the sbrk_top
+         * window below the DPB size even when a large free hole exists
+         * lower in the malloc heap), fall back to memalign so we can
+         * use that hole instead of giving up.
+         */
+        u32 frameSize = picSizeInMbs * 384 + 32 + 15;
+        /* Align each frame to 16 bytes within the bulk block */
+        u32 frameSizeAligned = (frameSize + 15) & ~15u;
+        u32 numFrames = dpb->dpbSize + 1;
+        u32 allocSize = frameSizeAligned * numFrames;
+#if H264BSD_TRACE_DPB
+        {
+            struct mallinfo mi = mallinfo();
+            scratch_stats_t ss; scratch_get_stats(&ss);
+            dpb_tracef("h264bsd DPB: req=%u (mbs=%u frames=%u) | heap.uord=%u ford=%u keep=%u | scratch.live=%u resv=%u\n",
+                (unsigned)allocSize, (unsigned)picSizeInMbs, (unsigned)numFrames,
+                (unsigned)mi.uordblks, (unsigned)mi.fordblks, (unsigned)mi.keepcost,
+                (unsigned)ss.live_bytes, (unsigned)ss.reserved_bytes);
+        }
+#endif
+        dpb->pAllocData = (u8*)scratch_malloc(allocSize);
+        dpb->pAllocViaMemalign = 0;
+        if (dpb->pAllocData == NULL) {
+            dpb_tracef("h264bsd DPB: scratch_malloc FAILED, trying memalign(%u)\n", (unsigned)allocSize);
+            dpb->pAllocData = (u8*)memalign(16, allocSize);
+            if (dpb->pAllocData != NULL) {
+                dpb_tracef("h264bsd DPB: memalign fallback OK\n");
+                dpb->pAllocViaMemalign = 1;
+            }
+        } else {
+            dpb_tracef("h264bsd DPB: scratch OK (%u bytes)\n", (unsigned)allocSize);
+        }
+        if (dpb->pAllocData != NULL) {
+            /* Bulk allocation succeeded. Lay out frames contiguously. */
+            data_cache_hit_invalidate(dpb->pAllocData, allocSize);
+            u8 *uncached = (u8*)UncachedAddr(dpb->pAllocData);
+            for (i = 0; i < numFrames; i++)
+            {
+                dpb->buffer[i].pAllocatedData = uncached + i * frameSizeAligned;
+                dpb->buffer[i].data = ALIGN(dpb->buffer[i].pAllocatedData, 16);
+            }
+        } else {
+            /* Per-frame fallback: when neither the scratch nor the malloc
+             * bulk allocation fits, allocate each frame independently. This
+             * succeeds when the available free space is fragmented into
+             * chunks each large enough for one frame but smaller than the
+             * full DPB size. Decoder access uses dpb->buffer[i] pointers,
+             * so contiguity isn't required for correctness — the bulk
+             * layout is only a memory-management convenience. Mark
+             * pAllocData NULL to signal the per-frame teardown path;
+             * h264bsdFreeDpb walks buffer[i] in that case. */
+            dpb_tracef("h264bsd DPB: bulk failed, trying per-frame allocation\n");
+            int allocated = 0;
+            for (i = 0; i < numFrames; i++) {
+                /* memalign first: dlmalloc tries to fit each frame into an
+                 * existing free chunk in fordblks. When fordblks runs out
+                 * of suitable holes, fall through to scratch which grows
+                 * top-of-RAM. Trying scratch first tends to leave the
+                 * malloc path with chunks too small to satisfy subsequent
+                 * frame requests, since scratch's downward growth would
+                 * otherwise eat the contiguous headroom that memalign
+                 * needs for its own splits. */
+                u8 *frame = (u8*)memalign(16, frameSizeAligned);
+                if (!frame) {
+                    frame = (u8*)scratch_malloc(frameSizeAligned);
+                }
+                if (!frame) {
+                    dpb_tracef("h264bsd DPB: per-frame failed at frame %u/%u (size %u)\n",
+                        (unsigned)i, (unsigned)numFrames, (unsigned)frameSizeAligned);
+                    /* Roll back any frames we already allocated. scratch_owns()
+                     * dispatches to the right deallocator per-frame since the
+                     * fallback mixes scratch and memalign sources. */
+                    for (u32 j = 0; j < i; j++) {
+                        void *cached = CachedAddr(dpb->buffer[j].pAllocatedData);
+                        if (scratch_owns(cached))
+                            scratch_free(cached);
+                        else
+                            free(cached);
+                        dpb->buffer[j].pAllocatedData = NULL;
+                        dpb->buffer[j].data = NULL;
+                    }
+                    return(MEMORY_ALLOCATION_ERROR);
+                }
+                data_cache_hit_invalidate(frame, frameSizeAligned);
+                dpb->buffer[i].pAllocatedData = (u8*)UncachedAddr(frame);
+                dpb->buffer[i].data = ALIGN(dpb->buffer[i].pAllocatedData, 16);
+                allocated++;
+            }
+            dpb_tracef("h264bsd DPB: per-frame OK (%u frames x %u bytes)\n",
+                (unsigned)allocated, (unsigned)frameSizeAligned);
+            /* pAllocData stays NULL — signals per-frame teardown path. */
+        }
+    }
+#else
     for (i = 0; i < dpb->dpbSize + 1; i++)
     {
         /* Allocate needed amount of memory, which is:
@@ -1057,6 +1174,7 @@ u32 h264bsdInitDpb(
 
         dpb->buffer[i].data = ALIGN(dpb->buffer[i].pAllocatedData, 16);
     }
+#endif
 
     ALLOCATE(dpb->list, MAX_NUM_REF_IDX_L0_ACTIVE + 1, dpbPicture_t*);
     ALLOCATE(dpb->outBuf, dpb->dpbSize+1, dpbOutPicture_t);
@@ -1705,10 +1823,44 @@ void h264bsdFreeDpb(dpbStorage_t *dpb)
 
     if (dpb->buffer)
     {
+#if H264BSD_N64
+        /* N64: Free either the bulk allocation or per-frame allocations.
+         * pAllocData != NULL means bulk; NULL means per-frame fallback was
+         * used (each buffer[i].pAllocatedData owns its own chunk, mixed
+         * between scratch and memalign sources). */
+        if (dpb->pAllocData)
+        {
+            if (dpb->pAllocViaMemalign)
+                free(dpb->pAllocData);
+            else
+                scratch_free(dpb->pAllocData);
+            dpb->pAllocData = NULL;
+            dpb->pAllocViaMemalign = 0;
+            for (i = 0; i < dpb->dpbSize+1; i++)
+            {
+                dpb->buffer[i].pAllocatedData = NULL;
+                dpb->buffer[i].data = NULL;
+            }
+        } else {
+            for (i = 0; i < dpb->dpbSize+1; i++)
+            {
+                if (dpb->buffer[i].pAllocatedData) {
+                    void *cached = CachedAddr(dpb->buffer[i].pAllocatedData);
+                    if (scratch_owns(cached))
+                        scratch_free(cached);
+                    else
+                        free(cached);
+                    dpb->buffer[i].pAllocatedData = NULL;
+                    dpb->buffer[i].data = NULL;
+                }
+            }
+        }
+#else
         for (i = 0; i < dpb->dpbSize+1; i++)
         {
             FREE_PIXELS(dpb->buffer[i].pAllocatedData);
         }
+#endif
     }
     FREE(dpb->buffer);
     FREE(dpb->list);

--- a/src/video/h264_decoder/h264bsd_dpb.h
+++ b/src/video/h264_decoder/h264bsd_dpb.h
@@ -94,6 +94,10 @@ typedef struct {
     u32 lastContainsMmco5;
     u32 noReordering;
     u32 flushed;
+#if H264BSD_N64
+    u8 *pAllocData;    /* bulk scratch allocation for all frame buffers */
+    u8 pAllocViaMemalign; /* 1 if pAllocData came from memalign fallback, 0 if from scratch_malloc */
+#endif
 } dpbStorage_t;
 
 /*------------------------------------------------------------------------------

--- a/src/video/h264_internal.h
+++ b/src/video/h264_internal.h
@@ -1,0 +1,46 @@
+/**
+ * @file h264_internal.h
+ * @author Giovanni Bajo <giovannibajo@gmail.com>
+ * @brief Internal (non-stable) hooks for the H.264 player
+ */
+#ifndef LIBDRAGON_H264_INTERNAL_H
+#define LIBDRAGON_H264_INTERNAL_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Custom allocator for the H.264 player instance.
+ *
+ * By default h264_open() allocates its player instance (the large h264_t state
+ * struct, ~268 KiB) via malloc(). Install a custom allocator to source that one
+ * block from a caller-owned region instead, so the player does not have to be
+ * carved out of the regular heap. The matching free() is called from
+ * h264_close() for a player that was allocated while a custom allocator was
+ * installed (the player records its own origin).
+ *
+ * @param alloc  Returns @p sz bytes aligned to @p align (>= 16), or NULL on failure.
+ * @param free   Releases a block previously returned by @p alloc.
+ */
+typedef struct h264_allocator_s {
+    void* (*alloc)(size_t sz, size_t align);
+    void  (*free)(void* p);
+} h264_allocator_t;
+
+/**
+ * @brief Install (or clear) the custom allocator used for H.264 player instances.
+ *
+ * Pass NULL to restore the default malloc/free. The allocator only affects
+ * players opened while it is installed; each player remembers how it was
+ * allocated and is freed accordingly in h264_close().
+ */
+void h264_set_allocator(const h264_allocator_t *allocator);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Stacked on top of #927 

Add h264_set_allocator so a caller can source the large (~268 KiB) h264_t player block from a caller-owned region instead of malloc. h264_open routes the player allocation through the hook (falling back to malloc if none is installed or it declines) and records the origin on the player so h264_close frees it through the matching path. Declared in a new internal header since it is not a stable public API.

Also, add fmv_parms_t::buffered_pics so callers can trade frame-pacing smoothness
for a smaller DPB. When unset, default to 8 on an Expansion Pak and 4 on a
4 MB N64 instead of an unconditional 8.

Additionally, the DPB frame buffers were one malloc per frame. Allocate them as a
single bulk block, preferring scratch (keeps the DPB out of the malloc
wilderness) and falling back to memalign when scratch lacks contiguous
headroom. When neither bulk allocation fits a fragmented heap, fall back to
per-frame allocation (memalign first, then scratch) since the decoder uses
per-frame pointers and contiguity is not required for correctness. Teardown
and mid-loop rollback dispatch per frame via scratch_owns.