### PR TITLE
Add O_SHORTLIVED to reduce memory fragmentation with short-lived files

### DIFF
--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -60,6 +60,7 @@
 #include "kqueue.h"
 #include "ksemaphore.h"
 #include "n64sys.h"
+#include "open_flags.h"
 #include "scratch.h"
 #include "vaddr64.h"
 #include "dd.h"

--- a/include/open_flags.h
+++ b/include/open_flags.h
@@ -1,0 +1,20 @@
+/**
+ * @file open_flags.h
+ * @author Giovanni Bajo <giovannibajo@gmail.com>
+ * @brief libdragon-specific flags for open().
+ * @ingroup system
+ */
+#ifndef __LIBDRAGON_OPEN_FLAGS_H
+#define __LIBDRAGON_OPEN_FLAGS_H
+
+/**
+ * @brief Hint that an opened file will be closed soon.
+ *
+ * Filesystems may use this libdragon-specific open flag to allocate per-open
+ * descriptors or buffers from the scratch heap instead of the main heap.
+ */
+#ifndef O_SHORTLIVED
+#define O_SHORTLIVED        0x01000000
+#endif
+
+#endif

--- a/include/system.h
+++ b/include/system.h
@@ -44,6 +44,7 @@
 #include <stdbool.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include "open_flags.h"
 
 /** @brief Number of filesystems that can be attached to the system */
 #define MAX_FILESYSTEMS     10

--- a/src/asset.c
+++ b/src/asset.c
@@ -9,6 +9,7 @@
 #include "compress/lz4_dec_internal.h"
 #include "compress/shrinkler_dec_internal.h"
 #include "utils.h"
+#include "open_flags.h"
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -93,9 +94,9 @@ void __asset_init_compression_lvl3(void)
     };
 }
 
-int must_open(const char *fn)
+static int must_open_flags(const char *fn, int flags)
 {
-    int fd = open(fn, O_RDONLY|O_BINARY);
+    int fd = open(fn, O_RDONLY|O_BINARY|flags);
     if (fd < 0) {
         // File not found.
         int errnum = errno;
@@ -117,6 +118,16 @@ int must_open(const char *fn)
         assertf(fd >= 0, "error opening file %s: %s\n", fn, strerror(errnum));
     }
     return fd;
+}
+
+int must_open(const char *fn)
+{
+    return must_open_flags(fn, 0);
+}
+
+int must_open_shortlived(const char *fn)
+{
+    return must_open_flags(fn, O_SHORTLIVED);
 }
 
 FILE *must_fopen(const char *fn)
@@ -309,7 +320,7 @@ void *asset_load(const char *fn, int *sz)
 {
     void *buf = NULL; int buf_size = 0;
     int size;
-    int fd = must_open(fn);
+    int fd = must_open_shortlived(fn);
     struct stat stat;
     fstat(fd, &stat);
     size = stat.st_size;

--- a/src/asset_internal.h
+++ b/src/asset_internal.h
@@ -120,6 +120,8 @@ typedef struct {
 FILE *must_fopen(const char *fn);
 /** @brief Open a file and assert on error */
 int must_open(const char *fn);
+/** @brief Open a short-lived file and assert on error */
+int must_open_shortlived(const char *fn);
 /** @brief Load an asset from file descriptor with automatic memory allocation */
 void *asset_loadfd(int fd, int *sz);
 /** @brief Load an asset from file descriptor into a provided buffer */

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -122,8 +122,8 @@ void xm64player_open(xm64player_t *player, const char *fn) {
 	// No pending seek at the moment, we start from beginning anyway.
 	player->seek.patidx = -1;
 
-	// Open the file as a file descriptor
-	int fd = must_open(fn);
+	// Open the file as a short-lived descriptor for metadata parsing.
+	int fd = must_open_shortlived(fn);
 
 	// Read the header to check if this is a valid XM64 file
 	xm64_header_t header;

--- a/src/bb/bbfs.c
+++ b/src/bb/bbfs.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include "debug.h"
 #include "system.h"
+#include "../system_internal.h"
 #include "nand.h"
 #include "bbfs.h"
 #include "utils.h"
@@ -412,7 +413,7 @@ static void *__bbfs_open(char *name, int flags)
     }
 
     int mode = flags & 7;
-    bbfs_openfile_t *file = malloc(sizeof(bbfs_openfile_t));
+    bbfs_openfile_t *file = fs_alloc_descriptor(sizeof(bbfs_openfile_t), flags);
     if (!file) {
         errno = ENOMEM;
         return NULL;
@@ -845,7 +846,7 @@ static int __bbfs_close(void *file)
         sb_flush();
     }
 
-    free(file);
+    fs_free_descriptor(file);
     return 0;
 }
 

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -18,6 +18,7 @@
 #include "dma.h"
 #include "debug.h"
 #include "system.h"
+#include "system_internal.h"
 #include "dfs_internal.h"
 #include "rompak_internal.h"
 #include "utils.h"
@@ -746,7 +747,7 @@ static dfs_lookup_file_t *lookup_file(const char *const path)
     return NULL;
 }
 
