### PR TITLE
Audio: improve pacing for mixing & decoding

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -872,10 +872,17 @@ void mixer_poll(int16_t *out16, int num_samples) {
 
 void mixer_try_play()
 {
-    while (audio_can_write())
-    {
-        short *buf = audio_write_begin();
-        mixer_poll(buf, audio_get_buffer_length());
-        audio_write_end();
-    }
+	// To smooth out the pacing for mixer and wav64 decodes, we fill buffers
+	// to at least audio_get_num_buffers()-1, but fill completely, if there is
+	// only one free one left.
+	int free_buffers = audio_get_num_buffers() - audio_get_queued_buffers();
+	if (free_buffers <= 0)
+		return;
+
+	int buffers_to_fill = MAX(free_buffers - 1, 1);
+	while (buffers_to_fill-- > 0) {
+		short *buf = audio_write_begin();
+		mixer_poll(buf, audio_get_buffer_length());
+		audio_write_end();
+	}
 }


### PR DESCRIPTION
This improves pacing for the mixer and various audio decoders. Previously, with `BUFFERS_PER_SECOND 25` we would decode & mix audio in large chunks of 40ms. The mixer itself is quite cheap, but audio decoders (such as Opus or the upcoming ULC) can be expensive. So we would like to distribute all the audio work over several frames, instead of doing a lot of work in one frame, then nothing in others. Flattening these peaks ensures that we have a more consistent frame budget for all the other things happening in the game.

Just increasing the `BUFFERS_PER_SECOND` alone is not the solution. Even with 120 buffers per second (8.33ms) there will be render frames where `audio_can_write()` reports true 3 times in one `mixer_try_play()` call and thus crossing one Opus frame (20ms), forcing 2 decodes.

A new function `audio_needs_write()` returns true whenever the number of filled audio buffers is a below a low-water mark. The changed `mixer_try_play()` now fills buffers opportunistically, while still ensuring buffers are always above the low-water mark.

With this and `BUFFERS_PER_SECOND 50` we only ever need to decode at most 1 Opus frame per 60hz render frame. The same holds true for PAL 50hz, because one render frame equals one Opus frame (20ms) at 44100hz. Of course, below 44100hz requirements are more relaxed. Because of the shorter buffers, this PR also increases `NUM_BUFFERS` from `4` to `8`.

⚠️ Since this lowers the buffer duration from 40ms to 20ms, this may break games that explicitly specify the number of buffers in `audio_init()`, expecting more headroom.

## Results

I captured some output of an otherwise empty game loop, playing one Opus or ULC stereo 44100hz file.

```c
uint32_t time_mix_start = TICKS_READ();
mixer_try_play();
mix_time = (TICKS_READ() - time_mix_start);

debugf("frame %4d mix %5d us\n", 
	frame,
	(int)(mix_time * (1000000.0 / TICKS_PER_SECOND))
);
```

### Opus before:

Decodes 0 or 2 Opus frames. Blows past the 16.6ms frame budget required for 60fps in many frames, then does nothing in others.

```
frame   10 mix 22759 us
frame   11 mix     1 us
frame   12 mix 21527 us
frame   13 mix     2 us
frame   14 mix 21515 us
frame   15 mix     1 us
frame   16 mix     2 us
frame   17 mix 23540 us
frame   18 mix     1 us
frame   19 mix 22555 us
frame   20 mix     1 us
frame   21 mix 22356 us
frame   22 mix     1 us
frame   23 mix     2 us
frame   24 mix 24841 us
frame   25 mix     1 us
frame   26 mix 22005 us
frame   27 mix     1 us
frame   28 mix     2 us
frame   29 mix 22368 us
frame   30 mix     1 us
```



### ULC before:

Decodes 0, 1 or 2 ULC frames

```
frame   10 mix  3422 us
frame   11 mix     1 us
frame   12 mix  5321 us
frame   13 mix     2 us
frame   14 mix  5178 us
frame   15 mix     2 us
frame   16 mix     2 us
frame   17 mix  5232 us
frame   18 mix     2 us
frame   19 mix  3475 us
frame   20 mix     1 us
frame   21 mix  5237 us
frame   22 mix     2 us
frame   23 mix     2 us
frame   24 mix  5372 us
frame   25 mix     1 us
frame   26 mix  3418 us
frame   27 mix     2 us
frame   28 mix     1 us
frame   29 mix  5305 us
frame   30 mix     2 us
```

### Opus after:

Decodes 0 or 1 Opus frames. All frames below 60fps budget.

```
frame   10 mix 10341 us
frame   11 mix 10469 us
frame   12 mix     3 us
frame   13 mix 10005 us
frame   14 mix 11209 us
frame   15 mix 12300 us
frame   16 mix 10870 us
frame   17 mix 10703 us
frame   18 mix     2 us
frame   19 mix 11271 us
frame   20 mix 10996 us
frame   21 mix 11818 us
frame   22 mix 12356 us
frame   23 mix 10416 us
frame   24 mix     2 us
frame   25 mix 11386 us
frame   26 mix 11892 us
frame   27 mix 10101 us
frame   28 mix 12552 us
frame   29 mix 10966 us
frame   30 mix     3 us
```

### ULC after:

Decodes 0 or 1 ULC frames

```
frame   10 mix  2893 us
frame   11 mix     3 us
frame   12 mix   688 us
frame   13 mix  2888 us
frame   14 mix  2884 us
frame   15 mix  2970 us
frame   16 mix  2963 us
frame   17 mix     2 us
frame   18 mix  2940 us
frame   19 mix  2894 us
frame   20 mix   687 us
frame   21 mix  2878 us
frame   22 mix  2959 us
frame   23 mix  2883 us
frame   24 mix     3 us
frame   25 mix  2934 us
frame   26 mix  2893 us
frame   27 mix  2933 us
frame   28 mix   685 us
frame   29 mix  2967 us
frame   30 mix     2 us
```