### PR TITLE
Fix optional blender for mkmaterial materials

### DIFF
--- a/tests/assets/basic.mat
+++ b/tests/assets/basic.mat
@@ -17,6 +17,9 @@ rm.alpha_compare = 1
 
 [empty]
 
+[blender_none]
+blender.mode = none
+
 [blender_multiply]
 blender.mode = multiply
 

--- a/tests/test_rdpq_mat.c
+++ b/tests/test_rdpq_mat.c
@@ -90,9 +90,21 @@ void test_rdpq_mat_blender(TestContext *ctx)
     rdpq_blender_t exp_multiply = get_expected_blender(RDPQ_BLENDER_MULTIPLY);
     rdpq_blender_t exp_multiply_const = get_expected_blender(RDPQ_BLENDER_MULTIPLY_CONST);
     rdpq_blender_t exp_additive = get_expected_blender(RDPQ_BLENDER_ADDITIVE);
-    rdpq_set_mode_standard();
     rdpq_matdb_t *mdb = rdpq_matdb_open("rom:/basic.mdb");
     DEFER(rdpq_matdb_close(mdb));
+
+    rdpq_set_mode_standard();
+    rdpq_mode_blender(RDPQ_BLENDER_MULTIPLY);
+    rdpq_mat_t *blender_none = rdpq_matdb_load(mdb, "blender_none");
+    ASSERT(blender_none != NULL, "Failed to load material 'blender_none'");
+
+    ASSERT_MAT_SOM("<multiply>", SOM_BLEND_MASK, exp_multiply);
+    rdpq_mat_draw_begin(blender_none);
+    ASSERT_MAT_SOM("blender_none", SOM_BLEND_MASK, 0);
+    rdpq_mat_draw_end(blender_none);
+    ASSERT_MAT_SOM("<multiply>", SOM_BLEND_MASK, exp_multiply);
+
+    rdpq_set_mode_standard();
 
     rdpq_mat_t *blender_multiply = rdpq_matdb_load(mdb, "blender_multiply");
     ASSERT(blender_multiply != NULL, "Failed to load material 'blender_multiply'");

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <utility>
+#include <cassert>
 #include "combexpr.cpp"
 
 extern char *flag_texdb_path;
@@ -38,7 +39,10 @@ struct MyEnum {
             throw std::runtime_error("invalid enum value: " + std::to_string(idx));        
     }
     operator int() const { return idx; }
-    std::string to_str() const { return values[idx]; }
+    std::string to_str() const {
+        assert(idx >= 0 && idx < (int)values.size());
+        return values[idx];
+    }
 
     void operator=(int i) {
         if (i < 0 || i >= (int)values.size())

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -120,7 +120,7 @@ struct Combiner {
 };
 
 struct Blender {
-    MyEnum mode{0, {"none", "multiply", "multiply_const", "additive"}};
+    MyEnum mode{{"none", "multiply", "multiply_const", "additive"}};
     float constant{-1};
 
     void parse_attr(std::string key, std::string value);

--- a/tools/mkmaterial/mkmaterial.h
+++ b/tools/mkmaterial/mkmaterial.h
@@ -104,7 +104,7 @@ typedef std::array<float, 4> Vec4;
 
 struct CombinerRegister {
     Vec4 value;
-    bool is_set;
+    bool is_set {false};
 
     void parse_float(std::string value);
     void parse_color(std::string value);

--- a/tools/mkmaterial/mkmaterial_export.cpp
+++ b/tools/mkmaterial/mkmaterial_export.cpp
@@ -184,7 +184,7 @@ void Material::write(FILE *f)
 
     uint16_t flags = MATFLAG_COMBINER; // always write the combiner
     if (tex[0] || tex[1])       flags |= MATFLAG_TEXTURE;
-    if (bl.mode > 0)            flags |= MATFLAG_BLENDER;
+    if (bl.mode >= 0)           flags |= MATFLAG_BLENDER;
     if (rm.antialias >= 0)      flags |= MATFLAG_RMO_AA;
     if (rm.fog >= 0)            flags |= MATFLAG_RMO_FOG;
     if (rm.dither[0] >= 0)      flags |= MATFLAG_RMO_DITHERING;

--- a/tools/mkmaterial/mkmaterial_parse.cpp
+++ b/tools/mkmaterial/mkmaterial_parse.cpp
@@ -217,6 +217,8 @@ void Blender::parse_attr(std::string key, std::string value)
 
 void Blender::validate(void)
 {
+    if (mode < 0)
+        return;
     if (mode.to_str() == "multiply_const" && constant < 0)
         throw std::runtime_error("blender.const must be specified for mode multiply_const");
     if (mode.to_str() != "multiply_const" && constant >= 0)


### PR DESCRIPTION
discussion on discord here: https://discord.com/channels/205520502922543113/1520425166482440324/1526932041621438575

This changes mkmaterial materials to not interpret the "none" blender as "unset" (current libdragon preview), but instead interpret the lack of blender property in the jmat as "unset", and "none" as the no-blending option.