### PR TITLE
allocator: purpose-tagged seam and pooled buffers for constrained targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ LIBDRAGON_OBJS += \
 	$(BUILD_DIR)/profile.o \
 	$(BUILD_DIR)/n64sys.o \
 	$(BUILD_DIR)/scratch.o \
+	$(BUILD_DIR)/sys_alloc.o \
 	$(BUILD_DIR)/vaddr64.o \
 	$(BUILD_DIR)/mi_memset.o \
 	$(BUILD_DIR)/interrupt.o \

--- a/include/asset.h
+++ b/include/asset.h
@@ -130,7 +130,7 @@ void *asset_load(const char *fn, int *sz);
 
 /**
  * @brief Load an asset file (possibly uncompressing it)
- * 
+ *
  * This function loads an asset embedded within a larger file. It requires in
  * input an open file pointer, seeked to the beginning of the asset, and the
  * size of the asset itself. If the asset is compressed, it is transparently

--- a/include/dragonfs.h
+++ b/include/dragonfs.h
@@ -31,15 +31,20 @@
  *
  * DFS files have a maximum size of 256 MiB.  Directories can have an unlimited
  * number of files in them.  Each token (separated by a / in the path) can be 243 characters
- * maximum.  Directories can be 100 levels deep at maximum.  There can be 4 files open
- * simultaneously.
+ * maximum.  Directories can be 100 levels deep at maximum.
+ *
+ * There is no hard limit on how many files can be open at once.  The handles for
+ * the first `DFS_FILE_POOL_SIZE` (128 by default) simultaneously-open files are
+ * served from a small static pool so they never fragment the heap; opening more
+ * than that transparently falls back to the heap.  Define `DFS_FILE_POOL_SIZE`
+ * when building libdragon to tune the pool (each slot costs 12 bytes of BSS).
  *
  * When DFS is initialized, it will register itself with newlib using 'rom:/' as a prefix.
  * Files can be accessed either with standard POSIX functions (open, fopen) using the 'rom:/'
  * prefix or the lower-level DFS API calls without prefix. In most cases, it is not necessary
  * to use the DFS API directly, given that the standard C functions are more comprehensive.
- * Files can be opened using both sets of API calls simultaneously as long as no more than
- * four files are open at any one time.
+ * Files can be opened using both sets of API calls simultaneously; open handles
+ * from both share the same pool described above.
  * 
  * DragonFS does not support file compression; if you want to compress your assets,
  * use the asset API (#asset_load / #asset_fopen).
@@ -156,6 +161,28 @@ extern "C" {
  * @return DFS_ESUCCESS on success or a negative error otherwise.
  */
 int dfs_init(pi_addr_t base_fs_loc);
+
+/**
+ * @brief Size of the DragonFS open-file handle pool (weak hook; default 0).
+ *
+ * DragonFS can serve open-file handles from a pool allocated once at #dfs_init,
+ * instead of malloc'ing one per open, so that many concurrently-open files do
+ * not churn or fragment the system heap with small, long-lived allocations.
+ *
+ * This is a weak function whose default returns 0 (no pool: every handle is
+ * malloc'd/freed, as in plain newlib). Override it to enable the pool and size
+ * it to how many files your application keeps open at once — an application-side
+ * decision that needs no libdragon rebuild:
+ *
+ * @code
+ * int __dfs_file_pool_size(void) { return 64; }
+ * @endcode
+ *
+ * Opens beyond the pool size fall back to malloc() transparently.
+ *
+ * @return Number of handles to keep in the pool, or 0 for none.
+ */
+int __dfs_file_pool_size(void);
 
 
 /**

--- a/include/fmv.h
+++ b/include/fmv.h
@@ -161,6 +161,15 @@ typedef struct fmv_parms_s {
      * @param info      Video metadata from the opened stream
      */
     yuv_blitter_t (*create_yuv_blitter)(void *osd_ctx, video_info_t *info);
+
+    /**
+     * @brief Number of decoded pictures to buffer in the DPB.
+     *
+     * If 0, defaults to 4 on a 4 MB N64 (8 on an Expansion Pak). Each
+     * buffered picture adds picSizeInMbs*384 bytes to the DPB. Set as low as
+     * 1 to minimize DPB size at the cost of frame-pacing smoothness.
+     */
+    int buffered_pics;
 } fmv_parms_t;
 
 

