### PR TITLE
mkmaterial: Miscellaneous fixes

### DIFF
--- a/src/rdpq/rdpq_mat.c
+++ b/src/rdpq/rdpq_mat.c
@@ -261,7 +261,7 @@ void rdpq_mat_draw_begin(rdpq_mat_t *mat_ptr)
     mat += namelen;
 
     uint16_t flags = FETCH(mat, uint16_t);
-    bool has_overrides = flags & MATFLAG_RMO_MASK;
+    bool has_overrides = flags & MATFLAG_SOM_MASK;
     if (has_overrides) {
         rdpq_mode_push();
     }
@@ -355,7 +355,7 @@ void rdpq_mat_draw_end(rdpq_mat_t *mat_ptr)
     void *mat = mat_ptr;
     mat += FETCH(mat, uint8_t); // skip the name
     uint16_t flags = FETCH(mat, uint16_t);
-    bool has_overrides = flags & MATFLAG_RMO_MASK;
+    bool has_overrides = flags & MATFLAG_SOM_MASK;
 
     if (has_overrides)
         rdpq_mode_pop();

--- a/src/rdpq/rdpq_mat_internal.h
+++ b/src/rdpq/rdpq_mat_internal.h
@@ -28,6 +28,8 @@
 #define MATFLAG_UNIFORM_ENV             (1 << 14)   ///< Combiner uniforms: env color
 #define MATFLAG_UNIFORM_PRIM            (1 << 15)   ///< Combiner uniforms: prim color
 
