### PR TITLE
audio: add a check for whether the calculated DAC rate will fit

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -201,6 +201,7 @@ void audio_init(const int frequency, float latency)
        is also used for the AI output), divided by the requested frequency,
        rounding up. */
     int dacrate = ((2 * clockrate / frequency) + 1) / 2;
+    assertf(dacrate <= (1 << 14), "Requested frequency %d is too low", frequency);
     /* Bitrate is the half period for each bit of the sample. We need to send
        32 bits, so 64 periods, but the datasheet of the DAC suggests to allow
        for 66 periods instead. So calculate the bitrate as dacrate / 66. We can


### PR DESCRIPTION
Specifying a too low frequency can lead to audio_init calculating a DAC rate value that won't actually fit in the register (the value is only 14-bit). This will only happen if someone gives a ridiculously slow audio frequency, but it's a bug nonetheless.

I ran into this because I was trying to play tones at specific frequencies without involving any resampling, and I was surprised when values that were too small would lead to completely wrong output.