--- a/include/sys_alloc.h
+++ b/include/sys_alloc.h
@@ -1,0 +1,68 @@
+/**
+ * @file sys_alloc.h
+ * @brief Single tagged allocation seam for large/fragmenting subsystem buffers.
+ *
+ * Several subsystems (asset, lspr3, yuv, wav64, h264, dlfcn) make large or
+ * numerous heap allocations that, on memory-constrained targets, an application
+ * may want to source from memory of its choosing (e.g. a pre-reserved region)
+ * to control heap layout and avoid mid-session fragmentation failures.
+ *
+ * Rather than a bespoke allocator setter per subsystem, all of these funnel
+ * through a single pair of hooks, ::__sys_alloc / ::__sys_free, tagged with a
+ * ::sys_alloc_purpose_t so the application can dispatch by purpose. Both are
+ * declared @c weak and default to a standard heap allocation (memalign/free, and
+ * uncached for #SYS_ALLOC_YUV), so this is a no-op for callers that do not
+ * override them. An application opts in simply by providing a strong definition
+ * of ::__sys_alloc / ::__sys_free.
+ *
+ * @note Freeing is symmetric: a block obtained via ::__sys_alloc with a given
+ * purpose must be released via ::__sys_free with the SAME purpose, because the
+ * override typically routes each purpose to a different backend.
+ */
+#ifndef __LIBDRAGON_SYS_ALLOC_H
+#define __LIBDRAGON_SYS_ALLOC_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Identifies which subsystem allocation ::__sys_alloc is servicing.
+ *
+ * The purpose lets an overriding application route each subsystem's buffer to a
+ * different backend (scratch, a reserve, an arena, ...). The parenthesised note
+ * on each value is the behaviour of the weak default.
+ */
+typedef enum {
+    SYS_ALLOC_ASSET = 0,    ///< asset_load() decompressed payload (memalign). Freed by the caller with the C free() unless overridden.
+    SYS_ALLOC_LSPR3_SPRITE, ///< lspr3 decoded output sprite buffer (memalign, 64-byte aligned).
+    SYS_ALLOC_LSPR3_MB,     ///< lspr3 transient mbStorage array (memalign; the decoder zeroes it itself).
+    SYS_ALLOC_YUV,          ///< yuv U/V interleave buffer. MUST be uncached (RSP-written, RDP-read); default is malloc_uncached().
+    SYS_ALLOC_WAV64,        ///< wav64 streaming handle block (memalign). Streaming loads only.
+    SYS_ALLOC_H264,         ///< h264 player instance (large; malloc).
+    SYS_ALLOC_DSO_MODULE,   ///< dlfcn resident DSO module image (memalign).
+} sys_alloc_purpose_t;
+
+/**
+ * @brief Allocate @p size bytes aligned to @p align for the given @p purpose.
+ *
+ * Weak default: uncached for #SYS_ALLOC_YUV, otherwise memalign(align|16).
+ * Override with a strong definition to dispatch by purpose. Returns NULL on
+ * failure (callers assert).
+ */
+void *__sys_alloc(sys_alloc_purpose_t purpose, size_t size, size_t align);
+
+/**
+ * @brief Free a block previously returned by ::__sys_alloc for @p purpose.
+ *
+ * Must be called with the same @p purpose the block was allocated under.
+ */
+void __sys_free(sys_alloc_purpose_t purpose, void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/asset.c
+++ b/src/asset.c
@@ -4,6 +4,7 @@
  */
 #include "asset.h"
 #include "asset_internal.h"
+#include "sys_alloc.h"
 #include "debug.h"
 #include "compress/aplib_dec_internal.h"
 #include "compress/lz4_dec_internal.h"
@@ -35,6 +36,20 @@
 /// @cond
 #define memalign(a, b) malloc(b)
 /// @endcond
+
+// On the host (tools) build, sys_alloc.c is not compiled (it depends on N64-only
+// headers), so provide the seam's default behaviour here for the asset payload.
+void *__sys_alloc(sys_alloc_purpose_t purpose, size_t size, size_t align)
+{
+    (void)purpose; (void)align;
+    return malloc(size);
+}
+
+void __sys_free(sys_alloc_purpose_t purpose, void *ptr)
+{
+    (void)purpose;
+    free(ptr);
+}
 #endif
 
 /** 
@@ -286,15 +301,20 @@ bool asset_loadf_into(FILE *f, int *sz, void *buf, int *buf_size)
     return asset_loadfd_into(fd, sz, buf, buf_size);
 }
 
-void *asset_loadfd(int fd, int *sz)
+void *asset_loadfd_ex(int fd, int *sz, sys_alloc_purpose_t purpose)
 {
     void *buf = NULL; int buf_size = 0;
     asset_parsed_header_t header;
     buf_size = asset_read_header(fd, &header, sz);
-    buf = memalign(ASSET_ALIGNMENT, buf_size);
+    buf = __sys_alloc(purpose, buf_size, ASSET_ALIGNMENT);
     assertf(buf, "Out of memory");
     asset_read(fd, &header, sz, buf, &buf_size);
     return buf;
+}
+
+void *asset_loadfd(int fd, int *sz)
+{
+    return asset_loadfd_ex(fd, sz, SYS_ALLOC_ASSET);
 }
 
 void *asset_loadf(FILE *f, int *sz)
@@ -315,7 +335,7 @@ void *asset_load(const char *fn, int *sz)
     size = stat.st_size;
     asset_parsed_header_t header;
     buf_size = asset_read_header(fd, &header, &size);
-    buf = memalign(ASSET_ALIGNMENT, buf_size);
+    buf = __sys_alloc(SYS_ALLOC_ASSET, buf_size, ASSET_ALIGNMENT);
     assertf(buf, "Out of memory");
     asset_read(fd, &header, &size, buf, &buf_size);
     if (sz) *sz = size;

--- a/src/asset_internal.h
+++ b/src/asset_internal.h
@@ -11,6 +11,8 @@
 
 #include <stdio.h>
 
+#include "sys_alloc.h"
+
 #define ASSET_MAGIC                 "DCA"   ///< Magic compressed asset header
 #define ASSET_FLAG_WINSIZE_MASK     0x07    ///< Mask to isolate the window size in the flags
 #define ASSET_FLAG_WINSIZE_16K      0x00    ///< 16 KiB window size
@@ -122,6 +124,8 @@ FILE *must_fopen(const char *fn);
 int must_open(const char *fn);
 /** @brief Load an asset from file descriptor with automatic memory allocation */
 void *asset_loadfd(int fd, int *sz);
+/** @brief Load an asset from file descriptor, allocating the payload via __sys_alloc(@p purpose) */
+void *asset_loadfd_ex(int fd, int *sz, sys_alloc_purpose_t purpose);
 /** @brief Load an asset from file descriptor into a provided buffer */
 bool asset_loadfd_into(int fd, int *sz, void *buf, int *buf_size);
 /** @brief Open a file descriptor as a FILE* with asset support */

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -13,6 +13,7 @@
 #include "mixer_internal.h"
 #include "dragonfs.h"
 #include "n64sys.h"
+#include "sys_alloc.h"
 #include "dma.h"
 #include "samplebuffer.h"
 #include "debug.h"
@@ -167,9 +168,21 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 	int heap_off_ext = heap_size;
 	heap_size += ROUND_UP(ext_size, 16);							// Extended header data
 	
-	// Allocate heap memory
+	// Allocate heap memory. Streaming handles are sourced through the tagged
+	// seam (SYS_ALLOC_WAV64) so an application can pool these small blocks in a
+	// contiguous arena instead of scattering them across the main heap. The
+	// preload path below reallocs this block, which a bump-style arena can't
+	// satisfy — so the seam is only used for streaming loads (where the block is
+	// never realloc'd); preload always uses memalign.
 	assert(heap_size % 16 == 0);
-	void *heap = memalign(16, heap_size);
+	bool heap_from_seam = false;
+	void *heap = NULL;
+	if (!preload) {
+		heap = __sys_alloc(SYS_ALLOC_WAV64, heap_size, 16);
+		heap_from_seam = (heap != NULL);
+	}
+	if (!heap)
+		heap = memalign(16, heap_size);
 	assertf(heap, "Out of memory");
 	if (!wav) wav = heap + heap_off_waveform;
 	wav->st = heap;
@@ -195,7 +208,8 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 	wav->st->format = head.format;
 	wav->st->current_fd = file_handle;
 	wav->st->base_offset = head.start_offset + start_offset;
-	wav->st->flags = owned_fd ? WAV64_FLAG_OWNED_FD : 0;
+	wav->st->flags = (owned_fd ? WAV64_FLAG_OWNED_FD : 0)
+	               | (heap_from_seam ? WAV64_FLAG_SEAM_OWNED : 0);
 
 	// Initialize the compression algorithm
 	algos[wav->st->format].init(wav, head.state_size);
@@ -219,6 +233,9 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 		if (algos[wav->st->format].close)
 			algos[wav->st->format].close(wav);
 
+		// realloc() can't act on a seam-sourced block; the seam path is gated to
+		// !preload above, so this is only ever reached for memalign blocks.
+		assertf(!heap_from_seam, "wav64: preload reached on a seam-owned block");
 		wav->st = realloc(wav->st, heap_off_preload_end);
 		wav->st->ext = NULL;
 
@@ -295,6 +312,11 @@ void wav64_close(wav64_t *wav)
 	if (!heap)
 		return;
 
+	// Remember how the heap block was allocated before the memset below wipes
+	// wav->st (and thus the flags). Seam-owned (streaming) blocks are released
+	// through __sys_free(SYS_ALLOC_WAV64); the rest via free().
+	const bool heap_from_seam = (wav->st->flags & WAV64_FLAG_SEAM_OWNED) != 0;
+
 	// Stop playing the waveform on all channels
 	for (int i=0; i<MIXER_MAX_CHANNELS; i++) {
 		if (mixer_ch_playing_waveform(i) == &wav->wave)
@@ -311,8 +333,13 @@ void wav64_close(wav64_t *wav)
 
 	memset(wav, 0, sizeof(wav64_t));
 
-	// Free the heap allocation (that might or might not include the wav64_t instance)
-	free(heap);
+	// Free the heap allocation (that might or might not include the wav64_t
+	// instance). Streaming blocks go back through the seam with the same purpose
+	// they were allocated under; the rest via free().
+	if (heap_from_seam)
+		__sys_free(SYS_ALLOC_WAV64, heap);
+	else
+		free(heap);
 }
 
 /** @brief Initialize wav64 compression level 3 */

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -5,6 +5,12 @@
 #ifndef __LIBDRAGON_WAV64_INTERNAL_H
 #define __LIBDRAGON_WAV64_INTERNAL_H
 
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define WAV64_ID            "WV64"    ///< WAV64 file identifier
 #define WAV64_FORMAT_RAW    0         ///< Raw audio format
 #define WAV64_FORMAT_VADPCM 1         ///< VADPCM compressed format
@@ -12,6 +18,7 @@
 #define WAV64_NUM_FORMATS   4         ///< Number of supported formats
 
 #define WAV64_FLAG_OWNED_FD (1 << 0)  ///< Flag indicating the file descriptor is owned by the wav64 structure
+#define WAV64_FLAG_SEAM_OWNED (1 << 1) ///< Streaming heap block came from __sys_alloc(SYS_ALLOC_WAV64); free via __sys_free
 
 /// @cond
 typedef struct wav64_s wav64_t;
@@ -67,5 +74,9 @@ typedef struct {
  * Similar to #wav64_load, but uses a file descriptor instead of a filename.
  */
 wav64_t *wav64_loadfd(int fd, const char *debug_file_name, wav64_loadparms_t *parms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/dlfcn.c
+++ b/src/dlfcn.c
@@ -523,7 +523,13 @@ void *dlopen(const char *filename, int mode)
         assertf(hdr.magic == DSO_FILE_MAGIC, "Invalid DSO file: %s", filename);
         lseek(fd, hdr.resident_off, SEEK_SET);
         int rsz = hdr.resident_size;
-        handle = asset_loadfd(fd, &rsz);
+        //Load the resident module image through the tagged seam
+        //(SYS_ALLOC_DSO_MODULE) so close_module() frees it symmetrically via
+        //__sys_free with the same purpose. The weak default is memalign/free;
+        //an application can override __sys_alloc to place the image elsewhere.
+        handle = asset_loadfd_ex(fd, &rsz, SYS_ALLOC_DSO_MODULE);
+        //Load the transient loadtmp section into scratch memory; it is only
+        //needed during linking and is released immediately afterwards.
         lseek(fd, hdr.loadtmp_off, SEEK_SET);
         int tsz = hdr.loadtmp_size, tbuf_size = 0;
         asset_loadfd_into(fd, &tsz, NULL, &tbuf_size);
@@ -664,7 +670,8 @@ static void close_module(dl_module_t *module)
     end_module(module);
     //Remove module from memory
     __dl_remove_module(module);
-    free(module);
+    //Release the module image via the same seam purpose that produced it.
+    __sys_free(SYS_ALLOC_DSO_MODULE, module);
 }
 
 static void close_unused_modules()

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include "dragonfs.h"
 #include "n64sys.h"
+#include "interrupt.h"
 #include "dma.h"
 #include "debug.h"
 #include "system.h"
@@ -64,6 +65,93 @@ static pi_addr_t next_entry = 0;
 #define OPENFILE_TO_HANDLE(file)        ((int)PhysicalAddr(file))
 /** @brief Convert a handle to an open file pointer */
 #define HANDLE_TO_OPENFILE(handle)      ((dfs_open_file_t*)((uint32_t)(handle) | 0x80000000))
+
+/**
+ * @brief Weak hook: number of open-file handles to serve from a pool.
+ *
+ * The default returns 0, so every open-file handle is malloc'd/freed as usual.
+ * An application that keeps many files open at once can override this to enable
+ * a handle pool sized to its workload — keeping those small, long-lived handles
+ * from churning and fragmenting the system heap — WITHOUT recompiling libdragon:
+ *
+ *     int __dfs_file_pool_size(void) { return 64; }
+ *
+ * See #__dfs_file_pool_size in dragonfs.h. The pool is allocated once at
+ * #dfs_init; opens beyond its size fall back to malloc() transparently.
+ */
+__attribute__((weak)) int __dfs_file_pool_size(void) { return 0; }
+
+/** @brief DFS file handle freelist entry slot */
+typedef union dfs_file_slot_s {
+    dfs_open_file_t file;
+    union dfs_file_slot_s *next;
+} dfs_file_slot_t;
+
+_Static_assert(sizeof(dfs_file_slot_t) == sizeof(dfs_open_file_t),
+    "dfs_file_slot_t must be the same size as dfs_open_file_t");
+
+/** @brief Open-file handle pool (sized by __dfs_file_pool_size). NULL if none. */
+static dfs_file_slot_t *dfs_file_pool;
+static int dfs_file_pool_count;
+static dfs_file_slot_t *dfs_file_freelist;
+
+/**
+ * @brief Allocate and link the open-file handle pool.
+ *
+ * Called once from dfs_init() — at boot, single-threaded — so the one-off pool
+ * buffer allocation happens outside any interrupt-critical section. If the hook
+ * returns 0 (or the allocation fails) there is no pool and every handle is
+ * malloc'd.
+ */
+static void dfs_file_pool_setup(void)
+{
+    if (dfs_file_freelist || dfs_file_pool) return;   // already set up
+    int n = __dfs_file_pool_size();
+    if (n <= 0) return;
+    dfs_file_slot_t *buf = malloc((size_t)n * sizeof(dfs_file_slot_t));
+    if (!buf) return;   // no pool: fall back to per-handle malloc
+    for (int i = 0; i < n - 1; i++)
+        buf[i].next = &buf[i + 1];
+    buf[n - 1].next = NULL;
+    dfs_file_pool = buf;
+    dfs_file_pool_count = n;
+    dfs_file_freelist = buf;
+}
+
+/** @brief Take an open-file handle from the pool, or malloc() if it is empty. */
+static dfs_open_file_t *dfs_file_pool_alloc(void)
+{
+    // The freelist is shared mutable state: dfs_open() can be called from
+    // multiple kthreads. Pop under a disabled-interrupt critical section, but
+    // fall back to malloc() outside it (malloc takes the newlib lock, which must
+    // not be entered with interrupts disabled). The pool buffer is allocated up
+    // front in dfs_init(), never here.
+    disable_interrupts();
+    dfs_file_slot_t *slot = dfs_file_freelist;
+    if (slot)
+        dfs_file_freelist = slot->next;
+    enable_interrupts();
+    if (!slot)
+        return malloc(sizeof(dfs_open_file_t));
+    return &slot->file;
+}
+
+/** @brief Return a handle to the pool (or free() it if it was malloc()'d). */
+static void dfs_file_pool_free(dfs_open_file_t *f)
+{
+    dfs_file_slot_t *slot = (dfs_file_slot_t *)f;
+    if (dfs_file_pool && slot >= dfs_file_pool && slot < dfs_file_pool + dfs_file_pool_count)
+    {
+        disable_interrupts();
+        slot->next = dfs_file_freelist;
+        dfs_file_freelist = slot;
+        enable_interrupts();
+    }
+    else
+    {
+        free(f);
+    }
+}
 
 /**
  * @brief Read a sector from cartspace
@@ -761,7 +849,7 @@ int dfs_open(const char *path)
             return DFS_ENOFILE;
         }
         /* Try to find a free slot */
-        file = malloc(sizeof(dfs_open_file_t));
+        file = dfs_file_pool_alloc();
         if(!file)
         {
             return DFS_ENOMEM;
@@ -782,7 +870,7 @@ int dfs_open(const char *path)
         }
 
         /* Try to find a free slot */
-        file = malloc(sizeof(dfs_open_file_t));
+        file = dfs_file_pool_alloc();
 
         if(!file)
         {
@@ -811,7 +899,7 @@ int dfs_close(uint32_t handle)
     }
 
     /* Free the open file */
-    free(file);
+    dfs_file_pool_free(file);
 
     return DFS_ESUCCESS;
 }
@@ -1401,6 +1489,11 @@ int dfs_init(uint32_t base_fs_loc)
         /* Failed, return so */
         return ret;
     }
