### PR TITLE
fix: RDP passthrough mem corruption

### DIFF
--- a/src/rdpq/rdpq.c
+++ b/src/rdpq/rdpq.c
@@ -911,8 +911,11 @@ void __rdpq_block_reserve(int num_rdp_commands)
             rspq_int_write(RSPQ_CMD_RDP_SET_BUFFER, 0, 0, 0);
         }
     } else if (num_rdp_commands > 0) {
-        if (__builtin_expect(st->wptr + num_rdp_commands*2 > st->wend, 0))
+        // Loop: a first call can restore a pending (possibly full) buffer, 
+        // So re-check until there is enough room. a potential second call then allocates a fresh buffer.
+        while (__builtin_expect(st->wptr + num_rdp_commands*2 > st->wend, 0)) {
             __rdpq_block_next_buffer();
+        }
 
         for (int i=0; i<num_rdp_commands; i++) {
             *st->wptr++ = 0xC0000000;

--- a/src/rdpq/rdpq_internal.h
+++ b/src/rdpq/rdpq_internal.h
@@ -190,7 +190,7 @@ extern volatile int __rdpq_syncpoint_at_syncfull;
     if (__builtin_expect(rspq_block_is_recording(), 0)) { \
         extern rdpq_block_state_t rdpq_block_state; \
         int nwords = 0; __rdpcmd_count_words(rdp_cmd); \
-        if (__builtin_expect(rdpq_block_state.wptr + nwords > rdpq_block_state.wend, 0)) \
+        while (__builtin_expect(rdpq_block_state.wptr + nwords > rdpq_block_state.wend, 0)) \
             __rdpq_block_next_buffer(); \
         volatile uint32_t *ptr = rdpq_block_state.wptr; \
         __rdpcmd_write(rdp_cmd); \


### PR DESCRIPTION
after a lot of debugging i found a general memory corruption that can happen with rspq blocks that have passthrough RDP commands:

```c
rspq_block_begin();

rdpq_set_prim_color(...); 
// ... + more material setup that fills the RDP static buffer to near-full

rspq_block_run(some_other_block); // internally backs up wptr/wend into pending_* and NULLs them

rdpq_set_env_color(...); 
// checks: "NULL + 2 > NULL" -> "full" -> next_buffer()
//   next_buffer sees pending_* set -> RESTORES the old near-full buffer and returns
//   then writes 2 RDP words, past "wend" if < 2 words left

rspq_block_end();
```

the fix is to just turn the if-check into a loop in the 2 places
