### PR TITLE
dma: implement an async PI DMA queue

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -30,6 +30,12 @@
  * manipulating registers on a cartridge such as a gameshark.  Code should never
  * make raw 32-bit reads or writes in the cartridge domain as it could collide with
  * an in-progress DMA transfer or run into caching issues.
+ *
+ * Async DMA requests are queued and executed one at a time, dequeued via the
+ * PI interrupt.  Each async function returns a ticket that can be used with
+ * #dma_get_progress and #dma_finished to query the transfer,
+ * #dma_wait_started or #dma_wait_finished to wait for that transfer, or
+ * #dma_wait to wait for all queued transfers to finish.
  * @{
  */
 
@@ -60,17 +66,20 @@ extern "C" {
  * well-defined only for RAM addresses which are multiple of 8, ROM addresses
  * which are  multiple of 2, and lengths which are multiple of 2.
  *
- * Use #dma_wait to wait for the end of the transfer.
- *
+ * Use #dma_wait_finished to wait for the end of the transfer, or #dma_finished
+ * to check it without blocking.
  *
  * @param[out] ram_address
  *             Pointer to a buffer to read data from (must be 8-byte aligned)
  * @param[in]  pi_address
  *             Memory address of the peripheral to write to (must be 2-byte aligned)
  * @param[in]  len
- *             Length in bytes to write into pi_address (must be multiple of 2)
+ *             Length in bytes to write into pi_address (must be a multiple of
+ *             2 and no greater than 16 MiB)
+ *
+ * @return Ticket identifying the transfer (always not 0)
  */
-void dma_write_raw_async(const void *ram_address, pi_addr_t pi_address, unsigned long len);
+uint64_t dma_write_raw_async(const void *ram_address, pi_addr_t pi_address, unsigned long len);
 
 /**
  * @brief Write to a peripheral
@@ -101,7 +110,8 @@ void dma_write(const void * ram_address, pi_addr_t pi_address, unsigned long len
  * well-defined only for RAM addresses which are multiple of 8, ROM addresses
  * which are  multiple of 2, and lengths which are multiple of 2.
  * 
- * Use #dma_wait to wait for the end of the transfer.
+ * Use #dma_wait_finished to wait for the end of the transfer, or #dma_finished
+ * to check it without blocking.
  * 
  * See #dma_read_async for a higher level primitive which can perform almost
  * arbitrary transfers.
@@ -111,9 +121,12 @@ void dma_write(const void * ram_address, pi_addr_t pi_address, unsigned long len
  * @param[in]  pi_address
  *             Memory address of the peripheral to read from (must be 2-byte aligned)
  * @param[in]  len
- *             Length in bytes to read into ram_address (must be multiple of 2)
+ *             Length in bytes to read into ram_address (must be a multiple of
+ *             2 and no greater than 16 MiB)
+ *
+ * @return Ticket identifying the transfer (always not 0)
  */
-void dma_read_raw_async(void *ram_address, pi_addr_t pi_address, unsigned long len);
+uint64_t dma_read_raw_async(void *ram_address, pi_addr_t pi_address, unsigned long len);
 
 /**
  * @brief Start reading data from a peripheral through PI DMA
@@ -129,7 +142,9 @@ void dma_read_raw_async(void *ram_address, pi_addr_t pi_address, unsigned long l
  * odd addresses. Notice that this function will assert if this constraint is
  * not respected.
  * 
- * Use #dma_wait to wait for the end of the transfer.
+ * Use #dma_wait_finished to wait for the end of the transfer, or #dma_finished
+ * to check it without blocking.
+ * The buffer is fully valid only after completion has been confirmed.
  *
  * For non performance sensitive tasks such as reading and parsing data from
  * ROM at loading time, a better option is to use DragonFS, where #dfs_read
@@ -140,9 +155,11 @@ void dma_read_raw_async(void *ram_address, pi_addr_t pi_address, unsigned long l
  * @param[in]  pi_address
  *             Memory address of the peripheral to read from
  * @param[in]  len
- *             Length in bytes to read into ram_pointer
+ *             Length in bytes to read into ram_pointer (no greater than 16 MiB)
+ *
+ * @return Ticket identifying the transfer (always not 0)
  */
-void dma_read_async(void *ram_pointer, pi_addr_t pi_address, unsigned long len);
+uint64_t dma_read_async(void *ram_pointer, pi_addr_t pi_address, unsigned long len);
 
 /** 
  * @brief Read data from a peripheral through PI DMA, waiting for completion.
@@ -166,9 +183,53 @@ void dma_read(void * ram_address, pi_addr_t pi_address, unsigned long len);
 
 
 /** 
- * @brief Wait until an async DMA or I/O transfer is finished.
+ * @brief Wait until all queued async DMA transfers are finished.
  */
 void dma_wait(void);
+
+/**
+ * @brief Wait until an async DMA transfer has started.
+ *
+ * If the kernel is running, the calling thread yields while the transfer is
+ * still queued. A transfer which has already completed is considered started.
+ *
+ * @param ticket    Ticket returned by an async DMA function
+ */
+void dma_wait_started(uint64_t ticket);
+
+/**
+ * @brief Wait until an async DMA transfer is finished.
+ *
+ * If the kernel is running, the calling thread yields while waiting.
+ *
+ * @param ticket    Ticket returned by an async DMA function
+ */
+void dma_wait_finished(uint64_t ticket);
+
+/**
+ * @brief Return the progress of an async DMA transfer.
+ *
+ * If the transfer has not started yet, this function returns zero.
+ *
+ * If it is currently running, the returned value identifies the offset of
+ * the next byte that will be transferred by the DMA, so all preceding bytes
+ * are safe to consume (when doing a DMA-racing approach).
+ *
+ * If the transfer has completed, it returns the total requested length. Notice
+ * that at this point, another transfer might already have started.
+ *
+ * @param ticket    Ticket returned by an async DMA function
+ * @return          Number of bytes already transferred
+ */
+unsigned long dma_get_progress(uint64_t ticket);
+
+/**
+ * @brief Check whether an async DMA transfer is finished.
+ *
+ * @param ticket    Ticket returned by an async DMA function
+ * @return          True if the transfer is fully complete
+ */
+bool dma_finished(uint64_t ticket);
 
 
 /**

--- a/include/n64types.h
+++ b/include/n64types.h
@@ -65,14 +65,16 @@ typedef uint32_t phys_addr_t;
  * 
  * The peripheral bus (PI) is a 32-bit address space used to address
  * devices on the cartridge slot or the bottom slot (N64DD).
+ *
+ * Peripherals connected to the PI bus can answer to any address in this address
+ * space. Cartridge ROMs are usually mapped at 0x10000000.
  * 
- * Accessing PI addresses is only possible via DMA or I/O operations, as performed
+ * Accessing PI addresses is only possible via DMA or CPU I/O operations, as performed
  * by #dma_read, #dma_write, #io_read, and #io_write.
  * 
- * A large portion of the PI address space is also memory mapped to the CPU's
- * address space, meaning that some PI addresses are also valid physical addresses.
- * Check the N64 memory map to see the full mapping of PI addresses, or use
- * #io_accessible if you need to check that at runtime.
+ * I/O operations (with CPU) are only possible with 32-bit access width, and only
+ * for a subset of PI addresses that are memory mapped to the CPU's address space.
+ * Check #io_accessible for a list.
  */
 typedef uint32_t pi_addr_t;
 

--- a/src/accounting_internal.h
+++ b/src/accounting_internal.h
@@ -25,6 +25,7 @@ typedef enum {
     ACCT_CAT_RSPQ         = 4,  ///< RSPQ time (various spinwaits)
     ACCT_CAT_VI           = 5,  ///< VI time (#vi_wait_vblank)
     ACCT_CAT_JOYBUS       = 6,  ///< Joybus time (#joybus_exec)
+    ACCT_CAT_PI           = 7,  ///< PI wait time (DMA and I/O)
 
     /** Keep this last. Buckets are addressed by index. */
     ACCT_CAT_MAX          = 8,

--- a/src/asset.c
+++ b/src/asset.c
@@ -180,7 +180,8 @@ static bool decompress_full(asset_compression_full_t *algo, int fd, size_t cmp_s
         // data flows in.
         uint32_t addr = rom_addr+lseek(fd, 0, SEEK_CUR);
         assertf(addr % 2 == 0, "asset_load requires ROM data to be 2-byte aligned");
-        dma_read_async(s+cmp_offset, addr, cmp_size);
+        uint64_t ticket = dma_read_async(s+cmp_offset, addr, cmp_size);
+        dma_wait_started(ticket);
 
         // Run the decompression racing with the DMA.
         n = algo->decompress_full(s+cmp_offset, cmp_size, s, size); (void)n;

--- a/src/compress/aplib_dec_internal.h
+++ b/src/compress/aplib_dec_internal.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 /** @brief Size of APLIB decompressor state */
-#define DECOMPRESS_APLIB_STATE_SIZE       352
+#define DECOMPRESS_APLIB_STATE_SIZE       368
 
 /** @brief Initialize APLIB decompressor */
 void decompress_aplib_init(void *state, int fd, int winsize);

--- a/src/compress/lzh5.c
+++ b/src/compress/lzh5.c
@@ -44,6 +44,7 @@ typedef struct {
 	uint8_t *buf_ptr, *buf_end;
 	int buf_size;
 	int cur_buf;
+	uint64_t ticket[2];
 
 	// Bits from the input stream that are waiting to be read.
 	uint64_t bit_buffer;
@@ -61,8 +62,9 @@ static void bit_stream_reader_init(BitStreamReader *reader, FILE *fp, uint32_t r
 
 	#ifdef N64
 	if (reader->rom_addr) {
-		data_cache_hit_invalidate(reader->buf[reader->cur_buf^1], sizeof(reader->buf[0]));
-		dma_read_raw_async(reader->buf[reader->cur_buf^1], reader->rom_addr, sizeof(reader->buf[0]));
+		int next = reader->cur_buf ^ 1;
+		data_cache_hit_invalidate(reader->buf[next], sizeof(reader->buf[0]));
+		reader->ticket[next] = dma_read_raw_async(reader->buf[next], reader->rom_addr, sizeof(reader->buf[0]));
 		reader->rom_addr += sizeof(reader->buf[0]);
 	}
 	#endif
@@ -74,8 +76,10 @@ static void refill_bits_fetch(BitStreamReader *reader)
 
 	#ifdef N64
 	if (reader->rom_addr) {
-		data_cache_hit_invalidate(reader->buf[reader->cur_buf^1], sizeof(reader->buf[0]));
-		dma_read_raw_async(reader->buf[reader->cur_buf^1], reader->rom_addr, sizeof(reader->buf[0]));
+		dma_wait_finished(reader->ticket[reader->cur_buf]);
+		int next = reader->cur_buf ^ 1;
+		data_cache_hit_invalidate(reader->buf[next], sizeof(reader->buf[0]));
+		reader->ticket[next] = dma_read_raw_async(reader->buf[next], reader->rom_addr, sizeof(reader->buf[0]));
 		reader->rom_addr += sizeof(reader->buf[0]);
 		reader->buf_size = sizeof(reader->buf[0]);
 	#else

--- a/src/compress/lzh5_internal.h
+++ b/src/compress/lzh5_internal.h
@@ -18,7 +18,7 @@ extern "C" {
  * Note that this can still be allocated on the stack, as the stack size
  * configured by libdragon is 64KB.
  */
-#define DECOMPRESS_LZH5_STATE_SIZE            (6096+16)
+#define DECOMPRESS_LZH5_STATE_SIZE            (6128)
 
 /**
  * @brief Default window size for LZH5 decompression.

--- a/src/compress/ringbuf.c
+++ b/src/compress/ringbuf.c
@@ -93,8 +93,10 @@ void __lookahead_buf_refill(__lookahead_buf_t *lb)
 
     #ifdef N64
     if (lb->rom_base) {
-        data_cache_hit_invalidate(lb->buf[lb->cur ^ 1], sizeof(lb->buf[0]));
-        dma_read_raw_async(lb->buf[lb->cur ^ 1], lb->rom_addr, sizeof(lb->buf[0]));
+        dma_wait_finished(lb->ticket[lb->cur]);
+        int next = lb->cur ^ 1;
+        data_cache_hit_invalidate(lb->buf[next], sizeof(lb->buf[0]));
+        lb->ticket[next] = dma_read_raw_async(lb->buf[next], lb->rom_addr, sizeof(lb->buf[0]));
         lb->rom_addr += sizeof(lb->buf[0]);
         buf_size = sizeof(lb->buf[0]);
     } else {
@@ -135,8 +137,9 @@ void __lookahead_buf_reset(__lookahead_buf_t *lb)
     if (lb->rom_base) {
         // Prefetch the first buffer (the logic expects the first refill() to flip
         // cur and start prefetching the other buffer).
-        data_cache_hit_invalidate(lb->buf[lb->cur ^ 1], sizeof(lb->buf[0]));
-        dma_read_raw_async(lb->buf[lb->cur ^ 1], lb->rom_addr, sizeof(lb->buf[0]));
+        int next = lb->cur ^ 1;
+        data_cache_hit_invalidate(lb->buf[next], sizeof(lb->buf[0]));
+        lb->ticket[next] = dma_read_raw_async(lb->buf[next], lb->rom_addr, sizeof(lb->buf[0]));
         lb->rom_addr += sizeof(lb->buf[0]);
     }
     #endif

--- a/src/compress/ringbuf_internal.h
+++ b/src/compress/ringbuf_internal.h
@@ -82,6 +82,7 @@ typedef struct {
     int fd;                 ///< File descriptor (used when rom_base == 0)
     uint32_t rom_base;      ///< Base ROM address (0 if not reading from ROM)
     uint32_t rom_addr;      ///< Current ROM address (advanced as we prefetch)
+    uint64_t ticket[2];     ///< DMA ticket for each prefetch buffer (ROM mode only)
     bool eof;               ///< True if EOF reached (fd mode only)
 } __lookahead_buf_t;
 

--- a/src/dma.c
+++ b/src/dma.c
@@ -5,7 +5,9 @@
  * @brief DMA Controller
  * @ingroup dma
  */
+#include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "dma.h"
 #include "n64types.h"
 #include "n64sys.h"
@@ -17,25 +19,314 @@
 #include "interrupt_internal.h"
 #include "kernel/kernel_internal.h"
 #include "kirq.h"
+#include "mi.h"
+#include "accounting_internal.h"
 
 /** @brief Structure used to interact with the PI registers */
 static volatile struct PI_regs_s * const PI_regs = (struct PI_regs_s *)0xa4600000;
+
+/** @brief Write this to PI_STATUS to acknowledge the PI interrupt */
+#define PI_CLEAR_INTERRUPT          0x02
+
+#define MAX_PI_MSGS                 16    ///< Maximum number of pending PI DMA messages
+
+#define PI_STATE_IDLE               0    ///< PI queue state: idle (no DMA in progress)
+#define PI_STATE_RUNNING            1    ///< PI queue state: DMA in progress
+
+#define PI_OP_READ_RAW              0    ///< Read raw bytes from PI bus
+#define PI_OP_WRITE_RAW             1    ///< Write raw bytes to PI bus
+#define PI_OP_READ_MISALIGNED       2    ///< Read misaligned bytes from PI bus
+
+#define PI_DMA_MAX_LEN              0x1000000UL ///< Maximum length of a PI DMA transfer
+#define PI_TICKET_LEN_BITS          24         ///< Number of bits used to encode the transfer length
+#define PI_TICKET_LEN_MASK          ((1ULL << PI_TICKET_LEN_BITS) - 1) ///< Mask to extract the transfer length from a ticket
+#define PI_TICKET_ID(ticket)        ((ticket) >> PI_TICKET_LEN_BITS) ///< Extract the transfer ID from a ticket
+#define PI_TICKET_LEN(ticket)       (((ticket) & PI_TICKET_LEN_MASK) + 1) ///< Extract the transfer length from a ticket
+
+/** @brief A PI DMA message in the pending queue */
+typedef struct {
+    void *ram;              ///< RDRAM address
+    pi_addr_t pi_addr;      ///< PI bus address
+    uint32_t len;           ///< Transfer length in bytes
+    uint8_t type;           ///< Operation type (#PI_OP_READ_RAW, etc.)
+} pi_msg_t;
+
+/** @brief Pending PI DMA messages (ring buffer) */
+static pi_msg_t pi_msgs[MAX_PI_MSGS];
+/** @brief Pending messages write index */
+static volatile int pi_msgs_widx;
+/** @brief Pending messages read index */
+static volatile int pi_msgs_ridx;
+/** @brief PI queue state (#PI_STATE_IDLE or #PI_STATE_RUNNING) */
+static volatile int pi_state;
+/** @brief Monotonic ticket counter (assigned at enqueue) */
+static volatile uint64_t pi_ticket_issued;
+/** @brief Ticket counter advanced when a transfer starts */
+static volatile uint64_t pi_ticket_started;
+/** @brief Ticket counter advanced when a transfer completes */
+static volatile uint64_t pi_ticket_done;
+
+static void pi_interrupt(void);
+static void pi_poll(void);
 
 static volatile int __dma_busy(void)
 {
     return PI_regs->status & (PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY);
 }
 
-__attribute__((noinline, warn_unused_result))
-static uint32_t wait_dma_and_disable_interrupts(void)
+static bool __pi_queue_empty(void)
 {
-    while (1) {
-        while (__dma_busy()) {} 
-        uint32_t sr = __disable_interrupts();
-        if (LIKELY(!__dma_busy()))
-            return sr;
-        __enable_interrupts(sr);
+    return pi_msgs_widx == pi_msgs_ridx;
+}
+
+static bool __pi_queue_full(void)
+{
+    return (pi_msgs_widx + 1) % MAX_PI_MSGS == pi_msgs_ridx;
+}
+
+static void pi_manual_interrupt_poll(void)
+{
+    // Poll PI interrupts manually. This is required when interrupts are
+    // disabled (eg: during dma_wait spin loops), as otherwise the queue
+    // would never make progress.
+    unsigned long status = *MI_INTERRUPT & *MI_MASK;
+    if (status & MI_INTERRUPT_PI) {
+        PI_regs->status = PI_CLEAR_INTERRUPT;
+        pi_interrupt();
     }
+}
+
+static void pi_start_read_raw(void *ram_address, pi_addr_t pi_address, unsigned long len)
+{
+    assert(len > 0);
+    *PI_DRAM_ADDR = PhysicalAddr(ram_address);
+    *PI_CART_ADDR = pi_address;
+    *PI_WR_LEN = len - 1;
+}
+
+static void pi_start_write_raw(const void *ram_address, pi_addr_t pi_address, unsigned long len)
+{
+    assert(len > 0);
+    *PI_DRAM_ADDR = PhysicalAddr(ram_address);
+    *PI_CART_ADDR = pi_address;
+    *PI_RD_LEN = len - 1;
+}
+
+/** @brief Low-level 16-bit aligned PI ROM read.
+ * 
+ * 16-bit PI ROM reads are undocumented. Testing on real hardware shows
+ * that they only work for 32-bit aligned addresses, so this function
+ * falls back to a full 32bit read for misaligned addresses.
+ * 
+ * @note This function must be called with interrupts disabled and PI idle.
+ */
+static uint16_t __io_read16(void *pi_pointer) {
+    uint32_t pi_address = (uint32_t)pi_pointer;
+    if (pi_address & 2) {
+        return (uint16_t)*(volatile uint32_t*)(pi_address^2);
+    } else {
+        return *(volatile uint16_t*)pi_pointer;
+    }
+}
+
+/** @brief Low-level 8-bit PI ROM read.
+ * 
+ * 8-bit PI ROM reads are undocumented. Testing on real hardware shows
+ * that they do not consistently work, so this function falls back to using
+ * 16-bit reads and extracting the requested byte.
+ * 
+ * @note This function must be called with interrupts disabled and PI idle.
+ */
+static uint8_t __io_read8(void *pi_pointer) {
+    uint32_t pi_address = (uint32_t)pi_pointer;
+    if (pi_address&1)
+        return (uint8_t)__io_read16((void*)(pi_address^1));
+    else
+        return __io_read16(pi_pointer)>>8;
+}
+
+/**
+ * @brief Execute a misaligned read: CPU fixups for the borders, then DMA.
+ *
+ * Transfers the misaligned head (up to the next 8-byte aligned RAM address)
+ * and the trailing odd byte (when the DMA would not handle it) via CPU
+ * reads, then starts the DMA transfer of the aligned portion, if any.
+ *
+ * @note This function must be called with interrupts disabled and PI idle.
+ *
+ * @return The length of the DMA portion (0 if the whole transfer was done
+ *         via CPU and no DMA was started).
+ */
+static unsigned long pi_exec_read_misaligned(const pi_msg_t *msg)
+{
+    void *ram = UncachedAddr(msg->ram);
+    void *rom = (void*)(msg->pi_addr | 0xA0000000);
+    unsigned long len = msg->len;
+
+    assert(io_accessible(msg->pi_addr));
+
+    // Transfer the first bytes manually up until the next 8-byte aligned
+    // address. Make sure to not transfer more than requested.
+    if ((uint32_t)ram & 7) {
+        if ((uint32_t)ram & 1) {
+            *(uint8_t*)ram = __io_read16(rom - 1);
+            ram++; rom++; len--;
+        }
+        if ((uint32_t)ram & 2 && len >= 2) {
+            *(uint16_t*)ram = __io_read16(rom);
+            ram += 2; rom += 2; len -= 2;
+        }
+        if ((uint32_t)ram & 4 && len >= 4) {
+            *(uint32_t*)ram = (__io_read16(rom) << 16) | __io_read16(rom+2);
+            ram += 4; rom += 4; len -= 4;
+        }
+        while ((uint32_t)ram & 7 && len > 0) {
+            *(uint8_t*)ram = __io_read8(rom);
+            ram++; rom++; len--;
+        }
+    }
+
+    // If there's an odd number of bytes left to transfer, check if the DMA
+    // will do that correctly. This happens only if the transfer fits the
+    // first DMA block, which is either 127 bytes or up to the end of the
+    // current RDRAM row (0x800 bytes).
+    int first_block_len = MIN(127, 0x800 - ((uint32_t)ram & 0x7ff));
+    if ((len & 1) && len >= first_block_len) {
+        // Odd transfers would not work correctly. Transfer the last byte
+        // manually.
+        *(uint8_t*)(ram+len-1) = __io_read16(rom+len-1) >> 8;
+        len -= 1;
+    }
+
+    // Start the actual DMA transfer, if still needed.
+    if (len)
+        pi_start_read_raw(ram, PhysicalAddr(rom), len);
+    return len;
+}
+
+/**
+ * @brief Mark the current transfer as complete and advance the queue.
+ *
+ * @note This function must be called with interrupts disabled.
+ */
+static void pi_complete_current(void)
+{
+    pi_ticket_done++;
+    pi_msgs_ridx = (pi_msgs_ridx + 1) % MAX_PI_MSGS;
+    pi_state = PI_STATE_IDLE;
+}
+
+/**
+ * @brief Start executing a queued PI DMA transfer.
+ *
+ * @note This function must be called with interrupts disabled and PI idle.
+ */
+static void pi_exec_entry(pi_msg_t *msg)
+{
+    assert((PI_regs->status & (PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY)) == 0);
+
+    pi_state = PI_STATE_RUNNING;
+
+    switch (msg->type) {
+    case PI_OP_READ_RAW:
+        pi_start_read_raw(msg->ram, msg->pi_addr, msg->len);
+        break;
+
+    case PI_OP_WRITE_RAW:
+        pi_start_write_raw(msg->ram, msg->pi_addr, msg->len);
+        break;
+
+    case PI_OP_READ_MISALIGNED:
+        // Run the CPU fixups for the borders, then start the DMA of the
+        // aligned portion. If the whole transfer was done via CPU, complete
+        // the entry inline (no interrupt will come).
+        if (pi_exec_read_misaligned(msg) == 0) {
+            pi_ticket_started++;
+            pi_complete_current();
+            return;
+        }
+        break;
+
+    default:
+        assertf(false, "Internal error: unknown PI queue entry type");
+    }
+
+    // Publish the started state only after all synchronous CPU fixups have
+    // completed and the hardware DMA has been launched.
+    pi_ticket_started++;
+}
+
+/**
+ * @brief Check whether there are new messages to send.
+ *
+ * @note This function must be called with interrupts disabled.
+ */
+static void pi_poll(void)
+{
+    // Execute entries until one starts an actual DMA. Entries which are
+    // fully executed via CPU (tiny misaligned reads) complete inline, so
+    // we must keep going to the next one.
+    while (pi_state == PI_STATE_IDLE && !__pi_queue_empty() && !__dma_busy())
+        pi_exec_entry(&pi_msgs[pi_msgs_ridx]);
+}
+
+/**
+ * @brief PI interrupt handler.
+ */
+static void pi_interrupt(void)
+{
+    if (pi_state == PI_STATE_RUNNING) {
+        pi_complete_current();
+        pi_poll();
+        return;
+    }
+
+    // External PI DMA (eg: iQue NAND). Poll the queue in case a transfer
+    // was enqueued while the PI was busy.
+    pi_poll();
+}
+
+static uint64_t pi_enqueue(uint8_t type, void *ram, pi_addr_t pi_addr, unsigned long len)
+{
+    assert(len > 0 && len <= PI_DMA_MAX_LEN);
+    assert(pi_ticket_issued < (1ULL << (64 - PI_TICKET_LEN_BITS)) - 1);
+
+    kirq_wait_t w = kirq_begin_wait_pi();
+
+    disable_interrupts();
+
+    // If the queue is full, wait until a slot is freed by the interrupt
+    // handler. Poll the PI interrupt manually so that this also works when
+    // the caller has interrupts disabled.
+    if (UNLIKELY(__pi_queue_full())) {
+        ACCT_SCOPE(ACCT_CAT_PI) while (UNLIKELY(__pi_queue_full())) {
+            pi_manual_interrupt_poll();
+            if (!__pi_queue_full())
+                break;
+            enable_interrupts();
+            if (__kernel)
+                kirq_wait(&w);
+            disable_interrupts();
+        }
+    }
+
+    // Write the new message into the ring buffer.
+    pi_msg_t *msg = &pi_msgs[pi_msgs_widx];
+    msg->ram = ram;
+    msg->pi_addr = pi_addr;
+    msg->len = len;
+    msg->type = type;
+
+    pi_msgs_widx = (pi_msgs_widx + 1) % MAX_PI_MSGS;
+    uint64_t ticket = (++pi_ticket_issued << PI_TICKET_LEN_BITS) | (len - 1);
+
+    // If the PI is idle, start the transfer immediately. For misaligned
+    // reads, this also runs the CPU fixups right now, in caller context.
+    if (pi_state == PI_STATE_IDLE && !__dma_busy())
+        pi_poll();
+
+    enable_interrupts();
+    return ticket;
 }
 
 bool io_accessible(pi_addr_t pi_address)
@@ -56,137 +347,169 @@ bool io_accessible(pi_addr_t pi_address)
     return true;
 }
 
-/** 
+/**
  * @brief Return whether the DMA controller is currently busy
  *
  * @return nonzero if the DMA controller is busy or 0 otherwise
  */
 volatile int dma_busy(void)
 {
-    return __dma_busy();
+    disable_interrupts();
+    int busy = !__pi_queue_empty() || __dma_busy();
+    enable_interrupts();
+    return busy;
 }
 
-__attribute__((noinline))
-void dma_read_raw_async(void * ram_address, pi_addr_t pi_address, unsigned long len) 
+uint64_t dma_read_raw_async(void *ram_address, pi_addr_t pi_address, unsigned long len)
 {
-    assert(len > 0);
-
-    uint32_t sr = wait_dma_and_disable_interrupts();
-    *PI_DRAM_ADDR = PhysicalAddr(ram_address);
-    *PI_CART_ADDR = pi_address;
-    *PI_WR_LEN = len-1;
-    __enable_interrupts(sr);
+    return pi_enqueue(PI_OP_READ_RAW, ram_address, pi_address, len);
 }
 
-void dma_write_raw_async(const void * ram_address, pi_addr_t pi_address, unsigned long len) 
+uint64_t dma_write_raw_async(const void *ram_address, pi_addr_t pi_address, unsigned long len)
 {
-    assert(len > 0);
-
-    uint32_t sr = wait_dma_and_disable_interrupts();
-    *PI_DRAM_ADDR = PhysicalAddr(ram_address);
-    *PI_CART_ADDR = pi_address;
-    *PI_RD_LEN = len-1;
-    __enable_interrupts(sr);
+    return pi_enqueue(PI_OP_WRITE_RAW, (void*)ram_address, pi_address, len);
 }
 
-/** @brief Low-level 16-bit aligned PI ROM read.
- * 
- * 16-bit PI ROM reads are undocumented. Testing on real hardware shows
- * that they only work for 32-bit aligned addresses, so this function
- * falls back to a full 32bit read for misaligned addresses.
- * 
- * @note This function must be called with interrupts disabled.
- */
-static uint16_t __io_read16(void *pi_pointer) {
-    uint32_t pi_address = (uint32_t)pi_pointer;
-    if (pi_address & 2) {
-        return (uint16_t)*(volatile uint32_t*)(pi_address^2);
-    } else {
-        return *(volatile uint16_t*)pi_pointer;
-    }
-}
-
-/** @brief Low-level 8-bit PI ROM read.
- * 
- * 8-bit PI ROM reads are undocumented. Testing on real hardware shows
- * that they do not consistently work, so this function falls back to using
- * 16-bit reads and extracting the requested byte.
- * 
- * @note This function must be called with interrupts disabled.
- */
-static uint8_t __io_read8(void *pi_pointer) {
-    uint32_t pi_address = (uint32_t)pi_pointer;
-    if (pi_address&1)
-        return (uint8_t)__io_read16((void*)(pi_address^1));
-    else
-        return __io_read16(pi_pointer)>>8;
-}
-
-void dma_read_async(void *ram_pointer, pi_addr_t pi_address, unsigned long len)
+uint64_t dma_read_async(void *ram_pointer, pi_addr_t pi_address, unsigned long len)
 {
     void *ram = UncachedAddr(ram_pointer);
     uint32_t ram_address = (uint32_t)ram;
-    void *rom = (void*)(pi_address | 0xA0000000);
 
     assert(len > 0);
-    assert(((ram_address ^ pi_address) & 1) == 0); (void)ram_address;
+    assert(((ram_address ^ pi_address) & 1) == 0);
 
-    disable_interrupts();
-
-    // Check if the PI address can be accessed with CPU.
-    // If not, we cannot perform a misaligned transfer.
-    if (!io_accessible(pi_address)) {        
+    if (!io_accessible(pi_address)) {
+        // Check if the PI address can be accessed with CPU.
+        // If not, we cannot perform a misaligned transfer.
         assertf((pi_address & 2) == 0 && (ram_address & 7) == 0,
             "misaligned transfer not supported at this PI address");
-        dma_read_raw_async(ram_pointer, pi_address, len);
-        enable_interrupts();
-        return;
+        return dma_read_raw_async(ram_pointer, pi_address, len);
     }
 
-    // Check if the address in RAM is misaligned.
-    if ((uint32_t)ram & 7) {
-        // Transfer the first bytes manually up until the next 8-byte aligned
-        // address. Make sure to not transfer more than requested.
-        if ((uint32_t)ram & 1) {
-            *(uint8_t*)ram = __io_read16(rom - 1);
-            ram++; rom++; len--;
-        }
-        if ((uint32_t)ram & 2 && len >= 2) {
-            *(uint16_t*)ram = __io_read16(rom);
-            ram += 2; rom += 2; len -= 2;
-        }
-        if ((uint32_t)ram & 4 && len >= 4) {
-            *(uint32_t*)ram = (__io_read16(rom) << 16) | __io_read16(rom+2);
-            ram += 4; rom += 4; len -= 4;
-        }
-        while ((uint32_t)ram & 7 && len > 0) {
-            *(uint8_t*)ram = __io_read8(rom);
-            ram++; rom++; len--;
-        }
-    }
+    // Misaligned reads are executed at dequeue time: the CPU fixups for the
+    // borders run either right now in caller context (if the queue is empty
+    // and PI is idle) or in the interrupt handler when the entry is dequeued.
+    if ((ram_address & 7) || ((len & 1) && len >= MIN(127, 0x800 - (ram_address & 0x7ff))))
+        return pi_enqueue(PI_OP_READ_MISALIGNED, ram_pointer, pi_address, len);
 
-    // If there's an odd number of bytes left to transfer, check if the DMA
-    // will do that correctly. This happens only if the transfers fits the
-    // first DMA block, which is either 127 bytes or up to the end of the
-    // current RDRAM row (0x800 bytes).
-    int first_block_len = MIN(127, 0x800 - ((uint32_t)ram & 0x7ff));
-    if ((len & 1) && len >= first_block_len) {
-        // Odd transfers would not work correctly. Transfer the last byte
-        // manually.
-        *(uint8_t*)(ram+len-1) = __io_read16(rom+len-1) >> 8;
-        len -= 1;
-    }
+    return dma_read_raw_async(ram_pointer, pi_address, len);
+}
 
-    // Start the actual DMA transfer, if still needed.
-    if (len)
-        dma_read_raw_async(ram, PhysicalAddr(rom), len);
+bool dma_finished(uint64_t ticket)
+{
+    disable_interrupts();
+    // Poll the PI interrupt manually, so that this function makes progress
+    // even when called with interrupts disabled.
+    pi_manual_interrupt_poll();
+    bool done = ticket && PI_TICKET_ID(ticket) <= pi_ticket_done;
+    enable_interrupts();
+    return done;
+}
+
+static bool dma_started(uint64_t ticket)
+{
+    disable_interrupts();
+    // Poll the PI interrupt manually, so that this function makes progress
+    // even when called with interrupts disabled.
+    pi_manual_interrupt_poll();
+    bool started = ticket && PI_TICKET_ID(ticket) <= pi_ticket_started;
+    enable_interrupts();
+    return started;
+}
+
+unsigned long dma_get_progress(uint64_t ticket)
+{
+    if (!ticket)
+        return 0;
+
+    disable_interrupts();
+    // Poll the PI interrupt manually, so that this function makes progress
+    // even when called with interrupts disabled.
+    pi_manual_interrupt_poll();
+
+    uint64_t id = PI_TICKET_ID(ticket);
+    unsigned long len = PI_TICKET_LEN(ticket);
+    unsigned long progress = 0;
+
+    if (id <= pi_ticket_done) {
+        // The PI registers might already refer to a later transfer.
+        progress = len;
+    } else if (id == pi_ticket_started) {
+        // This is the transfer currently running. PI_DRAM_ADDR tracks the
+        // current RDRAM pointer for both reads and writes.
+        pi_msg_t *msg = &pi_msgs[pi_msgs_ridx];
+        uint32_t start = PhysicalAddr(msg->ram);
+        uint32_t current = *PI_DRAM_ADDR;
+        if (current >= start)
+            progress = MIN(current - start, len);
+    }
 
     enable_interrupts();
+    return progress;
+}
+
+void dma_wait_started(uint64_t ticket)
+{
+    assert(ticket);
+
+    kirq_wait_t w = kirq_begin_wait_pi();
+
+    // Keep the common case outside the accounting scope.
+    if (LIKELY(dma_started(ticket)))
+        return;
+
+    ACCT_SCOPE(ACCT_CAT_PI) while (!dma_started(ticket)) {
+        if (__kernel)
+            kirq_wait(&w);
+    }
+}
+
+void dma_wait_finished(uint64_t ticket)
+{
+    assert(ticket);
+
+    kirq_wait_t w = kirq_begin_wait_pi();
+
+    // Keep the common case outside the accounting scope.
+    if (LIKELY(dma_finished(ticket)))
+        return;
+
+    ACCT_SCOPE(ACCT_CAT_PI) while (!dma_finished(ticket)) {
+        if (__kernel)
+            kirq_wait(&w);
+    }
+}
+
+__attribute__((noinline, warn_unused_result))
+static uint32_t dma_wait_and_disable_interrupts(void)
+{
+    kirq_wait_t w = kirq_begin_wait_pi();
+    uint32_t sr = __disable_interrupts();
+
+    // Poll the PI interrupt manually, so that this function makes progress
+    // even when called with interrupts disabled.
+    pi_manual_interrupt_poll();
+    if (LIKELY(__pi_queue_empty() && !__dma_busy()))
+        return sr;
+    __enable_interrupts(sr);
+
+    ACCT_SCOPE(ACCT_CAT_PI) while (1) {
+        if (__kernel)
+            kirq_wait(&w);
+
+        sr = __disable_interrupts();
+        pi_manual_interrupt_poll();
+        if (__pi_queue_empty() && !__dma_busy())
+            break;
+        __enable_interrupts(sr);
+    }
+    return sr;
 }
 
 void dma_wait(void)
 {
-    while (__dma_busy()) {}
+    uint32_t sr = dma_wait_and_disable_interrupts();
+    __enable_interrupts(sr);
 }
 
 void dma_read(void *ram_address, pi_addr_t pi_address, unsigned long len)
@@ -199,7 +522,7 @@ void dma_read(void *ram_address, pi_addr_t pi_address, unsigned long len)
     dma_wait();
 }
 
-void dma_write(const void * ram_address, pi_addr_t rom_address, unsigned long len) 
+void dma_write(const void * ram_address, pi_addr_t rom_address, unsigned long len)
 {
     // HORROR: this code makes no sense, but it's always been here. The original
     // goal was to make virtual addresses to PI addresses, but it is also
@@ -218,19 +541,19 @@ uint32_t io_read(pi_addr_t pi_address)
         debugf("io_read: WARNING: deprecated usage of virtual address: %08lX\n", pi_address);
         pi_address = PhysicalAddr((void*)pi_address);
     }
-    
+
     // Convert the PI address into a 64-bit virtual address, which allows a wider
     // range of PI addresses to be accessed.
     vaddr64_t va64 = VirtualUncachedAddr64(pi_address);
 
-    uint32_t sr = wait_dma_and_disable_interrupts();
+    uint32_t sr = dma_wait_and_disable_interrupts();
     uint32_t retval = sys_vaddr_read32(va64);
     __enable_interrupts(sr);
 
     return retval;
 }
 
-void io_write(pi_addr_t pi_address, uint32_t data) 
+void io_write(pi_addr_t pi_address, uint32_t data)
 {
     // HACK: to maintain backward compatibility, this function used to accept
     // also CPU virtual addresses. To still allow for that, we need to convert
@@ -245,7 +568,27 @@ void io_write(pi_addr_t pi_address, uint32_t data)
     // range of PI addresses to be accessed.
     vaddr64_t va64 = VirtualUncachedAddr64(pi_address);
 
-    uint32_t sr = wait_dma_and_disable_interrupts();
+    uint32_t sr = dma_wait_and_disable_interrupts();
     sys_vaddr_write32(va64, data);
     __enable_interrupts(sr);
+}
+
+/**
+ * @brief Initialize the PI DMA queue subsystem.
+ *
+ * NOTE: the DMA subsystem requires no explicit init function from the user.
+ * This constructor runs before main().
+ */
+__attribute__((constructor))
+void __dma_init(void)
+{
+    pi_msgs_widx = 0;
+    pi_msgs_ridx = 0;
+    pi_state = PI_STATE_IDLE;
+    pi_ticket_issued = 0;
+    pi_ticket_started = 0;
+    pi_ticket_done = 0;
+
+    register_PI_handler(pi_interrupt);
+    set_PI_interrupt(1);
 }

--- a/src/dma.c
+++ b/src/dma.c
@@ -112,37 +112,29 @@ static void pi_start_write_raw(const void *ram_address, pi_addr_t pi_address, un
     *PI_RD_LEN = len - 1;
 }
 
-/** @brief Low-level 16-bit aligned PI ROM read.
- * 
- * 16-bit PI ROM reads are undocumented. Testing on real hardware shows
- * that they only work for 32-bit aligned addresses, so this function
- * falls back to a full 32bit read for misaligned addresses.
- * 
+/**
+ * @brief Read arbitrary bytes from the PI bus using aligned 32-bit CPU reads.
+ *
+ * Sub-word CPU accesses to the PI bus are not reliable. Read aligned words
+ * through the 64-bit uncached address space and copy out the requested bytes.
+ *
  * @note This function must be called with interrupts disabled and PI idle.
  */
-static uint16_t __io_read16(void *pi_pointer) {
-    uint32_t pi_address = (uint32_t)pi_pointer;
-    if (pi_address & 2) {
-        return (uint16_t)*(volatile uint32_t*)(pi_address^2);
-    } else {
-        return *(volatile uint16_t*)pi_pointer;
-    }
-}
+static void pi_cpu_read(void *ram_address, pi_addr_t pi_address, unsigned long len)
+{
+    uint8_t *ram = ram_address;
 
-/** @brief Low-level 8-bit PI ROM read.
- * 
- * 8-bit PI ROM reads are undocumented. Testing on real hardware shows
- * that they do not consistently work, so this function falls back to using
- * 16-bit reads and extracting the requested byte.
- * 
- * @note This function must be called with interrupts disabled and PI idle.
- */
-static uint8_t __io_read8(void *pi_pointer) {
-    uint32_t pi_address = (uint32_t)pi_pointer;
-    if (pi_address&1)
-        return (uint8_t)__io_read16((void*)(pi_address^1));
-    else
-        return __io_read16(pi_pointer)>>8;
+    while (len) {
+        unsigned int offset = pi_address & 3;
+        unsigned int count = MIN(len, 4 - offset);
+        uint32_t word = sys_vaddr_read32(VirtualUncachedAddr64(pi_address ^ offset));
+        const uint8_t *bytes = (const uint8_t*)&word;
+        memcpy(ram, bytes + offset, count);
+
+        pi_address += count;
+        len -= count;
+        ram += count;
+    }
 }
 
 /**
@@ -159,31 +151,20 @@ static uint8_t __io_read8(void *pi_pointer) {
  */
 static unsigned long pi_exec_read_misaligned(const pi_msg_t *msg)
 {
-    void *ram = UncachedAddr(msg->ram);
-    void *rom = (void*)(msg->pi_addr | 0xA0000000);
+    uint8_t *ram = UncachedAddr(msg->ram);
+    pi_addr_t pi_address = msg->pi_addr;
     unsigned long len = msg->len;
 
-    assert(io_accessible(msg->pi_addr));
+    assert(io_accessible(pi_address));
 
     // Transfer the first bytes manually up until the next 8-byte aligned
     // address. Make sure to not transfer more than requested.
-    if ((uint32_t)ram & 7) {
-        if ((uint32_t)ram & 1) {
-            *(uint8_t*)ram = __io_read16(rom - 1);
-            ram++; rom++; len--;
-        }
-        if ((uint32_t)ram & 2 && len >= 2) {
-            *(uint16_t*)ram = __io_read16(rom);
-            ram += 2; rom += 2; len -= 2;
-        }
-        if ((uint32_t)ram & 4 && len >= 4) {
-            *(uint32_t*)ram = (__io_read16(rom) << 16) | __io_read16(rom+2);
-            ram += 4; rom += 4; len -= 4;
-        }
-        while ((uint32_t)ram & 7 && len > 0) {
-            *(uint8_t*)ram = __io_read8(rom);
-            ram++; rom++; len--;
-        }
+    unsigned long head = MIN(len, (-(uintptr_t)ram) & 7);
+    if (head > 0) {
+        pi_cpu_read(ram, pi_address, head);
+        ram += head;
+        pi_address += head;
+        len -= head;
     }
 
     // If there's an odd number of bytes left to transfer, check if the DMA
@@ -194,13 +175,13 @@ static unsigned long pi_exec_read_misaligned(const pi_msg_t *msg)
     if ((len & 1) && len >= first_block_len) {
         // Odd transfers would not work correctly. Transfer the last byte
         // manually.
-        *(uint8_t*)(ram+len-1) = __io_read16(rom+len-1) >> 8;
+        pi_cpu_read(ram+len-1, pi_address+len-1, 1);
         len -= 1;
     }
 
     // Start the actual DMA transfer, if still needed.
     if (len)
-        pi_start_read_raw(ram, PhysicalAddr(rom), len);
+        pi_start_read_raw(ram, pi_address, len);
     return len;
 }
 

--- a/src/dragonfs.c
+++ b/src/dragonfs.c
@@ -1367,7 +1367,7 @@ static void __dfs_check_emulation(void)
     assertf(0, "Your emulator is not accurate enough to run this ROM.\nSpecifically, it doesn't support accurate PI DMA");
 }
 
-int dfs_init(uint32_t base_fs_loc)
+int dfs_init(pi_addr_t base_fs_loc)
 {
     /* Detect if we are running on emulator accurate enough to emulate DragonFS. */
     __dfs_check_emulation();

--- a/src/profile.c
+++ b/src/profile.c
@@ -201,6 +201,7 @@ void profile_dump(void) {
 	DUMP_SYS(ACCT_CAT_RSPQ, "[sys] RSPQ wait");
 	DUMP_SYS(ACCT_CAT_VI, "[sys] VI wait");
 	DUMP_SYS(ACCT_CAT_JOYBUS, "[sys] Joybus wait");
+	DUMP_SYS(ACCT_CAT_PI, "[sys] PI wait");
 
 	debugf("------------------------------------------------------------------------\n");
 	debugf("Profiled frames:      %4d\n", frames);


### PR DESCRIPTION
Implement an asynchronous PI DMA queue, that is processed under interrupt. It works like this:

* `dma_read_async` and `dma_write_async` enqueue a transfer, without waiting for any existing transfer to finish. They are changed to return a 64-bit ticket, that refers to the transfer being scheduled.
* The queue is currently hardcoded to 16 slots. If more than 16 transfers are enqueued, the 17th `_async()` call will wait for the first one to finish.
* `dma_wait()` waits for all enqueue transfer to be finished, which is the most backward compatible behavior.
* `io_read()` / `io_write()` currently wait for all enqueue transfer to finish first, so they act as full barrier (they call `dma_wait()` internally, basically). This is also a very cautious backward compatibility approach. It could be revisited if needed.
* New functions: `dma_wait_started(ticket)` and `dma_wait_finished(ticket)` can be used to spinlock when needed, waiting for a certain transfer to happen.
* New function: `dma_get_progress(ticket)` returns the number of bytes currently transferred. It can be used to perform DMA racing (partial processing of data while a transfer is in progress)
* New function: `dma_finished(ticket)` is a non-blocking call to check if a certain transfer is done
* All functions can be called with interrupts enabled or disabled, and perform a best-effort eager semantic. For instance calling `dma_wait_finished()` with disabled interrupts will still work correctly and make the DMA queue proceed.