+
+    /* Set up the open-file handle pool (no-op unless __dfs_file_pool_size() is
+       overridden). Done here, at boot in thread context, so the one-off buffer
+       allocation stays out of the interrupt-critical handle alloc path. */
+    dfs_file_pool_setup();
 
     /* Succeeded, push our filesystem into newlib */
     attach_filesystem( "rom:/", &dragon_fs );

--- a/src/lspr3.c
+++ b/src/lspr3.c
@@ -26,6 +26,7 @@
 #include "sprite.h"
 #include "sprite_internal.h"
 #include "n64sys.h"
+#include "sys_alloc.h"
 #include "surface.h"
 #include "utils.h"
 #include "yuv.h"
@@ -167,8 +168,15 @@ static void lspr3_decode_intra_slice(
     assertf(slice.firstMbInSlice == 0, "H264I: first_mb_in_slice != 0");
     assertf(slice.picParameterSetId == 0, "H264I: unexpected PPS id");
 
-    mbStorage_t *mb = (mbStorage_t*)calloc(pic_size_in_mbs, sizeof(mbStorage_t));
+    // Transient macroblock storage. Sourced through the tagged seam
+    // (SYS_ALLOC_LSPR3_MB); the weak default is memalign on the main heap, and
+    // an application can override __sys_alloc to route it elsewhere. The seam
+    // does not zero the buffer, so memset it here (the decoder relies on the mb
+    // array being zero-initialised).
+    size_t mb_bytes = (size_t)pic_size_in_mbs * sizeof(mbStorage_t);
+    mbStorage_t *mb = (mbStorage_t*)__sys_alloc(SYS_ALLOC_LSPR3_MB, mb_bytes, 16);
     assertf(mb, "H264I: out of memory");
+    memset(mb, 0, mb_bytes);
     h264bsdInitMbNeighbours(mb, (u32)mb_w, pic_size_in_mbs);
 
     i32 qpY = (i32)pps.picInitQp + slice.sliceQpDelta;
@@ -225,7 +233,7 @@ static void lspr3_decode_intra_slice(
     // before the memory is released.
     rsph264_sync();
     assertf(currMbAddr == pic_size_in_mbs, "H264I: incomplete slice");
-    free(mb);
+    __sys_free(SYS_ALLOC_LSPR3_MB, mb);
 
     *out_yuv = yuv;
     *out_yuv_size = yuv_size;
@@ -323,7 +331,13 @@ static sprite_t *lspr3_load_buf(const void *encoded_buf, int encoded_sz) {
     // Allocate the buffer for the decoded sprite.
     size_t decoded_sz = lspr3_decoded_size_buf(encoded_buf, encoded_sz);
     assertf(decoded_sz > 0, "Invalid H264I buffer");
-    sprite_t *sprite = (sprite_t *)memalign(H264I_BUF_ALIGN, decoded_sz);
+    // Decoded sprite buffer, sourced through the tagged seam
+    // (SYS_ALLOC_LSPR3_SPRITE), aligned to H264I_BUF_ALIGN so the post-header
+    // pixel area lands on a 64-byte boundary. The weak default is memalign, so
+    // a sprite from the standard path may still be released with sprite_free();
+    // an application overriding __sys_alloc owns the matching
+    // __sys_free(SYS_ALLOC_LSPR3_SPRITE) and must not call sprite_free() on it.
+    sprite_t *sprite = (sprite_t *)__sys_alloc(SYS_ALLOC_LSPR3_SPRITE, decoded_sz, H264I_BUF_ALIGN);
     assertf(sprite, "Out of memory");
     sprite->flags = SPRITE_FLAGS_OWNEDBUFFER;
 

--- a/src/sys_alloc.c
+++ b/src/sys_alloc.c
@@ -1,0 +1,32 @@
+/**
+ * @file sys_alloc.c
+ * @brief Weak default implementation of the tagged subsystem allocation seam.
+ *
+ * See sys_alloc.h. These defaults provide a standard heap allocation for each
+ * subsystem; a build that does not override them uses them directly. An
+ * application that wants to place these buffers elsewhere provides a strong
+ * ::__sys_alloc / ::__sys_free.
+ */
+#include "sys_alloc.h"
+#include "n64sys.h"     // malloc_uncached / free_uncached
+#include <malloc.h>
+
+__attribute__((weak))
+void *__sys_alloc(sys_alloc_purpose_t purpose, size_t size, size_t align)
+{
+    // The YUV interleave buffer is DMA'd by the RSP and sampled by the RDP with
+    // no CPU cache involvement, so it must be uncached.
+    if (purpose == SYS_ALLOC_YUV)
+        return malloc_uncached(size);
+    return memalign(align ? align : 16, size);
+}
+
+__attribute__((weak))
+void __sys_free(sys_alloc_purpose_t purpose, void *ptr)
+{
+    if (purpose == SYS_ALLOC_YUV) {
+        free_uncached(ptr);
+        return;
+    }
+    free(ptr);
+}

--- a/src/video/fmv.c
+++ b/src/video/fmv.c
@@ -20,7 +20,10 @@
 
 void fmv_play(const char *video_fn, const fmv_parms_t *parms)
 {
-    video_t *video = video_open(video_fn, &(video_parms_t){ .buffered_pics = 8 });
+    int buffered_pics = (parms && parms->buffered_pics)
+        ? parms->buffered_pics
+        : (is_memory_expanded() ? 8 : 4);
+    video_t *video = video_open(video_fn, &(video_parms_t){ .buffered_pics = buffered_pics });
     video_info_t info = video_get_info(video);
     if (!parms) {
         parms = alloca(sizeof(fmv_parms_t));

--- a/src/video/h264.c
+++ b/src/video/h264.c
@@ -5,6 +5,7 @@
  */
 
 #include "h264.h"
+#include "sys_alloc.h"
 #include "h264_decoder.h"
 #include "rsph264_internal.h"
 #include "asset_internal.h"
@@ -196,9 +197,13 @@ static void h264_rewind(video_t *v) {
 }
 
 static video_t* h264_open(const char *fn, const video_parms_t *parms) {
-    h264_t *player = malloc(sizeof(h264_t) + H264_BUF_SIZE);
+    const size_t player_size = sizeof(h264_t) + H264_BUF_SIZE;
+    // The player instance is large. It is sourced through the tagged allocation
+    // seam (SYS_ALLOC_H264); the weak default is malloc, and an application can
+    // override __sys_alloc to place it in a dedicated region.
+    h264_t *player = __sys_alloc(SYS_ALLOC_H264, player_size, 16);
     assertf(player, "Out of memory");
-    sys_hw_memset(player, 0, sizeof(h264_t) + H264_BUF_SIZE);
+    sys_hw_memset(player, 0, player_size);
     player->fd = -1;
     if (parms && parms->buffered_pics)
         player->max_buffered_pics = parms->buffered_pics;
@@ -228,7 +233,7 @@ static void h264_close(video_t *v) {
         player->fd = -1;
     }
     h264bsdShutdown(&player->s);
-    free(player);
+    __sys_free(SYS_ALLOC_H264, player);
 }
 
 static const char* h264_status_str(int status) {

--- a/src/video/h264_decoder/h264bsd_dpb.c
+++ b/src/video/h264_decoder/h264bsd_dpb.c
@@ -59,6 +59,22 @@
 #include "h264bsd_image.h"
 #include "h264bsd_util.h"
 #include "basetype.h"
+#if H264BSD_N64
+#include "n64sys.h"
+#include "scratch.h"
+#include <malloc.h>
+
+/* Set to 1 to debugf DPB allocation request size, heap/scratch state, and
+ * which allocator served each frame in the per-frame fallback. Off in
+ * production; the MEMORY_ALLOCATION_ERROR return is enough signal for
+ * normal use. */
+#define H264BSD_TRACE_DPB 0
+#if H264BSD_TRACE_DPB
+#define dpb_tracef(fmt, ...) debugf(fmt, ##__VA_ARGS__)
+#else
+#define dpb_tracef(fmt, ...) ((void)0)
+#endif
+#endif
 
 /*------------------------------------------------------------------------------
     2. External compiler flags
@@ -1044,6 +1060,107 @@ u32 h264bsdInitDpb(
         return(MEMORY_ALLOCATION_ERROR);
     H264SwDecMemset(dpb->buffer, 0,
             (dpb->dpbSize + 1)*sizeof(dpbPicture_t));
+#if H264BSD_N64
+    {
+        /* N64: Allocate all frame buffers as one contiguous block. Prefer
+         * the scratch heap (backed by sbrk_top, growing downward from the
+         * top of RDRAM) because that keeps the DPB out of the regular
+         * malloc heap and avoids fragmenting the wilderness. If the
+         * scratch heap doesn't have enough contiguous headroom (small
+         * persistent allocations near the top can shrink the sbrk_top
+         * window below the DPB size even when a large free hole exists
+         * lower in the malloc heap), fall back to memalign so we can
+         * use that hole instead of giving up.
+         */
+        u32 frameSize = picSizeInMbs * 384 + 32 + 15;
+        /* Align each frame to 16 bytes within the bulk block */
+        u32 frameSizeAligned = (frameSize + 15) & ~15u;
+        u32 numFrames = dpb->dpbSize + 1;
+        u32 allocSize = frameSizeAligned * numFrames;
+#if H264BSD_TRACE_DPB
+        {
+            struct mallinfo mi = mallinfo();
+            scratch_stats_t ss; scratch_get_stats(&ss);
+            dpb_tracef("h264bsd DPB: req=%u (mbs=%u frames=%u) | heap.uord=%u ford=%u keep=%u | scratch.live=%u resv=%u\n",
+                (unsigned)allocSize, (unsigned)picSizeInMbs, (unsigned)numFrames,
+                (unsigned)mi.uordblks, (unsigned)mi.fordblks, (unsigned)mi.keepcost,
+                (unsigned)ss.live_bytes, (unsigned)ss.reserved_bytes);
+        }
+#endif
+        dpb->pAllocData = (u8*)scratch_malloc(allocSize);
+        dpb->pAllocViaMemalign = 0;
+        if (dpb->pAllocData == NULL) {
+            dpb_tracef("h264bsd DPB: scratch_malloc FAILED, trying memalign(%u)\n", (unsigned)allocSize);
+            dpb->pAllocData = (u8*)memalign(16, allocSize);
+            if (dpb->pAllocData != NULL) {
+                dpb_tracef("h264bsd DPB: memalign fallback OK\n");
+                dpb->pAllocViaMemalign = 1;
+            }
+        } else {
+            dpb_tracef("h264bsd DPB: scratch OK (%u bytes)\n", (unsigned)allocSize);
+        }
+        if (dpb->pAllocData != NULL) {
+            /* Bulk allocation succeeded. Lay out frames contiguously. */
+            data_cache_hit_invalidate(dpb->pAllocData, allocSize);
+            u8 *uncached = (u8*)UncachedAddr(dpb->pAllocData);
+            for (i = 0; i < numFrames; i++)
+            {
+                dpb->buffer[i].pAllocatedData = uncached + i * frameSizeAligned;
+                dpb->buffer[i].data = ALIGN(dpb->buffer[i].pAllocatedData, 16);
+            }
+        } else {
+            /* Per-frame fallback: when neither the scratch nor the malloc
+             * bulk allocation fits, allocate each frame independently. This
+             * succeeds when the available free space is fragmented into
+             * chunks each large enough for one frame but smaller than the
+             * full DPB size. Decoder access uses dpb->buffer[i] pointers,
+             * so contiguity isn't required for correctness — the bulk
+             * layout is only a memory-management convenience. Mark
+             * pAllocData NULL to signal the per-frame teardown path;
+             * h264bsdFreeDpb walks buffer[i] in that case. */
+            dpb_tracef("h264bsd DPB: bulk failed, trying per-frame allocation\n");
+            int allocated = 0;
+            for (i = 0; i < numFrames; i++) {
+                /* memalign first: dlmalloc tries to fit each frame into an
+                 * existing free chunk in fordblks. When fordblks runs out
+                 * of suitable holes, fall through to scratch which grows
+                 * top-of-RAM. Trying scratch first tends to leave the
+                 * malloc path with chunks too small to satisfy subsequent
+                 * frame requests, since scratch's downward growth would
+                 * otherwise eat the contiguous headroom that memalign
+                 * needs for its own splits. */
+                u8 *frame = (u8*)memalign(16, frameSizeAligned);
+                if (!frame) {
+                    frame = (u8*)scratch_malloc(frameSizeAligned);
+                }
+                if (!frame) {
+                    dpb_tracef("h264bsd DPB: per-frame failed at frame %u/%u (size %u)\n",
+                        (unsigned)i, (unsigned)numFrames, (unsigned)frameSizeAligned);
+                    /* Roll back any frames we already allocated. scratch_owns()
+                     * dispatches to the right deallocator per-frame since the
+                     * fallback mixes scratch and memalign sources. */
+                    for (u32 j = 0; j < i; j++) {
+                        void *cached = CachedAddr(dpb->buffer[j].pAllocatedData);
+                        if (scratch_owns(cached))
+                            scratch_free(cached);
+                        else
+                            free(cached);
+                        dpb->buffer[j].pAllocatedData = NULL;
+                        dpb->buffer[j].data = NULL;
+                    }
+                    return(MEMORY_ALLOCATION_ERROR);
+                }
+                data_cache_hit_invalidate(frame, frameSizeAligned);
+                dpb->buffer[i].pAllocatedData = (u8*)UncachedAddr(frame);
+                dpb->buffer[i].data = ALIGN(dpb->buffer[i].pAllocatedData, 16);
+                allocated++;
+            }
+            dpb_tracef("h264bsd DPB: per-frame OK (%u frames x %u bytes)\n",
+                (unsigned)allocated, (unsigned)frameSizeAligned);
+            /* pAllocData stays NULL — signals per-frame teardown path. */
+        }
+    }
+#else
     for (i = 0; i < dpb->dpbSize + 1; i++)
     {
         /* Allocate needed amount of memory, which is:
@@ -1057,6 +1174,7 @@ u32 h264bsdInitDpb(
 
         dpb->buffer[i].data = ALIGN(dpb->buffer[i].pAllocatedData, 16);
     }
+#endif
 
     ALLOCATE(dpb->list, MAX_NUM_REF_IDX_L0_ACTIVE + 1, dpbPicture_t*);
     ALLOCATE(dpb->outBuf, dpb->dpbSize+1, dpbOutPicture_t);
@@ -1705,10 +1823,44 @@ void h264bsdFreeDpb(dpbStorage_t *dpb)
 
     if (dpb->buffer)
     {
+#if H264BSD_N64
+        /* N64: Free either the bulk allocation or per-frame allocations.
+         * pAllocData != NULL means bulk; NULL means per-frame fallback was
+         * used (each buffer[i].pAllocatedData owns its own chunk, mixed
+         * between scratch and memalign sources). */
+        if (dpb->pAllocData)
+        {
+            if (dpb->pAllocViaMemalign)
+                free(dpb->pAllocData);
+            else
+                scratch_free(dpb->pAllocData);
+            dpb->pAllocData = NULL;
+            dpb->pAllocViaMemalign = 0;
+            for (i = 0; i < dpb->dpbSize+1; i++)
+            {
+                dpb->buffer[i].pAllocatedData = NULL;
+                dpb->buffer[i].data = NULL;
+            }
+        } else {
+            for (i = 0; i < dpb->dpbSize+1; i++)
+            {
+                if (dpb->buffer[i].pAllocatedData) {
+                    void *cached = CachedAddr(dpb->buffer[i].pAllocatedData);
+                    if (scratch_owns(cached))
+                        scratch_free(cached);
+                    else
+                        free(cached);
+                    dpb->buffer[i].pAllocatedData = NULL;
+                    dpb->buffer[i].data = NULL;
+                }
+            }
+        }
+#else
         for (i = 0; i < dpb->dpbSize+1; i++)
         {
             FREE_PIXELS(dpb->buffer[i].pAllocatedData);
         }
+#endif
     }
     FREE(dpb->buffer);
     FREE(dpb->list);

--- a/src/video/h264_decoder/h264bsd_dpb.h
+++ b/src/video/h264_decoder/h264bsd_dpb.h
@@ -94,6 +94,10 @@ typedef struct {
     u32 lastContainsMmco5;
     u32 noReordering;
     u32 flushed;
+#if H264BSD_N64
+    u8 *pAllocData;    /* bulk scratch allocation for all frame buffers */
+    u8 pAllocViaMemalign; /* 1 if pAllocData came from memalign fallback, 0 if from scratch_malloc */
+#endif
 } dpbStorage_t;
 
 /*------------------------------------------------------------------------------

--- a/src/video/yuv.c
+++ b/src/video/yuv.c
@@ -16,12 +16,26 @@
 #include "rdpq_debug.h"
 #include "rspq.h"
 #include "n64sys.h"
+#include "sys_alloc.h"
 #include "debug.h"
 #include "utils.h"
 #include <math.h>
 
 /** @brief Internal buffer used to interleave U and V components */
 static surface_t internal_buffer;
+
+// The interleave buffer is sourced through the tagged allocation seam
+// (SYS_ALLOC_YUV, see sys_alloc.h). The weak default returns uncached memory; an
+// application can override __sys_alloc to place it in a contiguous
+// scratch/transient heap so a fragmented system heap can't fail this allocation
+// mid-session — a failed alloc would leave a NULL buffer that rsp_yuv would DMA
+// to physical 0, corrupting low RDRAM.
+static void internal_buffer_release(void)
+{
+    if (internal_buffer.buffer)
+        __sys_free(SYS_ALLOC_YUV, internal_buffer.buffer);
+    internal_buffer = (surface_t){0};
+}
 
 // Calculated with: yuv_new_colorspace(0.299, 0.114, 16, 219, 224);
 const yuv_colorspace_t YUV_BT601_TV = {
@@ -51,8 +65,15 @@ const yuv_colorspace_t YUV_BT709_FULL = {
 static void resize_internal_buffer(int w, int h)
 {
     if (internal_buffer.width != w || internal_buffer.height != h) {
-        surface_free(&internal_buffer);
-        internal_buffer = surface_alloc(FMT_IA16, w, h);
+        internal_buffer_release();
+        // Build a non-owning surface around the seam-allocated buffer so
+        // surface_free() won't touch it; internal_buffer_release() returns it
+        // through __sys_free(SYS_ALLOC_YUV).
+        size_t stride = TEX_FORMAT_PIX2BYTES(FMT_IA16, w);
+        void *buf = __sys_alloc(SYS_ALLOC_YUV, stride * h, 16);
+        internal_buffer = surface_make_linear(buf, FMT_IA16, w, h);
+        assertf(internal_buffer.buffer,
+            "yuv: out of memory allocating %dx%d internal interleave buffer", w, h);
     }
 }
 
@@ -98,7 +119,7 @@ void yuv_close(void)
     assert(yuv_initialized > 0);
     yuv_initialized--;
     if (yuv_initialized == 0) {
-        surface_free(&internal_buffer);
+        internal_buffer_release();
         rspq_overlay_unregister(ovl_yuv);
     }
 }
@@ -248,6 +269,11 @@ void rsp_yuv_set_input_buffer(uint8_t *y, uint8_t *cb, uint8_t *cr, int y_pitch)
 
 void rsp_yuv_set_output_buffer(uint8_t *out, int out_pitch)
 {
+    // Never let the RSP DMA to physical 0: a NULL output buffer (e.g. a failed
+    // surface_alloc under low memory) would otherwise interleave chroma straight
+    // into low RDRAM, silently smashing .text. Fail loudly instead.
+    assertf(out != NULL && PhysicalAddr(out) != 0,
+        "rsp_yuv: output buffer is NULL (out of memory?)");
     rspq_write(ovl_yuv, CMD_YUV_SET_OUTPUT,
         PhysicalAddr(out), out_pitch);
 }


### PR DESCRIPTION
Replaces the per-subsystem allocator proposals in #926 #928 #929 #930 #931 #932

Give applications optional control over the large or numerous heap allocations made by several subsystems, so a game on a memory-constrained target can source them from memory of its choosing (a pre-reserved region, scratch, an arena) to control heap layout and avoid mid-session fragmentation failures. Every hook defaults to the existing behaviour, so this is a no-op unless an application opts in.

### Tagged allocation seam (`sys_alloc.h`):

A single weak `__sys_alloc` / `__sys_free` pair, tagged with a `sys_alloc_purpose_t`, funnels the large or fragmenting allocations of `asset`, `lspr3`, `yuv`, `wav64`, `h264` and `dlfcn` through one place. The weak defaults reproduce each subsystem's standard behavior (`memalign`/`free`, and uncached memory for the YUV interleave buffer); an application opts in by providing a strong definition of the pair and dispatching by purpose. Freeing is symmetric: a block is released via `__sys_free` under the same purpose it was allocated with.

### DragonFS open-file handle pool (`dragonfs.c`):

Open-file handles can be served from a pool allocated once at `dfs_init` instead of `malloc`'d per open, so many concurrently-open files do not churn or fragment the system heap with small, long-lived allocations. The pool size is a weak hook (`__dfs_file_pool_size`) defaulting to 0 (no pool); an application overrides it to opt in and size it to its workload. Opens beyond the pool fall back to `malloc` transparently.

### H.264 decoded-picture-buffer allocation (`fmv.c`, `h264bsd`):

The DPB frames are allocated with `memalign` from scratch, with a per-frame fallback when a single bulk allocation cannot be satisfied, and the picture-buffer count is configurable with RAM-based defaults.