-int dfs_open(const char *path)
+static int dfs_open_flags(const char *path, int flags)
 {
     dfs_open_file_t *file;
     //Skip initial slash
@@ -761,7 +762,7 @@ int dfs_open(const char *path)
             return DFS_ENOFILE;
         }
         /* Try to find a free slot */
-        file = malloc(sizeof(dfs_open_file_t));
+        file = fs_alloc_descriptor(sizeof(dfs_open_file_t), flags);
         if(!file)
         {
             return DFS_ENOMEM;
@@ -782,7 +783,7 @@ int dfs_open(const char *path)
         }
 
         /* Try to find a free slot */
-        file = malloc(sizeof(dfs_open_file_t));
+        file = fs_alloc_descriptor(sizeof(dfs_open_file_t), flags);
 
         if(!file)
         {
@@ -801,6 +802,11 @@ int dfs_open(const char *path)
     return OPENFILE_TO_HANDLE(file);
 }
 
+int dfs_open(const char *path)
+{
+    return dfs_open_flags(path, 0);
+}
+
 int dfs_close(uint32_t handle)
 {
     dfs_open_file_t *file = HANDLE_TO_OPENFILE(handle);
@@ -811,7 +817,7 @@ int dfs_close(uint32_t handle)
     }
 
     /* Free the open file */
-    free(file);
+    fs_free_descriptor(file);
 
     return DFS_ESUCCESS;
 }
@@ -1121,8 +1127,7 @@ static void *__open( char *name, int flags )
         return NULL;
     }
 
-    /* We disregard flags here */
-    int handle = dfs_open( name );
+    int handle = dfs_open_flags( name, flags );
     if (handle <= 0) {
         __dfs_set_errno(handle);
         return NULL;

--- a/src/fat.c
+++ b/src/fat.c
@@ -14,6 +14,7 @@
 #include "fatfs/diskio.h"
 #include "debug.h"
 #include "system.h"
+#include "system_internal.h"
 #include "n64sys.h"
 #include "dma.h"
 #include "utils.h"
@@ -142,7 +143,7 @@ static void *__fat_open(char *name, int flags, int volid)
 			break;
 		}
 	if (!fp) {
-		fp = malloc(sizeof(FIL));
+		fp = fs_alloc_descriptor(sizeof(FIL), flags);
 		if (!fp) {
 			errno = ENOMEM;
 			return NULL;
@@ -175,7 +176,7 @@ static void *__fat_open(char *name, int flags, int volid)
 		if (fp >= static_fat_files && fp < static_fat_files+NUM_STATIC_FAT_FILES)
 			fp->obj.fs = NULL;
 		else
-			free(fp);
+			fs_free_descriptor(fp);
 		return NULL;
 	}
 	return fp;
@@ -255,7 +256,7 @@ static int __fat_close(void *file)
 	if (fp >= static_fat_files && fp < static_fat_files+NUM_STATIC_FAT_FILES)
 		fp->obj.fs = NULL;
 	else
-		free(fp);
+		fs_free_descriptor(fp);
 
 	if (res != FR_OK) {
 		__fresult_set_errno(res);

--- a/src/joybus/cpakfs.c
+++ b/src/joybus/cpakfs.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include "system.h"
+#include "../system_internal.h"
 #include "cpak.h"
 #include "cpakfs.h"
 #include "cpakfs_internal.h"
@@ -651,7 +652,7 @@ static void *__cpakfs_open(char *name, int flags, int port)
     }
 
     int mode = flags & 7;
-    cpakfs_openfile_t *file = malloc(sizeof(cpakfs_openfile_t));
+    cpakfs_openfile_t *file = fs_alloc_descriptor(sizeof(cpakfs_openfile_t), flags);
     if (!file) {
         errno = ENOMEM;
         return NULL;
@@ -690,7 +691,7 @@ static void *__cpakfs_open(char *name, int flags, int port)
             file->size = calc_size(fs, note);
             if (file->size < 0) {
                 errno = EFTYPE;
-                free(file);
+                fs_free_descriptor(file);
                 return NULL;
             }
         }
@@ -752,7 +753,7 @@ static int __cpakfs_close(void *file)
             err = -1;
     }
 
-    free(file);
+    fs_free_descriptor(file);
     return err;
 }
 

--- a/src/pifile.c
+++ b/src/pifile.c
@@ -14,6 +14,7 @@
 #include "pifile.h"
 #include "n64sys.h"
 #include "system.h"
+#include "system_internal.h"
 #include "dma.h"
 
 /** @brief A PI-mapped open file */
