### PR TITLE
wav64: ensure NULL huff_tbl for vadpcm streams

### DIFF
--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -422,6 +422,7 @@ void wav64_vadpcm_init(wav64_t *wav, int state_size)
 
     // Init huffman
     wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
+    assertf(vhead->huff_tbl == NULL, "huff_tbl must be NULL before initialization");
     if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
         wav64_vadpcm_init_huffman(wav);
     }


### PR DESCRIPTION
`wav64_vadpcm_init` only sets `vhead->huff_tbl` (via `init_huffman`) when the `VADPCM_FLAG_HUFFMAN` bit is set. `huff_tbl` is a runtime pointer that physically lives inside the file-loaded packed ext header, so for a non-huffman stream it retains its file bytes (which *should be* `0`/`NULL`). `wav64_vadpcm_close` then does `if (huff_tbl) free(huff_tbl)`, freeing a garbage pointer -- a wild `free()` that can corrupt the dlmalloc heap and manifests intermittently as corruption far from the source. NULL it in the non-huffman branch.