+#define MATFLAG_SOM_MASK                (MATFLAG_RMO_MASK|MATFLAG_BLENDER)  ///< Mask for all flags that set other modes
+
 /** Material database structure */
 typedef struct rdpq_matdb_s {
     uint8_t id[3];                ///< ID: "MDB"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ ASSETS = filesystem/grass1.ci8.sprite \
 		 filesystem/grass1.rgba32.sprite \
 		 filesystem/grass1sq.rgba32.sprite \
 		 filesystem/grass2.rgba32.sprite \
-		 filesystem/materials.mdb
+		 filesystem/basic.mdb
 
 OBJS = $(BUILD_DIR)/test_constructors_cpp.o \
 	   $(BUILD_DIR)/rsp_test.o \
@@ -31,10 +31,10 @@ filesystem/%.sprite: assets/%.png
 	@echo "    [SPRITE] $@"
 	$(N64_MKSPRITE) $(MKSPRITE_FLAGS) -o filesystem "$<"
 
-filesystem/materials.mdb: $(wildcard assets/*.mat)
+filesystem/%.mdb: assets/%.mat
 	@mkdir -p $(dir $@)
 	@echo "    [MDB] $@"
-	$(N64_MKMATERIAL) -o filesystem "$^"
+	$(N64_MKMATERIAL) -o filesystem "$<"
 
 filesystem/test_dir:
 	@mkdir -p $(dir $@)

--- a/tests/assets/basic.mat
+++ b/tests/assets/basic.mat
@@ -15,6 +15,18 @@ rm.alpha_compare = 1
 #blender.mode = multiply_const
 #blender.fog.a = 0.3
 
+[empty]
+
+[blender_multiply]
+blender.mode = multiply
+
+[blender_multiply_const]
+blender.mode = multiply_const
+blender.const = 0.6
+
+[blender_additive]
+blender.mode = additive
+
 [ext_test]
 combiner.rgb = prim
 

--- a/tests/test_rdpq_mat.c
+++ b/tests/test_rdpq_mat.c
@@ -61,6 +61,66 @@ void test_rdpq_mat_basic(TestContext *ctx)
     ASSERT_MAT_SOM("<none>", SOM_ALPHACOMPARE_MASK | SOM_AA_ENABLE, SOM_AA_ENABLE);
 }
 
+void test_rdpq_mat_empty(TestContext *ctx)
+{
+    RDPQ_INIT();
+    rdpq_set_mode_standard();
+
+    rdpq_matdb_t *mdb = rdpq_matdb_open("rom:/basic.mdb");
+    DEFER(rdpq_matdb_close(mdb));
+
+    rdpq_mat_t *empty = rdpq_matdb_load(mdb, "empty");
+    ASSERT(empty != NULL, "Failed to load material 'empty'");
+
+    rdpq_mat_draw_begin(empty);
+    ASSERT_MAT_CC("empty", RDPQ_COMBINER1((0, 0, 0, TEX0), (0, 0, 0, TEX0)));
+    rdpq_mat_draw_end(empty);
+}
+
+inline rdpq_blender_t get_expected_blender(rdpq_blender_t bl)
+{
+    rdpq_set_mode_standard();
+    rdpq_mode_blender(bl);
+    return rdpq_get_other_modes_raw() & SOM_BLEND_MASK;
+}
+
+void test_rdpq_mat_blender(TestContext *ctx)
+{
+    RDPQ_INIT();
+    rdpq_blender_t exp_multiply = get_expected_blender(RDPQ_BLENDER_MULTIPLY);
+    rdpq_blender_t exp_multiply_const = get_expected_blender(RDPQ_BLENDER_MULTIPLY_CONST);
+    rdpq_blender_t exp_additive = get_expected_blender(RDPQ_BLENDER_ADDITIVE);
+    rdpq_set_mode_standard();
+    rdpq_matdb_t *mdb = rdpq_matdb_open("rom:/basic.mdb");
+    DEFER(rdpq_matdb_close(mdb));
+
+    rdpq_mat_t *blender_multiply = rdpq_matdb_load(mdb, "blender_multiply");
+    ASSERT(blender_multiply != NULL, "Failed to load material 'blender_multiply'");
+
+    ASSERT_MAT_SOM("<none>", SOM_BLEND_MASK, 0);
+    rdpq_mat_draw_begin(blender_multiply);
+    ASSERT_MAT_SOM("blender_multiply", SOM_BLEND_MASK, exp_multiply);
+    rdpq_mat_draw_end(blender_multiply);
+    ASSERT_MAT_SOM("<none>", SOM_BLEND_MASK, 0);
+
+    rdpq_mat_t *blender_multiply_const = rdpq_matdb_load(mdb, "blender_multiply_const");
+    ASSERT(blender_multiply_const != NULL, "Failed to load material 'blender_multiply_const'");
+
+    ASSERT_MAT_SOM("<none>", SOM_BLEND_MASK, 0);
+    rdpq_mat_draw_begin(blender_multiply_const);
+    ASSERT_MAT_SOM("blender_multiply_const", SOM_BLEND_MASK, exp_multiply_const);
+    rdpq_mat_draw_end(blender_multiply_const);
+    ASSERT_MAT_SOM("<none>", SOM_BLEND_MASK, 0);
+
+    rdpq_mat_t *blender_additive = rdpq_matdb_load(mdb, "blender_additive");
+    ASSERT(blender_additive != NULL, "Failed to load material 'blender_additive'");
+
+    ASSERT_MAT_SOM("<none>", SOM_BLEND_MASK, 0);
+    rdpq_mat_draw_begin(blender_additive);
+    ASSERT_MAT_SOM("blender_additive", SOM_BLEND_MASK, exp_additive);
+    rdpq_mat_draw_end(blender_additive);
+    ASSERT_MAT_SOM("<none>", SOM_BLEND_MASK, 0);
+}
 
 void test_rdpq_mat_ext(TestContext *ctx)
 {

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -412,6 +412,8 @@ static const struct Testsuite
 	TEST_FUNC(test_rdpq_sprite_upload,         0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_sprite_lod,            0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_mat_basic,             0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_rdpq_mat_empty,             0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_rdpq_mat_blender,           0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rdpq_mat_ext,               0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_mpeg1_idct,                 0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_mpeg1_block_decode,         0, TEST_FLAGS_NO_BENCHMARK),

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -112,6 +112,9 @@ struct Combiner {
     combexpr::CombinerExprFull full;
     CombinerRegister registers[combexpr::internal::UNIFORM_COUNT];
 
+    Combiner();
+
+    void sync_expr_full();
     void parse_attr(std::string key, std::string value);
     uint64_t to_rdpq_mode_arg(void);
 };

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -125,6 +125,7 @@ struct Blender {
 
     void parse_attr(std::string key, std::string value);
     void validate(void);
+    uint32_t to_rdpq_mode_arg(void);
 };
 
 struct Extension {

--- a/tools/mkmaterial/mkmaterial_export.cpp
+++ b/tools/mkmaterial/mkmaterial_export.cpp
@@ -184,6 +184,7 @@ void Material::write(FILE *f)
 
     uint16_t flags = MATFLAG_COMBINER; // always write the combiner
     if (tex[0] || tex[1])       flags |= MATFLAG_TEXTURE;
+    if (bl.mode > 0)            flags |= MATFLAG_BLENDER;
     if (rm.antialias >= 0)      flags |= MATFLAG_RMO_AA;
     if (rm.fog >= 0)            flags |= MATFLAG_RMO_FOG;
     if (rm.dither[0] >= 0)      flags |= MATFLAG_RMO_DITHERING;
@@ -212,8 +213,8 @@ void Material::write(FILE *f)
         w64(f, cmd);
     }
     if (flags & MATFLAG_BLENDER) {
-        int mode = bl.mode;
-        w8(f, mode);
+        uint32_t cmd = bl.to_rdpq_mode_arg();
+        w32(f, cmd);
     }
     if (flags & MATFLAG_RMO_AA) {
         w8(f, rm.antialias);

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -177,10 +177,6 @@ void Combiner::parse_attr(std::string key, std::string value)
         registers[combexpr::internal::UNIFORM_K4].parse_float(value);
     } else if (key == "reg.k5") {
         registers[combexpr::internal::UNIFORM_K5].parse_float(value);
-    } else if (key == "reg.keyscale") {
-        registers[combexpr::internal::UNIFORM_KEYSCALE].parse_float(value);
-    } else if (key == "reg.keycenter") {
-        registers[combexpr::internal::UNIFORM_KEYCENTER].parse_float(value);
     } else if (key == "reg.prim_lod_frac") {
         registers[combexpr::internal::UNIFORM_PRIM_LOD_FRAC].parse_float(value);
     } else if (key == "reg.env") {

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -17,6 +17,7 @@
 #include <float.h>
 #include "../common/json.hpp"
 #include "../common/utils.h"
+#include "../include/rdpq_macros.h"
 
 #define INI_HANDLER_LINENO 1
 #define INI_INLINE_COMMENT_PREFIXES ";#"
@@ -220,6 +221,18 @@ void Blender::validate(void)
         throw std::runtime_error("blender.const must be specified for mode multiply_const");
     if (mode.to_str() != "multiply_const" && constant >= 0)
         throw std::runtime_error("blender.const is only valid for mode multiply_const");
+}
+
+uint32_t Blender::to_rdpq_mode_arg(void)
+{
+    static const uint32_t builtin_modes[] = {
+        0,
+        RDPQ_BLENDER((IN_RGB, IN_ALPHA, MEMORY_RGB, INV_MUX_ALPHA)),
+        RDPQ_BLENDER((IN_RGB, FOG_ALPHA, MEMORY_RGB, INV_MUX_ALPHA)),
+        RDPQ_BLENDER((IN_RGB, IN_ALPHA, MEMORY_RGB, ONE)),
+    };
+
+    return builtin_modes[mode];
 }
 
 void Texture::validate_name(void)

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -131,6 +131,16 @@ void CombinerRegister::parse_color(std::string value)
     is_set = true;
 }
 
+Combiner::Combiner()
+{
+    sync_expr_full();
+}
+
+void Combiner::sync_expr_full()
+{
+    full = combexpr::CombinerExprFull(rgb, alpha);
+}
+
 void Combiner::parse_attr(std::string key, std::string value)
 {
     static const std::regex expr(R"(\s*\(\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*\)(?:\s*,\s*\(\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*,\s*([\w.]+)\s*\))?)");
@@ -141,14 +151,14 @@ void Combiner::parse_attr(std::string key, std::string value)
         combexpr::Matcher matcher(root);
     
         rgb = matcher.matchCombiner(combexpr::RGB);
-        full = combexpr::CombinerExprFull(rgb, alpha);
+        sync_expr_full();
     } else if (key == "alpha") {
         combexpr::Parser parser(value);
         auto root = parser.parseExpression();
         combexpr::Matcher matcher(root);
     
         alpha = matcher.matchCombiner(combexpr::ALPHA);
-        full = combexpr::CombinerExprFull(rgb, alpha);
+        sync_expr_full();
     } else if (key == "rgb.raw") {
         // Match regex for raw combiner expression: (a,b,c,d), optionally repeated for the second step
         std::smatch match;
@@ -157,7 +167,7 @@ void Combiner::parse_attr(std::string key, std::string value)
             if (match[5].matched) {
                 rgb.set(1, 'a', match[5]); rgb.set(1, 'b', match[6]); rgb.set(1, 'c', match[7]); rgb.set(1, 'd', match[8]);
             }
-            full = combexpr::CombinerExprFull(rgb, alpha);
+            sync_expr_full();
         } else {
             throw std::runtime_error("invalid rgb.raw combiner expression: must be in format \"(a,b,c,d)\"");
         }
@@ -169,7 +179,7 @@ void Combiner::parse_attr(std::string key, std::string value)
             if (match[5].matched) {
                 alpha.set(1, 'a', match[5]); alpha.set(1, 'b', match[6]); alpha.set(1, 'c', match[7]); alpha.set(1, 'd', match[8]);
             }
-            full = combexpr::CombinerExprFull(rgb, alpha);
+            sync_expr_full();
         } else {
             throw std::runtime_error("invalid alpha.raw combiner expression: must be in format \"(a,b,c,d)\"");
         }


### PR DESCRIPTION
This PR does the following:
- Removes the material keys "combiner.reg.keyscale" and "combiner.reg.keycenter", due to them not being correctly implemented and raising an assert at runtime.
- Fixes #924
- Fixes a bug with materials that only contain a blender formula but no other render mode overrides, which caused the rdpq mode not to be reset properly by `rdpq_mat_draw_end`.
- Fixes a bug with materials that don't override the combiner, which caused an invalid combiner to be written.
- Adds tests for some of the cases described above.