@@ -25,7 +26,7 @@ typedef struct {
 
 static void *__pifile_open(char *name, int flags)
 {
-    if (flags != O_RDONLY) {
+    if ((flags & O_ACCMODE) != O_RDONLY) {
         errno = EACCES;
         return NULL;
     }
@@ -43,7 +44,7 @@ static void *__pifile_open(char *name, int flags)
         return NULL;
     }
 
-    pifile_t *file = malloc(sizeof(pifile_t));
+    pifile_t *file = fs_alloc_descriptor(sizeof(pifile_t), flags);
     if (!file) {
         errno = ENOMEM;
         return NULL;
@@ -126,7 +127,7 @@ static int __pifile_read(void *file, uint8_t *buf, int len)
 
 static int __pifile_close(void *file)
 {
-    free(file);
+    fs_free_descriptor(file);
     return 0;
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -1250,7 +1250,7 @@ int stat( const char *file, struct stat *st )
     }
 
     /* Dirty hack, open read only */
-    int fd = open( (char *)file, O_RDONLY );
+    int fd = open( (char *)file, O_RDONLY | O_SHORTLIVED );
     if( fd < 0 )
         return fd;
 
@@ -1487,7 +1487,7 @@ int ftruncate( int file, off_t length )
  */
 int truncate( const char *path, off_t length )
 {
-    int fd = open( path, O_WRONLY );
+    int fd = open( path, O_WRONLY | O_SHORTLIVED );
     if (fd < 0)
         return fd;
 

--- a/src/system_internal.h
+++ b/src/system_internal.h
@@ -5,6 +5,34 @@
 #ifndef LIBDRAGON_SYSTEM_INTERNAL_H
 #define LIBDRAGON_SYSTEM_INTERNAL_H
 
+#include <stddef.h>
+#include <stdlib.h>
+#include "system.h"
+
+#ifdef N64
+#include "scratch.h"
+#endif
+
 void* sbrk_top( int incr );
+
+static inline void *fs_alloc_descriptor(size_t size, int flags)
+{
+#ifdef N64
+    if (flags & O_SHORTLIVED)
+        return scratch_malloc(size);
+#endif
+    return malloc(size);
+}
+
+static inline void fs_free_descriptor(void *ptr)
+{
+#ifdef N64
+    if (scratch_owns(ptr)) {
+        scratch_free(ptr);
+        return;
+    }
+#endif
+    free(ptr);
+}
 
 #endif

--- a/tests/test_dfs.c
+++ b/tests/test_dfs.c
@@ -1,4 +1,7 @@
 
+#include <fcntl.h>
+#include <unistd.h>
+
 void test_dfs_read(TestContext *ctx) {
 	int fh = dfs_open("counter.dat");
 	ASSERT(fh >= 0, "counter.dat not found");
@@ -110,6 +113,33 @@ void test_dfs_ioctl(TestContext *ctx) {
     int ret = ioctl(fileno(file), IODFS_GET_ROM_BASE, &rom_addr);
     ASSERT(ret >= 0, "DFS ioctl failed");
     ASSERT(rom_addr == (dfs_rom_addr("counter.dat") & 0x1FFFFFFF), "IODFS_GET_ROM_BASE ioctl returns wrong address");
+}
+
+void test_dfs_shortlived_open(TestContext *ctx) {
+    scratch_stats_t before, opened, after;
+    scratch_get_stats(&before);
+
+    int fd = open("rom:/counter.dat", O_RDONLY | O_SHORTLIVED);
+    ASSERT(fd >= 0, "counter.dat not found");
+    DEFER(if (fd >= 0) close(fd));
+
+    scratch_get_stats(&opened);
+    ASSERT_EQUAL_UNSIGNED(opened.live_blocks, before.live_blocks + 1,
+        "O_SHORTLIVED open should allocate one scratch descriptor");
+
+    uint8_t buf[8];
+    ASSERT_EQUAL_SIGNED(read(fd, buf, sizeof(buf)), (int)sizeof(buf), "short-lived read failed");
+    ASSERT_EQUAL_MEM(buf, (uint8_t*)"\x00\x01\x02\x03\x04\x05\x06\x07", sizeof(buf),
+        "short-lived read returned wrong data");
+
+    ASSERT_EQUAL_SIGNED(close(fd), 0, "short-lived close failed");
+    fd = -1;
+
+    scratch_get_stats(&after);
+    ASSERT_EQUAL_UNSIGNED(after.live_blocks, before.live_blocks,
+        "O_SHORTLIVED close should release the scratch descriptor");
+    ASSERT_EQUAL_UNSIGNED(after.live_bytes, before.live_bytes,
+        "O_SHORTLIVED close should restore scratch live bytes");
 }
 
 typedef struct {

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -282,6 +282,7 @@ static const struct Testsuite
 	TEST_FUNC(test_dfs_rom_addr,              25, TEST_FLAGS_IO),
 	TEST_FUNC(test_dfs_rom_size,              25, TEST_FLAGS_IO),
 	TEST_FUNC(test_dfs_ioctl,                  0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_dfs_shortlived_open,        0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_dfs_directory,              0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_eepromfs,                   0, TEST_FLAGS_IO),
 	TEST_FUNC(test_cache_invalidate,        1763, TEST_FLAGS_NONE),


### PR DESCRIPTION
This PR adds support for a custom open flag `O_SHORTLIVED` that informs libdragon filesystems that a file is going to be opened for a very short of time. Filesystems that know about this flag can for instance allocate the file descriptors in scratch memory.

All existing filesystems are updated to honor the flag. Moreover, `asset_load` is updated to specify `O_SHORTLIVED`, as that's a good case where it should be useful.

TODO: waiting for confirmation this actually helps