### PR TITLE
fix/sram_main_include

### DIFF
--- a/include/libdragon.h
+++ b/include/libdragon.h
@@ -112,5 +112,6 @@
 #include "magma.h"
 #include "magma_math.h"
 #include "mgfx.h"
+#include "sram.h"
 
 #endif


### PR DESCRIPTION
Follow-on task for https://github.com/DragonMinded/libdragon/pull/813 (initial SRAM support).

Per [discussion in Discord](https://discord.com/channels/205520502922543113/1523308991294472374/1524455789958533270), adding `sram.h` to `libdragon.h` wrapper. 

Also added a commit to sort the list of include files alphabetically for readability.