### PR TITLE
mixer: various optimizations and speedups

### DIFF
--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -4,6 +4,7 @@
 // We need to show lots of internal details of the module which are not
 // exposed via public API, so include the internal header file.
 #include "../../src/audio/libxm/xm_internal.h"
+#include "../../src/audio/mixer_internal.h"
 #include "../../src/accounting_internal.h"
 
 #define CLAMP(x, min, max) ((x) < (min) ? (min) : ((x) > (max) ? (max) : (x)))
@@ -307,6 +308,7 @@ enum Page page_song(void) {
 		}
 
 		display_show(disp);
+		profile_next_frame();
 
 		uint32_t start_play_loop = TICKS_READ();
 		//int audiosz = audio_get_buffer_length();
@@ -404,6 +406,7 @@ enum Page page_song(void) {
 int main(void) {
 	debug_init_emulog();
 	debug_init_usblog();
+	emux_ioctl_fast();
 	joypad_init();
 
 	display_init(RESOLUTION_512x240, DEPTH_16_BPP, 3, GAMMA_NONE, FILTERS_RESAMPLE);
@@ -426,14 +429,22 @@ int main(void) {
 	if (num_songs == 0)
 		page = PAGE_INTRO_ERROR;
 
-#if 0
-	// Force immediately playback of a song
+#if 1
+	// Force immediately playback of a song (for mixer profiling).
 	page = PAGE_SONG;
-	cur_rom = "rom:/Claustrophobia.xm64";
+	cur_rom = "rom:/BUTTERFL.xm64";
 #endif
 
 	audio_init(44100, 4);
 	mixer_init(32);
+
+	profile_parms_t pparms = {
+		.num_slots = 32,
+		.dump_stderr_interval = 5.0f,
+	};
+	profile_init(&pparms);
+	__mixer_profile_init();
+	profile_set_target_fps(60.0f);
 
 	while(1) {
 		switch (page) {

--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -4,6 +4,7 @@
 // We need to show lots of internal details of the module which are not
 // exposed via public API, so include the internal header file.
 #include "../../src/audio/libxm/xm_internal.h"
+#include "../../src/accounting_internal.h"
 
 #define CLAMP(x, min, max) ((x) < (min) ? (min) : ((x) > (max) ? (max) : (x)))
 
@@ -169,7 +170,8 @@ enum Page page_menu(void) {
 
 enum Page page_song(void) {
 	char sbuf[1024];
-	int64_t tot_time = 0, tot_cpu = 0, tot_rsp = 0, tot_dma = 0;
+	int64_t tot_time = 0, tot_cpu = 0, tot_rsp = 0, tot_dma = 0, tot_frames = 0;
+	int64_t avg_time = 0, avg_cpu = 0, avg_rsp = 0, avg_dma = 0;
 	int screen_first_inst = 0;
 	enum SONG_TYPE { SONG_XM, SONG_YM };
 
@@ -262,18 +264,10 @@ enum Page page_song(void) {
 			graphics_draw_text(disp, 280, 50, sbuf);						
 		}
 
-		if (tot_time) {
-			float pcpu = (float)tot_cpu * 100.f / (float)tot_time;
-			float prsp = (float)tot_rsp * 100.f / (float)tot_time;
-			float pdma = (float)tot_dma * 100.f / (float)tot_time;
-
-			sprintf(sbuf, "CPU: %.2f%%  RSP: %.2f%%\n", pcpu, prsp);
-			graphics_draw_text(disp, 280, 60, sbuf);
-			sprintf(sbuf, "DMA: %.2f%%", pdma);
-			graphics_draw_text(disp, 280, 70, sbuf);
-
-			debugf("CPU: %.2f%%  RSP: %.2f%%  DMA: %.2f%%\n", pcpu, prsp, pdma);
-		}
+		sprintf(sbuf, "CPU: %lldus\n", avg_time);
+		graphics_draw_text(disp, 280, 60, sbuf);
+		sprintf(sbuf, "Wait: DMA: %lldus RSP: %lldus", avg_dma, avg_rsp);
+		graphics_draw_text(disp, 280, 70, sbuf);
 
 		for (int i=0; i<32; i++) {
 			if (i == song_channels) break;
@@ -314,35 +308,36 @@ enum Page page_song(void) {
 
 		display_show(disp);
 
-		tot_time = 0, tot_cpu = 0, tot_rsp = 0, tot_dma = 0;
-
 		uint32_t start_play_loop = TICKS_READ();
-		bool first_loop = true;
-		int audiosz = audio_get_buffer_length();
-		while (TICKS_DISTANCE(start_play_loop, TICKS_READ()) < TICKS_PER_SECOND)
+		//int audiosz = audio_get_buffer_length();
+		//while (TICKS_DISTANCE(start_play_loop, TICKS_READ()) < TICKS_PER_SECOND)
+		do
 		{
-			extern int64_t __mixer_profile_rsp, __wav64_profile_dma;
-			__mixer_profile_rsp = __wav64_profile_dma = 0;
+			uint32_t t1t = get_ticks_us();
+			uint32_t t1u = get_user_ticks();
+			uint64_t t1rsp = acct_get_ticks(ACCT_CAT_RSP);
+			uint64_t t1dma = acct_get_ticks(ACCT_CAT_PI);
 
-			uint32_t t0 = TICKS_READ();
+			mixer_try_play();
 
-			while (!audio_can_write()) {}
+			uint32_t t2t = get_ticks_us();
+			uint32_t t2u = get_user_ticks();
+			uint64_t t2rsp = acct_get_ticks(ACCT_CAT_RSP);
+			uint64_t t2dma = acct_get_ticks(ACCT_CAT_PI);
 
-			uint32_t t1 = TICKS_READ();
-
-			int16_t *out = audio_write_begin();
-			mixer_poll(out, audiosz);
-			audio_write_end();
-
-			uint32_t t2 = TICKS_READ();
-
-			if (!first_loop) {
-				tot_dma += __wav64_profile_dma;	
-				tot_rsp += __mixer_profile_rsp;
-				tot_cpu += (t2-t1) - __mixer_profile_rsp - __wav64_profile_dma;
-				tot_time += t2-t0;
+			tot_dma += TICKS_TO_US(t2dma-t1dma);
+			tot_rsp += TICKS_TO_US(t2rsp-t1rsp);
+			tot_cpu += TICKS_TO_US(t2u-t1u);
+			tot_time += t2t-t1t;
+			tot_frames++;
+			if (tot_frames >= 60) {
+				avg_time = tot_time / tot_frames;
+				avg_cpu = tot_cpu / tot_frames;
+				avg_rsp = tot_rsp / tot_frames;
+				avg_dma = tot_dma / tot_frames;
+				tot_time = 0, tot_cpu = 0, tot_rsp = 0, tot_dma = 0, tot_frames = 0;
+				debugf("CPU: %lldus | Wait DMA: %lldus | Wait RSP: %lldus\n", avg_time, avg_dma, avg_rsp);
 			}
-			first_loop = false;
 
 			joypad_poll();
 			joypad_buttons_t ckeys = joypad_get_buttons_pressed(JOYPAD_PORT_1);
@@ -402,7 +397,7 @@ enum Page page_song(void) {
 					ym64player_close(&ym);
 				return PAGE_MENU;
 			}
-		}
+		} while (0);
 	}
 }
 

--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -429,7 +429,7 @@ int main(void) {
 	if (num_songs == 0)
 		page = PAGE_INTRO_ERROR;
 
-#if 1
+#if 0
 	// Force immediately playback of a song (for mixer profiling).
 	page = PAGE_SONG;
 	cur_rom = "rom:/BUTTERFL.xm64";

--- a/examples/audioplayer/audioplayer.c
+++ b/examples/audioplayer/audioplayer.c
@@ -315,14 +315,14 @@ enum Page page_song(void) {
 		{
 			uint32_t t1t = get_ticks_us();
 			uint32_t t1u = get_user_ticks();
-			uint64_t t1rsp = acct_get_ticks(ACCT_CAT_RSP);
+			uint64_t t1rsp = acct_get_ticks(ACCT_CAT_RSP) + acct_get_ticks(ACCT_CAT_RSPQ);
 			uint64_t t1dma = acct_get_ticks(ACCT_CAT_PI);
 
 			mixer_try_play();
 
 			uint32_t t2t = get_ticks_us();
 			uint32_t t2u = get_user_ticks();
-			uint64_t t2rsp = acct_get_ticks(ACCT_CAT_RSP);
+			uint64_t t2rsp = acct_get_ticks(ACCT_CAT_RSP) + acct_get_ticks(ACCT_CAT_RSPQ);
 			uint64_t t2dma = acct_get_ticks(ACCT_CAT_PI);
 
 			tot_dma += TICKS_TO_US(t2dma-t1dma);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -645,6 +645,18 @@ typedef struct waveform_s {
       */
 	void *ctx;
 
+	/**
+	 * @brief True if #read returns with its transfer still in flight.
+	 *
+	 * Set this when the samples are fetched with an asynchronous PI DMA
+	 * (see #samplebuffer_dma_wait). The mixer then fetches ahead of time
+	 * (#samplebuffer_prefetch), so that the transfer runs while the CPU does
+	 * something else. Leave it false for readers that produce the samples
+	 * synchronously (CPU decoding, filesystem reads): fetching those early
+	 * would just move the same work around, and waste it on a seek.
+	 */
+	bool async_read;
+
     /**
       * @brief State size required for this waveform to operate
       * 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -552,6 +552,30 @@ typedef void (*WaveformStart)(void *ctx, samplebuffer_t *sbuf);
  * with #mixer_ch_play, they will use automatically two channels (the specified
  * one and the following).
  */
+/** @brief Waveform sample format (stored in #waveform_t::format). */
+typedef enum {
+	/** Interleaved PCM samples (8/16-bit). Default. */
+	WAVEFORM_FORMAT_PCM = 0,
+	/**
+	 * Mono VADPCM: the samplebuffer holds compressed 9-byte frames; the mixer
+	 * ucode decodes them in DMEM during mixing. Stereo VADPCM is not supported
+	 * in this mode (use PCM / legacy decompress-to-samplebuffer instead).
+	 */
+	WAVEFORM_FORMAT_VADPCM = 1,
+} waveform_format_t;
+
+/** @brief Codec side-data for #WAVEFORM_FORMAT_VADPCM waveforms. */
+typedef struct {
+	/** Predictor codebook in RDRAM (must stay valid for the waveform lifetime). */
+	void *codebook;
+	/**
+	 * Decoder state at the loop start (16-byte vector), or NULL if the
+	 * waveform does not loop / loop state is unknown. Used by the RSP on
+	 * cached-loop wraps.
+	 */
+	void *loop_state;
+} waveform_vadpcm_t;
+
 typedef struct waveform_s {
 	/** @brief Name of the waveform (for debugging purposes) */
 	const char *name;
@@ -560,6 +584,7 @@ typedef struct waveform_s {
      * @brief Width of a sample of this waveform, in bits.
      * 
      * Supported values are 8 or 16. Notice that samples must always be signed.
+     * For #WAVEFORM_FORMAT_VADPCM this is the decoded width (always 16).
      */
 	uint8_t bits;
 
@@ -568,8 +593,16 @@ typedef struct waveform_s {
      * 
      * Supported values are 1 and 2 (mono and stereo waveforms). Notice that
      * a stereo waveform will use two consecutive mixer channels to be played back.
+     * #WAVEFORM_FORMAT_VADPCM requires channels == 1.
      */
 	uint8_t channels;
+
+	/**
+	 * @brief Sample format (see #waveform_format_t).
+	 *
+	 * Defaults to #WAVEFORM_FORMAT_PCM when zero-initialized.
+	 */
+	uint8_t format;
 
 	/** @brief Desired playback frequency (in samples per second, aka Hz). */
 	float frequency;
@@ -624,6 +657,14 @@ typedef struct waveform_s {
       * function via the "state" field of the #samplebuffer_t.
       */
      int state_size;
+
+	/**
+	 * @brief Codec-specific data (format-dependent).
+	 *
+	 * For #WAVEFORM_FORMAT_VADPCM this points to a #waveform_vadpcm_t that
+	 * must outlive playback. NULL for PCM.
+	 */
+	void *codec;
 
      ///@cond
      ///  Mixer private state. Do not touch, initialize to zero

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -378,8 +378,8 @@ void mixer_unthrottle(void);
  * A common pattern would be to call #audio_write_begin to obtain an audio
  * buffer's pointer, and pass it to mixer_poll.
  *
- * mixer_poll performs mixing using RSP. If RSP is busy, mixer_poll will
- * spin-wait until the RSP is free, to perform audio processing.
+ * mixer_poll performs mixing using RSP: it enqueues the mix commands in the
+ * high priority queue and waits for the RSP to execute them before returning.
  *
  * Since the N64 AI can only be fed with an even number of samples, mixer_poll
  * does not accept odd numbers.
@@ -557,9 +557,10 @@ typedef enum {
 	/** Interleaved PCM samples (8/16-bit). Default. */
 	WAVEFORM_FORMAT_PCM = 0,
 	/**
-	 * Mono VADPCM: the samplebuffer holds compressed 9-byte frames; the mixer
-	 * ucode decodes them in DMEM during mixing. Stereo VADPCM is not supported
-	 * in this mode (use PCM / legacy decompress-to-samplebuffer instead).
+	 * Mono or stereo VADPCM: the samplebuffer holds compressed 9-byte frames
+	 * (one plane per mixer channel); the mixer ucode decodes them in DMEM
+	 * during mixing. Stereo files are block-planar on disk and use two
+	 * consecutive mixer channels as independent mono VADPCM streams.
 	 */
 	WAVEFORM_FORMAT_VADPCM = 1,
 } waveform_format_t;
@@ -593,7 +594,6 @@ typedef struct waveform_s {
      * 
      * Supported values are 1 and 2 (mono and stereo waveforms). Notice that
      * a stereo waveform will use two consecutive mixer channels to be played back.
-     * #WAVEFORM_FORMAT_VADPCM requires channels == 1.
      */
 	uint8_t channels;
 
@@ -665,6 +665,16 @@ typedef struct waveform_s {
 	 * must outlive playback. NULL for PCM.
 	 */
 	void *codec;
+
+	/**
+	 * @brief Resident sample data in RDRAM, or NULL if streamed.
+	 *
+	 * When non-NULL, the mixer addresses these bytes directly (PCM samples
+	 * or compressed VADPCM frames) and does not allocate a samplebuffer for
+	 * this waveform. #read is still invoked for seeking side-effects when
+	 * #state_size is non-zero (e.g. VADPCM predictor state).
+	 */
+	const void *mem;
 
      ///@cond
      ///  Mixer private state. Do not touch, initialize to zero

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -533,6 +533,19 @@ typedef void (*WaveformRead)(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen
  */
 typedef void (*WaveformStart)(void *ctx, samplebuffer_t *sbuf);
 
+/** @brief Waveform sample format (stored in #waveform_t::format). */
+typedef enum {
+	/** Interleaved PCM samples (8/16-bit). Default. */
+	WAVEFORM_FORMAT_PCM = 0,
+	/**
+	 * Mono or stereo VADPCM: the samplebuffer holds compressed 9-byte frames
+	 * (one plane per mixer channel); the mixer ucode decodes them in DMEM
+	 * during mixing. Stereo files are block-planar on disk and use two
+	 * consecutive mixer channels as independent mono VADPCM streams.
+	 */
+	WAVEFORM_FORMAT_VADPCM = 1,
+} waveform_format_t;
+
 /**
  * @brief A waveform that can be played back through the mixer.
  * 
@@ -552,32 +565,7 @@ typedef void (*WaveformStart)(void *ctx, samplebuffer_t *sbuf);
  * with #mixer_ch_play, they will use automatically two channels (the specified
  * one and the following).
  */
-/** @brief Waveform sample format (stored in #waveform_t::format). */
-typedef enum {
-	/** Interleaved PCM samples (8/16-bit). Default. */
-	WAVEFORM_FORMAT_PCM = 0,
-	/**
-	 * Mono or stereo VADPCM: the samplebuffer holds compressed 9-byte frames
-	 * (one plane per mixer channel); the mixer ucode decodes them in DMEM
-	 * during mixing. Stereo files are block-planar on disk and use two
-	 * consecutive mixer channels as independent mono VADPCM streams.
-	 */
-	WAVEFORM_FORMAT_VADPCM = 1,
-} waveform_format_t;
-
-/** @brief Codec side-data for #WAVEFORM_FORMAT_VADPCM waveforms. */
-typedef struct {
-	/** Predictor codebook in RDRAM (must stay valid for the waveform lifetime). */
-	void *codebook;
-	/**
-	 * Decoder state at the loop start (16-byte vector), or NULL if the
-	 * waveform does not loop / loop state is unknown. Used by the RSP on
-	 * cached-loop wraps.
-	 */
-	void *loop_state;
-} waveform_vadpcm_t;
-
-typedef struct waveform_s {
+ typedef struct waveform_s {
 	/** @brief Name of the waveform (for debugging purposes) */
 	const char *name;
 
@@ -684,15 +672,7 @@ typedef struct waveform_s {
       * of memory for the waveform, and make it available to the read
       * function via the "state" field of the #samplebuffer_t.
       */
-     int state_size;
-
-	/**
-	 * @brief Codec-specific data (format-dependent).
-	 *
-	 * For #WAVEFORM_FORMAT_VADPCM this points to a #waveform_vadpcm_t that
-	 * must outlive playback. NULL for PCM.
-	 */
-	void *codec;
+    int state_size;
 
 	/**
 	 * @brief Resident sample data in RDRAM, or NULL if streamed.
@@ -705,6 +685,8 @@ typedef struct waveform_s {
 	const void *mem;
 
      ///@cond
+	 /// Codec-specific runtime data (format-dependent)
+	 void *codec;
      ///  Mixer private state. Do not touch, initialize to zero
      uint32_t __uuid;
      ///@endcond

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -657,6 +657,22 @@ typedef struct waveform_s {
 	 */
 	bool async_read;
 
+	/**
+	 * @brief Granularity in units of the appends made by #read (0 if unknown).
+	 *
+	 * Set this when #read always appends a whole multiple of a fixed chunk
+	 * (a codec frame: 960 samples for Opus, one audioframe for YM64). The
+	 * samplebuffer then keeps its usable size a multiple of the chunk, so that
+	 * a chunk is never split by the wrap and the live window does not have to
+	 * be relocated to keep the append contiguous.
+	 *
+	 * Any value is allowed: the samplebuffer applies it only when it is worth
+	 * it (a chunk that fits the tail margin never needs a relocate anyway) and
+	 * only when the buffer is large enough to keep a couple of chunks after
+	 * the rounding. Leave it 0 if the appends have no fixed size.
+	 */
+	int append_units;
+
     /**
       * @brief State size required for this waveform to operate
       * 

--- a/include/profile.h
+++ b/include/profile.h
@@ -250,11 +250,12 @@ inline void __profile_record(int slot, int32_t len) {
 	 * @see PROFILE_STOP
 	 */
 	#define PROFILE_SCOPE(slot) \
-		for (int64_t __prof_start_##slot = emux_prof_start(slot), TICKS_READ() - get_system_ticks() ; ) \
-			for (int __prof_once_##slot = ({ MEMORY_BARRIER(); 1; }); __prof_once_##slot; __prof_once_##slot = 0, \
-				({ MEMORY_BARRIER(); }), \
-				emux_prof_stop(slot), \
-				__profile_record(slot, TICKS_READ() - get_system_ticks() - __prof_start_##slot))
+		for (int64_t __prof_start_##slot = TICKS_READ() - get_system_ticks(), \
+			__prof_once_##slot = ({ emux_prof_start(slot); MEMORY_BARRIER(); (int64_t)1; }); \
+			__prof_once_##slot; \
+			__prof_once_##slot = 0, \
+			({ MEMORY_BARRIER(); emux_prof_stop(slot); \
+			   __profile_record(slot, TICKS_READ() - get_system_ticks() - __prof_start_##slot); }))
 #else
 	///@cond
 	#define PROFILE_START(slot, ...)  ((void)(false), false)

--- a/include/rspq.h
+++ b/include/rspq.h
@@ -1101,6 +1101,11 @@ void rspq_highpri_end(void);
  * all high-priority queues. It is meant for debugging purposes or for situations
  * in which the high-priority queue is known to be very short and fast to run.
  * Also note that it is not possible to create syncpoints in the high-priority queue.
+ * 
+ * The function can either be called while a high-priority queue is being built
+ * (that is, between #rspq_highpri_begin and #rspq_highpri_end), or
+ * after the high-priority queue has been closed (that is, after
+ * #rspq_highpri_end).
  */
 void rspq_highpri_sync(void);
 

--- a/include/rspq_constants.h
+++ b/include/rspq_constants.h
@@ -11,7 +11,7 @@
 #define RSPQ_PROFILE                   0       ///< Enable RSPQ profiling
 
 #define RSPQ_DRAM_LOWPRI_BUFFER_SIZE   0x200   ///< Size of each RSPQ RDRAM buffer for lowpri queue (in 32-bit words)
-#define RSPQ_DRAM_HIGHPRI_BUFFER_SIZE  0x80    ///< Size of each RSPQ RDRAM buffer for highpri queue (in 32-bit words)
+#define RSPQ_DRAM_HIGHPRI_BUFFER_SIZE  0x200   ///< Size of each RSPQ RDRAM buffer for highpri queue (in 32-bit words)
 
 #define RSPQ_DMEM_BUFFER_SIZE          0x100   ///< Size of the RSPQ DMEM buffer (in bytes)
 

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -226,6 +226,21 @@ void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRe
 void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen);
 
 /**
+ * @brief Start fetching samples that will be requested later (zero-wait).
+ *
+ * Fetches the part of [wpos, wpos+wlen) that the buffer does not hold yet,
+ * leaving any PI DMA in flight: the next #samplebuffer_get finds the samples
+ * already there and only has to wait for a transfer that ran meanwhile.
+ *
+ * This is best-effort: the call does nothing unless the waveform declares
+ * #waveform_t::async_read (there would be nothing to overlap with), and
+ * likewise if the window is already available, if it is not contiguous with
+ * what the buffer holds (a seek is coming, so anything fetched now would be
+ * discarded), or if the ring has no room for it.
+ */
+void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen);
+
+/**
  * @brief Append samples into the buffer (zero-copy).
  *
  * Returns a contiguous uncached pointer where the caller must write `wlen`

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -141,6 +141,13 @@ typedef struct samplebuffer_s {
      */
     uint32_t last_round;
 
+    /**
+     * Ticket of the most recent async PI DMA into this buffer (0 = none).
+     * Producers set it when issuing dma_read_async; consumers wait via
+     * #samplebuffer_dma_wait before touching the bytes or freeing memory.
+     */
+    uint64_t dma_ticket;
+
     /** Total bytes allocated for the sample area (ring + margin). */
     int capacity_bytes;
 
@@ -235,6 +242,11 @@ void samplebuffer_undo(samplebuffer_t *buf, int wlen);
  * Flush (reset) the sample buffer to empty status, discarding all samples.
  */
 void samplebuffer_flush(samplebuffer_t *buf);
+
+/**
+ * Wait for any in-flight async PI DMA into this buffer to complete.
+ */
+void samplebuffer_dma_wait(samplebuffer_t *buf);
 
 /**
  * Close the sample buffer.

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -1,7 +1,7 @@
 /**
  * @file samplebuffer.h
  * @author Giovanni Bajo <giovannibajo@gmail.com>
- * @brief Sample buffer (ring FIFO)
+ * @brief Sample buffer
  * @ingroup mixer
  */
 
@@ -20,41 +20,25 @@ typedef struct waveform_s waveform_t;
 /// @endcond
 
 /**
- * Tagged pointer to an array of samples. It contains both the void*
- * sample pointer, and byte-per-sample information (encoded as shift value).
+ * Pointer to the sample area (historically a tagged pointer; the low bits are
+ * unused and the width of each unit lives in #samplebuffer_t::unit_bytes).
  */
 typedef uint32_t sample_ptr_t;
 
 /**
- * SAMPLES_BPS_SHIFT extracts the byte-per-sample information from a sample_ptr_t.
- * Byte-per-sample is encoded as shift value, so the actual number of bits is
- * 1 << BPS. Valid shift values are 0, 1, 2 (which corresponds to 1, 2 or 4
- * bytes per sample).
+ * Extract the raw void* to the sample array from a samplebuffer.
  */
-#define SAMPLES_BPS_SHIFT(buf)      ((buf)->ptr_and_flags & 3)
-
-/**
- * SAMPLES_PTR extract the raw void* to the sample array. The size of array
- * is not encoded in the tagged pointer. Notice that it is implemented with a
- * XOR because on MIPS it's faster than using a reverse mask.
- */
-#define SAMPLES_PTR(buf)            (void*)((buf)->ptr_and_flags ^ SAMPLES_BPS_SHIFT(buf))
-
-/**
- * SAMPLES_PTR_MAKE create a tagged pointer, given a pointer to an array of
- * samples and a byte-per-sample value (encoded as shift value).
- */
-#define SAMPLES_PTR_MAKE(ptr, bps)  ((sample_ptr_t)(ptr) | (bps))
+#define SAMPLES_PTR(buf)            ((void*)(uintptr_t)((buf)->ptr_and_flags))
 
 /**
  * Maximum window (in units) that #samplebuffer_get / #samplebuffer_append may
- * request. Matches the ring tail margin: one MIX_CHANNEL input span plus
- * RSP sample-cache overread.
+ * request. Matches the samplebuffer tail margin: one MIX_CHANNEL input span
+ * plus RSP sample-cache overread.
  */
 #define SAMPLEBUFFER_MARGIN_UNITS  128
 
 /**
- * samplebuffer_t is a ring FIFO of samples used by the mixer to feed the RSP.
+ * samplebuffer_t holds samples used by the mixer to feed the RSP.
  *
  * The mixer follows a "pull" architecture. During mixer_poll, it will call
  * samplebuffer_get() to extract samples from the buffer. If the required
@@ -63,11 +47,11 @@ typedef uint32_t sample_ptr_t;
  * waveform read function will push samples into the buffer via samplebuffer_append,
  * so that they become available for the mixer.
  *
- * Data is stored in a circular ring with a small tail margin so that any
- * window up to the margin size is always contiguous in physical memory
- * (required by RSP DMA). RING_SIZE * unit_bytes is kept a multiple of 8 so
- * that absolute waveform positions preserve their 2-byte phase in the ring
- * (dma_read / dfs compatibility).
+ * Data is stored circularly with a small tail margin so that any window up to
+ * the margin size is always contiguous in physical memory (required by RSP
+ * DMA). size * unit_bytes is kept a multiple of 8 so that absolute waveform
+ * positions preserve their 2-byte phase in the samplebuffer (dma_read / dfs
+ * compatibility).
  *
  * In general, the sample buffer assumes that the contained data is committed
  * to physical memory, not just CPU cache. It is responsibility of the client
@@ -76,31 +60,37 @@ typedef uint32_t sample_ptr_t;
  */
 typedef struct samplebuffer_s {
     /**
-     * Tagged pointer to the actual buffer. Lower bits contain bit-per-shift.
+     * Pointer to the sample area (8-byte aligned, uncached).
      */
     sample_ptr_t ptr_and_flags;
 
     /**
-     * Bytes per logical unit when not a power-of-two sample width.
-     * 0 means "use 1 << SAMPLES_BPS_SHIFT(buf)" (PCM path). Non-zero is used
-     * for compressed frame stores (e.g. 9 for mono VADPCM frames). In that
-     * mode wpos/widx/size are counted in units (frames), not PCM samples.
+     * Bytes per logical unit counted by wpos/widx/size.
+     * PCM: 1, 2, or 4. Compressed frame stores: e.g. 9 for mono VADPCM.
      */
     uint8_t unit_bytes;
 
     /**
-     * Ring size in units (excludes the tail margin).
+     * Usable size in units (excludes the tail margin).
      **/
     int size;
 
     /**
+     * Granularity in units of the appends done by the producer, or 0 if
+     * unknown: declared via #waveform_t::append_units, or learnt from the
+     * appends themselves. When it exceeds the tail margin (only then can an
+     * append need a relocate), #size is kept a multiple of it.
+     */
+    int append_units;
+
+    /**
      * Absolute position in the waveform of the first sample
-     * currently valid in the ring.
+     * currently valid in the samplebuffer.
      */
     int wpos;
 
     /**
-     * Number of valid units currently stored in the ring.
+     * Number of valid units currently stored in the samplebuffer.
      */
     int widx;
 
@@ -136,25 +126,29 @@ typedef struct samplebuffer_s {
     WaveformRead wv_read;
 
     /**
-     * Highest mix round id whose RSP mix command still references bytes
-     * in this buffer.
-     */
-    uint32_t last_round;
-
-    /**
      * Ticket of the most recent async PI DMA into this buffer (0 = none).
      * Producers set it when issuing dma_read_async; consumers wait via
      * #samplebuffer_dma_wait before touching the bytes or freeing memory.
      */
     uint64_t dma_ticket;
 
-    /** Total bytes allocated for the sample area (ring + margin). */
+    /** Total bytes allocated for the sample area (usable size + margin). */
     int capacity_bytes;
 
-    /** Physical slot of wpos within the ring. */
+    /**
+     * Physical index (0 .. size-1) of #wpos in the circular sample area.
+     * A unit at relative offset `rel` from wpos lives at
+     * `(head + rel) % size`. Advances when the oldest units are discarded.
+     */
     int head;
 
-    /** Pending append into the margin that needs a mirror copy-back. */
+    /**
+     * Latest #samplebuffer_append that has not been committed yet: physical
+     * start slot and length in units. An append may spill into the tail
+     * margin so the write stays contiguous; commit then mirrors the overflow
+     * back to the start of the sample area (after any PI DMA has finished).
+     * pending_len == 0 means nothing is pending.
+     */
     int pending_slot;
     int pending_len;
 } samplebuffer_t;
@@ -170,7 +164,7 @@ typedef struct samplebuffer_s {
  *
  * The memory buffer will be used for storing samples and for the state.
  * Part of the sample area is reserved as a tail margin for contiguous
- * RSP DMA across the ring wrap.
+ * RSP DMA across the wrap.
  *
  * @param[in]   buf              Sample buffer
  * @param[in]   uncached_mem     Memory buffer to use. Must be 8-byte aligned,
@@ -186,29 +180,22 @@ void samplebuffer_init(samplebuffer_t *buf, uint8_t *uncached_mem, int size, int
 bool samplebuffer_is_inited(samplebuffer_t *buf);
 
 /**
- * @brief Configure the bit width of the samples stored in the buffer.
- *
- * Valid values for "bps" are 1, 2, or 4: 1 can be used for 8-bit mono samples,
- * 2 for either 8-bit interleaved stereo or 16-bit mono, and 4 for 16-bit
- * interleaved stereo.
- *
- * Clears any previous #samplebuffer_set_unit_bytes setting.
- */
-void samplebuffer_set_bps(samplebuffer_t *buf, int bps);
-
-/**
- * @brief Configure a non-power-of-two unit size (compressed frames).
+ * @brief Configure the logical unit size (bytes per wpos/widx step).
  *
  * After this call, wpos/widx/size are expressed in units of `unit_bytes`
- * each (e.g. VADPCM frames of 9 bytes). The buffer must be empty.
+ * each (e.g. 2 for 16-bit mono PCM, 9 for mono VADPCM frames). The buffer
+ * must be empty.
  */
 void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes);
 
 /**
- * @brief Bytes per logical unit in the sample buffer.
+ * @brief Configure the bit width of PCM samples stored in the buffer.
+ *
+ * Valid values are 8, 16, or 32 (total bits per interleaved frame).
+ * Wrapper for #samplebuffer_set_unit_bytes with `bps / 8`.
  */
-static inline int samplebuffer_unit_bytes(const samplebuffer_t *buf) {
-	return buf->unit_bytes ? (int)buf->unit_bytes : (1 << SAMPLES_BPS_SHIFT(buf));
+static inline void samplebuffer_set_bps(samplebuffer_t *buf, int bps) {
+	samplebuffer_set_unit_bytes(buf, bps / 8);
 }
 
 /**
@@ -236,7 +223,7 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen);
  * #waveform_t::async_read (there would be nothing to overlap with), and
  * likewise if the window is already available, if it is not contiguous with
  * what the buffer holds (a seek is coming, so anything fetched now would be
- * discarded), or if the ring has no room for it.
+ * discarded), or if the samplebuffer has no room for it.
  */
 void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen);
 
@@ -244,7 +231,9 @@ void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen);
  * @brief Append samples into the buffer (zero-copy).
  *
  * Returns a contiguous uncached pointer where the caller must write `wlen`
- * units. The window size must not exceed the ring margin.
+ * units. Windows larger than the samplebuffer margin are allowed, but they
+ * may force the live window to be relocated to keep the write contiguous:
+ * declare their size in #waveform_t::append_units to avoid that.
  */
 void* samplebuffer_append(samplebuffer_t *buf, int wlen);
 

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -1,7 +1,7 @@
 /**
  * @file samplebuffer.h
  * @author Giovanni Bajo <giovannibajo@gmail.com>
- * @brief Sample buffer 
+ * @brief Sample buffer (ring FIFO)
  * @ingroup mixer
  */
 
@@ -19,7 +19,7 @@ extern "C" {
 typedef struct waveform_s waveform_t;
 /// @endcond
 
-/** 
+/**
  * Tagged pointer to an array of samples. It contains both the void*
  * sample pointer, and byte-per-sample information (encoded as shift value).
  */
@@ -47,37 +47,27 @@ typedef uint32_t sample_ptr_t;
 #define SAMPLES_PTR_MAKE(ptr, bps)  ((sample_ptr_t)(ptr) | (bps))
 
 /**
- * samplebuffer_t is a circular buffer of samples. It is used by the mixer
- * to store and cache the samples required for playback on each channel.
- * The mixer creates a sample buffer for each initialized channel. The size
- * of the buffers is calculated for optimal playback, and might grow depending
- * on channel usage (what waveforms are played on each channel).
+ * Maximum window (in units) that #samplebuffer_get / #samplebuffer_append may
+ * request. Matches the ring tail margin: one MIX_CHANNEL input span plus
+ * RSP sample-cache overread.
+ */
+#define SAMPLEBUFFER_MARGIN_UNITS  128
+
+/**
+ * samplebuffer_t is a ring FIFO of samples used by the mixer to feed the RSP.
  *
  * The mixer follows a "pull" architecture. During mixer_poll, it will call
  * samplebuffer_get() to extract samples from the buffer. If the required
  * samples are not available, the sample buffer will callback the waveform
  * decoder to produce more samples, through the WaveformRead API. The
  * waveform read function will push samples into the buffer via samplebuffer_append,
- * so that they become available for the mixer. The decoder can be configured
- * with samplebuffer_set_decoder.
+ * so that they become available for the mixer.
  *
- * The current implementation of samplebuffer does not achieve full zero copy,
- * because when the buffer is full, it is flushed and samples that need to 
- * be preserved (that is, already in the buffer but not yet played back) are
- * copied back at the beginning of the buffer with the CPU. This limitation
- * exists because the RSP ucode (rsp_audio.S) isn't currently able to "wrap around"
- * in the sample buffer. In future, this limitation could be lifted to achieve
- * full zero copy.
- *
- * The sample buffer tries to always stay 8-byte aligned to simplify operations
- * of decoders that might need to use DMA transfers (either PI DMA or RSP DMA).
- * To guarantee this property, #WaveformRead must collaborate by decoding
- * the requested number of samples. If WaveformRead decodes a different
- * number of samples, the alignment might be lost. Moreover, it always guarantees
- * that the buffer has the same 2-byte phase of the waveforms (that is, odd
- * samples of the waveforms are stored at odd addresses in memory); this is
- * the minimal property required by #dma_read (libdragon's optimized PI DMA
- * transfer for unaligned addresses).
+ * Data is stored in a circular ring with a small tail margin so that any
+ * window up to the margin size is always contiguous in physical memory
+ * (required by RSP DMA). RING_SIZE * unit_bytes is kept a multiple of 8 so
+ * that absolute waveform positions preserve their 2-byte phase in the ring
+ * (dma_read / dfs compatibility).
  *
  * In general, the sample buffer assumes that the contained data is committed
  * to physical memory, not just CPU cache. It is responsibility of the client
@@ -98,45 +88,34 @@ typedef struct samplebuffer_s {
      */
     uint8_t unit_bytes;
 
-    /** 
-     * Size of the buffer (in samples, or units if unit_bytes != 0).
+    /**
+     * Ring size in units (excludes the tail margin).
      **/
     int size;
 
     /**
      * Absolute position in the waveform of the first sample
-     * in the sample buffer (the sample at index 0). It keeps track of
-     * which part of the waveform this sample buffer contains.
+     * currently valid in the ring.
      */
     int wpos;
 
     /**
-     * Write pointer in the sample buffer (expressed as index of samples).
-     * Since sample buffers are always filled from index 0, it is also
-     * the number of samples stored in the buffer.
+     * Number of valid units currently stored in the ring.
      */
     int widx;
 
     /**
-     * Read pointer in the sample buffer (expressed as index of samples).
-     * It remembers which sample was last read. Assuming a forward
-     * streaming, it is used by the sample buffer to discard unused samples
-     * when not needed anymore.
+     * Read cursor relative to wpos (first unit still needed for playback).
      */
     int ridx;
 
     /**
-     * Value of the "next" sample to be loaded into the sample buffer,
-     * to continue a linear reading. This is used to notify the wv_read
-     * function whether a seeking was performed or not.
+     * Next absolute position expected for a linear read (for seeking detection).
      */
     int wnext;
 
     /**
      * @brief Pointer to the state of the waveform decoder.
-     * 
-     * The waveform decoder can use this pointer to store its internal
-     * state.
      */
     void *state;
 
@@ -157,43 +136,20 @@ typedef struct samplebuffer_s {
     WaveformRead wv_read;
 
     /**
-     * @brief UUID of the waveform being played back on this sample buffer.
-     */
-    uint32_t wave_uuid;
-
-    /**
      * Highest mix round id whose RSP mix command still references bytes
-     * in this buffer. Compaction must wait until that round is done.
+     * in this buffer.
      */
     uint32_t last_round;
 
-    /**
-     * High-watermark (in samples from wpos) of bytes that an in-flight RSP
-     * producer command will still write past widx. Set by samplebuffer_undo;
-     * cleared once the owning round completes.
-     */
-    int wdirty;
+    /** Total bytes allocated for the sample area (ring + margin). */
+    int capacity_bytes;
 
-    /**
-     * Mix round that owns the dirty tail (see wdirty).
-     */
-    uint32_t dirty_round;
+    /** Physical slot of wpos within the ring. */
+    int head;
 
-    /**
-     * Pending RSP-side compaction: region of the buffer (in sample-sized
-     * slots, that is byte offset >> bps) that an enqueued RSP memmove still
-     * has to read. CPU appends must not overwrite it before the RSP executes
-     * the move. wmove_end == 0 means no pending move.
-     */
-    int wmove_start;
-    /** End of the pending compaction source region (see wmove_start). */
-    int wmove_end;
-
-    /** Mix round that covers the pending compaction memmove (see wmove_start). */
-    uint32_t move_round;
-
-    /** Mix round that covers the most recent producer writes (appends). */
-    uint32_t prod_round;
+    /** Pending append into the margin that needs a mirror copy-back. */
+    int pending_slot;
+    int pending_len;
 } samplebuffer_t;
 
 /**
@@ -204,9 +160,11 @@ typedef struct samplebuffer_s {
  * in the uncached segment and not loaded in any CPU cacheline. It is
  * strongly advised to allocate the buffer via #malloc_uncached, that takes
  * care of these constraints.
- * 
+ *
  * The memory buffer will be used for storing samples and for the state.
- * 
+ * Part of the sample area is reserved as a tail margin for contiguous
+ * RSP DMA across the ring wrap.
+ *
  * @param[in]   buf              Sample buffer
  * @param[in]   uncached_mem     Memory buffer to use. Must be 8-byte aligned,
  *                               and in the uncached segment.
@@ -217,24 +175,17 @@ void samplebuffer_init(samplebuffer_t *buf, uint8_t *uncached_mem, int size, int
 
 /**
  * @brief Return true if the samplebuffer is initialized.
- * 
- * @param buf               Sample buffer
- * @return true             If the sample buffer is initialized.
- * @return false            If the sample buffer is not initialized.
  */
 bool samplebuffer_is_inited(samplebuffer_t *buf);
 
 /**
  * @brief Configure the bit width of the samples stored in the buffer.
- * 
+ *
  * Valid values for "bps" are 1, 2, or 4: 1 can be used for 8-bit mono samples,
  * 2 for either 8-bit interleaved stereo or 16-bit mono, and 4 for 16-bit
  * interleaved stereo.
- * 
+ *
  * Clears any previous #samplebuffer_set_unit_bytes setting.
- * 
- * @param[in]   buf     Sample buffer
- * @param[in]   bps     Bytes per sample.
  */
 void samplebuffer_set_bps(samplebuffer_t *buf, int bps);
 
@@ -243,9 +194,6 @@ void samplebuffer_set_bps(samplebuffer_t *buf, int bps);
  *
  * After this call, wpos/widx/size are expressed in units of `unit_bytes`
  * each (e.g. VADPCM frames of 9 bytes). The buffer must be empty.
- *
- * @param[in]   buf          Sample buffer
- * @param[in]   unit_bytes   Bytes per unit (must be > 0)
  */
 void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes);
 
@@ -257,132 +205,39 @@ static inline int samplebuffer_unit_bytes(const samplebuffer_t *buf) {
 }
 
 /**
- * Connect a waveform reader callback to this sample buffer. The waveform
- * will be use to produce samples whenever they are required by the mixer
- * as playback progresses.
- *
- * "read" is the main decoding function, that is invoked to produce a specified
- * number of samples. Normally, the function is invoked by #samplebuffer_get,
- * whenever the mixer requests more samples. See #WaveformRead for more
- * information.
- * 
- * @param[in]       buf     Sample buffer
- * @param[in]       wave    Waveform to connect to the sample buffer
- * @param[in]       read    Waveform read function
+ * Connect a waveform reader callback to this sample buffer.
  */
 void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read);
 
 /**
  * @brief Get a pointer to specific set of samples in the buffer (zero-copy).
- * 
+ *
  * "wpos" is the absolute waveform position of the first sample that the
  * caller needs access to. "wlen" is the number of requested samples.
- *
- * The function returns a pointer within the sample buffer where the samples
- * should be read, and optionally changes "wlen" with the maximum number of
- * samples that can be read. "wlen" is always less or equal to the requested value.
- *
- * If the samples are available in the buffer, they will be returned immediately.
- * Otherwise, if the samplebuffer has a sample decoder registered via
- * samplebuffer_set_decoder, the decoder "read" function is called once to
- * produce the samples.
- *
- * If "wlen" is changed with a value less than "wlen", it means that
- * not all samples were available in the buffer and it was not possible to
- * generate more, so the caller should not loop calling this function, but
- * rather use what was obtained and possibly pad with silence.
- *
- * @param[in]       buf     Sample buffer
- * @param[in]       wpos    Absolute waveform position of the first samples to
- *                          return.
- * @param[in,out]   wlen    Number of samples to return. After return, it is
- *                          modified with the actual number of samples that
- *                          have been returned.
- * @return                  Pointer to samples.
+ * wpos must be monotonic between seeks.
  */
 void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen);
 
 /**
- * @brief Append samples into the buffer (zero-copy). 
+ * @brief Append samples into the buffer (zero-copy).
  *
- * "wlen" is the number of samples that the caller will append.
- *
- * The function returns a pointer within the sample buffer where the samples
- * should be written. The samples to be written to physical memory, not just
- * CPU cache, and to enforce this, the function returns a pointer in the
- * uncached segment. Most of the times, we expect samples to be generated
- * or manipulated via RSP/DMA anyway.
- *
- * The function is meant only to "append" samples, as in add samples that are
- * consecutive within the waveform to the ones already stored in the sample
- * buffer. This is necessary because #samplebuffer_t can only store a single
- * range of samples of the waveform; there is no way to hold two disjoint
- * ranges.
- *
- * For instance, if the sample buffer currently contains 50 samples
- * starting from position 100 in the waverform, the next call to
- * samplebuffer_append will append samples starting at 150.
- *
- * If required, samplebuffer_append will discard older samples to make space
- * for the new ones, through #samplebuffer_discard. It will only discard samples
- * that come before the "wpos" specified in the last #samplebuffer_get call, so
- * to make sure that nothing required for playback is discarded. If there is
- * not enough space in the buffer, it will assert.
- * 
- * @param[in]   buf     Sample buffer
- * @param[in]   wlen    Number of samples to append.
- * @return              Pointer to the area where new samples can be written.
+ * Returns a contiguous uncached pointer where the caller must write `wlen`
+ * units. The window size must not exceed the ring margin.
  */
 void* samplebuffer_append(samplebuffer_t *buf, int wlen);
 
 /**
  * @brief Remove the a specified number of samples from the tail of the buffer.
- * 
- * This function removes the last \a wlen samples from the buffer. It can be
- * used to revert the behavior of a #samplebuffer_append call, if the data
- * written to the buffer was too much.
- * 
- * A common situation is an implementation of a waveform codec with fixed
- * audio frames. The last frame at the end of the waveform will likely need
- * to be truncated, but the compressor would have likely padded it with zeros
- * to make it the same size as the others. In this case, at playing time,
- * it is possible to call #samplebuffer_append to append the whole frame,
- * but then remove the unneeded padding with a call to #samplebuffer_undo.
- * 
- * @param buf       Sample buffer
- * @param wlen      Number of samples to remove
  */
 void samplebuffer_undo(samplebuffer_t *buf, int wlen);
 
 /**
- * Discard all samples from the buffer that come before a specified
- * absolute waveform position.
- * 
- * This function can be used to discard samples that are not needed anymore
- * in the sample buffer. "wpos" specifies the absolute position of the first
- * sample that should be kept: all samples that come before will be discarded.
- * This function will silently do nothing if there are no samples to discard.
- * 
- * @param[in]   buf     Sample buffer
- * @param[in]   wpos    Absolute waveform position of the first sample that
- *                      must be kept.
- */
-void samplebuffer_discard(samplebuffer_t *buf, int wpos);
-
-/**
  * Flush (reset) the sample buffer to empty status, discarding all samples.
- * 
- * @param[in]   buf     Sample buffer.
  */
 void samplebuffer_flush(samplebuffer_t *buf);
 
 /**
  * Close the sample buffer.
- * 
- * After calling close, the sample buffer must be initialized again before
- * using it.
- * 
- * @param[in]   buf     Sample buffer.
  */
 void samplebuffer_close(samplebuffer_t *buf);
 

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -90,8 +90,16 @@ typedef struct samplebuffer_s {
      */
     sample_ptr_t ptr_and_flags;
 
+    /**
+     * Bytes per logical unit when not a power-of-two sample width.
+     * 0 means "use 1 << SAMPLES_BPS_SHIFT(buf)" (PCM path). Non-zero is used
+     * for compressed frame stores (e.g. 9 for mono VADPCM frames). In that
+     * mode wpos/widx/size are counted in units (frames), not PCM samples.
+     */
+    uint8_t unit_bytes;
+
     /** 
-     * Size of the buffer (in samples).
+     * Size of the buffer (in samples, or units if unit_bytes != 0).
      **/
     int size;
 
@@ -223,10 +231,30 @@ bool samplebuffer_is_inited(samplebuffer_t *buf);
  * 2 for either 8-bit interleaved stereo or 16-bit mono, and 4 for 16-bit
  * interleaved stereo.
  * 
+ * Clears any previous #samplebuffer_set_unit_bytes setting.
+ * 
  * @param[in]   buf     Sample buffer
  * @param[in]   bps     Bytes per sample.
  */
 void samplebuffer_set_bps(samplebuffer_t *buf, int bps);
+
+/**
+ * @brief Configure a non-power-of-two unit size (compressed frames).
+ *
+ * After this call, wpos/widx/size are expressed in units of `unit_bytes`
+ * each (e.g. VADPCM frames of 9 bytes). The buffer must be empty.
+ *
+ * @param[in]   buf          Sample buffer
+ * @param[in]   unit_bytes   Bytes per unit (must be > 0)
+ */
+void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes);
+
+/**
+ * @brief Bytes per logical unit in the sample buffer.
+ */
+static inline int samplebuffer_unit_bytes(const samplebuffer_t *buf) {
+	return buf->unit_bytes ? (int)buf->unit_bytes : (1 << SAMPLES_BPS_SHIFT(buf));
+}
 
 /**
  * Connect a waveform reader callback to this sample buffer. The waveform

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -170,6 +170,22 @@ typedef struct samplebuffer_s {
      * Mix round that owns the dirty tail (see wdirty).
      */
     uint32_t dirty_round;
+
+    /**
+     * Pending RSP-side compaction: region of the buffer (in sample-sized
+     * slots, that is byte offset >> bps) that an enqueued RSP memmove still
+     * has to read. CPU appends must not overwrite it before the RSP executes
+     * the move. wmove_end == 0 means no pending move.
+     */
+    int wmove_start;
+    /** End of the pending compaction source region (see wmove_start). */
+    int wmove_end;
+
+    /** Mix round that covers the pending compaction memmove (see wmove_start). */
+    uint32_t move_round;
+
+    /** Mix round that covers the most recent producer writes (appends). */
+    uint32_t prod_round;
 } samplebuffer_t;
 
 /**

--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -152,6 +152,24 @@ typedef struct samplebuffer_s {
      * @brief UUID of the waveform being played back on this sample buffer.
      */
     uint32_t wave_uuid;
+
+    /**
+     * Highest mix round id whose RSP mix command still references bytes
+     * in this buffer. Compaction must wait until that round is done.
+     */
+    uint32_t last_round;
+
+    /**
+     * High-watermark (in samples from wpos) of bytes that an in-flight RSP
+     * producer command will still write past widx. Set by samplebuffer_undo;
+     * cleared once the owning round completes.
+     */
+    int wdirty;
+
+    /**
+     * Mix round that owns the dirty tail (see wdirty).
+     */
+    uint32_t dirty_round;
 } samplebuffer_t;
 
 /**

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -1048,6 +1048,10 @@ static void mixer_refresh_max_ns(int ch) {
 
 // Number of samples the next round can mix: a full round, unless a streamed
 // channel would outrun what the CPU is able to feed it in one go.
+//
+// The result is always even, so that each round advances the output pointer by
+// a multiple of 8 bytes and MIX_FLUSH can DMA the accumulator out as-is
+// (see #mixer_poll_async).
 static int mixer_round_length(int max_ns) {
 	int ns = MIN(max_ns, MIXER_MAX_SAMPLES_PER_ROUND);
 
@@ -1074,7 +1078,15 @@ static int mixer_round_length(int max_ns) {
 			}
 		}
 	}
-	return MAX(ns, 1);
+
+	// Truncate to an even number of samples. Stopping one sample before a
+	// constraint is always safe (the next round resumes there); the only
+	// exception is a limit exactly one sample away, where we mix one sample
+	// too many. That sample is still valid data: past a small loop point it
+	// is the loop body the CPU is about to pin, past the end of a large loop
+	// it is covered by #MIXER_LOOP_OVERREAD, and in both cases the CPU takes
+	// over from the next round.
+	return MAX(ns & ~1, 2);
 }
 
 // Volumes to send for a channel: a stereo owner only carries the L plane and
@@ -1397,6 +1409,14 @@ static void mixer_poll_async(int16_t *out16, int num_samples) {
 	// otherwise buffering might become complicated / impossible.
 	assert(num_samples % 2 == 0);
 
+	// MIX_FLUSH DMAs the accumulator straight out of DMEM, so every output
+	// address the RSP is given must be 8-byte aligned. That holds as long as
+	// the buffer itself is aligned and we only ever advance it by an even
+	// number of stereo samples, which is what the rest of this function and
+	// #mixer_round_length guarantee.
+	assertf(((uint32_t)out16 & 7) == 0,
+		"mixer output buffer must be 8-byte aligned: %p", out16);
+
 	// Check if the mixer is throttled. If so, do not produce more
 	// than the allowance (with a small extra equal to a full audio buffer,
 	// to avoid issues with fixed-size buffers like those provided by audio.c),
@@ -1404,7 +1424,7 @@ static void mixer_poll_async(int16_t *out16, int num_samples) {
 	if (Mixer.throttled) {
 		int extra = Mixer.sample_rate / MIXER_POLL_PER_SECOND;
 		int total = num_samples;
-		num_samples = MIN(num_samples, Mixer.max_samples+extra);
+		num_samples = (int)MIN(num_samples, Mixer.max_samples+extra) & ~1;
 		Mixer.max_samples -= num_samples;
 		memset(out + num_samples, 0, (total - num_samples) * sizeof(int32_t));
 	}
@@ -1412,13 +1432,20 @@ static void mixer_poll_async(int16_t *out16, int num_samples) {
 	while (num_samples > 0) {
 		mixer_event_t *e = mixer_next_event();
 
-		int ns = MIN(num_samples, e ? e->ticks - Mixer.ticks : num_samples);
+		// Stop at the next event, rounding the split up to an even number of
+		// samples. The event then fires up to one sample late, but without
+		// drifting: its schedule stays anchored to absolute ticks.
+		int ns = num_samples;
+		if (e) {
+			int64_t delay = e->ticks - Mixer.ticks;
+			ns = delay > 0 ? MIN(ns, (int)ROUND_UP(delay, 2)) : 0;
+		}
 		if (ns > 0) {
 			mixer_exec(out, ns);
 			out += ns;
 			num_samples -= ns;
 		}
-		if (e && Mixer.ticks == e->ticks) {
+		if (e && Mixer.ticks >= e->ticks) {
 			int64_t repeat = e->cb(e->ctx);
 			if (repeat)
 				e->ticks += repeat;

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -63,19 +63,29 @@ DEFINE_RSP_UCODE(rsp_mixer);
 /** @brief Size of the ucode state that is automatically persisted by rspq.
  * Layout must match RSPQ_BeginSavedState in rsp_mixer.S:
  *   XVOL_L[32] + XVOL_R[32] (128 bytes) + COUNTER_RDRAM + pad (16 bytes).
+ * ACCUM lives in .bss (not saved state) so the VADPCM bssovl1 bank still fits.
  */
 #define MIXER_STATE_SIZE 144
 
-/** @brief Number of in-flight settings slots for async mix rounds */
-#define MIXER_SETTINGS_SLOTS  16
+/** @brief Max output samples per mix round (must match rsp_mixer.S). */
+#define MIXER_MAX_SAMPLES_PER_ROUND  256
 
 // NOTE: keep these in sync with rsp_mixer.S
 #define CH_FLAGS_BPS_SHIFT  	(3<<0)   ///< BPS shift value
 #define CH_FLAGS_16BIT      	(1<<2)   ///< Set if the channel is 16 bit
 #define CH_FLAGS_STEREO     	(1<<3)   ///< Set if the channel is stereo (left)
 #define CH_FLAGS_STEREO_SUB 	(1<<4)   ///< The channel is the second half of a stereo (right)
-#define CH_FLAGS_STEREO_ALLOC	(1<<5)   ///< The channel has a buffer sized for stereo
+#define CH_FLAGS_VADPCM     	(1<<5)   ///< In-mixer VADPCM mono (wire + CPU)
 #define CH_FLAGS_FORCE_MONO  	(1<<6)   ///< Fold this channel's output to both buses (mono downmix). CPU-side only; RSP ucode ignores this bit.
+#define CH_FLAGS_CLEAR_ACCUM 	(1<<7)   ///< Zero ACCUM before mixing (first MIX_CHANNEL of a round)
+#define CH_FLAGS_STEREO_ALLOC	(1<<9)   ///< The channel has a buffer sized for stereo (CPU-side only)
+
+/** @brief rspq command IDs for rsp_mixer.S */
+#define MIXER_CMD_CHANNEL     0x0
+#define MIXER_CMD_VADPCM      0x1
+#define MIXER_CMD_SETSTATE    0x2
+#define MIXER_CMD_MEMMOVE     0x3
+#define MIXER_CMD_FLUSH       0x4
 
 /// @brief Fixed point value used in waveform position calculations.
 /// This is a signed 64-bit integer with the fractional part using
@@ -96,58 +106,28 @@ typedef int16_t mixer_fx15_t;
 /// Convert a floating point value to #mixer_fx15_t
 #define MIXER_FX15(f)      (int16_t)((f) * ((1<<MIXER_FX15_FRAC)-1))
 
+/// @brief Fixed point 16.16 value, used for the global volume.
+/// You can use #MIXER_FX16 to convert from float.
+typedef int32_t mixer_fx16_t;
+
 /// Number of fractional bits for a fixed 16.16 value
 #define MIXER_FX16_FRAC    16
 /// Convert a floating point value to a fixed 16.16 value
-#define MIXER_FX16(f)      (int16_t)((f) * ((1<<MIXER_FX16_FRAC)-1))
+#define MIXER_FX16(f)      (mixer_fx16_t)((f) * (1<<MIXER_FX16_FRAC))
 
 /** @brief Mixer channel state - CPU side */
 typedef struct mixer_channel_s {
-	mixer_fx64_t pos;      ///< Current position within the waveform (in bytes)
-	mixer_fx64_t step;     ///< Step between samples (in bytes) to playback at the correct frequency
-	mixer_fx64_t len;      ///< Length of the waveform (in bytes)
-	mixer_fx64_t loop_len; ///< Length of the loop in the waveform (in bytes)
-	void *ptr;             ///< Pointer to the waveform
+	mixer_fx64_t pos;      ///< Position (bytes for PCM, samples for VADPCM)
+	mixer_fx64_t step;     ///< Step per output sample (same units as pos)
+	mixer_fx64_t len;      ///< Waveform length (same units as pos)
+	mixer_fx64_t loop_len; ///< Loop length (same units as pos)
+	void *ptr;             ///< Waveform data base (PCM samples or VADPCM frames)
+	void *codec_state;     ///< Per-channel codec state (VADPCM decoder state)
+	void *codebook;        ///< VADPCM codebook (NULL for PCM)
+	void *loop_state;      ///< VADPCM state at loop start (NULL if none)
 	uint32_t flags;        ///< Misc flags (see CH_FLAGS_*)
 	waveform_t *wave;      ///< Waveform being played back on this channel
 } mixer_channel_t;
-
-/** @brief Mixer channel state - RSP side
- *
- * This structure represents the state of a mixer channel as stored in RSP
- * DMEM. Structure-wise, it is similar to #mixer_channel_t, but waveform-related
- * offsets are 32-bit wide rather than 64-bit, since RSP cannot easily work
- * with 64-bit integers. Check #mixer_poll to see how this difference is handled.
- */
-typedef struct rsp_mixer_channel_s {
-	uint32_t pos;           ///< Current position within the waveform (in bytes)
-	uint32_t step;          ///< Step between samples (in bytes) to playback at the correct frequency
-	uint32_t len;           ///< Length of the waveform (in bytes)
-	uint32_t loop_len;      ///< Length of the loop in the waveform (in bytes)
-	void *ptr;              ///< Pointer to the waveform
-	uint32_t flags;         ///< Misc flags (see CH_FLAGS_*)
-} __attribute__((packed)) rsp_mixer_channel_t;
-
-/// @cond
-_Static_assert(sizeof(rsp_mixer_channel_t) == 6*4);
-/// @endcond
-
-/** @brief Mixer ucode settings.
- *
- * This struct reflects the settings defined in rsp_mixer.S.
- */
-typedef struct rsp_mixer_settings_s {
-	uint16_t lvol[MIXER_MAX_CHANNELS] __attribute__((aligned(16)));
-	uint16_t rvol[MIXER_MAX_CHANNELS];
-	rsp_mixer_channel_t channels[MIXER_MAX_CHANNELS] __attribute__((aligned(16)));
-} rsp_mixer_settings_t;
-
-/** @brief One settings ring slot tagged with the round that consumes it */
-typedef struct {
-	rsp_mixer_settings_t settings;
-	uint32_t round_id;
-	uint32_t pad[3];
-} __attribute__((aligned(16))) mixer_settings_slot_t;
 
 /** @brief RDRAM completion counter published by the mixer ucode */
 typedef struct {
@@ -206,10 +186,6 @@ static struct {
 	uint32_t round_next;
 	uint32_t round_enqueued;
 
-	mixer_settings_slot_t *slot_ring;
-	int slot_head;
-	int slot_tail;
-
 } Mixer;
 
 /** @brief Count of ticks spent waiting on mixer rounds (rare fallback path). */
@@ -259,7 +235,7 @@ bool __mixer_memmove_async(void *dst, void *src, int len) {
 	assert(((uint32_t)dst & 7) == 0 && ((uint32_t)src & 7) == 0 && (len & 7) == 0);
 	bool highpri = rspq_in_highpri();
 	if (!highpri) rspq_highpri_begin();
-	rspq_write(__mixer_overlay_id, 0x3,
+	rspq_write(__mixer_overlay_id, MIXER_CMD_MEMMOVE,
 		PhysicalAddr(dst), PhysicalAddr(src), len);
 	if (!highpri) rspq_highpri_end();
 	return true;
@@ -298,29 +274,7 @@ void __mixer_wait_idle(void) {
 	rspq_highpri_sync();
 }
 
-static void mixer_settings_reclaim(void) {
-	while (Mixer.slot_tail != Mixer.slot_head &&
-	       __mixer_round_done(Mixer.slot_ring[Mixer.slot_tail].round_id))
-		Mixer.slot_tail = (Mixer.slot_tail + 1) % MIXER_SETTINGS_SLOTS;
-}
-
-static rsp_mixer_settings_t *mixer_settings_acquire(uint32_t round_id) {
-	int next = (Mixer.slot_head + 1) % MIXER_SETTINGS_SLOTS;
-	if (next == Mixer.slot_tail) {
-		// Ring full: rare fallback. Wait for the oldest in-flight round.
-		__mixer_round_wait(Mixer.slot_ring[Mixer.slot_tail].round_id);
-		mixer_settings_reclaim();
-		next = (Mixer.slot_head + 1) % MIXER_SETTINGS_SLOTS;
-		assertf(next != Mixer.slot_tail, "mixer settings ring still full after wait");
-	}
-	Mixer.slot_ring[Mixer.slot_head].round_id = round_id;
-	rsp_mixer_settings_t *s = &Mixer.slot_ring[Mixer.slot_head].settings;
-	Mixer.slot_head = next;
-	return s;
-}
-
 static void mixer_reclaim(void) {
-	mixer_settings_reclaim();
 	for (int i = 0; i < Mixer.num_channels; i++) {
 		samplebuffer_t *sbuf = &Mixer.ch_buf[i];
 		mixer_channel_t *ch = &Mixer.channels[i];
@@ -333,6 +287,9 @@ static void mixer_reclaim(void) {
 		// in mixer_exec, which runs at most once per waveform.
 		int bps_fx64 = (ch->flags & CH_FLAGS_BPS_SHIFT) + MIXER_FX64_FRAC;
 		int loop_len = ch->loop_len >> bps_fx64;
+		// VADPCM samplebuffers are in frames; loop_len above is in samples.
+		if (ch->flags & CH_FLAGS_VADPCM)
+			loop_len /= 16;
 		if (loop_len && loop_len < sbuf->size)
 			continue;
 		if (!__mixer_round_done(sbuf->last_round))
@@ -362,10 +319,6 @@ void mixer_init(int num_channels) {
 	assertf(Mixer.rstate, "Out of memory");
 	memset((void*)Mixer.rstate, 0, sizeof(*Mixer.rstate));
 
-	Mixer.slot_ring = malloc_uncached(sizeof(mixer_settings_slot_t) * MIXER_SETTINGS_SLOTS);
-	assertf(Mixer.slot_ring, "Out of memory");
-	memset(Mixer.slot_ring, 0, sizeof(mixer_settings_slot_t) * MIXER_SETTINGS_SLOTS);
-
 	rspq_init();
 	__mixer_overlay_id = rspq_overlay_register(&rsp_mixer);
 
@@ -375,21 +328,22 @@ void mixer_init(int num_channels) {
 	data_cache_hit_writeback(mixer_state, sizeof(*mixer_state));
 }
 
-static int mixer_calc_buffer_size(int ch, int nchannels)
+static int mixer_calc_buffer_size(int ch, waveform_t *wave)
 {
-	// Get maximum frequency for this channel
 	int64_t nsamples = Mixer.limits[ch].max_frequency;
+	int64_t size;
 
-	// Multiple by maximum byte per sample
-	nsamples *= Mixer.limits[ch].max_bits / 8;
+	if (wave->format == WAVEFORM_FORMAT_VADPCM) {
+		// Samplebuffer stores 9-byte frames (16 samples each).
+		int64_t nframes = (int64_t)ceilf((float)nsamples / (float)MIXER_POLL_PER_SECOND);
+		nframes = (nframes + 15) / 16;
+		size = ROUND_UP(nframes * 9, 8);
+	} else {
+		nsamples *= Mixer.limits[ch].max_bits / 8;
+		nsamples *= wave->channels;
+		size = ROUND_UP((int64_t)ceilf((float)nsamples / (float)MIXER_POLL_PER_SECOND), 8);
+	}
 
-	// Multiply by number of channels
-	nsamples *= nchannels;
-
-	// Calculate buffer size according to number of expected polls per second.
-	int64_t size = ROUND_UP((int64_t)ceilf((float)nsamples / (float)MIXER_POLL_PER_SECOND), 8);
-
-	// If we're over the allowed maximum, clamp to it
 	if (Mixer.limits[ch].max_buf_sz && size > Mixer.limits[ch].max_buf_sz)
 		size = Mixer.limits[ch].max_buf_sz;
 
@@ -417,10 +371,6 @@ void mixer_close(void) {
 			samplebuffer_close(&Mixer.ch_buf[i]);
 	}
 
-	if (Mixer.slot_ring) {
-		free_uncached(Mixer.slot_ring);
-		Mixer.slot_ring = NULL;
-	}
 	if (Mixer.rstate) {
 		free_uncached((void*)Mixer.rstate);
 		Mixer.rstate = NULL;
@@ -436,7 +386,10 @@ void mixer_ch_set_freq(int ch, float frequency) {
 	// Check if the frequency is within the configured limit. Allow for a 1% margin because of rounding errors
 	// for default maximum frequency being the output sample rate converted from fixed point.
 	assertf(frequency <= Mixer.limits[ch].max_frequency*1.01f, "frequency %.1f exceeds configured limit %.1f on channel %d; use mixer_ch_set_limit to change the limit for this channel", frequency, Mixer.limits[ch].max_frequency, ch);
-	c->step = MIXER_FX64(frequency / (float)Mixer.sample_rate) << (c->flags & CH_FLAGS_BPS_SHIFT);
+	mixer_fx64_t step = MIXER_FX64(frequency / (float)Mixer.sample_rate);
+	if (!(c->flags & CH_FLAGS_VADPCM))
+		step <<= (c->flags & CH_FLAGS_BPS_SHIFT);
+	c->step = step;
 }
 
 void mixer_ch_set_vol(int ch, float lvol, float rvol) {
@@ -513,63 +466,51 @@ static int waveform_wrap_wpos(int wpos, int len, int loop_len) {
 // in the range [0, len].
 static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	waveform_t *wave = sbuf->wave;
+	// Samplebuffer units: PCM samples, or VADPCM frames. Wave metadata is
+	// always in samples; convert bounds when the buffer stores frames.
+	int wave_len = wave->len;
+	int wave_loop = wave->loop_len;
+	if (wave->format == WAVEFORM_FORMAT_VADPCM) {
+		wave_len /= 16;
+		wave_loop /= 16;
+	}
+	int ub = samplebuffer_unit_bytes(sbuf);
 
-	if (!wave->loop_len) {
-		// If we're asked to read past the waveform length (because overread),
-		// call the underlying function only up to the actual length,
-		// and then zero the rest of data.
+	if (!wave_loop) {
 		int len1 = wlen;
-		if (wpos + wlen > wave->len)
-			len1 = MAX(wave->len - wpos, 0);
+		if (wpos + wlen > wave_len)
+			len1 = MAX(wave_len - wpos, 0);
 		int len2 = wlen-len1;
 
 		if (len1 > 0)
 			wave->read(ctx, sbuf, wpos, len1, seeking);
 		if (len2 > 0) {
 			void *dest = samplebuffer_append(sbuf, len2);
-			memset(dest, 0, len2 << SAMPLES_BPS_SHIFT(sbuf));
+			memset(dest, 0, len2 * ub);
 		}
 	} else {
-		// Calculate wrapped position
-		if (wpos >= wave->len)
-			wpos = waveform_wrap_wpos(wpos, wave->len, wave->loop_len);
+		if (wpos >= wave_len)
+			wpos = waveform_wrap_wpos(wpos, wave_len, wave_loop);
 
-		// If we are requesting a read from loop start, we force seeking because it
-		// means that previous read finished just exactly at the loop point.
-		if (wpos == wave->len - wave->loop_len)
+		if (wpos == wave_len - wave_loop)
 			seeking = true;
 
-		// The read might cross the end point of the waveform
-		// and continue at the loop point. We would need to handle
-		// this case by performing two reads with a seek inbetween.
-
-		// Split the length into two segments: before loop and loop.
 		int len1 = wlen;
-		if (wpos + wlen > wave->len)
-			len1 = wave->len - wpos;
+		if (wpos + wlen > wave_len)
+			len1 = wave_len - wpos;
 		int len2 = wlen-len1;
 
-		// Logic check: the second segment (loop) shouldn't be longer
-		// than the loop length plus the loop overread. Otherwise, it means
-		// that we've been requested a single read that spans more than two
-		// full loops, but that's impossible! In fact, a single request must fit
-		// a sample buffer, and if a whole loop fits the sample buffer,
-		// we wouldn't get here: the mixer handles fully-cachable loops
-		// without unrolling them (see mixer_poll).
-		assertf(len2 <= wave->loop_len + (MIXER_LOOP_OVERREAD >> SAMPLES_BPS_SHIFT(sbuf)),
+		int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+		assertf(len2 <= wave_loop + overread,
 			"waveform %s: logic error: double loop in single read\n"
 			"wpos:%x, wlen:%x, len:%x loop_len:%x",
-			wave->name, wpos, wlen, wave->len, wave->loop_len);
+			wave->name, wpos, wlen, wave_len, wave_loop);
 
-		// Perform the first read
 		wave->read(ctx, sbuf, wpos, len1, seeking);
 
-		// See if we need to perform a second read for the loop. Because of
-		// overread, we need to read the loop as many times as necessary
-		// (though technically, once would be sufficient without overread).
 		while (len2 > 0) {
-			int loop_start = wave->len - wave->loop_len;
-			int ns = MIN(len2, wave->loop_len);
+			int loop_start = wave_len - wave_loop;
+			int ns = MIN(len2, wave_loop);
 			wave->read(ctx, sbuf, loop_start, ns, true);
 			len2 -= ns;
 		}
@@ -603,7 +544,7 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		// If we have not yet allocated the memory for the sample buffers,
 		// this is a good moment to do so, as we might need the configure
 		// the samplebuffer in a moment.
-		int size = ROUND_UP(mixer_calc_buffer_size(ch, wave->channels), 16);
+		int size = ROUND_UP(mixer_calc_buffer_size(ch, wave), 16);
 		int state_size = ROUND_UP(wave->state_size, 16);
 		void *ptr = malloc_uncached(size + state_size);
 		assertf(ptr, "Out of memory");
@@ -633,17 +574,37 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		// Configure the sample buffer for this waveform
 		assert(wave->channels == 1 || wave->channels == 2);
 		assert(wave->bits == 8 || wave->bits == 16);
-		samplebuffer_set_bps(sbuf, wave->bits*wave->channels);
+		assertf(wave->format != WAVEFORM_FORMAT_VADPCM || wave->channels == 1,
+			"waveform %s: in-mixer VADPCM requires mono", wave->name);
+		if (wave->format == WAVEFORM_FORMAT_VADPCM) {
+			samplebuffer_set_unit_bytes(sbuf, 9);
+		} else {
+			samplebuffer_set_bps(sbuf, wave->bits*wave->channels);
+		}
 		samplebuffer_set_waveform(sbuf, wave, wave->read ? waveform_read : NULL);
 
 		// Configure the mixer channel structured used by the RSP ucode
 		assertf(wave->len >= 0 && wave->len <= WAVEFORM_MAX_LEN, "waveform %s: invalid length %x", wave->name, wave->len);
 		assertf(wave->len != WAVEFORM_UNKNOWN_LEN || wave->loop_len == 0, "waveform %s with unknown length cannot loop", wave->name);
-		int bps = SAMPLES_BPS_SHIFT(sbuf);
-		c->flags &= ~(CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO);
-		c->flags |= bps | (wave->channels == 2 ? CH_FLAGS_STEREO : 0) | (wave->bits == 16 ? CH_FLAGS_16BIT : 0);
-		c->len = MIXER_FX64((int64_t)wave->len) << bps;
-		c->loop_len = MIXER_FX64((int64_t)wave->loop_len) << bps;
+		c->flags &= ~(CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO | CH_FLAGS_VADPCM);
+		c->codebook = NULL;
+		c->loop_state = NULL;
+		c->codec_state = sbuf->state;
+		if (wave->format == WAVEFORM_FORMAT_VADPCM) {
+			waveform_vadpcm_t *vc = wave->codec;
+			assertf(vc && vc->codebook, "waveform %s: VADPCM missing codec/codebook", wave->name);
+			c->flags |= CH_FLAGS_VADPCM | CH_FLAGS_16BIT;
+			c->codebook = vc->codebook;
+			c->loop_state = vc->loop_state;
+			// Positions are in samples (no bps shift).
+			c->len = MIXER_FX64((int64_t)wave->len);
+			c->loop_len = MIXER_FX64((int64_t)wave->loop_len);
+		} else {
+			int bps = SAMPLES_BPS_SHIFT(sbuf);
+			c->flags |= bps | (wave->channels == 2 ? CH_FLAGS_STEREO : 0) | (wave->bits == 16 ? CH_FLAGS_16BIT : 0);
+			c->len = MIXER_FX64((int64_t)wave->len) << bps;
+			c->loop_len = MIXER_FX64((int64_t)wave->loop_len) << bps;
+		}
 		mixer_ch_set_freq(ch, wave->frequency);
 
 		// Invoke start callback if specified. This is only done when the
@@ -679,14 +640,19 @@ void mixer_ch_play(int ch, waveform_t *wave)
 void mixer_ch_set_pos(int ch, double pos) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	assertf(!(c->flags & CH_FLAGS_STEREO_SUB), "mixer_ch_set_pos: cannot call on secondary stereo channel %d", ch);
-	c->pos = MIXER_FX64(pos) << (c->flags & CH_FLAGS_BPS_SHIFT);
+	mixer_fx64_t p = MIXER_FX64(pos);
+	if (!(c->flags & CH_FLAGS_VADPCM))
+		p <<= (c->flags & CH_FLAGS_BPS_SHIFT);
+	c->pos = p;
 	tracef("mixer_ch_set_pos: ch=%d pos=%.32g(%llx)\n", ch, pos, c->pos);
 }
 
 double mixer_ch_get_pos(int ch) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	assertf(!(c->flags & CH_FLAGS_STEREO_SUB), "mixer_ch_get_pos: cannot call on secondary stereo channel %d", ch);
-	uint64_t pos = c->pos >> (c->flags & CH_FLAGS_BPS_SHIFT);
+	uint64_t pos = c->pos;
+	if (!(c->flags & CH_FLAGS_VADPCM))
+		pos >>= (c->flags & CH_FLAGS_BPS_SHIFT);
 	return (double)pos / (double)(1<<MIXER_FX64_FRAC);
 }
 
@@ -757,32 +723,62 @@ void mixer_ch_set_limits(int ch, int max_bits, float max_frequency, int max_buf_
 	}
 }
 
+/** @brief Apply global volume (FX16) to a channel volume (FX15). */
+static inline mixer_fx15_t mixer_apply_gvol(mixer_fx15_t vol, mixer_fx16_t gvol_fx16) {
+	int32_t v = (int32_t)(((int64_t)vol * gvol_fx16) >> 16);
+	if (v > 0x7FFF) v = 0x7FFF;
+	if (v < -0x8000) v = -0x8000;
+	return (mixer_fx15_t)v;
+}
+
+/** @brief Emit a MIX_CHANNEL rspq command for one channel. */
+static void mixer_emit_channel(int ch, uint32_t flags, mixer_fx15_t lvol, mixer_fx15_t rvol,
+	uint32_t pos, uint32_t step, uint32_t len, uint32_t loop_len, void *ptr,
+	int nsamples, int acc_offset, void *codebook, void *state, void *loop_state)
+{
+	rspq_write_t w = rspq_write_begin(__mixer_overlay_id, MIXER_CMD_CHANNEL, 12);
+	// a0 payload (24 bits): ch_idx<<16 | flags<<8
+	rspq_write_arg(&w, ((uint32_t)ch << 16) | ((flags & 0xFF) << 8));
+	rspq_write_arg(&w, ((uint32_t)(uint16_t)lvol << 16) | (uint16_t)rvol);
+	rspq_write_arg(&w, pos);
+	rspq_write_arg(&w, step);
+	rspq_write_arg(&w, len);
+	rspq_write_arg(&w, loop_len);
+	rspq_write_arg(&w, ptr ? PhysicalAddr(ptr) : 0);
+	rspq_write_arg(&w, ((uint32_t)(uint16_t)acc_offset << 16) | (uint16_t)nsamples);
+	rspq_write_arg(&w, codebook ? PhysicalAddr(codebook) : 0);
+	rspq_write_arg(&w, state ? PhysicalAddr(state) : 0);
+	rspq_write_arg(&w, loop_state ? PhysicalAddr(loop_state) : 0);
+	rspq_write_arg(&w, 0);
+	rspq_write_end(&w);
+}
+
+/** @brief Emit VADPCM_SetState (copy src→dst, or clear if src is NULL). */
+static void mixer_emit_setstate(void *dst, void *src)
+{
+	rspq_write(__mixer_overlay_id, MIXER_CMD_SETSTATE,
+		PhysicalAddr(dst), src ? PhysicalAddr(src) : 0);
+}
+
 static void mixer_exec(int32_t *out, int num_samples) {
 	tracef("mixer_exec: 0x%x samples\n", num_samples);
 
-	uint32_t round_id = ++Mixer.round_next;
-	rsp_mixer_settings_t *settings = mixer_settings_acquire(round_id);
-	rsp_mixer_channel_t *rsp_wv = settings->channels;
 	uint32_t fake_loop = 0;
+	uint32_t last_round_id = Mixer.round_next + 1;
 
+	// ---- Phase 1: ensure samplebuffers have data for the full span ----
 	for (int i=0; i<Mixer.num_channels; i++) {
 		samplebuffer_t *sbuf = &Mixer.ch_buf[i];
 		mixer_channel_t *ch = &Mixer.channels[i];
-		int bps = ch->flags & CH_FLAGS_BPS_SHIFT;
+		bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
+		int bps = vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT);
 		int bps_fx64 = bps + MIXER_FX64_FRAC;
+		int ub = samplebuffer_unit_bytes(sbuf);
 
 		if (ch->ptr) {
 			int len = ch->len >> bps_fx64;
 			int loop_len = ch->loop_len >> bps_fx64;
 			int wpos = ch->pos >> bps_fx64;
-			// Calculate how many samples we need to have available for this
-			// frame. We used to only calculate the last sample, but in the unlikely
-			// case the playback rate is much higher than the output rate,
-			// this might cause a seek in the waveform (eg: if we play
-			// one sample every 10, we don't want to cause a seek forward by 9,
-			// between the last sample of this frame and the first sample of
-			// next frame). Seeking creates problem with compressed streams, so
-			// we want to avoid it.
 			int wlast = (ch->pos + ch->step*(num_samples-1)) >> bps_fx64;
 			int wnext = (ch->pos + ch->step*num_samples) >> bps_fx64;
 			int wlen = MAX(wlast-wpos+1, wnext-wpos);
@@ -790,167 +786,82 @@ static void mixer_exec(int32_t *out, int num_samples) {
 			assertf(wlen >= 0, "channel %d: wpos overflow", i);
 			tracef("ch:%d wpos:%x wlen:%x len:%x loop_len:%x sbuf_size:%x\n", i, wpos, wlen, len, loop_len, sbuf->size);
 
+			// VADPCM samplebuffers are addressed in frames.
+			int spos = wpos, slen = len, sloop = loop_len, swlen = wlen;
+			if (vadpcm) {
+				spos = wpos / 16;
+				slen = len / 16;
+				sloop = loop_len / 16;
+				swlen = (wpos + wlen + 15) / 16 - spos;
+			}
+
 			if (!loop_len) {
-				// If we reached the end of the waveform, stop the channel
-				// by NULL-ing the buffer pointer.
 				if (wpos >= len) {
 					mixer_ch_stop(i);
 					continue;
 				}
-				// When there's no loop, do not ask for more samples then
-				// actually present in the waveform.
 				if (wpos+wlen > len)
 					wlen = len-wpos;
-				// FIXME: due to a limit in the RSP ucode, we need to overread
-				// more data, possibly even past the end of the sample
-				wlen += MIXER_LOOP_OVERREAD >> bps;
-				assert(wlen >= 0);
-			} else if (loop_len < sbuf->size) {
-				// If the whole loop fits the sample buffer, we just need to
-				// make sure that it is aligned at the start of the buffer, so
-				// that it can be fully cached.
-				// To do so, we discard everything that comes before the loop 
-				// (once we enter the loop).
-				int loop_pos = len - loop_len;
-				if (sbuf->size < len && wpos >= loop_pos && sbuf->wpos != loop_pos) {
-					tracef("ch:%d discard to align loop wpos:%x loop_pos:%x\n", i, wpos, loop_pos);
-					samplebuffer_discard(sbuf, loop_pos);
+				if (vadpcm) {
+					swlen = (wpos + wlen + 15) / 16 - spos;
+					swlen += (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+				} else {
+					swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
 				}
-
-				// Do not ask more samples than the end of waveform. When we
-				// get there, the loop has been already fully cached. The RSP
-				// will correctly follow the loop.
+				assert(swlen >= 0);
+			} else if ((vadpcm ? sloop : loop_len) < sbuf->size) {
+				int loop_pos = len - loop_len;
+				int sloop_pos = vadpcm ? loop_pos / 16 : loop_pos;
+				if (sbuf->size < (vadpcm ? slen : len) && wpos >= loop_pos && sbuf->wpos != sloop_pos) {
+					tracef("ch:%d discard to align loop wpos:%x loop_pos:%x\n", i, wpos, loop_pos);
+					samplebuffer_discard(sbuf, sloop_pos);
+				}
 				while (wpos >= len)
 					wpos -= loop_len;
 				if (wpos+wlen > len)
 					wlen = len-wpos;
-
-				// FIXME: due to a limit in the RSP ucode, we need to overread
-				// more data past the loop end.
-				wlen += MIXER_LOOP_OVERREAD >> bps;
-				assertf(wlen >= 0, "ch:%d wlen=%x wpos=%x len=%x\n", i, wlen, wpos, len);
+				if (vadpcm) {
+					spos = wpos / 16;
+					swlen = (wpos + wlen + 15) / 16 - spos;
+					swlen += (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+				} else {
+					swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
+				}
+				assertf(swlen >= 0, "ch:%d wlen=%x wpos=%x len=%x\n", i, swlen, wpos, len);
 			} else {
-				// The loop is larger than the sample buffer. We cannot fully
-				// cache it, so we will have to unroll it in the sample buffer.
-				// This happens by default without doing anything: wpos will
-				// increase, and the actual unrolling logic will be performed
-				// by waveform_read() (see above).
-
-				// To avoid having wpos growing indefinitely (and overflowing),
-				// let's force a manual wrapping of the coordinates. Check if
-				// this is a good moment to do it.
-				if (sbuf->wpos > len && wpos > len) {
-					tracef("mixer_poll: wrapping sample buffer loop: sbuf->wpos:%x len:%x\n", sbuf->wpos, len);
-					samplebuffer_discard(sbuf, wpos);
-					sbuf->wpos = waveform_wrap_wpos(sbuf->wpos, len, loop_len);
+				int sbuf_len = vadpcm ? slen : len;
+				int sbuf_loop = vadpcm ? sloop : loop_len;
+				if (sbuf->wpos > sbuf_len && wpos > len) {
+					tracef("mixer_poll: wrapping sample buffer loop: sbuf->wpos:%x len:%x\n", sbuf->wpos, sbuf_len);
+					int wrap_pos = vadpcm ? wpos / 16 : wpos;
+					samplebuffer_discard(sbuf, wrap_pos);
+					sbuf->wpos = waveform_wrap_wpos(sbuf->wpos, sbuf_len, sbuf_loop);
 					if (sbuf->wnext >= 0)
 						sbuf->wnext = sbuf->wpos + sbuf->widx;
 					int wpos2 = waveform_wrap_wpos(wpos, len, loop_len);
 					ch->pos -= (int64_t)(wpos-wpos2) << bps_fx64;
 					wpos = wpos2;
+					if (vadpcm)
+						spos = wpos / 16;
 				}
-
-				// We will also lie to the RSP ucode telling it that there is
-				// no loop in this waveform, since the RSP will always see
-				// the loop unrolled in the buffer, so it doesn't need to
-				// do anything.
 				fake_loop |= 1<<i;
+				if (vadpcm) {
+					spos = wpos / 16;
+					swlen = (wlen + 15) / 16 + (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+				} else {
+					swlen = wlen;
+				}
 			}
 
-			void* ptr = samplebuffer_get(sbuf, wpos, &wlen);
+			void* ptr = samplebuffer_get(sbuf, vadpcm ? spos : wpos, &swlen);
 			assert(ptr);
-			ch->ptr = (uint8_t*)ptr - (wpos<<bps);
-			sbuf->last_round = round_id;
+			if (vadpcm)
+				ch->ptr = (uint8_t*)ptr - spos * 9;
+			else
+				ch->ptr = (uint8_t*)ptr - (wpos<<bps);
 		}
 	}
 
-	for (int ch=0;ch<Mixer.num_channels;ch++) {
-		mixer_channel_t *c = &Mixer.channels[ch];
-
-		// Stereo sub-channel. Will be ignored by RSP but we need to configure
-		// volume correctly. The force-mono flag lives on the OWNER channel
-		// (ch-1), since it's a property of the voice — check there.
-		if (c->flags & CH_FLAGS_STEREO_SUB) {
-			rsp_wv[ch].ptr = 0;
-			if (Mixer.channels[ch-1].flags & CH_FLAGS_FORCE_MONO) {
-				// R sample stream → half-amplitude to both buses.
-				mixer_fx15_t v = Mixer.rvol[ch-1] >> 1;
-				settings->lvol[ch] = v;
-				settings->rvol[ch] = v;
-			} else {
-				settings->lvol[ch] = 0;
-				settings->rvol[ch] = Mixer.rvol[ch-1];
-			}
-			continue;
-		}
-
-		// Check if the channel is stopped
-		if (!c->ptr) {
-			rsp_wv[ch].ptr = 0;
-			// Configure the volume to 0 when the channel is keyed off. This
-			// makes sure that we smooth volume correctly even for waveforms
-			// where the sequencer creates an a attack ramp (which would nullify
-			// the one-tap volume filter if the volume started from max).
-			settings->lvol[ch] = 0;
-			settings->rvol[ch] = 0;
-			continue;
-		}
-
-		// Convert to RSP mixer channel structure truncating 64-bit values to 32-bit.
-		// We don't need full absolute position on the RSP, so 32-bit is more
-		// than enough. In fact, we only expose 31 bits, so that we can use the
-		// 32nd bit later to correctly update the position without overflow bugs.
-		rsp_wv[ch].pos = (uint32_t)c->pos & 0x7FFFFFFF;
-		rsp_wv[ch].step = (uint32_t)c->step & 0x7FFFFFFF;
-		rsp_wv[ch].ptr = c->ptr + ((c->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
-		rsp_wv[ch].flags = c->flags;
-
-		// If the loop is fake (i.e. we are unrolling it), or the current
-		// position has been truncated but it's far from the end of the waveform,
-		// just tell the RSP that there is no loop.
-		if (fake_loop & (1<<ch) || c->pos>>31 != c->len>>31) {
-			rsp_wv[ch].len = 0xFFFFFFFF;
-			rsp_wv[ch].loop_len = 0;
-		} else {
-			rsp_wv[ch].len = (uint32_t)c->len & 0x7FFFFFFF;
-			// We can't represent a very long loop in RSP. But those loops
-			// should be unrolled anyway (and thus be a fake_loop), so we
-			// should not get here.
-			assert(c->loop_len <= 0x7FFFFFFF);
-			rsp_wv[ch].loop_len = (uint32_t)c->loop_len & 0x7FFFFFFF;
-		}
-
-		if (c->flags & CH_FLAGS_STEREO) {
-			if (c->flags & CH_FLAGS_FORCE_MONO) {
-				// L sample stream → half-amplitude to both buses.
-				// Combined with the SUB branch above, this folds a stereo
-				// voice to mono: L_out = R_out = 0.5*(L*lvol + R*rvol).
-				mixer_fx15_t v = Mixer.lvol[ch] >> 1;
-				settings->lvol[ch] = v;
-				settings->rvol[ch] = v;
-			} else {
-				settings->lvol[ch] = Mixer.lvol[ch];
-				settings->rvol[ch] = 0;
-			}
-		} else {
-			if (c->flags & CH_FLAGS_FORCE_MONO) {
-				// Mono source: average the pan and write to both buses.
-				// A hard-panned source loses its panning and -6 dB; a
-				// centered source (lvol==rvol) is unaffected.
-				mixer_fx15_t v = (Mixer.lvol[ch] + Mixer.rvol[ch]) >> 1;
-				settings->lvol[ch] = v;
-				settings->rvol[ch] = v;
-			} else {
-				settings->lvol[ch] = Mixer.lvol[ch];
-				settings->rvol[ch] = Mixer.rvol[ch];
-			}
-		}
-	}
-
-	// Check if we the user pressed RESET. If so, we can apply
-	// a simple global volume ramp to fade out the volume.
-	// This is just a user-level feature. audio.c will truncate
-	// DMA transfers to AI anyway.
 	float gvol = Mixer.vol;
 	uint32_t reset_time = exception_reset_time();
 	if (reset_time) {
@@ -958,23 +869,150 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		float elapsed = (float)reset_time / TICKS_PER_SECOND;
 		gvol *= (FADE_OUT_TIME - MIN(elapsed, FADE_OUT_TIME)) / FADE_OUT_TIME;
 	}
+	mixer_fx16_t gvol_fx16 = MIXER_FX16(gvol);
 
-	rspq_highpri_begin();
-	rspq_write(__mixer_overlay_id, 0,
-		(((uint32_t)MIXER_FX16(gvol)) & 0xFFFF),
-		(num_samples << 16) | Mixer.num_channels,
-		PhysicalAddr(out),
-		PhysicalAddr(settings),
-		round_id);
-	rspq_highpri_end();
-	Mixer.round_enqueued = round_id;
+	// ---- Phase 2: emit per-channel mix rounds of <= MAX_SAMPLES_PER_ROUND ----
+	for (int offset = 0; offset < num_samples; offset += MIXER_MAX_SAMPLES_PER_ROUND) {
+		int ns = MIN(num_samples - offset, MIXER_MAX_SAMPLES_PER_ROUND);
+		uint32_t round_id = ++Mixer.round_next;
+		last_round_id = round_id;
+		bool clear_accum = true;
 
-	// CPU-authoritative position update. The RSP advances pos by step per
-	// output sample and wraps by loop_len when past len; we compute the same
-	// value in 64-bit fixed point. For RSP-visible loops, both sides are
-	// congruent mod loop_len (the exact wrap count may differ depending on
-	// fetch boundaries); the next round's wpos normalization handles that.
-	// Fake/unrolled loops keep growing pos; existing wrap logic above rebases.
+		rspq_highpri_begin();
+
+		for (int ch = 0; ch < Mixer.num_channels; ch++) {
+			mixer_channel_t *c = &Mixer.channels[ch];
+			mixer_fx15_t lvol, rvol;
+			uint32_t flags = c->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT |
+				CH_FLAGS_STEREO | CH_FLAGS_STEREO_SUB | CH_FLAGS_VADPCM);
+			void *ptr = NULL;
+			void *codebook = NULL, *state = NULL, *loop_state = NULL;
+			uint32_t pos = 0, step = 0, len = 0xFFFFFFFF, loop_len = 0;
+			int ns0 = ns, ns1 = 0;
+			uint32_t pos1 = 0;
+
+			if (c->flags & CH_FLAGS_STEREO_SUB) {
+				mixer_channel_t *owner = &Mixer.channels[ch-1];
+				if (!owner->ptr)
+					continue;
+				if (owner->flags & CH_FLAGS_FORCE_MONO) {
+					mixer_fx15_t v = mixer_apply_gvol(Mixer.rvol[ch-1] >> 1, gvol_fx16);
+					lvol = rvol = v;
+				} else {
+					lvol = 0;
+					rvol = mixer_apply_gvol(Mixer.rvol[ch-1], gvol_fx16);
+				}
+				mixer_fx64_t abs_pos = owner->pos + owner->step * (uint64_t)offset;
+				pos = (uint32_t)abs_pos & 0x7FFFFFFF;
+				step = (uint32_t)owner->step & 0x7FFFFFFF;
+				ptr = (uint8_t*)owner->ptr + ((abs_pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
+				flags = (owner->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO)) | CH_FLAGS_STEREO_SUB;
+				if ((fake_loop & (1<<(ch-1))) || owner->pos>>31 != owner->len>>31) {
+					len = 0xFFFFFFFF;
+					loop_len = 0;
+				} else {
+					len = (uint32_t)owner->len & 0x7FFFFFFF;
+					loop_len = (uint32_t)owner->loop_len & 0x7FFFFFFF;
+				}
+			} else if (!c->ptr) {
+				lvol = rvol = 0;
+				ptr = NULL;
+			} else {
+				mixer_fx64_t abs_pos = c->pos + c->step * (uint64_t)offset;
+				pos = (uint32_t)abs_pos & 0x7FFFFFFF;
+				step = (uint32_t)c->step & 0x7FFFFFFF;
+				if (c->flags & CH_FLAGS_VADPCM) {
+					// ptr is the frame base; high bits of pos are sample index bits
+					// above 31 — not used for byte offset (samples, not bytes).
+					ptr = c->ptr;
+					codebook = c->codebook;
+					state = c->codec_state;
+					loop_state = c->loop_state;
+				} else {
+					ptr = (uint8_t*)c->ptr + ((abs_pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
+				}
+				if ((fake_loop & (1<<ch)) || c->pos>>31 != c->len>>31) {
+					len = 0xFFFFFFFF;
+					loop_len = 0;
+				} else {
+					len = (uint32_t)c->len & 0x7FFFFFFF;
+					assert(c->loop_len <= 0x7FFFFFFF);
+					loop_len = (uint32_t)c->loop_len & 0x7FFFFFFF;
+				}
+
+				// Unrolled VADPCM loop: split this channel at the wrap tick and
+				// insert SetState(loop_state) so the second half continues with
+				// the correct predictor state.
+				if ((c->flags & CH_FLAGS_VADPCM) && (fake_loop & (1<<ch)) &&
+					c->loop_state && c->step)
+				{
+					mixer_fx64_t wlen = c->len;
+					mixer_fx64_t wpos = abs_pos;
+					mixer_fx64_t end = wpos + c->step * (uint64_t)ns;
+					if (wpos < wlen && end >= wlen) {
+						int64_t dist = (int64_t)(wlen - wpos);
+						ns0 = (int)((dist + (int64_t)c->step - 1) / (int64_t)c->step);
+						if (ns0 < 1) ns0 = 1;
+						if (ns0 > ns) ns0 = ns;
+						ns1 = ns - ns0;
+						if (ns1 > 0) {
+							mixer_fx64_t p1 = wpos + c->step * (uint64_t)ns0;
+							while (p1 >= c->len)
+								p1 -= c->loop_len;
+							pos1 = (uint32_t)p1 & 0x7FFFFFFF;
+						}
+					}
+				}
+
+				if (c->flags & CH_FLAGS_STEREO) {
+					if (c->flags & CH_FLAGS_FORCE_MONO) {
+						mixer_fx15_t v = mixer_apply_gvol(Mixer.lvol[ch] >> 1, gvol_fx16);
+						lvol = rvol = v;
+					} else {
+						lvol = mixer_apply_gvol(Mixer.lvol[ch], gvol_fx16);
+						rvol = 0;
+					}
+				} else if (c->flags & CH_FLAGS_FORCE_MONO) {
+					mixer_fx15_t v = mixer_apply_gvol(
+						(Mixer.lvol[ch] + Mixer.rvol[ch]) >> 1, gvol_fx16);
+					lvol = rvol = v;
+				} else {
+					lvol = mixer_apply_gvol(Mixer.lvol[ch], gvol_fx16);
+					rvol = mixer_apply_gvol(Mixer.rvol[ch], gvol_fx16);
+				}
+			}
+
+			if (clear_accum) {
+				flags |= CH_FLAGS_CLEAR_ACCUM;
+				clear_accum = false;
+			}
+
+			mixer_emit_channel(ch, flags, lvol, rvol, pos, step, len, loop_len, ptr,
+				ns0, 0, codebook, state, loop_state);
+			if (ns1 > 0) {
+				mixer_emit_setstate(state, loop_state);
+				mixer_emit_channel(ch, flags & ~CH_FLAGS_CLEAR_ACCUM, lvol, rvol,
+					pos1, step, len, loop_len, ptr,
+					ns1, ns0, codebook, state, loop_state);
+			}
+		}
+
+		if (clear_accum) {
+			mixer_emit_channel(0, CH_FLAGS_CLEAR_ACCUM, 0, 0, 0, 0, 0, 0, NULL,
+				ns, 0, NULL, NULL, NULL);
+		}
+
+		rspq_write(__mixer_overlay_id, MIXER_CMD_FLUSH,
+			(uint32_t)ns, PhysicalAddr(out + offset), round_id);
+		rspq_highpri_end();
+		Mixer.round_enqueued = round_id;
+	}
+
+	for (int i = 0; i < Mixer.num_channels; i++) {
+		if (Mixer.channels[i].ptr)
+			Mixer.ch_buf[i].last_round = last_round_id;
+	}
+
 	for (int i=0;i<Mixer.num_channels;i++) {
 		mixer_channel_t *ch = &Mixer.channels[i];
 		if (!ch->ptr || (ch->flags & CH_FLAGS_STEREO_SUB))

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -547,16 +547,30 @@ void mixer_ch_play(int ch, waveform_t *wave)
 	bool stereo_vadpcm = vadpcm && wave->channels == 2;
 
 	// Stereo VADPCM uses two mono rings (ch and ch+1). PCM stereo uses one
-	// interleaved buffer on the owner (STEREO_ALLOC).
+	// interleaved buffer on the owner (STEREO_ALLOC). The ring on ch+1 belongs
+	// to this channel for as long as it keeps playing stereo VADPCM: ch+1
+	// cannot be played on its own while STEREO_SUB is set.
+	bool was_stereo_vadpcm = !(c->flags & CH_FLAGS_RESIDENT) &&
+		(c->flags & (CH_FLAGS_VADPCM|CH_FLAGS_STEREO)) == (CH_FLAGS_VADPCM|CH_FLAGS_STEREO);
 	if (!resident && stereo_vadpcm) {
-		if (!samplebuffer_is_inited(sbuf) || !samplebuffer_is_inited(&Mixer.ch_buf[ch+1])) {
+		// Only reuse the pair if it was allocated as a pair and is still intact
+		// (mixer_ch_set_limits frees just the primary ring).
+		if (!was_stereo_vadpcm || !samplebuffer_is_inited(sbuf)) {
 			rspq_highpri_sync();
 			samplebuffer_close(sbuf);
 			samplebuffer_close(&Mixer.ch_buf[ch+1]);
 		}
-	} else if (!resident && wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC)) {
-		rspq_highpri_sync();
-		samplebuffer_close(sbuf);
+	} else if (!resident) {
+		// Leaving stereo VADPCM: release the secondary ring, or the next stereo
+		// VADPCM would find it allocated but still holding the previous stream.
+		if (was_stereo_vadpcm) {
+			rspq_highpri_sync();
+			samplebuffer_close(&Mixer.ch_buf[ch+1]);
+		}
+		if (wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC)) {
+			rspq_highpri_sync();
+			samplebuffer_close(sbuf);
+		}
 	}
 	// Check if the state buffer is big enough, otherwise we need to reallocate
 	if (!resident && sbuf->state_size < wave->state_size) {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -53,11 +53,11 @@ DEFINE_RSP_UCODE(rsp_mixer);
 
 /** @brief Size of the ucode state that is automatically persisted by rspq.
  * Layout must match RSPQ_BeginSavedState in rsp_mixer.S:
- *   XVOL_L[32] + XVOL_R[32] (128 bytes) + COUNTER_RDRAM + pad (16 bytes) +
+ *   XVOL_L[32] + XVOL_R[32] (128 bytes) +
  *   the per-channel VADPCM pointer table (384 bytes).
  * ACCUM lives in .bss (not saved state) so the VADPCM bssovl1 bank still fits.
  */
-#define MIXER_STATE_SIZE 528
+#define MIXER_STATE_SIZE 512
 
 /** @brief Max output samples per mix round (must match rsp_mixer.S). */
 #define MIXER_MAX_SAMPLES_PER_ROUND  512
@@ -132,21 +132,13 @@ typedef struct mixer_channel_s {
 	uint32_t wave_uuid;    ///< UUID of last configured waveform (survives stop)
 	int silence_ns;        ///< Samples still to be emitted while silent (volume ramp)
 	int vframe;            ///< VADPCM frame the decoder state in RDRAM refers to
-	int max_round_ns;      ///< Max round length from step + ring margin (streamed)
+	int max_round_ns;      ///< Max round length from step + samplebuffer margin (streamed)
 } mixer_channel_t;
-
-/** @brief RDRAM completion counter published by the mixer ucode */
-typedef struct {
-	uint32_t rounds_done;
-	uint32_t pad[3];
-} mixer_rdram_state_t;
 
 /** @brief Overlay saved-state layout (must match rsp_mixer.S) */
 typedef struct {
 	uint16_t xvol_l[MIXER_MAX_CHANNELS];
 	uint16_t xvol_r[MIXER_MAX_CHANNELS];
-	uint32_t counter_rdram;
-	uint32_t pad[3];
 	uint32_t codebook[MIXER_MAX_CHANNELS];
 	uint32_t state[MIXER_MAX_CHANNELS];
 	uint32_t loop_state[MIXER_MAX_CHANNELS];
@@ -199,10 +191,6 @@ static struct {
 	mixer_fx15_t lvol[MIXER_MAX_CHANNELS];
 	mixer_fx15_t rvol[MIXER_MAX_CHANNELS];
 
-	volatile mixer_rdram_state_t *rstate;
-	uint32_t round_next;
-	uint32_t round_enqueued;
-
 	uint32_t chtbl_dirty;   ///< VADPCM channels whose SETCHANNEL is out of date
 	int hi_ch;              ///< Exclusive upper bound of channels to scan
 
@@ -235,42 +223,10 @@ static inline void mixer_touch_ch(int ch) {
 		Mixer.hi_ch = ch + 1;
 }
 
-/** Recompute #mixer_channel_t.max_round_ns from step and ring margin. */
+/** Recompute #mixer_channel_t.max_round_ns from step and samplebuffer margin. */
 static void mixer_refresh_max_ns(int ch);
 
 static inline int mixer_initialized(void) { return Mixer.num_channels != 0; }
-
-bool __mixer_round_done(uint32_t round_id) {
-	// Before mixer_init (e.g. wav64 preload), nothing is in flight.
-	if (!Mixer.rstate)
-		return true;
-	return (int32_t)(Mixer.rstate->rounds_done - round_id) >= 0;
-}
-
-void __mixer_round_wait(uint32_t round_id) {
-	if (__mixer_round_done(round_id))
-		return;
-	// Waiting on a round whose mix command is not in the queue yet would
-	// deadlock: the counter is published by the mix command itself.
-	assertf((int32_t)(round_id - Mixer.round_enqueued) <= 0,
-		"mixer: wait on round %lx not yet enqueued (last enqueued: %lx)",
-		round_id, Mixer.round_enqueued);
-	rspq_flush();
-	ACCT_SCOPE(ACCT_CAT_RSP) RSP_WAIT_LOOP(500) {
-		if (__mixer_round_done(round_id))
-			break;
-	}
-}
-
-void __mixer_wait_idle(void) {
-	if (!mixer_initialized())
-		return;
-	if (Mixer.round_enqueued)
-		__mixer_round_wait(Mixer.round_enqueued);
-	// The round counter only covers commands up to the last mix round, so
-	// drain the queue before the caller frees or reuses memory.
-	rspq_highpri_sync();
-}
 
 void mixer_init(int num_channels) {
 	memset(&Mixer, 0, sizeof(Mixer));
@@ -285,16 +241,11 @@ void mixer_init(int num_channels) {
 		mixer_ch_set_limits(ch, 16, Mixer.sample_rate, 0);
 	}
 
-	Mixer.rstate = malloc_uncached(sizeof(*Mixer.rstate));
-	assertf(Mixer.rstate, "Out of memory");
-	memset((void*)Mixer.rstate, 0, sizeof(*Mixer.rstate));
-
 	rspq_init();
 	__mixer_overlay_id = rspq_overlay_register(&rsp_mixer);
 
 	mixer_overlay_state_t *mixer_state = rspq_overlay_get_state(&rsp_mixer);
 	memset(mixer_state, 0, sizeof(*mixer_state));
-	mixer_state->counter_rdram = PhysicalAddr((void*)Mixer.rstate);
 	data_cache_hit_writeback(mixer_state, sizeof(*mixer_state));
 }
 
@@ -323,7 +274,7 @@ static int mixer_calc_buffer_size(int ch, waveform_t *wave)
 	if (Mixer.limits[ch].max_buf_sz && size > Mixer.limits[ch].max_buf_sz)
 		size = Mixer.limits[ch].max_buf_sz;
 
-	// Ring needs ≥MARGIN units of usable space plus the mirrored tail.
+	// samplebuffer needs ≥MARGIN units of usable space plus the mirrored tail.
 	int ub = (wave && wave->format == WAVEFORM_FORMAT_VADPCM) ? 9
 		: (Mixer.limits[ch].max_bits / 8) * (wave ? wave->channels : 1);
 	int min_bytes = SAMPLEBUFFER_MARGIN_UNITS * 2 * ub;
@@ -343,7 +294,7 @@ void mixer_set_vol(float vol) {
 void mixer_close(void) {
 	assert(mixer_initialized());
 
-	__mixer_wait_idle();
+	rspq_highpri_sync();
 
 	rspq_overlay_unregister(__mixer_overlay_id);
 	__mixer_overlay_id = 0;
@@ -357,11 +308,6 @@ void mixer_close(void) {
 		}
 		if (samplebuffer_is_inited(&Mixer.ch_buf[i]))
 			samplebuffer_close(&Mixer.ch_buf[i]);
-	}
-
-	if (Mixer.rstate) {
-		free_uncached((void*)Mixer.rstate);
-		Mixer.rstate = NULL;
 	}
 
 	Mixer.num_channels = 0;
@@ -450,15 +396,15 @@ static int waveform_wrap_wpos(int wpos, int len, int loop_len) {
 	return ((wpos - len) % loop_len) + (len - loop_len);
 }
 
-// A wrapper for a waveform's read function that handles loops.
-// Sample buffers are not aware of loops. The way the mixer handles
-// loops is by unrolling them in the sample buffer: that is, the sample
-// buffer is called with an unlimited growing wpos, and the
-// WaveformRead callback is expected to unroll the loop as wpos
-// grows. To alleviate all waveforms implementations to handle loop
-// unrolling, this simple wrapper performs the wpos wrapping calculations
-// and convert it in a sequence of calls to read callbacks using only positions
-// in the range [0, len].
+// Clamp a WaveformRead so codecs only ever see positions in [0, len).
+//
+// Samplebuffers and codecs are not loop-aware. The mixer stops rounds at
+// loop boundaries (or pins small loops for the RSP to wrap), but a fetch
+// window still includes #MIXER_LOOP_OVERREAD past the last useful sample,
+// and a streamed wpos can sit past len while the samplebuffer keeps a
+// contiguous unrolled view of the stream. This wrapper maps those cases
+// onto reads in [0, len) — silence for one-shots, samples from loop_start
+// for looping waveforms — without forcing a seek on a contiguous wrap.
 static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	waveform_t *wave = sbuf->wave;
 	// Samplebuffer units: PCM samples, or VADPCM frames. Wave metadata is
@@ -469,42 +415,45 @@ static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, b
 		wave_len /= 16;
 		wave_loop /= 16;
 	}
-	int ub = samplebuffer_unit_bytes(sbuf);
+	int ub = sbuf->unit_bytes;
+
+	if (wpos >= wave_len) {
+		if (!wave_loop) {
+			void *dest = samplebuffer_append(sbuf, wlen);
+			memset(dest, 0, wlen * ub);
+			return;
+		}
+		// Keep seeking as-is: a contiguous fetch past len is still sequential
+		// for the codec (it just continues); only force a seek when the
+		// wrapped position lands exactly on the loop point.
+		wpos = waveform_wrap_wpos(wpos, wave_len, wave_loop);
+	}
+	if (wave_loop && wpos == wave_len - wave_loop)
+		seeking = true;
+
+	int len1 = wlen;
+	if (wpos + wlen > wave_len)
+		len1 = wave_len - wpos;
+	int len2 = wlen - len1;
+
+	if (len1 > 0)
+		wave->read(ctx, sbuf, wpos, len1, seeking);
+	if (len2 <= 0)
+		return;
 
 	if (!wave_loop) {
-		int len1 = wlen;
-		if (wpos + wlen > wave_len)
-			len1 = MAX(wave_len - wpos, 0);
-		int len2 = wlen-len1;
+		void *dest = samplebuffer_append(sbuf, len2);
+		memset(dest, 0, len2 * ub);
+		return;
+	}
 
-		if (len1 > 0)
-			wave->read(ctx, sbuf, wpos, len1, seeking);
-		if (len2 > 0) {
-			void *dest = samplebuffer_append(sbuf, len2);
-			memset(dest, 0, len2 * ub);
-		}
-	} else {
-		if (wpos >= wave_len)
-			wpos = waveform_wrap_wpos(wpos, wave_len, wave_loop);
-
-		if (wpos == wave_len - wave_loop)
-			seeking = true;
-
-		int len1 = wlen;
-		if (wpos + wlen > wave_len)
-			len1 = wave_len - wpos;
-		int len2 = wlen-len1;
-
-		wave->read(ctx, sbuf, wpos, len1, seeking);
-
-		// Unroll across as many loop iterations as needed (read-ahead may
-		// ask for more than one loop's worth past the end).
-		while (len2 > 0) {
-			int loop_start = wave_len - wave_loop;
-			int ns = MIN(len2, wave_loop);
-			wave->read(ctx, sbuf, loop_start, ns, true);
-			len2 -= ns;
-		}
+	// Overread past the end: refill from the loop start. A single fragment
+	// covers MIXER_LOOP_OVERREAD; tiny loops may need more than one.
+	int loop_start = wave_len - wave_loop;
+	while (len2 > 0) {
+		int ns = MIN(len2, wave_loop);
+		wave->read(ctx, sbuf, loop_start, ns, true);
+		len2 -= ns;
 	}
 }
 
@@ -531,7 +480,7 @@ static void mixer_vadpcm_seek(mixer_channel_t *c, int sample_pos) {
  *
  * The RSP always resumes a channel from where the CPU says it is, assuming
  * that what it needs is already in place: the samples of that position in the
- * ring, and (for VADPCM) a decoder state in RDRAM saved exactly for the frame
+ * samplebuffer, and (for VADPCM) a decoder state in RDRAM saved exactly for the frame
  * containing it. Both assumptions only hold while playback advances
  * sequentially, so any jump made by the CPU must be fixed up here.
  */
@@ -576,8 +525,8 @@ static void mixer_ch_seek(int ch) {
 		return;
 	}
 
-	// Streamed: flushing the ring forces the next fetch to seek, which is
-	// what re-seeds the decoder state.
+	// Streamed: flushing the samplebuffer forces the next fetch to seek, which
+	// is what re-seeds the decoder state.
 	if (vadpcm && frame != c->vframe)
 		samplebuffer_flush(sbuf);
 }
@@ -601,17 +550,17 @@ void mixer_ch_play(int ch, waveform_t *wave)
 	// interleaved buffer on the owner (STEREO_ALLOC).
 	if (!resident && stereo_vadpcm) {
 		if (!samplebuffer_is_inited(sbuf) || !samplebuffer_is_inited(&Mixer.ch_buf[ch+1])) {
-			__mixer_wait_idle();
+			rspq_highpri_sync();
 			samplebuffer_close(sbuf);
 			samplebuffer_close(&Mixer.ch_buf[ch+1]);
 		}
 	} else if (!resident && wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC)) {
-		__mixer_wait_idle();
+		rspq_highpri_sync();
 		samplebuffer_close(sbuf);
 	}
 	// Check if the state buffer is big enough, otherwise we need to reallocate
 	if (!resident && sbuf->state_size < wave->state_size) {
-		__mixer_wait_idle();
+		rspq_highpri_sync();
 		samplebuffer_close(sbuf);
 		if (stereo_vadpcm) samplebuffer_close(&Mixer.ch_buf[ch+1]);
 	}
@@ -627,7 +576,7 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		samplebuffer_init(sbuf, ptr, size, state_size);
 		if (stereo_vadpcm) {
 			assertf(ch != Mixer.num_channels-1, "cannot play stereo VADPCM on last channel");
-			void *ptr_r = malloc_uncached(size); // R ring: no second state (shared)
+			void *ptr_r = malloc_uncached(size); // R samplebuffer: no second state (shared)
 			assertf(ptr_r, "Out of memory");
 			samplebuffer_init(&Mixer.ch_buf[ch+1], ptr_r, size, 0);
 			c->flags |= CH_FLAGS_STEREO_ALLOC;
@@ -701,9 +650,7 @@ void mixer_ch_play(int ch, waveform_t *wave)
 				r->wave_uuid = wave->__uuid;
 			}
 		} else {
-			int bps = resident
-				? ((wave->bits == 16 ? 1 : 0) + (wave->channels == 2 ? 1 : 0))
-				: SAMPLES_BPS_SHIFT(sbuf);
+			int bps = (wave->bits == 16 ? 1 : 0) + (wave->channels == 2 ? 1 : 0);
 			c->flags |= bps | (wave->channels == 2 ? CH_FLAGS_STEREO : 0) | (wave->bits == 16 ? CH_FLAGS_16BIT : 0);
 			c->len = MIXER_FX64((int64_t)wave->len) << bps;
 			c->loop_len = MIXER_FX64((int64_t)wave->loop_len) << bps;
@@ -746,7 +693,7 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		if (!(c->flags & CH_FLAGS_VADPCM)) {
 			// PCM interleaved: R has no samplebuffer of its own. Replace flags
 			// so a previous mono/VADPCM occupant cannot leave VADPCM set and
-			// make Phase A try to fetch from a null-wave ring.
+			// make Phase A try to fetch from a null-wave samplebuffer.
 			Mixer.channels[ch+1].flags = (Mixer.channels[ch+1].flags & CH_FLAGS_FORCE_MONO) | CH_FLAGS_STEREO_SUB;
 			Mixer.channels[ch+1].ptr = NULL;
 		} else {
@@ -862,7 +809,7 @@ void mixer_ch_set_limits(int ch, int max_bits, float max_frequency, int max_buf_
 	// Free the memory immediately, as it doesn't match the new limits anymore.
 	// We will reallocate it later lazily if needed.
 	if (samplebuffer_is_inited(&Mixer.ch_buf[ch])) {
-		__mixer_wait_idle();
+		rspq_highpri_sync();
 		samplebuffer_close(&Mixer.ch_buf[ch]);
 		Mixer.channels[ch].flags &= ~CH_FLAGS_STEREO_ALLOC;
 	}
@@ -903,8 +850,8 @@ static void mixer_emit_setchannel(int ch, void *codebook, void *state, void *loo
 		loop_state ? PhysicalAddr(loop_state) : 0);
 }
 
-// True if the whole waveform fits in the ring, so that it can be pinned as a
-// unit instead of just its loop region.
+// True if the whole waveform fits in the samplebuffer, so that it can be pinned
+// as a unit instead of just its loop region.
 static bool mixer_wave_fits(int i) {
 	mixer_channel_t *ch = &Mixer.channels[i];
 	samplebuffer_t *sbuf = &Mixer.ch_buf[i];
@@ -927,7 +874,7 @@ static void mixer_fill_loop_cache(int ch) {
 	bool stereo_vadpcm = vadpcm && (c->flags & CH_FLAGS_STEREO);
 	int bps = vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT);
 	int bps_fx64 = bps + MIXER_FX64_FRAC;
-	int ub = samplebuffer_unit_bytes(sbuf);
+	int ub = sbuf->unit_bytes;
 	int len = c->len >> bps_fx64;
 	int loop_len = c->loop_len >> bps_fx64;
 	// A waveform that fits entirely is pinned from its start, so that its
@@ -939,7 +886,7 @@ static void mixer_fill_loop_cache(int ch) {
 	int sloop_len = vadpcm ? (cache_len + 15) / 16 : cache_len;
 	int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
 	int fill = sloop_len + overread;
-	assertf(fill <= sbuf->size, "ch:%d loop cache %x > ring %x", ch, fill, sbuf->size);
+	assertf(fill <= sbuf->size, "ch:%d loop cache %x > samplebuffer %x", ch, fill, sbuf->size);
 	assert(wave && wave->read);
 
 	samplebuffer_flush(sbuf);
@@ -948,7 +895,7 @@ static void mixer_fill_loop_cache(int ch) {
 	sbuf->head = 0;
 	if (stereo_vadpcm) {
 		samplebuffer_t *sbuf_r = &Mixer.ch_buf[ch+1];
-		assertf(fill <= sbuf_r->size, "ch:%d R loop cache %x > ring %x", ch+1, fill, sbuf_r->size);
+		assertf(fill <= sbuf_r->size, "ch:%d R loop cache %x > samplebuffer %x", ch+1, fill, sbuf_r->size);
 		samplebuffer_flush(sbuf_r);
 		sbuf_r->wpos = 0;
 		sbuf_r->wnext = 0;
@@ -978,8 +925,8 @@ static void mixer_fill_loop_cache(int ch) {
 	tracef("ch:%d loop cached at %x len=%x\n", ch, sloop_start, sloop_len);
 }
 
-// True if the channel's loop is small enough to be pinned into the ring, so
-// that the RSP can wrap it by itself. Large loops are handled via wrap=seek.
+// True if the channel's loop is small enough to be pinned into the samplebuffer,
+// so that the RSP can wrap it by itself. Large loops are handled via wrap=seek.
 static bool mixer_loop_fits(int i) {
 	mixer_channel_t *ch = &Mixer.channels[i];
 	samplebuffer_t *sbuf = &Mixer.ch_buf[i];
@@ -1072,7 +1019,16 @@ static mixer_fx16_t mixer_global_volume(void) {
 	return MIXER_FX16(gvol);
 }
 
-/** Cap of output samples a streamed channel can take in one round. */
+/** Cap of output samples a streamed channel can take in one round.
+ *
+ * A streamed channel can only be given one contiguous window of the
+ * samplebuffer, that is #SAMPLEBUFFER_MARGIN_UNITS minus the units the RSP may
+ * overread past its end. Convert that window (16 samples per unit for VADPCM,
+ * one otherwise) into output samples through the resampling step: past this
+ * point the RSP would outrun what the CPU can hand it in a single piece.
+ * Channels reading straight from RDRAM (resident, pinned loop, stereo sub)
+ * have no such limit.
+ */
 static void mixer_refresh_max_ns(int ch) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	if (!c->ptr || !c->step ||
@@ -1082,7 +1038,7 @@ static void mixer_refresh_max_ns(int ch) {
 	}
 	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
 	int bps_fx64 = (vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
-	int ub = samplebuffer_unit_bytes(&Mixer.ch_buf[ch]);
+	int ub = Mixer.ch_buf[ch].unit_bytes;
 	int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
 	int max_wlen = MAX(SAMPLEBUFFER_MARGIN_UNITS - overread, 1);
 	uint64_t units = vadpcm ? (uint64_t)max_wlen * 16 : (uint64_t)max_wlen;
@@ -1158,7 +1114,7 @@ static void mixer_rsp_bounds(mixer_channel_t *c, bool wrap, uint32_t *len, uint3
 	}
 }
 
-// Ring window that @p ns output samples read from a channel, in ring units
+// samplebuffer window that @p ns output samples read from a channel, in units
 // (VADPCM frames or PCM samples), including the overread the RSP does at loops.
 static void mixer_channel_window(int ch, int ns, int *wpos, int *wlen) {
 	mixer_channel_t *c = &Mixer.channels[ch];
@@ -1166,7 +1122,7 @@ static void mixer_channel_window(int ch, int ns, int *wpos, int *wlen) {
 	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
 	int bps = vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT);
 	int bps_fx64 = bps + MIXER_FX64_FRAC;
-	int ub = samplebuffer_unit_bytes(sbuf);
+	int ub = sbuf->unit_bytes;
 
 	int pos = c->pos >> bps_fx64;
 	int last = (c->pos + c->step * (uint64_t)(ns > 0 ? ns-1 : 0)) >> bps_fx64;
@@ -1182,7 +1138,7 @@ static void mixer_channel_window(int ch, int ns, int *wpos, int *wlen) {
 	}
 }
 
-// Fetch from the ring the input window this round is going to read.
+// Fetch from the samplebuffer the input window this round is going to read.
 // Updates c->ptr to the waveform base; the RSP pointer for PCM may need
 // the high-bit pos offset applied by the caller.
 static void mixer_fetch_window(int ch, int ns) {
@@ -1238,12 +1194,11 @@ static void mixer_wait_channel_dma(int ch) {
 }
 
 // Emit one mix round: a MIX_CHANNEL per active channel, plus the flush that
-// writes the accumulator out to @p out. Returns the id of the round.
+// writes the accumulator out to @p out.
 //
 // Phase A kicks all streamed fetches so PI DMAs pipeline across channels;
 // Phase B waits for each channel's DMA only when about to emit its command.
-static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
-	uint32_t round_id = ++Mixer.round_next;
+static void mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 	bool clear_accum = true;
 
 	// Phase A: enqueue all PI DMAs back-to-back.
@@ -1339,9 +1294,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 		mixer_emit_channel(0, CH_FLAGS_CLEAR_ACCUM, 0, 0, 0, 0, 0, 0, NULL, ns, 0);
 
 	rspq_write(__mixer_overlay_id, MIXER_CMD_FLUSH,
-		(uint32_t)ns, PhysicalAddr(out), round_id);
-	Mixer.round_enqueued = round_id;
-	return round_id;
+		(uint32_t)ns, PhysicalAddr(out));
 }
 
 // Advance all channels by the samples just mixed, wrapping the loops that the
@@ -1373,7 +1326,6 @@ static void mixer_exec(int32_t *out, int num_samples) {
 	tracef("mixer_exec: 0x%x samples\n", num_samples);
 
 	mixer_fx16_t gvol = mixer_global_volume();
-	uint32_t last_round_id = Mixer.round_next + 1;
 
 	rspq_highpri_begin();
 	for (int offset = 0; offset < num_samples; ) {
@@ -1384,7 +1336,7 @@ static void mixer_exec(int32_t *out, int num_samples) {
 			ns = mixer_round_length(num_samples - offset);
 		}
 		PROFILE_SCOPE(PS_MIXER_EMIT) {
-			last_round_id = mixer_emit_round(out + offset, ns, gvol);
+			mixer_emit_round(out + offset, ns, gvol);
 		}
 		PROFILE_SCOPE(PS_MIXER_ADVANCE) {
 			mixer_advance(ns);
@@ -1392,15 +1344,6 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		offset += ns;
 	}
 	rspq_highpri_end();
-
-	// Record the last round reading each ring, so that producers know when the
-	// RSP is done with the samples they are about to overwrite.
-	for (int i = 0; i < Mixer.hi_ch; i++) {
-		mixer_channel_t *ch = &Mixer.channels[i];
-		if (!ch->ptr || (ch->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED | CH_FLAGS_STEREO_SUB)))
-			continue;
-		Mixer.ch_buf[i].last_round = last_round_id;
-	}
 
 	mixer_prefetch_next(num_samples);
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -130,6 +130,7 @@ typedef struct mixer_channel_s {
 	waveform_t *wave;      ///< Waveform being played back on this channel
 	uint32_t wave_uuid;    ///< UUID of last configured waveform (survives stop)
 	int silence_ns;        ///< Samples still to be emitted while silent (volume ramp)
+	int vframe;            ///< VADPCM frame the decoder state in RDRAM refers to
 } mixer_channel_t;
 
 /** @brief RDRAM completion counter published by the mixer ucode */
@@ -471,15 +472,77 @@ static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, b
 	}
 }
 
+static bool mixer_wave_fits(int ch);
+
 /** @brief Apply a VADPCM seek to the channel's codec state via WaveformRead. */
 static void mixer_vadpcm_seek(mixer_channel_t *c, int sample_pos) {
 	assert(c->flags & CH_FLAGS_VADPCM);
 	assert(c->wave && c->wave->read && c->codec_state);
-	samplebuffer_t tmp = {0};
-	tmp.wave = c->wave;
-	tmp.state = c->codec_state;
-	tmp.state_size = c->wave->state_size;
-	c->wave->read(c->wave->ctx, &tmp, sample_pos / 16, 0, true);
+	// Two buffers: a stereo read also touches the right-plane one, even when
+	// seeking with no data to fetch.
+	samplebuffer_t tmp[2] = {{0}};
+	tmp[0].wave = c->wave;
+	tmp[0].state = c->codec_state;
+	tmp[0].state_size = c->wave->state_size;
+	c->wave->read(c->wave->ctx, tmp, sample_pos / 16, 0, true);
+	c->vframe = sample_pos / 16;
+	if (c->flags & CH_FLAGS_STEREO)
+		c[1].vframe = c->vframe;
+}
+
+/**
+ * @brief Re-establish the playback state after the CPU moved a position.
+ *
+ * The RSP always resumes a channel from where the CPU says it is, assuming
+ * that what it needs is already in place: the samples of that position in the
+ * ring, and (for VADPCM) a decoder state in RDRAM saved exactly for the frame
+ * containing it. Both assumptions only hold while playback advances
+ * sequentially, so any jump made by the CPU must be fixed up here.
+ */
+static void mixer_ch_seek(int ch) {
+	mixer_channel_t *c = &Mixer.channels[ch];
+	samplebuffer_t *sbuf = &Mixer.ch_buf[ch];
+	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
+	int bps_fx64 = (vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
+	int frame = (int)(c->pos >> (MIXER_FX64_FRAC + 4));
+
+	if (!c->wave)
+		return;
+
+	// Resident waveforms are always fully available: only the decoder state
+	// has to be moved.
+	if (c->flags & CH_FLAGS_RESIDENT) {
+		if (vadpcm && frame != c->vframe)
+			mixer_vadpcm_seek(c, frame * 16);
+		return;
+	}
+
+	if (c->flags & CH_FLAGS_LOOP_CACHED) {
+		int len = c->len >> bps_fx64;
+		int loop_len = c->loop_len >> bps_fx64;
+		int cache_start = mixer_wave_fits(ch) ? 0 : len - loop_len;
+		bool have_samples = (c->pos >> bps_fx64) >= cache_start;
+		if (have_samples) {
+			// The samples are pinned already: just move the decoder.
+			if (vadpcm && frame != c->vframe)
+				mixer_vadpcm_seek(c, frame * 16);
+			return;
+		}
+		// Seeking before the pinned region: go back to streaming, and let the
+		// next round pin the loop again (re-seeding the decoder while at it).
+		c->flags &= ~CH_FLAGS_LOOP_CACHED;
+		if (vadpcm && (c->flags & CH_FLAGS_STEREO)) {
+			Mixer.channels[ch+1].flags &= ~CH_FLAGS_LOOP_CACHED;
+			samplebuffer_flush(&Mixer.ch_buf[ch+1]);
+		}
+		samplebuffer_flush(sbuf);
+		return;
+	}
+
+	// Streamed: flushing the ring forces the next fetch to seek, which is
+	// what re-seeds the decoder state.
+	if (vadpcm && frame != c->vframe)
+		samplebuffer_flush(sbuf);
 }
 
 void mixer_ch_play(int ch, waveform_t *wave)
@@ -634,8 +697,7 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		c->ptr = resident ? (void*)wave->mem : SAMPLES_PTR(sbuf);
 	}
 	c->pos = 0;
-	if (resident && (c->flags & CH_FLAGS_VADPCM))
-		mixer_vadpcm_seek(c, 0);
+	mixer_ch_seek(ch);
 
 	// Mark ch+1 as stereo sub for PCM interleaved or VADPCM dual-mono.
 	if (c->flags & CH_FLAGS_STEREO) {
@@ -655,9 +717,7 @@ void mixer_ch_set_pos(int ch, double pos) {
 	if (!(c->flags & CH_FLAGS_VADPCM))
 		p <<= (c->flags & CH_FLAGS_BPS_SHIFT);
 	c->pos = p;
-	// Resident VADPCM has no samplebuffer seek path: update predictor state now.
-	if ((c->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_VADPCM)) == (CH_FLAGS_RESIDENT | CH_FLAGS_VADPCM))
-		mixer_vadpcm_seek(c, (int)pos);
+	mixer_ch_seek(ch);
 	tracef("mixer_ch_set_pos: ch=%d pos=%.32g(%llx)\n", ch, pos, c->pos);
 }
 
@@ -842,6 +902,10 @@ static void mixer_fill_loop_cache(int ch) {
 	else
 		c->ptr = (uint8_t*)SAMPLES_PTR(sbuf) - (cache_start << bps);
 	c->flags |= CH_FLAGS_LOOP_CACHED;
+	if (vadpcm) {
+		c->vframe = sloop_start;
+		if (stereo_vadpcm) Mixer.channels[ch+1].vframe = sloop_start;
+	}
 	tracef("ch:%d loop cached at %x len=%x\n", ch, sloop_start, sloop_len);
 }
 
@@ -1033,6 +1097,8 @@ static void mixer_fetch_window(int ch, int ns) {
 	if (vadpcm) {
 		int spos = wpos / 16;
 		int swlen = (wpos + wlen + 15) / 16 - spos + (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+		if (sbuf->widx == 0 || spos < sbuf->wpos || spos > sbuf->wpos + sbuf->widx)
+			c->vframe = spos;
 		void *p = samplebuffer_get(sbuf, spos, &swlen);
 		assert(p);
 		c->ptr = (uint8_t*)p - spos * 9;
@@ -1170,14 +1236,18 @@ static void mixer_advance(int ns) {
 		if (!ch->ptr || (ch->flags & CH_FLAGS_STEREO_SUB))
 			continue;
 		ch->pos += ch->step * (uint64_t)ns;
-		if (!ch->loop_len || ch->pos < ch->len)
-			continue;
-		if (ch->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)) {
-			while (ch->pos >= ch->len)
-				ch->pos -= ch->loop_len;
-		} else if (!mixer_loop_fits(i)) {
-			// Large loop crossing len between two rounds of the same call.
-			mixer_large_loop_wrap(i);
+		if (ch->loop_len && ch->pos >= ch->len) {
+			if (ch->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)) {
+				while (ch->pos >= ch->len)
+					ch->pos -= ch->loop_len;
+			} else if (!mixer_loop_fits(i)) {
+				// Large loop crossing len between two rounds of the same call.
+				mixer_large_loop_wrap(i);
+			}
+		}
+		if (ch->flags & CH_FLAGS_VADPCM) {
+			ch->vframe = (int)(ch->pos >> (MIXER_FX64_FRAC+4));
+			if (ch->flags & CH_FLAGS_STEREO) ch[1].vframe = ch->vframe;
 		}
 	}
 }

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -16,6 +16,7 @@
 #include "audio.h"
 #include "n64sys.h"
 #include "interrupt.h"
+#include "profile.h"
 #include "accounting_internal.h"
 #include "../rspq/rspq_internal.h"
 #include <memory.h>
@@ -59,7 +60,7 @@ DEFINE_RSP_UCODE(rsp_mixer);
 #define MIXER_STATE_SIZE 528
 
 /** @brief Max output samples per mix round (must match rsp_mixer.S). */
-#define MIXER_MAX_SAMPLES_PER_ROUND  256
+#define MIXER_MAX_SAMPLES_PER_ROUND  512
 
 /**
  * @brief Samples for which a stopped channel keeps being emitted to the RSP.
@@ -131,6 +132,7 @@ typedef struct mixer_channel_s {
 	uint32_t wave_uuid;    ///< UUID of last configured waveform (survives stop)
 	int silence_ns;        ///< Samples still to be emitted while silent (volume ramp)
 	int vframe;            ///< VADPCM frame the decoder state in RDRAM refers to
+	int max_round_ns;      ///< Max round length from step + ring margin (streamed)
 } mixer_channel_t;
 
 /** @brief RDRAM completion counter published by the mixer ucode */
@@ -201,9 +203,40 @@ static struct {
 	uint32_t round_next;
 	uint32_t round_enqueued;
 
+	uint32_t chtbl_dirty;   ///< VADPCM channels whose SETCHANNEL is out of date
+	int hi_ch;              ///< Exclusive upper bound of channels to scan
+
 } Mixer;
 
 uint32_t __mixer_overlay_id;
+
+void __mixer_profile_init(void) {
+	profile_register(PS_MIXER,        "mixer_try_play", 0);
+	profile_register(PS_XM_TICK,      "xm_tick", 1);
+	profile_register(PS_XM_GETPOS,    "xm_getpos", 2);
+	profile_register(PS_XM_LIBXM,     "xm_libxm", 2);
+	profile_register(PS_XM_SYNC,      "xm_sync", 2);
+	profile_register(PS_MIXER_EXEC,   "mixer_exec", 1);
+	profile_register(PS_MIXER_PREP,   "prep", 2);
+	profile_register(PS_MIXER_EMIT,   "emit", 2);
+	profile_register(PS_SBUF_GET,     "sbuf_get", 3);
+	profile_register(PS_VADPCM_READ,  "vadpcm_read", 4);
+	profile_register(PS_VADPCM_HUFF,  "vadpcm_huff", 5);
+	profile_register(PS_VADPCM_IO,    "vadpcm_io", 5);
+	profile_register(PS_MIXER_ADVANCE,"advance", 2);
+	profile_register(PS_MIXER_SEEK,   "ch_seek", 3);
+}
+
+static inline uint32_t mixer_bit(int ch) { return 1u << ch; }
+
+/** Grow the exclusive scan limit so channel @p ch is included. */
+static inline void mixer_touch_ch(int ch) {
+	if (ch + 1 > Mixer.hi_ch)
+		Mixer.hi_ch = ch + 1;
+}
+
+/** Recompute #mixer_channel_t.max_round_ns from step and ring margin. */
+static void mixer_refresh_max_ns(int ch);
 
 static inline int mixer_initialized(void) { return Mixer.num_channels != 0; }
 
@@ -344,14 +377,21 @@ void mixer_ch_set_freq(int ch, float frequency) {
 	mixer_fx64_t step = MIXER_FX64(frequency / (float)Mixer.sample_rate);
 	if (!(c->flags & CH_FLAGS_VADPCM))
 		step <<= (c->flags & CH_FLAGS_BPS_SHIFT);
+	if (c->step == step)
+		return;
 	c->step = step;
+	mixer_refresh_max_ns(ch);
 }
 
 void mixer_ch_set_vol(int ch, float lvol, float rvol) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	assertf(!(c->flags & CH_FLAGS_STEREO_SUB), "mixer_ch_set_vol: cannot call on secondary stereo channel %d", ch);
-	Mixer.lvol[ch] = MIXER_FX15(lvol);
-	Mixer.rvol[ch] = MIXER_FX15(rvol);
+	mixer_fx15_t l = MIXER_FX15(lvol);
+	mixer_fx15_t r = MIXER_FX15(rvol);
+	if (Mixer.lvol[ch] == l && Mixer.rvol[ch] == r)
+		return;
+	Mixer.lvol[ch] = l;
+	Mixer.rvol[ch] = r;
 }
 
 void mixer_ch_set_vol_pan(int ch, float vol, float pan) {
@@ -455,14 +495,10 @@ static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, b
 			len1 = wave_len - wpos;
 		int len2 = wlen-len1;
 
-		int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
-		assertf(len2 <= wave_loop + overread,
-			"waveform %s: logic error: double loop in single read\n"
-			"wpos:%x, wlen:%x, len:%x loop_len:%x",
-			wave->name, wpos, wlen, wave_len, wave_loop);
-
 		wave->read(ctx, sbuf, wpos, len1, seeking);
 
+		// Unroll across as many loop iterations as needed (read-ahead may
+		// ask for more than one loop's worth past the end).
 		while (len2 > 0) {
 			int loop_start = wave_len - wave_loop;
 			int ns = MIN(len2, wave_loop);
@@ -536,6 +572,7 @@ static void mixer_ch_seek(int ch) {
 			samplebuffer_flush(&Mixer.ch_buf[ch+1]);
 		}
 		samplebuffer_flush(sbuf);
+		mixer_refresh_max_ns(ch);
 		return;
 	}
 
@@ -697,7 +734,9 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		c->ptr = resident ? (void*)wave->mem : SAMPLES_PTR(sbuf);
 	}
 	c->pos = 0;
+	PROFILE_START(PS_MIXER_SEEK);
 	mixer_ch_seek(ch);
+	PROFILE_STOP(PS_MIXER_SEEK);
 
 	// Mark ch+1 as stereo sub for PCM interleaved or VADPCM dual-mono.
 	if (c->flags & CH_FLAGS_STEREO) {
@@ -716,6 +755,16 @@ void mixer_ch_play(int ch, waveform_t *wave)
 	} else if (ch != Mixer.num_channels-1) {
 		Mixer.channels[ch+1].flags &= ~CH_FLAGS_STEREO_SUB;
 	}
+
+	mixer_touch_ch(ch);
+	if (c->flags & CH_FLAGS_VADPCM)
+		Mixer.chtbl_dirty |= mixer_bit(ch);
+	if (c->flags & CH_FLAGS_STEREO) {
+		mixer_touch_ch(ch+1);
+		if (c->flags & CH_FLAGS_VADPCM)
+			Mixer.chtbl_dirty |= mixer_bit(ch+1);
+	}
+	mixer_refresh_max_ns(ch);
 }
 
 void mixer_ch_set_pos(int ch, double pos) {
@@ -725,7 +774,9 @@ void mixer_ch_set_pos(int ch, double pos) {
 	if (!(c->flags & CH_FLAGS_VADPCM))
 		p <<= (c->flags & CH_FLAGS_BPS_SHIFT);
 	c->pos = p;
+	PROFILE_START(PS_MIXER_SEEK);
 	mixer_ch_seek(ch);
+	PROFILE_STOP(PS_MIXER_SEEK);
 	tracef("mixer_ch_set_pos: ch=%d pos=%.32g(%llx)\n", ch, pos, c->pos);
 }
 
@@ -741,16 +792,25 @@ double mixer_ch_get_pos(int ch) {
 void mixer_ch_stop(int ch) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 
+	// Already stopped: do not re-arm the silence ramp. The XM tick calls stop
+	// every tick for idle channels; re-arming would keep emitting silent
+	// MIX_CHANNEL commands forever.
+	if (!c->ptr)
+		return;
+
 	tracef("mixer_ch_stop: ch=%d\n", ch);
 
-	if (c->flags & CH_FLAGS_STEREO) {
+	bool stereo = (c->flags & CH_FLAGS_STEREO) != 0;
+	if (stereo) {
 		c[1].flags &= ~CH_FLAGS_STEREO_SUB;
 		c[1].silence_ns = MIXER_SILENCE_RAMP_SAMPLES;
+		Mixer.chtbl_dirty &= ~mixer_bit(ch+1);
 	}
 
 	c->ptr = 0;
 	c->pos = 0;
 	c->silence_ns = MIXER_SILENCE_RAMP_SAMPLES;
+	Mixer.chtbl_dirty &= ~mixer_bit(ch);
 
 	// Invalidate the wave pointer, as it might become dangling
 	// anyway, as the user can free the waveform memory at any time after stop.
@@ -914,6 +974,7 @@ static void mixer_fill_loop_cache(int ch) {
 		c->vframe = sloop_start;
 		if (stereo_vadpcm) Mixer.channels[ch+1].vframe = sloop_start;
 	}
+	mixer_refresh_max_ns(ch);
 	tracef("ch:%d loop cached at %x len=%x\n", ch, sloop_start, sloop_len);
 }
 
@@ -951,7 +1012,7 @@ static void mixer_large_loop_wrap(int i) {
 // round: a short loop can be reached in the middle of a mixer_exec, and from
 // that point on the RSP must be the one wrapping it.
 static void mixer_update_loops(void) {
-	for (int i=0; i<Mixer.num_channels; i++) {
+	for (int i = 0; i < Mixer.hi_ch; i++) {
 		mixer_channel_t *ch = &Mixer.channels[i];
 		bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
 		int bps_fx64 = (vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
@@ -983,14 +1044,16 @@ static void mixer_update_loops(void) {
 // Refresh the ucode per-channel VADPCM table. The pointers only change when a
 // new waveform starts playing, so in steady state this emits nothing.
 static void mixer_refresh_chtbl(void) {
-	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+	if (!Mixer.chtbl_dirty)
+		return;
+	for (int ch = 0; ch < Mixer.hi_ch; ch++) {
+		if (!(Mixer.chtbl_dirty & mixer_bit(ch)))
+			continue;
 		mixer_channel_t *c = &Mixer.channels[ch];
 		mixer_chtbl_t *sh = &Mixer.chtbl[ch];
 		mixer_channel_t *src = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
+		Mixer.chtbl_dirty &= ~mixer_bit(ch);
 		if (!src->ptr || !(c->flags & CH_FLAGS_VADPCM))
-			continue;
-		if (c->codebook == sh->codebook && c->codec_state == sh->state &&
-			c->loop_state == sh->loop_state)
 			continue;
 		*sh = (mixer_chtbl_t){ c->codebook, c->codec_state, c->loop_state };
 		mixer_emit_setchannel(ch, c->codebook, c->codec_state, c->loop_state);
@@ -1009,30 +1072,39 @@ static mixer_fx16_t mixer_global_volume(void) {
 	return MIXER_FX16(gvol);
 }
 
+/** Cap of output samples a streamed channel can take in one round. */
+static void mixer_refresh_max_ns(int ch) {
+	mixer_channel_t *c = &Mixer.channels[ch];
+	if (!c->ptr || !c->step ||
+		(c->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED | CH_FLAGS_STEREO_SUB))) {
+		c->max_round_ns = MIXER_MAX_SAMPLES_PER_ROUND;
+		return;
+	}
+	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
+	int bps_fx64 = (vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
+	int ub = samplebuffer_unit_bytes(&Mixer.ch_buf[ch]);
+	int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+	int max_wlen = MAX(SAMPLEBUFFER_MARGIN_UNITS - overread, 1);
+	uint64_t units = vadpcm ? (uint64_t)max_wlen * 16 : (uint64_t)max_wlen;
+	int ns = (int)((units << bps_fx64) / c->step);
+	c->max_round_ns = MIN(MAX(ns, 1), MIXER_MAX_SAMPLES_PER_ROUND);
+}
+
 // Number of samples the next round can mix: a full round, unless a streamed
 // channel would outrun what the CPU is able to feed it in one go.
 static int mixer_round_length(int max_ns) {
 	int ns = MIN(max_ns, MIXER_MAX_SAMPLES_PER_ROUND);
 
-	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+	for (int ch = 0; ch < Mixer.hi_ch; ch++) {
 		mixer_channel_t *c = &Mixer.channels[ch];
 		if (!c->ptr || !c->step ||
 			(c->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED | CH_FLAGS_STEREO_SUB)))
 			continue;
-		bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
-		int bps_fx64 = (vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
-
-		// The input window must fit the ring margin, which is the largest
-		// contiguous window the samplebuffer can hand out.
-		int ub = samplebuffer_unit_bytes(&Mixer.ch_buf[ch]);
-		int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
-		int max_wlen = MAX(SAMPLEBUFFER_MARGIN_UNITS - overread, 1);
-		int64_t span = (int64_t)((c->step * (uint64_t)ns) >> bps_fx64) + 1;
-		if (vadpcm) span = (span + 15) / 16;
-		if (span > max_wlen) {
-			uint64_t units = vadpcm ? (uint64_t)max_wlen * 16 : (uint64_t)max_wlen;
-			ns = MIN(ns, MAX((int)((units << bps_fx64) / c->step), 1));
-		}
+		// max_round_ns is 0 until the first set_freq/play refresh; treat as
+		// unlimited so a stale zero cannot collapse the round to empty (which
+		// would spin forever in mixer_exec).
+		if (c->max_round_ns > 0)
+			ns = MIN(ns, c->max_round_ns);
 
 		// Stop where the CPU has to step in: the start of a small loop (pinned
 		// by mixer_update_loops before the next round), or len for a large one
@@ -1046,7 +1118,7 @@ static int mixer_round_length(int max_ns) {
 			}
 		}
 	}
-	return ns;
+	return MAX(ns, 1);
 }
 
 // Volumes to send for a channel: a stereo owner only carries the L plane and
@@ -1086,10 +1158,9 @@ static void mixer_rsp_bounds(mixer_channel_t *c, bool wrap, uint32_t *len, uint3
 	}
 }
 
-// Fetch from the ring the input window this round is going to read.
-// Updates c->ptr to the waveform base; the RSP pointer for PCM may need
-// the high-bit pos offset applied by the caller.
-static void mixer_fetch_window(int ch, int ns) {
+// Ring window that @p ns output samples read from a channel, in ring units
+// (VADPCM frames or PCM samples), including the overread the RSP does at loops.
+static void mixer_channel_window(int ch, int ns, int *wpos, int *wlen) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	samplebuffer_t *sbuf = &Mixer.ch_buf[ch];
 	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
@@ -1097,24 +1168,61 @@ static void mixer_fetch_window(int ch, int ns) {
 	int bps_fx64 = bps + MIXER_FX64_FRAC;
 	int ub = samplebuffer_unit_bytes(sbuf);
 
-	int wpos = c->pos >> bps_fx64;
-	int wlast = (c->pos + c->step * (uint64_t)(ns > 0 ? ns-1 : 0)) >> bps_fx64;
-	int wnext = (c->pos + c->step * (uint64_t)ns) >> bps_fx64;
-	int wlen = MAX(wlast - wpos + 1, wnext - wpos);
+	int pos = c->pos >> bps_fx64;
+	int last = (c->pos + c->step * (uint64_t)(ns > 0 ? ns-1 : 0)) >> bps_fx64;
+	int next = (c->pos + c->step * (uint64_t)ns) >> bps_fx64;
+	int len = MAX(last - pos + 1, next - pos);
 
 	if (vadpcm) {
-		int spos = wpos / 16;
-		int swlen = (wpos + wlen + 15) / 16 - spos + (MIXER_LOOP_OVERREAD + ub - 1) / ub;
-		if (sbuf->widx == 0 || spos < sbuf->wpos || spos > sbuf->wpos + sbuf->widx)
-			c->vframe = spos;
-		void *p = samplebuffer_get(sbuf, spos, &swlen);
-		assert(p);
-		c->ptr = (uint8_t*)p - spos * 9;
+		*wpos = pos / 16;
+		*wlen = (pos + len + 15) / 16 - *wpos + (MIXER_LOOP_OVERREAD + ub - 1) / ub;
 	} else {
-		int swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
-		void *p = samplebuffer_get(sbuf, wpos, &swlen);
+		*wpos = pos;
+		*wlen = len + (MIXER_LOOP_OVERREAD >> bps);
+	}
+}
+
+// Fetch from the ring the input window this round is going to read.
+// Updates c->ptr to the waveform base; the RSP pointer for PCM may need
+// the high-bit pos offset applied by the caller.
+static void mixer_fetch_window(int ch, int ns) {
+	mixer_channel_t *c = &Mixer.channels[ch];
+	samplebuffer_t *sbuf = &Mixer.ch_buf[ch];
+	int wpos, wlen;
+	mixer_channel_window(ch, ns, &wpos, &wlen);
+
+	if (c->flags & CH_FLAGS_VADPCM) {
+		if (sbuf->widx == 0 || wpos < sbuf->wpos || wpos > sbuf->wpos + sbuf->widx)
+			c->vframe = wpos;
+		void *p = samplebuffer_get(sbuf, wpos, &wlen);
 		assert(p);
-		c->ptr = (uint8_t*)p - (wpos << bps);
+		c->ptr = (uint8_t*)p - wpos * 9;
+	} else {
+		void *p = samplebuffer_get(sbuf, wpos, &wlen);
+		assert(p);
+		c->ptr = (uint8_t*)p - (wpos << (c->flags & CH_FLAGS_BPS_SHIFT));
+	}
+}
+
+// Kick the fetches the next mixer_exec will need, so their PI DMA flies while
+// the CPU sequences the song and the RSP mixes the rounds just enqueued.
+static void mixer_prefetch_next(int num_samples) {
+	for (int ch = 0; ch < Mixer.hi_ch; ch++) {
+		mixer_channel_t *c = &Mixer.channels[ch];
+		mixer_channel_t *owner = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
+		if (!owner->ptr || !c->step ||
+			(owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)))
+			continue;
+		// A stereo pair streams through the owner's read, which fills both rings.
+		if (c->flags & CH_FLAGS_STEREO_SUB)
+			continue;
+		// Nothing to overlap with if the waveform is produced synchronously.
+		waveform_t *wave = Mixer.ch_buf[ch].wave;
+		if (!wave || !wave->async_read)
+			continue;
+		int wpos, wlen;
+		mixer_channel_window(ch, num_samples, &wpos, &wlen);
+		samplebuffer_prefetch(&Mixer.ch_buf[ch], wpos, wlen);
 	}
 }
 
@@ -1139,7 +1247,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 	bool clear_accum = true;
 
 	// Phase A: enqueue all PI DMAs back-to-back.
-	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+	for (int ch = 0; ch < Mixer.hi_ch; ch++) {
 		mixer_channel_t *c = &Mixer.channels[ch];
 		mixer_channel_t *owner = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
 		if (!owner->ptr || (owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)))
@@ -1156,7 +1264,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 	}
 
 	// Phase B: emit, syncing each channel's DMA at the last moment.
-	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+	for (int ch = 0; ch < Mixer.hi_ch; ch++) {
 		mixer_channel_t *c = &Mixer.channels[ch];
 		mixer_channel_t *owner = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
 		uint32_t flags = c->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT |
@@ -1239,7 +1347,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 // Advance all channels by the samples just mixed, wrapping the loops that the
 // RSP does not wrap by itself.
 static void mixer_advance(int ns) {
-	for (int i=0; i<Mixer.num_channels; i++) {
+	for (int i = 0; i < Mixer.hi_ch; i++) {
 		mixer_channel_t *ch = &Mixer.channels[i];
 		if (!ch->ptr || (ch->flags & CH_FLAGS_STEREO_SUB))
 			continue;
@@ -1261,6 +1369,7 @@ static void mixer_advance(int ns) {
 }
 
 static void mixer_exec(int32_t *out, int num_samples) {
+	PROFILE_SCOPE(PS_MIXER_EXEC) {
 	tracef("mixer_exec: 0x%x samples\n", num_samples);
 
 	mixer_fx16_t gvol = mixer_global_volume();
@@ -1268,24 +1377,35 @@ static void mixer_exec(int32_t *out, int num_samples) {
 
 	rspq_highpri_begin();
 	for (int offset = 0; offset < num_samples; ) {
-		mixer_update_loops();
-		mixer_refresh_chtbl();
-
-		int ns = mixer_round_length(num_samples - offset);
-		last_round_id = mixer_emit_round(out + offset, ns, gvol);
-		mixer_advance(ns);
+		int ns;
+		PROFILE_SCOPE(PS_MIXER_PREP) {
+			mixer_update_loops();
+			mixer_refresh_chtbl();
+			ns = mixer_round_length(num_samples - offset);
+		}
+		PROFILE_SCOPE(PS_MIXER_EMIT) {
+			last_round_id = mixer_emit_round(out + offset, ns, gvol);
+		}
+		PROFILE_SCOPE(PS_MIXER_ADVANCE) {
+			mixer_advance(ns);
+		}
 		offset += ns;
 	}
 	rspq_highpri_end();
 
 	// Record the last round reading each ring, so that producers know when the
 	// RSP is done with the samples they are about to overwrite.
-	for (int i = 0; i < Mixer.num_channels; i++) {
-		if (Mixer.channels[i].ptr && !(Mixer.channels[i].flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)))
-			Mixer.ch_buf[i].last_round = last_round_id;
+	for (int i = 0; i < Mixer.hi_ch; i++) {
+		mixer_channel_t *ch = &Mixer.channels[i];
+		if (!ch->ptr || (ch->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED | CH_FLAGS_STEREO_SUB)))
+			continue;
+		Mixer.ch_buf[i].last_round = last_round_id;
 	}
 
+	mixer_prefetch_next(num_samples);
+
 	Mixer.ticks += num_samples;
+	}
 }
 
 static mixer_event_t* mixer_next_event(void) {
@@ -1375,12 +1495,13 @@ void mixer_poll(int16_t *out16, int num_samples) {
 
 void mixer_try_play(void)
 {
+	PROFILE_SCOPE(PS_MIXER) {
 	// To smooth out the pacing for mixer and wav64 decodes, we fill buffers
 	// to at least audio_get_num_buffers()-1, but fill completely, if there is
 	// only one free one left.
 	int free_buffers = audio_get_num_buffers() - audio_get_queued_buffers();
 	if (free_buffers <= 0)
-		return;
+		goto done;
 
 	int buffers_to_fill = MAX(free_buffers - 1, 1);
 	while (buffers_to_fill-- > 0) {
@@ -1389,4 +1510,6 @@ void mixer_try_play(void)
 		audio_write_end();
 	}
 	rspq_flush();
+done: ;
+	}
 }

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -704,7 +704,15 @@ void mixer_ch_play(int ch, waveform_t *wave)
 		assertf(ch != Mixer.num_channels-1, "cannot configure last channel (%d) as stereo", ch);
 		assertf(!mixer_ch_playing(ch+1) || (Mixer.channels[ch+1].flags & CH_FLAGS_STEREO_SUB),
 			"cannot play stereo waveform on channel %d because channel %d is active", ch, ch+1);
-		Mixer.channels[ch+1].flags |= CH_FLAGS_STEREO_SUB;
+		if (!(c->flags & CH_FLAGS_VADPCM)) {
+			// PCM interleaved: R has no samplebuffer of its own. Replace flags
+			// so a previous mono/VADPCM occupant cannot leave VADPCM set and
+			// make Phase A try to fetch from a null-wave ring.
+			Mixer.channels[ch+1].flags = (Mixer.channels[ch+1].flags & CH_FLAGS_FORCE_MONO) | CH_FLAGS_STEREO_SUB;
+			Mixer.channels[ch+1].ptr = NULL;
+		} else {
+			Mixer.channels[ch+1].flags |= CH_FLAGS_STEREO_SUB;
+		}
 	} else if (ch != Mixer.num_channels-1) {
 		Mixer.channels[ch+1].flags &= ~CH_FLAGS_STEREO_SUB;
 	}
@@ -1137,7 +1145,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 		if (!owner->ptr || (owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)))
 			continue;
 		if (c->flags & CH_FLAGS_STEREO_SUB) {
-			if (!(c->flags & CH_FLAGS_VADPCM))
+			if (!(owner->flags & CH_FLAGS_VADPCM))
 				continue; // PCM R shares the owner's fetch
 			c->pos = owner->pos;
 			c->step = owner->step;
@@ -1167,7 +1175,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 		} else if (c->flags & CH_FLAGS_STEREO_SUB) {
 			mixer_channel_volumes(ch, owner->flags, true, gvol, &lvol, &rvol);
 
-			if (!(c->flags & CH_FLAGS_VADPCM)) {
+			if (!(owner->flags & CH_FLAGS_VADPCM)) {
 				// PCM interleaved: extract R from the owner's sample stream.
 				flags = (owner->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO)) | CH_FLAGS_STEREO_SUB;
 				pos = (uint32_t)owner->pos & 0x7FFFFFFF;

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -1014,9 +1014,10 @@ static void mixer_rsp_bounds(mixer_channel_t *c, bool wrap, uint32_t *len, uint3
 	}
 }
 
-// Fetch from the ring the input window this round is going to read, and return
-// the pointer the RSP must use for the current position.
-static void *mixer_fetch_window(int ch, int ns) {
+// Fetch from the ring the input window this round is going to read.
+// Updates c->ptr to the waveform base; the RSP pointer for PCM may need
+// the high-bit pos offset applied by the caller.
+static void mixer_fetch_window(int ch, int ns) {
 	mixer_channel_t *c = &Mixer.channels[ch];
 	samplebuffer_t *sbuf = &Mixer.ch_buf[ch];
 	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
@@ -1035,22 +1036,52 @@ static void *mixer_fetch_window(int ch, int ns) {
 		void *p = samplebuffer_get(sbuf, spos, &swlen);
 		assert(p);
 		c->ptr = (uint8_t*)p - spos * 9;
-		return c->ptr;
+	} else {
+		int swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
+		void *p = samplebuffer_get(sbuf, wpos, &swlen);
+		assert(p);
+		c->ptr = (uint8_t*)p - (wpos << bps);
 	}
+}
 
-	int swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
-	void *p = samplebuffer_get(sbuf, wpos, &swlen);
-	assert(p);
-	c->ptr = (uint8_t*)p - (wpos << bps);
-	return (uint8_t*)c->ptr + ((c->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
+/** Wait for any in-flight PI DMA into the samplebuffer this channel reads. */
+static void mixer_wait_channel_dma(int ch) {
+	mixer_channel_t *c = &Mixer.channels[ch];
+	if (c->flags & CH_FLAGS_RESIDENT)
+		return;
+	// PCM stereo R shares the owner's interleaved buffer.
+	int bufch = ((c->flags & CH_FLAGS_STEREO_SUB) && !(c->flags & CH_FLAGS_VADPCM)) ? ch - 1 : ch;
+	if (samplebuffer_is_inited(&Mixer.ch_buf[bufch]))
+		samplebuffer_dma_wait(&Mixer.ch_buf[bufch]);
 }
 
 // Emit one mix round: a MIX_CHANNEL per active channel, plus the flush that
 // writes the accumulator out to @p out. Returns the id of the round.
+//
+// Phase A kicks all streamed fetches so PI DMAs pipeline across channels;
+// Phase B waits for each channel's DMA only when about to emit its command.
 static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 	uint32_t round_id = ++Mixer.round_next;
 	bool clear_accum = true;
 
+	// Phase A: enqueue all PI DMAs back-to-back.
+	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+		mixer_channel_t *c = &Mixer.channels[ch];
+		mixer_channel_t *owner = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
+		if (!owner->ptr || (owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)))
+			continue;
+		if (c->flags & CH_FLAGS_STEREO_SUB) {
+			if (!(c->flags & CH_FLAGS_VADPCM))
+				continue; // PCM R shares the owner's fetch
+			c->pos = owner->pos;
+			c->step = owner->step;
+			c->len = owner->len;
+			c->loop_len = owner->loop_len;
+		}
+		mixer_fetch_window(ch, ns);
+	}
+
+	// Phase B: emit, syncing each channel's DMA at the last moment.
 	for (int ch = 0; ch < Mixer.num_channels; ch++) {
 		mixer_channel_t *c = &Mixer.channels[ch];
 		mixer_channel_t *owner = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
@@ -1078,8 +1109,7 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 				ptr = (uint8_t*)owner->ptr + ((owner->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
 				mixer_rsp_bounds(owner, true, &len, &loop_len);
 			} else {
-				// Stereo VADPCM R: a full mono channel on its own plane, but
-				// with the timing of the owner.
+				// Stereo VADPCM R: timing already synced in Phase A when streamed.
 				c->pos = owner->pos;
 				c->step = owner->step;
 				c->len = owner->len;
@@ -1087,12 +1117,9 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 				flags = CH_FLAGS_VADPCM | CH_FLAGS_16BIT;
 				pos = (uint32_t)c->pos & 0x7FFFFFFF;
 				step = (uint32_t)c->step & 0x7FFFFFFF;
-				if (owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)) {
-					ptr = c->ptr;
+				ptr = c->ptr;
+				if (owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED))
 					mixer_rsp_bounds(c, true, &len, &loop_len);
-				} else {
-					ptr = mixer_fetch_window(ch, ns);
-				}
 			}
 		} else {
 			mixer_channel_volumes(ch, c->flags, false, gvol, &lvol, &rvol);
@@ -1103,7 +1130,8 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 				ptr = c->ptr;
 				mixer_rsp_bounds(c, true, &len, &loop_len);
 			} else {
-				ptr = mixer_fetch_window(ch, ns);
+				ptr = (c->flags & CH_FLAGS_VADPCM) ? c->ptr :
+					(void*)((uint8_t*)c->ptr + ((c->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC));
 				// Small loops are pinned by mixer_update_loops, large ones are
 				// wrapped by the CPU between rounds: either way the RSP is
 				// never allowed to wrap a streamed channel.
@@ -1111,6 +1139,9 @@ static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
 					mixer_rsp_bounds(c, false, &len, &loop_len);
 			}
 		}
+
+		if (owner->ptr)
+			mixer_wait_channel_dma(ch);
 
 		if (clear_accum) {
 			flags |= CH_FLAGS_CLEAR_ACCUM;

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -35,16 +35,6 @@
 #define tracef(fmt, ...)  ({ })
 #endif
 
-/**
- * @name AI Status Register Values
- * @{
- */
-/** @brief Bit representing that the AI is busy */
-#define AI_STATUS_BUSY  ( 1 << 30 )
-/** @brief Bit representing that the AI is full */
-#define AI_STATUS_FULL  ( 1 << 31 )
-/** @} */
-
 /** @brief Maximum number of mixer events */
 #define MAX_EVENTS              32
 /** @brief Number of expected #mixer_poll calls per second 
@@ -62,13 +52,24 @@ DEFINE_RSP_UCODE(rsp_mixer);
 
 /** @brief Size of the ucode state that is automatically persisted by rspq.
  * Layout must match RSPQ_BeginSavedState in rsp_mixer.S:
- *   XVOL_L[32] + XVOL_R[32] (128 bytes) + COUNTER_RDRAM + pad (16 bytes).
+ *   XVOL_L[32] + XVOL_R[32] (128 bytes) + COUNTER_RDRAM + pad (16 bytes) +
+ *   the per-channel VADPCM pointer table (384 bytes).
  * ACCUM lives in .bss (not saved state) so the VADPCM bssovl1 bank still fits.
  */
-#define MIXER_STATE_SIZE 144
+#define MIXER_STATE_SIZE 528
 
 /** @brief Max output samples per mix round (must match rsp_mixer.S). */
 #define MIXER_MAX_SAMPLES_PER_ROUND  256
+
+/**
+ * @brief Samples for which a stopped channel keeps being emitted to the RSP.
+ *
+ * A channel with no data only runs the RSP volume ramp (it mixes nothing), so
+ * once the ramp has decayed we stop emitting it altogether. The ramp is a
+ * one-pole filter with coefficient 0.9837^8 per 8 samples, which reaches the
+ * 16-bit noise floor in ~640 samples.
+ */
+#define MIXER_SILENCE_RAMP_SAMPLES   1024
 
 // NOTE: keep these in sync with rsp_mixer.S
 #define CH_FLAGS_BPS_SHIFT  	(3<<0)   ///< BPS shift value
@@ -78,14 +79,14 @@ DEFINE_RSP_UCODE(rsp_mixer);
 #define CH_FLAGS_VADPCM     	(1<<5)   ///< In-mixer VADPCM mono (wire + CPU)
 #define CH_FLAGS_FORCE_MONO  	(1<<6)   ///< Fold this channel's output to both buses (mono downmix). CPU-side only; RSP ucode ignores this bit.
 #define CH_FLAGS_CLEAR_ACCUM 	(1<<7)   ///< Zero ACCUM before mixing (first MIX_CHANNEL of a round)
+#define CH_FLAGS_RESIDENT       (1<<8)   ///< Channel plays from waveform->mem (no samplebuffer)
+#define CH_FLAGS_LOOP_CACHED    (1<<10)  ///< Streamed loop pinned in the samplebuffer; RSP wraps
 #define CH_FLAGS_STEREO_ALLOC	(1<<9)   ///< The channel has a buffer sized for stereo (CPU-side only)
 
 /** @brief rspq command IDs for rsp_mixer.S */
 #define MIXER_CMD_CHANNEL     0x0
-#define MIXER_CMD_VADPCM      0x1
-#define MIXER_CMD_SETSTATE    0x2
-#define MIXER_CMD_MEMMOVE     0x3
-#define MIXER_CMD_FLUSH       0x4
+#define MIXER_CMD_SETCHANNEL  0x1
+#define MIXER_CMD_FLUSH       0x2
 
 /// @brief Fixed point value used in waveform position calculations.
 /// This is a signed 64-bit integer with the fractional part using
@@ -127,6 +128,8 @@ typedef struct mixer_channel_s {
 	void *loop_state;      ///< VADPCM state at loop start (NULL if none)
 	uint32_t flags;        ///< Misc flags (see CH_FLAGS_*)
 	waveform_t *wave;      ///< Waveform being played back on this channel
+	uint32_t wave_uuid;    ///< UUID of last configured waveform (survives stop)
+	int silence_ns;        ///< Samples still to be emitted while silent (volume ramp)
 } mixer_channel_t;
 
 /** @brief RDRAM completion counter published by the mixer ucode */
@@ -141,9 +144,19 @@ typedef struct {
 	uint16_t xvol_r[MIXER_MAX_CHANNELS];
 	uint32_t counter_rdram;
 	uint32_t pad[3];
+	uint32_t codebook[MIXER_MAX_CHANNELS];
+	uint32_t state[MIXER_MAX_CHANNELS];
+	uint32_t loop_state[MIXER_MAX_CHANNELS];
 } mixer_overlay_state_t;
 
 _Static_assert(sizeof(mixer_overlay_state_t) == MIXER_STATE_SIZE, "mixer overlay state size mismatch");
+
+/** @brief Shadow of the VADPCM pointers currently held by the ucode table. */
+typedef struct {
+	void *codebook;
+	void *state;
+	void *loop_state;
+} mixer_chtbl_t;
 
 /** @brief Configured limits of a mixer channel.
  *
@@ -179,6 +192,7 @@ static struct {
 	channel_limit_t limits[MIXER_MAX_CHANNELS];
 
 	mixer_channel_t channels[MIXER_MAX_CHANNELS];
+	mixer_chtbl_t chtbl[MIXER_MAX_CHANNELS];
 	mixer_fx15_t lvol[MIXER_MAX_CHANNELS];
 	mixer_fx15_t rvol[MIXER_MAX_CHANNELS];
 
@@ -187,9 +201,6 @@ static struct {
 	uint32_t round_enqueued;
 
 } Mixer;
-
-/** @brief Count of ticks spent waiting on mixer rounds (rare fallback path). */
-int64_t __mixer_profile_rsp = 0;
 
 uint32_t __mixer_overlay_id;
 
@@ -211,55 +222,9 @@ void __mixer_round_wait(uint32_t round_id) {
 		"mixer: wait on round %lx not yet enqueued (last enqueued: %lx)",
 		round_id, Mixer.round_enqueued);
 	rspq_flush();
-	uint32_t t0 = TICKS_READ();
 	ACCT_SCOPE(ACCT_CAT_RSP) RSP_WAIT_LOOP(500) {
 		if (__mixer_round_done(round_id))
 			break;
-	}
-	__mixer_profile_rsp += TICKS_READ() - t0;
-}
-
-uint32_t __mixer_round_producer(void) {
-	// ID of the mix round that will publish completion of highpri commands
-	// enqueued right now: the round being prepared (if inside mixer_exec),
-	// or the next one that will be issued. Note that the latter may never be
-	// issued: __mixer_dirty_wait handles that case by draining the queue.
-	if ((int32_t)(Mixer.round_next - Mixer.round_enqueued) > 0)
-		return Mixer.round_next;
-	return Mixer.round_next + 1;
-}
-
-bool __mixer_memmove_async(void *dst, void *src, int len) {
-	if (!mixer_initialized())
-		return false;
-	assert(((uint32_t)dst & 7) == 0 && ((uint32_t)src & 7) == 0 && (len & 7) == 0);
-	bool highpri = rspq_in_highpri();
-	if (!highpri) rspq_highpri_begin();
-	rspq_write(__mixer_overlay_id, MIXER_CMD_MEMMOVE,
-		PhysicalAddr(dst), PhysicalAddr(src), len);
-	if (!highpri) rspq_highpri_end();
-	return true;
-}
-
-void __mixer_dirty_wait(uint32_t round_id) {
-	if (__mixer_round_done(round_id))
-		return;
-	if ((int32_t)(round_id - Mixer.round_enqueued) > 0) {
-		// The round that owns the dirty tail is the one currently being
-		// prepared: its mix command (which publishes the counter) is not in
-		// the queue yet, so waiting on the counter would deadlock. The
-		// producer commands (eg: VADPCM decodes) are already enqueued
-		// though, so drain the highpri queue instead. This happens only at
-		// a streamed-loop wrap, when waveform_read chains a second decode
-		// right after the undo, within the same mix round.
-		uint32_t t0 = TICKS_READ();
-		bool highpri = rspq_in_highpri();
-		if (highpri) rspq_highpri_end();
-		rspq_highpri_sync();
-		if (highpri) rspq_highpri_begin();
-		__mixer_profile_rsp += TICKS_READ() - t0;
-	} else {
-		__mixer_round_wait(round_id);
 	}
 }
 
@@ -268,38 +233,9 @@ void __mixer_wait_idle(void) {
 		return;
 	if (Mixer.round_enqueued)
 		__mixer_round_wait(Mixer.round_enqueued);
-	// Compaction memmoves can be enqueued after the last mix round (e.g. by
-	// mixer_reclaim at frame start): the round counter does not cover them,
-	// so drain the highpri queue before the caller frees/reuses memory.
+	// The round counter only covers commands up to the last mix round, so
+	// drain the queue before the caller frees or reuses memory.
 	rspq_highpri_sync();
-}
-
-static void mixer_reclaim(void) {
-	for (int i = 0; i < Mixer.num_channels; i++) {
-		samplebuffer_t *sbuf = &Mixer.ch_buf[i];
-		mixer_channel_t *ch = &Mixer.channels[i];
-		if (!samplebuffer_is_inited(sbuf) || !ch->ptr)
-			continue;
-		// Fully-cachable loop: the loop must stay resident in the buffer
-		// forever (the RSP plays it straight from the cache, and wrapped
-		// positions jump backwards to the loop start). There is nothing to
-		// reclaim: compaction (if any) is handled by the loop-align discard
-		// in mixer_exec, which runs at most once per waveform.
-		int bps_fx64 = (ch->flags & CH_FLAGS_BPS_SHIFT) + MIXER_FX64_FRAC;
-		int loop_len = ch->loop_len >> bps_fx64;
-		// VADPCM samplebuffers are in frames; loop_len above is in samples.
-		if (ch->flags & CH_FLAGS_VADPCM)
-			loop_len /= 16;
-		if (loop_len && loop_len < sbuf->size)
-			continue;
-		if (!__mixer_round_done(sbuf->last_round))
-			continue;
-		if (sbuf->wdirty && __mixer_round_done(sbuf->dirty_round))
-			sbuf->wdirty = 0;
-		// Free consumed samples now so mid-frame appends rarely need to
-		// compact while rounds are still in flight.
-		samplebuffer_discard(sbuf, sbuf->wpos + sbuf->ridx);
-	}
 }
 
 void mixer_init(int num_channels) {
@@ -334,18 +270,31 @@ static int mixer_calc_buffer_size(int ch, waveform_t *wave)
 	int64_t size;
 
 	if (wave->format == WAVEFORM_FORMAT_VADPCM) {
-		// Samplebuffer stores 9-byte frames (16 samples each).
-		int64_t nframes = (int64_t)ceilf((float)nsamples / (float)MIXER_POLL_PER_SECOND);
+		// Live window is SAMPLEBUFFER_MARGIN_UNITS; size for ~1/16 s so
+		// typical streamed loops still fit the loop-cache pin.
+		int64_t nframes = (int64_t)ceilf((float)nsamples / (float)(MIXER_POLL_PER_SECOND * 2));
 		nframes = (nframes + 15) / 16;
+		if (nframes < SAMPLEBUFFER_MARGIN_UNITS * 2)
+			nframes = SAMPLEBUFFER_MARGIN_UNITS * 2;
 		size = ROUND_UP(nframes * 9, 8);
 	} else {
 		nsamples *= Mixer.limits[ch].max_bits / 8;
 		nsamples *= wave->channels;
-		size = ROUND_UP((int64_t)ceilf((float)nsamples / (float)MIXER_POLL_PER_SECOND), 8);
+		int64_t nbytes = (int64_t)ceilf((float)nsamples / (float)(MIXER_POLL_PER_SECOND * 2));
+		int min_bytes = SAMPLEBUFFER_MARGIN_UNITS * 2 * (Mixer.limits[ch].max_bits / 8) * wave->channels;
+		if (nbytes < min_bytes) nbytes = min_bytes;
+		size = ROUND_UP(nbytes, 8);
 	}
 
 	if (Mixer.limits[ch].max_buf_sz && size > Mixer.limits[ch].max_buf_sz)
 		size = Mixer.limits[ch].max_buf_sz;
+
+	// Ring needs ≥MARGIN units of usable space plus the mirrored tail.
+	int ub = (wave && wave->format == WAVEFORM_FORMAT_VADPCM) ? 9
+		: (Mixer.limits[ch].max_bits / 8) * (wave ? wave->channels : 1);
+	int min_bytes = SAMPLEBUFFER_MARGIN_UNITS * 2 * ub;
+	if (size < min_bytes)
+		size = min_bytes;
 
 	assert((size % 8) == 0);
 	assert((int32_t)size == size);
@@ -367,6 +316,11 @@ void mixer_close(void) {
 
 	for (int i=0; i<Mixer.num_channels; i++)
 	{
+		mixer_channel_t *c = &Mixer.channels[i];
+		if ((c->flags & CH_FLAGS_RESIDENT) && c->codec_state) {
+			free_uncached(c->codec_state);
+			c->codec_state = NULL;
+		}
 		if (samplebuffer_is_inited(&Mixer.ch_buf[i]))
 			samplebuffer_close(&Mixer.ch_buf[i]);
 	}
@@ -517,6 +471,17 @@ static void waveform_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, b
 	}
 }
 
+/** @brief Apply a VADPCM seek to the channel's codec state via WaveformRead. */
+static void mixer_vadpcm_seek(mixer_channel_t *c, int sample_pos) {
+	assert(c->flags & CH_FLAGS_VADPCM);
+	assert(c->wave && c->wave->read && c->codec_state);
+	samplebuffer_t tmp = {0};
+	tmp.wave = c->wave;
+	tmp.state = c->codec_state;
+	tmp.state_size = c->wave->state_size;
+	c->wave->read(c->wave->ctx, &tmp, sample_pos / 16, 0, true);
+}
+
 void mixer_ch_play(int ch, waveform_t *wave)
 {
 	assert(ch < Mixer.num_channels);
@@ -528,109 +493,155 @@ void mixer_ch_play(int ch, waveform_t *wave)
 	if (wave->__uuid == 0) 
 		wave->__uuid = ++Mixer.uuid_counter;
 
-	// If we're going to play a stereo waveform on a channel that was allocated
-	// for mono, we need to reallocate the buffer.
-	if (wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC)) {
+	bool resident = wave->mem != NULL;
+	bool vadpcm = wave->format == WAVEFORM_FORMAT_VADPCM;
+	bool stereo_vadpcm = vadpcm && wave->channels == 2;
+
+	// Stereo VADPCM uses two mono rings (ch and ch+1). PCM stereo uses one
+	// interleaved buffer on the owner (STEREO_ALLOC).
+	if (!resident && stereo_vadpcm) {
+		if (!samplebuffer_is_inited(sbuf) || !samplebuffer_is_inited(&Mixer.ch_buf[ch+1])) {
+			__mixer_wait_idle();
+			samplebuffer_close(sbuf);
+			samplebuffer_close(&Mixer.ch_buf[ch+1]);
+		}
+	} else if (!resident && wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC)) {
 		__mixer_wait_idle();
 		samplebuffer_close(sbuf);
 	}
 	// Check if the state buffer is big enough, otherwise we need to reallocate
-	if (sbuf->state_size < wave->state_size) {
+	if (!resident && sbuf->state_size < wave->state_size) {
 		__mixer_wait_idle();
 		samplebuffer_close(sbuf);
+		if (stereo_vadpcm) samplebuffer_close(&Mixer.ch_buf[ch+1]);
 	}
 
-	if (!samplebuffer_is_inited(sbuf)) {
-		// If we have not yet allocated the memory for the sample buffers,
-		// this is a good moment to do so, as we might need the configure
-		// the samplebuffer in a moment.
+	if (!resident && !samplebuffer_is_inited(sbuf)) {
 		int size = ROUND_UP(mixer_calc_buffer_size(ch, wave), 16);
+		int ub = vadpcm ? 9 : ((wave->bits / 8) * (stereo_vadpcm ? 1 : wave->channels));
+		size += SAMPLEBUFFER_MARGIN_UNITS * ub;
+		size = ROUND_UP(size, 16);
 		int state_size = ROUND_UP(wave->state_size, 16);
 		void *ptr = malloc_uncached(size + state_size);
 		assertf(ptr, "Out of memory");
 		samplebuffer_init(sbuf, ptr, size, state_size);
-		if (wave->channels == 2) c->flags |= CH_FLAGS_STEREO_ALLOC;
+		if (stereo_vadpcm) {
+			assertf(ch != Mixer.num_channels-1, "cannot play stereo VADPCM on last channel");
+			void *ptr_r = malloc_uncached(size); // R ring: no second state (shared)
+			assertf(ptr_r, "Out of memory");
+			samplebuffer_init(&Mixer.ch_buf[ch+1], ptr_r, size, 0);
+			c->flags |= CH_FLAGS_STEREO_ALLOC;
+		} else if (wave->channels == 2) {
+			c->flags |= CH_FLAGS_STEREO_ALLOC;
+		}
 	}
 
-	// Configure the waveform on this channel, if we have not
-	// already. This optimization is useful in case the caller
-	// wants to play the same waveform on the same channel multiple
-	// times, and the waveform has been already decoded and cached
-	// in the sample buffer.
-	// We compare:
-	//  - The UUID of the waveform (not the wave pointer, as that
-	//    could have been even recycled by the caller)
-	//  - The context pointer: if that changes, probably the internal
-	//    state of the callback is also different (eg: compression state),
-	//    so the next (not already buffered) sample could cause
-	//    an error because it'd be decompressed with the wrong state.
-	if (wave->__uuid != sbuf->wave_uuid) {
-		samplebuffer_flush(sbuf);
+	// Configure the waveform on this channel, if we have not already.
+	if (wave->__uuid != c->wave_uuid || (c->flags & CH_FLAGS_RESIDENT) != (resident ? CH_FLAGS_RESIDENT : 0)) {
+		if (!resident)
+			samplebuffer_flush(sbuf);
 
 		// If this channel is playing something else, stop it
 		if (mixer_ch_playing(ch))
 			mixer_ch_stop(ch);
 
-		// Configure the sample buffer for this waveform
+		// Free a previous resident-only codec state if switching away.
+		if ((c->flags & CH_FLAGS_RESIDENT) && c->codec_state) {
+			free_uncached(c->codec_state);
+			c->codec_state = NULL;
+		}
+
 		assert(wave->channels == 1 || wave->channels == 2);
 		assert(wave->bits == 8 || wave->bits == 16);
-		assertf(wave->format != WAVEFORM_FORMAT_VADPCM || wave->channels == 1,
-			"waveform %s: in-mixer VADPCM requires mono", wave->name);
-		if (wave->format == WAVEFORM_FORMAT_VADPCM) {
-			samplebuffer_set_unit_bytes(sbuf, 9);
-		} else {
-			samplebuffer_set_bps(sbuf, wave->bits*wave->channels);
-		}
-		samplebuffer_set_waveform(sbuf, wave, wave->read ? waveform_read : NULL);
-
-		// Configure the mixer channel structured used by the RSP ucode
 		assertf(wave->len >= 0 && wave->len <= WAVEFORM_MAX_LEN, "waveform %s: invalid length %x", wave->name, wave->len);
 		assertf(wave->len != WAVEFORM_UNKNOWN_LEN || wave->loop_len == 0, "waveform %s with unknown length cannot loop", wave->name);
-		c->flags &= ~(CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO | CH_FLAGS_VADPCM);
+
+		c->flags &= ~(CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO | CH_FLAGS_VADPCM | CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED);
 		c->codebook = NULL;
 		c->loop_state = NULL;
-		c->codec_state = sbuf->state;
+		c->codec_state = NULL;
+
+		if (resident) {
+			c->flags |= CH_FLAGS_RESIDENT;
+			if (wave->state_size) {
+				c->codec_state = malloc_uncached(ROUND_UP(wave->state_size, 16));
+				assertf(c->codec_state, "Out of memory");
+				memset(c->codec_state, 0, wave->state_size);
+			}
+		} else {
+			if (wave->format == WAVEFORM_FORMAT_VADPCM) {
+				samplebuffer_set_unit_bytes(sbuf, 9);
+				if (stereo_vadpcm)
+					samplebuffer_set_unit_bytes(&Mixer.ch_buf[ch+1], 9);
+			} else {
+				samplebuffer_set_bps(sbuf, wave->bits*wave->channels);
+			}
+			samplebuffer_set_waveform(sbuf, wave, wave->read ? waveform_read : NULL);
+			c->codec_state = sbuf->state;
+		}
+
 		if (wave->format == WAVEFORM_FORMAT_VADPCM) {
 			waveform_vadpcm_t *vc = wave->codec;
 			assertf(vc && vc->codebook, "waveform %s: VADPCM missing codec/codebook", wave->name);
 			c->flags |= CH_FLAGS_VADPCM | CH_FLAGS_16BIT;
+			if (wave->channels == 2) c->flags |= CH_FLAGS_STEREO;
 			c->codebook = vc->codebook;
 			c->loop_state = vc->loop_state;
-			// Positions are in samples (no bps shift).
 			c->len = MIXER_FX64((int64_t)wave->len);
 			c->loop_len = MIXER_FX64((int64_t)wave->loop_len);
+			if (stereo_vadpcm) {
+				mixer_channel_t *r = &Mixer.channels[ch+1];
+				r->flags = (r->flags & CH_FLAGS_FORCE_MONO) | CH_FLAGS_STEREO_SUB | CH_FLAGS_VADPCM | CH_FLAGS_16BIT;
+				r->codebook = (uint8_t*)vc->codebook + 128; // 8 vectors × 16 bytes
+				r->codec_state = (uint8_t*)c->codec_state + 16;
+				r->loop_state = vc->loop_state ? (uint8_t*)vc->loop_state + 16 : NULL;
+				r->len = c->len;
+				r->loop_len = c->loop_len;
+				r->wave = wave;
+				r->wave_uuid = wave->__uuid;
+			}
 		} else {
-			int bps = SAMPLES_BPS_SHIFT(sbuf);
+			int bps = resident
+				? ((wave->bits == 16 ? 1 : 0) + (wave->channels == 2 ? 1 : 0))
+				: SAMPLES_BPS_SHIFT(sbuf);
 			c->flags |= bps | (wave->channels == 2 ? CH_FLAGS_STEREO : 0) | (wave->bits == 16 ? CH_FLAGS_16BIT : 0);
 			c->len = MIXER_FX64((int64_t)wave->len) << bps;
 			c->loop_len = MIXER_FX64((int64_t)wave->loop_len) << bps;
 		}
 		mixer_ch_set_freq(ch, wave->frequency);
 
-		// Invoke start callback if specified. This is only done when the
-		// waveform is assigned to this channel, and not at the start of all
-		// subsequent playbacks.
-		if (wave->start)
+		if (!resident && wave->start)
 			wave->start(wave->ctx, sbuf);
 
-		tracef("mixer_ch_play[new]: ch=%d len=%llx loop_len=%llx wave=%s\n", ch, c->len >> (MIXER_FX64_FRAC+SAMPLES_BPS_SHIFT(sbuf)), c->loop_len >> (MIXER_FX64_FRAC+SAMPLES_BPS_SHIFT(sbuf)), wave->name);
-	} else {
-		tracef("mixer_ch_play[old]: ch=%d len=%llx loop_len=%llx wave=%s\n", ch, c->len >> (MIXER_FX64_FRAC+SAMPLES_BPS_SHIFT(sbuf)), c->loop_len >> (MIXER_FX64_FRAC+SAMPLES_BPS_SHIFT(sbuf)), wave->name);
-
-		// There is a UUID match. There must also be a pointer match then.
-		assertf(sbuf->wave == wave, "%s: uuid match (%ld) but pointer mismatch: %p != %p", wave->name, wave->__uuid, sbuf->wave, wave);
+		c->wave_uuid = wave->__uuid;
+		tracef("mixer_ch_play[new]: ch=%d len=%llx loop_len=%llx wave=%s%s\n",
+			ch, (uint64_t)wave->len, (uint64_t)wave->loop_len, wave->name,
+			resident ? " [resident]" : "");
+	} else if (!resident) {
+		tracef("mixer_ch_play[old]: ch=%d wave=%s\n", ch, wave->name);
+		assertf(sbuf->wave == wave, "%s: uuid match (%ld) but pointer mismatch: %p != %p",
+			wave->name, wave->__uuid, sbuf->wave, wave);
 	}
 
 	// Restart from the beginning of the waveform
 	c->wave = wave;
-	c->ptr = SAMPLES_PTR(sbuf);
+	if (resident && stereo_vadpcm) {
+		int nframes = wave->len / 16;
+		c->ptr = (void*)wave->mem;
+		Mixer.channels[ch+1].ptr = (uint8_t*)wave->mem + nframes * 9;
+		Mixer.channels[ch+1].pos = 0;
+	} else {
+		c->ptr = resident ? (void*)wave->mem : SAMPLES_PTR(sbuf);
+	}
 	c->pos = 0;
+	if (resident && (c->flags & CH_FLAGS_VADPCM))
+		mixer_vadpcm_seek(c, 0);
 
-	// If we start playing a stereo waveform, configure channel ch+1 as stereo sub,
-	// to help catching errors where it is used as a separate channel.
+	// Mark ch+1 as stereo sub for PCM interleaved or VADPCM dual-mono.
 	if (c->flags & CH_FLAGS_STEREO) {
 		assertf(ch != Mixer.num_channels-1, "cannot configure last channel (%d) as stereo", ch);
-		assertf(!mixer_ch_playing(ch+1), "cannot play stereo waveform on channel %d because channel %d is active", ch, ch+1);
+		assertf(!mixer_ch_playing(ch+1) || (Mixer.channels[ch+1].flags & CH_FLAGS_STEREO_SUB),
+			"cannot play stereo waveform on channel %d because channel %d is active", ch, ch+1);
 		Mixer.channels[ch+1].flags |= CH_FLAGS_STEREO_SUB;
 	} else if (ch != Mixer.num_channels-1) {
 		Mixer.channels[ch+1].flags &= ~CH_FLAGS_STEREO_SUB;
@@ -644,6 +655,9 @@ void mixer_ch_set_pos(int ch, double pos) {
 	if (!(c->flags & CH_FLAGS_VADPCM))
 		p <<= (c->flags & CH_FLAGS_BPS_SHIFT);
 	c->pos = p;
+	// Resident VADPCM has no samplebuffer seek path: update predictor state now.
+	if ((c->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_VADPCM)) == (CH_FLAGS_RESIDENT | CH_FLAGS_VADPCM))
+		mixer_vadpcm_seek(c, (int)pos);
 	tracef("mixer_ch_set_pos: ch=%d pos=%.32g(%llx)\n", ch, pos, c->pos);
 }
 
@@ -661,11 +675,14 @@ void mixer_ch_stop(int ch) {
 
 	tracef("mixer_ch_stop: ch=%d\n", ch);
 
-	if (c->flags & CH_FLAGS_STEREO)
+	if (c->flags & CH_FLAGS_STEREO) {
 		c[1].flags &= ~CH_FLAGS_STEREO_SUB;
+		c[1].silence_ns = MIXER_SILENCE_RAMP_SAMPLES;
+	}
 
 	c->ptr = 0;
 	c->pos = 0;
+	c->silence_ns = MIXER_SILENCE_RAMP_SAMPLES;
 
 	// Invalidate the wave pointer, as it might become dangling
 	// anyway, as the user can free the waveform memory at any time after stop.
@@ -734,9 +751,9 @@ static inline mixer_fx15_t mixer_apply_gvol(mixer_fx15_t vol, mixer_fx16_t gvol_
 /** @brief Emit a MIX_CHANNEL rspq command for one channel. */
 static void mixer_emit_channel(int ch, uint32_t flags, mixer_fx15_t lvol, mixer_fx15_t rvol,
 	uint32_t pos, uint32_t step, uint32_t len, uint32_t loop_len, void *ptr,
-	int nsamples, int acc_offset, void *codebook, void *state, void *loop_state)
+	int nsamples, int acc_offset)
 {
-	rspq_write_t w = rspq_write_begin(__mixer_overlay_id, MIXER_CMD_CHANNEL, 12);
+	rspq_write_t w = rspq_write_begin(__mixer_overlay_id, MIXER_CMD_CHANNEL, 8);
 	// a0 payload (24 bits): ch_idx<<16 | flags<<8
 	rspq_write_arg(&w, ((uint32_t)ch << 16) | ((flags & 0xFF) << 8));
 	rspq_write_arg(&w, ((uint32_t)(uint16_t)lvol << 16) | (uint16_t)rvol);
@@ -746,122 +763,170 @@ static void mixer_emit_channel(int ch, uint32_t flags, mixer_fx15_t lvol, mixer_
 	rspq_write_arg(&w, loop_len);
 	rspq_write_arg(&w, ptr ? PhysicalAddr(ptr) : 0);
 	rspq_write_arg(&w, ((uint32_t)(uint16_t)acc_offset << 16) | (uint16_t)nsamples);
-	rspq_write_arg(&w, codebook ? PhysicalAddr(codebook) : 0);
-	rspq_write_arg(&w, state ? PhysicalAddr(state) : 0);
-	rspq_write_arg(&w, loop_state ? PhysicalAddr(loop_state) : 0);
-	rspq_write_arg(&w, 0);
 	rspq_write_end(&w);
 }
 
-/** @brief Emit VADPCM_SetState (copy src→dst, or clear if src is NULL). */
-static void mixer_emit_setstate(void *dst, void *src)
+/** @brief Record a channel's VADPCM pointers in the ucode channel table. */
+static void mixer_emit_setchannel(int ch, void *codebook, void *state, void *loop_state)
 {
-	rspq_write(__mixer_overlay_id, MIXER_CMD_SETSTATE,
-		PhysicalAddr(dst), src ? PhysicalAddr(src) : 0);
+	rspq_write(__mixer_overlay_id, MIXER_CMD_SETCHANNEL, (uint32_t)ch << 16,
+		codebook ? PhysicalAddr(codebook) : 0,
+		state ? PhysicalAddr(state) : 0,
+		loop_state ? PhysicalAddr(loop_state) : 0);
 }
 
-static void mixer_exec(int32_t *out, int num_samples) {
-	tracef("mixer_exec: 0x%x samples\n", num_samples);
+// True if the whole waveform fits in the ring, so that it can be pinned as a
+// unit instead of just its loop region.
+static bool mixer_wave_fits(int i) {
+	mixer_channel_t *ch = &Mixer.channels[i];
+	samplebuffer_t *sbuf = &Mixer.ch_buf[i];
+	if (!samplebuffer_is_inited(sbuf))
+		return false;
+	bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
+	int bps = vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT);
+	int len = ch->len >> (bps + MIXER_FX64_FRAC);
+	int slen = vadpcm ? (len + 15) / 16 : len;
+	return slen > 0 &&
+		slen + (MIXER_LOOP_OVERREAD / (vadpcm ? 9 : (1<<bps)) + 1) <= sbuf->size;
+}
 
-	uint32_t fake_loop = 0;
-	uint32_t last_round_id = Mixer.round_next + 1;
+/** @brief Pin a streamed loop into the samplebuffer (one-shot). RSP wraps after. */
+static void mixer_fill_loop_cache(int ch) {
+	mixer_channel_t *c = &Mixer.channels[ch];
+	samplebuffer_t *sbuf = &Mixer.ch_buf[ch];
+	waveform_t *wave = c->wave;
+	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
+	bool stereo_vadpcm = vadpcm && (c->flags & CH_FLAGS_STEREO);
+	int bps = vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT);
+	int bps_fx64 = bps + MIXER_FX64_FRAC;
+	int ub = samplebuffer_unit_bytes(sbuf);
+	int len = c->len >> bps_fx64;
+	int loop_len = c->loop_len >> bps_fx64;
+	// A waveform that fits entirely is pinned from its start, so that its
+	// attack stays available and the RSP can wrap it right away.
+	bool whole = mixer_wave_fits(ch);
+	int cache_start = whole ? 0 : len - loop_len;
+	int cache_len = whole ? len : loop_len;
+	int sloop_start = vadpcm ? cache_start / 16 : cache_start;
+	int sloop_len = vadpcm ? (cache_len + 15) / 16 : cache_len;
+	int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+	int fill = sloop_len + overread;
+	assertf(fill <= sbuf->size, "ch:%d loop cache %x > ring %x", ch, fill, sbuf->size);
+	assert(wave && wave->read);
 
-	// ---- Phase 1: ensure samplebuffers have data for the full span ----
-	for (int i=0; i<Mixer.num_channels; i++) {
-		samplebuffer_t *sbuf = &Mixer.ch_buf[i];
-		mixer_channel_t *ch = &Mixer.channels[i];
-		bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
-		int bps = vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT);
-		int bps_fx64 = bps + MIXER_FX64_FRAC;
-		int ub = samplebuffer_unit_bytes(sbuf);
-
-		if (ch->ptr) {
-			int len = ch->len >> bps_fx64;
-			int loop_len = ch->loop_len >> bps_fx64;
-			int wpos = ch->pos >> bps_fx64;
-			int wlast = (ch->pos + ch->step*(num_samples-1)) >> bps_fx64;
-			int wnext = (ch->pos + ch->step*num_samples) >> bps_fx64;
-			int wlen = MAX(wlast-wpos+1, wnext-wpos);
-
-			assertf(wlen >= 0, "channel %d: wpos overflow", i);
-			tracef("ch:%d wpos:%x wlen:%x len:%x loop_len:%x sbuf_size:%x\n", i, wpos, wlen, len, loop_len, sbuf->size);
-
-			// VADPCM samplebuffers are addressed in frames.
-			int spos = wpos, slen = len, sloop = loop_len, swlen = wlen;
-			if (vadpcm) {
-				spos = wpos / 16;
-				slen = len / 16;
-				sloop = loop_len / 16;
-				swlen = (wpos + wlen + 15) / 16 - spos;
-			}
-
-			if (!loop_len) {
-				if (wpos >= len) {
-					mixer_ch_stop(i);
-					continue;
-				}
-				if (wpos+wlen > len)
-					wlen = len-wpos;
-				if (vadpcm) {
-					swlen = (wpos + wlen + 15) / 16 - spos;
-					swlen += (MIXER_LOOP_OVERREAD + ub - 1) / ub;
-				} else {
-					swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
-				}
-				assert(swlen >= 0);
-			} else if ((vadpcm ? sloop : loop_len) < sbuf->size) {
-				int loop_pos = len - loop_len;
-				int sloop_pos = vadpcm ? loop_pos / 16 : loop_pos;
-				if (sbuf->size < (vadpcm ? slen : len) && wpos >= loop_pos && sbuf->wpos != sloop_pos) {
-					tracef("ch:%d discard to align loop wpos:%x loop_pos:%x\n", i, wpos, loop_pos);
-					samplebuffer_discard(sbuf, sloop_pos);
-				}
-				while (wpos >= len)
-					wpos -= loop_len;
-				if (wpos+wlen > len)
-					wlen = len-wpos;
-				if (vadpcm) {
-					spos = wpos / 16;
-					swlen = (wpos + wlen + 15) / 16 - spos;
-					swlen += (MIXER_LOOP_OVERREAD + ub - 1) / ub;
-				} else {
-					swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
-				}
-				assertf(swlen >= 0, "ch:%d wlen=%x wpos=%x len=%x\n", i, swlen, wpos, len);
-			} else {
-				int sbuf_len = vadpcm ? slen : len;
-				int sbuf_loop = vadpcm ? sloop : loop_len;
-				if (sbuf->wpos > sbuf_len && wpos > len) {
-					tracef("mixer_poll: wrapping sample buffer loop: sbuf->wpos:%x len:%x\n", sbuf->wpos, sbuf_len);
-					int wrap_pos = vadpcm ? wpos / 16 : wpos;
-					samplebuffer_discard(sbuf, wrap_pos);
-					sbuf->wpos = waveform_wrap_wpos(sbuf->wpos, sbuf_len, sbuf_loop);
-					if (sbuf->wnext >= 0)
-						sbuf->wnext = sbuf->wpos + sbuf->widx;
-					int wpos2 = waveform_wrap_wpos(wpos, len, loop_len);
-					ch->pos -= (int64_t)(wpos-wpos2) << bps_fx64;
-					wpos = wpos2;
-					if (vadpcm)
-						spos = wpos / 16;
-				}
-				fake_loop |= 1<<i;
-				if (vadpcm) {
-					spos = wpos / 16;
-					swlen = (wlen + 15) / 16 + (MIXER_LOOP_OVERREAD + ub - 1) / ub;
-				} else {
-					swlen = wlen;
-				}
-			}
-
-			void* ptr = samplebuffer_get(sbuf, vadpcm ? spos : wpos, &swlen);
-			assert(ptr);
-			if (vadpcm)
-				ch->ptr = (uint8_t*)ptr - spos * 9;
-			else
-				ch->ptr = (uint8_t*)ptr - (wpos<<bps);
-		}
+	samplebuffer_flush(sbuf);
+	sbuf->wpos = 0;
+	sbuf->wnext = 0;
+	sbuf->head = 0;
+	if (stereo_vadpcm) {
+		samplebuffer_t *sbuf_r = &Mixer.ch_buf[ch+1];
+		assertf(fill <= sbuf_r->size, "ch:%d R loop cache %x > ring %x", ch+1, fill, sbuf_r->size);
+		samplebuffer_flush(sbuf_r);
+		sbuf_r->wpos = 0;
+		sbuf_r->wnext = 0;
+		sbuf_r->head = 0;
+	}
+	wave->read(wave->ctx, sbuf, sloop_start, sloop_len + overread, true);
+	sbuf->wpos = sloop_start;
+	sbuf->wnext = sloop_start + sbuf->widx;
+	if (stereo_vadpcm) {
+		samplebuffer_t *sbuf_r = &Mixer.ch_buf[ch+1];
+		sbuf_r->wpos = sloop_start;
+		sbuf_r->wnext = sloop_start + sbuf_r->widx;
+		Mixer.channels[ch+1].ptr = (uint8_t*)SAMPLES_PTR(sbuf_r) - sloop_start * 9;
+		Mixer.channels[ch+1].flags |= CH_FLAGS_LOOP_CACHED;
 	}
 
+	if (vadpcm)
+		c->ptr = (uint8_t*)SAMPLES_PTR(sbuf) - sloop_start * 9;
+	else
+		c->ptr = (uint8_t*)SAMPLES_PTR(sbuf) - (cache_start << bps);
+	c->flags |= CH_FLAGS_LOOP_CACHED;
+	tracef("ch:%d loop cached at %x len=%x\n", ch, sloop_start, sloop_len);
+}
+
+// True if the channel's loop is small enough to be pinned into the ring, so
+// that the RSP can wrap it by itself. Large loops are handled via wrap=seek.
+static bool mixer_loop_fits(int i) {
+	mixer_channel_t *ch = &Mixer.channels[i];
+	samplebuffer_t *sbuf = &Mixer.ch_buf[i];
+	if (!samplebuffer_is_inited(sbuf))
+		return false;
+	bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
+	int bps = vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT);
+	int loop_len = ch->loop_len >> (bps + MIXER_FX64_FRAC);
+	int sloop = vadpcm ? loop_len / 16 : loop_len;
+	return sloop > 0 &&
+		sloop + (MIXER_LOOP_OVERREAD / (vadpcm ? 9 : (1<<bps)) + 1) <= sbuf->size;
+}
+
+// Wrap a large loop: rebase the position within the loop and restart the
+// stream there. Must be done between rounds, as the RSP never wraps these.
+static void mixer_large_loop_wrap(int i) {
+	mixer_channel_t *ch = &Mixer.channels[i];
+	bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
+	int bps_fx64 = (vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
+	int wpos = ch->pos >> bps_fx64;
+	int wpos2 = waveform_wrap_wpos(wpos, ch->len >> bps_fx64, ch->loop_len >> bps_fx64);
+	ch->pos -= (int64_t)(wpos - wpos2) << bps_fx64;
+	samplebuffer_flush(&Mixer.ch_buf[i]);
+	if (vadpcm)
+		mixer_vadpcm_seek(ch, wpos2);
+	tracef("ch:%d large-loop seek %x -> %x\n", i, wpos, wpos2);
+}
+
+// End-of-sample, loop-cache transition and large-loop seek. Runs before each
+// round: a short loop can be reached in the middle of a mixer_exec, and from
+// that point on the RSP must be the one wrapping it.
+static void mixer_update_loops(void) {
+	for (int i=0; i<Mixer.num_channels; i++) {
+		mixer_channel_t *ch = &Mixer.channels[i];
+		bool vadpcm = (ch->flags & CH_FLAGS_VADPCM) != 0;
+		int bps_fx64 = (vadpcm ? 0 : (ch->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
+
+		if (!ch->ptr || (ch->flags & CH_FLAGS_STEREO_SUB))
+			continue;
+
+		int len = ch->len >> bps_fx64;
+		int loop_len = ch->loop_len >> bps_fx64;
+		int wpos = ch->pos >> bps_fx64;
+
+		if (!loop_len) {
+			if (wpos >= len)
+				mixer_ch_stop(i);
+			continue;
+		}
+		if (ch->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED))
+			continue;
+
+		if (mixer_loop_fits(i)) {
+			if (wpos >= len - loop_len || mixer_wave_fits(i))
+				mixer_fill_loop_cache(i);
+		} else if (wpos >= len) {
+			mixer_large_loop_wrap(i);
+		}
+	}
+}
+
+// Refresh the ucode per-channel VADPCM table. The pointers only change when a
+// new waveform starts playing, so in steady state this emits nothing.
+static void mixer_refresh_chtbl(void) {
+	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+		mixer_channel_t *c = &Mixer.channels[ch];
+		mixer_chtbl_t *sh = &Mixer.chtbl[ch];
+		mixer_channel_t *src = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
+		if (!src->ptr || !(c->flags & CH_FLAGS_VADPCM))
+			continue;
+		if (c->codebook == sh->codebook && c->codec_state == sh->state &&
+			c->loop_state == sh->loop_state)
+			continue;
+		*sh = (mixer_chtbl_t){ c->codebook, c->codec_state, c->loop_state };
+		mixer_emit_setchannel(ch, c->codebook, c->codec_state, c->loop_state);
+	}
+}
+
+// Global volume to apply this call, including the fade-out on reset.
+static mixer_fx16_t mixer_global_volume(void) {
 	float gvol = Mixer.vol;
 	uint32_t reset_time = exception_reset_time();
 	if (reset_time) {
@@ -869,161 +934,246 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		float elapsed = (float)reset_time / TICKS_PER_SECOND;
 		gvol *= (FADE_OUT_TIME - MIN(elapsed, FADE_OUT_TIME)) / FADE_OUT_TIME;
 	}
-	mixer_fx16_t gvol_fx16 = MIXER_FX16(gvol);
+	return MIXER_FX16(gvol);
+}
 
-	// ---- Phase 2: emit per-channel mix rounds of <= MAX_SAMPLES_PER_ROUND ----
-	for (int offset = 0; offset < num_samples; offset += MIXER_MAX_SAMPLES_PER_ROUND) {
-		int ns = MIN(num_samples - offset, MIXER_MAX_SAMPLES_PER_ROUND);
-		uint32_t round_id = ++Mixer.round_next;
-		last_round_id = round_id;
-		bool clear_accum = true;
+// Number of samples the next round can mix: a full round, unless a streamed
+// channel would outrun what the CPU is able to feed it in one go.
+static int mixer_round_length(int max_ns) {
+	int ns = MIN(max_ns, MIXER_MAX_SAMPLES_PER_ROUND);
 
-		rspq_highpri_begin();
+	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+		mixer_channel_t *c = &Mixer.channels[ch];
+		if (!c->ptr || !c->step ||
+			(c->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED | CH_FLAGS_STEREO_SUB)))
+			continue;
+		bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
+		int bps_fx64 = (vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT)) + MIXER_FX64_FRAC;
 
-		for (int ch = 0; ch < Mixer.num_channels; ch++) {
-			mixer_channel_t *c = &Mixer.channels[ch];
-			mixer_fx15_t lvol, rvol;
-			uint32_t flags = c->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT |
-				CH_FLAGS_STEREO | CH_FLAGS_STEREO_SUB | CH_FLAGS_VADPCM);
-			void *ptr = NULL;
-			void *codebook = NULL, *state = NULL, *loop_state = NULL;
-			uint32_t pos = 0, step = 0, len = 0xFFFFFFFF, loop_len = 0;
-			int ns0 = ns, ns1 = 0;
-			uint32_t pos1 = 0;
+		// The input window must fit the ring margin, which is the largest
+		// contiguous window the samplebuffer can hand out.
+		int ub = samplebuffer_unit_bytes(&Mixer.ch_buf[ch]);
+		int overread = (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+		int max_wlen = MAX(SAMPLEBUFFER_MARGIN_UNITS - overread, 1);
+		int64_t span = (int64_t)((c->step * (uint64_t)ns) >> bps_fx64) + 1;
+		if (vadpcm) span = (span + 15) / 16;
+		if (span > max_wlen) {
+			uint64_t units = vadpcm ? (uint64_t)max_wlen * 16 : (uint64_t)max_wlen;
+			ns = MIN(ns, MAX((int)((units << bps_fx64) / c->step), 1));
+		}
 
-			if (c->flags & CH_FLAGS_STEREO_SUB) {
-				mixer_channel_t *owner = &Mixer.channels[ch-1];
-				if (!owner->ptr)
-					continue;
-				if (owner->flags & CH_FLAGS_FORCE_MONO) {
-					mixer_fx15_t v = mixer_apply_gvol(Mixer.rvol[ch-1] >> 1, gvol_fx16);
-					lvol = rvol = v;
-				} else {
-					lvol = 0;
-					rvol = mixer_apply_gvol(Mixer.rvol[ch-1], gvol_fx16);
-				}
-				mixer_fx64_t abs_pos = owner->pos + owner->step * (uint64_t)offset;
-				pos = (uint32_t)abs_pos & 0x7FFFFFFF;
-				step = (uint32_t)owner->step & 0x7FFFFFFF;
-				ptr = (uint8_t*)owner->ptr + ((abs_pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
+		// Stop where the CPU has to step in: the start of a small loop (pinned
+		// by mixer_update_loops before the next round), or len for a large one
+		// (rebased by a seek).
+		if (c->loop_len) {
+			mixer_fx64_t limit = mixer_loop_fits(ch) ? c->len - c->loop_len : c->len;
+			if (c->pos < limit && c->pos + c->step * (uint64_t)ns >= limit) {
+				int64_t dist = (int64_t)(limit - c->pos);
+				int ns2 = (int)((dist + (int64_t)c->step - 1) / (int64_t)c->step);
+				ns = MIN(ns, MAX(ns2, 1));
+			}
+		}
+	}
+	return ns;
+}
+
+// Volumes to send for a channel: a stereo owner only carries the L plane and
+// its sub channel only the R one, and FORCE_MONO folds the surviving plane
+// onto both outputs. @p flags are the owner's flags.
+static void mixer_channel_volumes(int ch, uint32_t flags, bool sub,
+	mixer_fx16_t gvol, mixer_fx15_t *lvol, mixer_fx15_t *rvol)
+{
+	bool mono = (flags & CH_FLAGS_FORCE_MONO) != 0;
+	if (sub) {
+		mixer_fx15_t v = Mixer.rvol[ch-1];
+		*lvol = mono ? mixer_apply_gvol(v >> 1, gvol) : 0;
+		*rvol = mixer_apply_gvol(mono ? v >> 1 : v, gvol);
+	} else if (flags & CH_FLAGS_STEREO) {
+		mixer_fx15_t v = Mixer.lvol[ch];
+		*lvol = mixer_apply_gvol(mono ? v >> 1 : v, gvol);
+		*rvol = mono ? *lvol : 0;
+	} else if (mono) {
+		*lvol = *rvol = mixer_apply_gvol((Mixer.lvol[ch] + Mixer.rvol[ch]) >> 1, gvol);
+	} else {
+		*lvol = mixer_apply_gvol(Mixer.lvol[ch], gvol);
+		*rvol = mixer_apply_gvol(Mixer.rvol[ch], gvol);
+	}
+}
+
+// Waveform bounds to send to the RSP. The top bit of pos and len is a wrap
+// flag: when the two differ the position is past the end of the waveform, and
+// the RSP must not compare against len. @p wrap is false for the loops that
+// the CPU wraps by itself between rounds.
+static void mixer_rsp_bounds(mixer_channel_t *c, bool wrap, uint32_t *len, uint32_t *loop_len) {
+	if (c->pos>>31 != c->len>>31) {
+		*len = 0xFFFFFFFF;
+		*loop_len = 0;
+	} else {
+		*len = (uint32_t)c->len & 0x7FFFFFFF;
+		*loop_len = wrap ? (uint32_t)c->loop_len & 0x7FFFFFFF : 0;
+	}
+}
+
+// Fetch from the ring the input window this round is going to read, and return
+// the pointer the RSP must use for the current position.
+static void *mixer_fetch_window(int ch, int ns) {
+	mixer_channel_t *c = &Mixer.channels[ch];
+	samplebuffer_t *sbuf = &Mixer.ch_buf[ch];
+	bool vadpcm = (c->flags & CH_FLAGS_VADPCM) != 0;
+	int bps = vadpcm ? 0 : (c->flags & CH_FLAGS_BPS_SHIFT);
+	int bps_fx64 = bps + MIXER_FX64_FRAC;
+	int ub = samplebuffer_unit_bytes(sbuf);
+
+	int wpos = c->pos >> bps_fx64;
+	int wlast = (c->pos + c->step * (uint64_t)(ns > 0 ? ns-1 : 0)) >> bps_fx64;
+	int wnext = (c->pos + c->step * (uint64_t)ns) >> bps_fx64;
+	int wlen = MAX(wlast - wpos + 1, wnext - wpos);
+
+	if (vadpcm) {
+		int spos = wpos / 16;
+		int swlen = (wpos + wlen + 15) / 16 - spos + (MIXER_LOOP_OVERREAD + ub - 1) / ub;
+		void *p = samplebuffer_get(sbuf, spos, &swlen);
+		assert(p);
+		c->ptr = (uint8_t*)p - spos * 9;
+		return c->ptr;
+	}
+
+	int swlen = wlen + (MIXER_LOOP_OVERREAD >> bps);
+	void *p = samplebuffer_get(sbuf, wpos, &swlen);
+	assert(p);
+	c->ptr = (uint8_t*)p - (wpos << bps);
+	return (uint8_t*)c->ptr + ((c->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
+}
+
+// Emit one mix round: a MIX_CHANNEL per active channel, plus the flush that
+// writes the accumulator out to @p out. Returns the id of the round.
+static uint32_t mixer_emit_round(int32_t *out, int ns, mixer_fx16_t gvol) {
+	uint32_t round_id = ++Mixer.round_next;
+	bool clear_accum = true;
+
+	for (int ch = 0; ch < Mixer.num_channels; ch++) {
+		mixer_channel_t *c = &Mixer.channels[ch];
+		mixer_channel_t *owner = (c->flags & CH_FLAGS_STEREO_SUB) ? c-1 : c;
+		uint32_t flags = c->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT |
+			CH_FLAGS_STEREO | CH_FLAGS_STEREO_SUB | CH_FLAGS_VADPCM);
+		mixer_fx15_t lvol = 0, rvol = 0;
+		void *ptr = NULL;
+		uint32_t pos = 0, step = 0, len = 0xFFFFFFFF, loop_len = 0;
+
+		if (!owner->ptr) {
+			// A channel with no data mixes nothing: it only runs the RSP
+			// volume ramp. Keep emitting it until the ramp has decayed, then
+			// drop it from the round entirely.
+			if (c->silence_ns <= 0)
+				continue;
+			c->silence_ns -= ns;
+		} else if (c->flags & CH_FLAGS_STEREO_SUB) {
+			mixer_channel_volumes(ch, owner->flags, true, gvol, &lvol, &rvol);
+
+			if (!(c->flags & CH_FLAGS_VADPCM)) {
+				// PCM interleaved: extract R from the owner's sample stream.
 				flags = (owner->flags & (CH_FLAGS_BPS_SHIFT | CH_FLAGS_16BIT | CH_FLAGS_STEREO)) | CH_FLAGS_STEREO_SUB;
-				if ((fake_loop & (1<<(ch-1))) || owner->pos>>31 != owner->len>>31) {
-					len = 0xFFFFFFFF;
-					loop_len = 0;
-				} else {
-					len = (uint32_t)owner->len & 0x7FFFFFFF;
-					loop_len = (uint32_t)owner->loop_len & 0x7FFFFFFF;
-				}
-			} else if (!c->ptr) {
-				lvol = rvol = 0;
-				ptr = NULL;
+				pos = (uint32_t)owner->pos & 0x7FFFFFFF;
+				step = (uint32_t)owner->step & 0x7FFFFFFF;
+				ptr = (uint8_t*)owner->ptr + ((owner->pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
+				mixer_rsp_bounds(owner, true, &len, &loop_len);
 			} else {
-				mixer_fx64_t abs_pos = c->pos + c->step * (uint64_t)offset;
-				pos = (uint32_t)abs_pos & 0x7FFFFFFF;
+				// Stereo VADPCM R: a full mono channel on its own plane, but
+				// with the timing of the owner.
+				c->pos = owner->pos;
+				c->step = owner->step;
+				c->len = owner->len;
+				c->loop_len = owner->loop_len;
+				flags = CH_FLAGS_VADPCM | CH_FLAGS_16BIT;
+				pos = (uint32_t)c->pos & 0x7FFFFFFF;
 				step = (uint32_t)c->step & 0x7FFFFFFF;
-				if (c->flags & CH_FLAGS_VADPCM) {
-					// ptr is the frame base; high bits of pos are sample index bits
-					// above 31 — not used for byte offset (samples, not bytes).
+				if (owner->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)) {
 					ptr = c->ptr;
-					codebook = c->codebook;
-					state = c->codec_state;
-					loop_state = c->loop_state;
+					mixer_rsp_bounds(c, true, &len, &loop_len);
 				} else {
-					ptr = (uint8_t*)c->ptr + ((abs_pos & ~0x7FFFFFFF) >> MIXER_FX64_FRAC);
-				}
-				if ((fake_loop & (1<<ch)) || c->pos>>31 != c->len>>31) {
-					len = 0xFFFFFFFF;
-					loop_len = 0;
-				} else {
-					len = (uint32_t)c->len & 0x7FFFFFFF;
-					assert(c->loop_len <= 0x7FFFFFFF);
-					loop_len = (uint32_t)c->loop_len & 0x7FFFFFFF;
-				}
-
-				// Unrolled VADPCM loop: split this channel at the wrap tick and
-				// insert SetState(loop_state) so the second half continues with
-				// the correct predictor state.
-				if ((c->flags & CH_FLAGS_VADPCM) && (fake_loop & (1<<ch)) &&
-					c->loop_state && c->step)
-				{
-					mixer_fx64_t wlen = c->len;
-					mixer_fx64_t wpos = abs_pos;
-					mixer_fx64_t end = wpos + c->step * (uint64_t)ns;
-					if (wpos < wlen && end >= wlen) {
-						int64_t dist = (int64_t)(wlen - wpos);
-						ns0 = (int)((dist + (int64_t)c->step - 1) / (int64_t)c->step);
-						if (ns0 < 1) ns0 = 1;
-						if (ns0 > ns) ns0 = ns;
-						ns1 = ns - ns0;
-						if (ns1 > 0) {
-							mixer_fx64_t p1 = wpos + c->step * (uint64_t)ns0;
-							while (p1 >= c->len)
-								p1 -= c->loop_len;
-							pos1 = (uint32_t)p1 & 0x7FFFFFFF;
-						}
-					}
-				}
-
-				if (c->flags & CH_FLAGS_STEREO) {
-					if (c->flags & CH_FLAGS_FORCE_MONO) {
-						mixer_fx15_t v = mixer_apply_gvol(Mixer.lvol[ch] >> 1, gvol_fx16);
-						lvol = rvol = v;
-					} else {
-						lvol = mixer_apply_gvol(Mixer.lvol[ch], gvol_fx16);
-						rvol = 0;
-					}
-				} else if (c->flags & CH_FLAGS_FORCE_MONO) {
-					mixer_fx15_t v = mixer_apply_gvol(
-						(Mixer.lvol[ch] + Mixer.rvol[ch]) >> 1, gvol_fx16);
-					lvol = rvol = v;
-				} else {
-					lvol = mixer_apply_gvol(Mixer.lvol[ch], gvol_fx16);
-					rvol = mixer_apply_gvol(Mixer.rvol[ch], gvol_fx16);
+					ptr = mixer_fetch_window(ch, ns);
 				}
 			}
+		} else {
+			mixer_channel_volumes(ch, c->flags, false, gvol, &lvol, &rvol);
+			pos = (uint32_t)c->pos & 0x7FFFFFFF;
+			step = (uint32_t)c->step & 0x7FFFFFFF;
 
-			if (clear_accum) {
-				flags |= CH_FLAGS_CLEAR_ACCUM;
-				clear_accum = false;
-			}
-
-			mixer_emit_channel(ch, flags, lvol, rvol, pos, step, len, loop_len, ptr,
-				ns0, 0, codebook, state, loop_state);
-			if (ns1 > 0) {
-				mixer_emit_setstate(state, loop_state);
-				mixer_emit_channel(ch, flags & ~CH_FLAGS_CLEAR_ACCUM, lvol, rvol,
-					pos1, step, len, loop_len, ptr,
-					ns1, ns0, codebook, state, loop_state);
+			if (c->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)) {
+				ptr = c->ptr;
+				mixer_rsp_bounds(c, true, &len, &loop_len);
+			} else {
+				ptr = mixer_fetch_window(ch, ns);
+				// Small loops are pinned by mixer_update_loops, large ones are
+				// wrapped by the CPU between rounds: either way the RSP is
+				// never allowed to wrap a streamed channel.
+				if (!c->loop_len)
+					mixer_rsp_bounds(c, false, &len, &loop_len);
 			}
 		}
 
 		if (clear_accum) {
-			mixer_emit_channel(0, CH_FLAGS_CLEAR_ACCUM, 0, 0, 0, 0, 0, 0, NULL,
-				ns, 0, NULL, NULL, NULL);
+			flags |= CH_FLAGS_CLEAR_ACCUM;
+			clear_accum = false;
 		}
 
-		rspq_write(__mixer_overlay_id, MIXER_CMD_FLUSH,
-			(uint32_t)ns, PhysicalAddr(out + offset), round_id);
-		rspq_highpri_end();
-		Mixer.round_enqueued = round_id;
+		mixer_emit_channel(ch, flags, lvol, rvol, pos, step, len, loop_len, ptr, ns, 0);
 	}
 
-	for (int i = 0; i < Mixer.num_channels; i++) {
-		if (Mixer.channels[i].ptr)
-			Mixer.ch_buf[i].last_round = last_round_id;
-	}
+	// All channels were silent: the accumulator must still be cleared before
+	// being flushed out.
+	if (clear_accum)
+		mixer_emit_channel(0, CH_FLAGS_CLEAR_ACCUM, 0, 0, 0, 0, 0, 0, NULL, ns, 0);
 
-	for (int i=0;i<Mixer.num_channels;i++) {
+	rspq_write(__mixer_overlay_id, MIXER_CMD_FLUSH,
+		(uint32_t)ns, PhysicalAddr(out), round_id);
+	Mixer.round_enqueued = round_id;
+	return round_id;
+}
+
+// Advance all channels by the samples just mixed, wrapping the loops that the
+// RSP does not wrap by itself.
+static void mixer_advance(int ns) {
+	for (int i=0; i<Mixer.num_channels; i++) {
 		mixer_channel_t *ch = &Mixer.channels[i];
 		if (!ch->ptr || (ch->flags & CH_FLAGS_STEREO_SUB))
 			continue;
-
-		ch->pos += ch->step * (uint64_t)num_samples;
-
-		if (ch->loop_len && !(fake_loop & (1<<i))) {
+		ch->pos += ch->step * (uint64_t)ns;
+		if (!ch->loop_len || ch->pos < ch->len)
+			continue;
+		if (ch->flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)) {
 			while (ch->pos >= ch->len)
 				ch->pos -= ch->loop_len;
+		} else if (!mixer_loop_fits(i)) {
+			// Large loop crossing len between two rounds of the same call.
+			mixer_large_loop_wrap(i);
 		}
+	}
+}
+
+static void mixer_exec(int32_t *out, int num_samples) {
+	tracef("mixer_exec: 0x%x samples\n", num_samples);
+
+	mixer_fx16_t gvol = mixer_global_volume();
+	uint32_t last_round_id = Mixer.round_next + 1;
+
+	rspq_highpri_begin();
+	for (int offset = 0; offset < num_samples; ) {
+		mixer_update_loops();
+		mixer_refresh_chtbl();
+
+		int ns = mixer_round_length(num_samples - offset);
+		last_round_id = mixer_emit_round(out + offset, ns, gvol);
+		mixer_advance(ns);
+		offset += ns;
+	}
+	rspq_highpri_end();
+
+	// Record the last round reading each ring, so that producers know when the
+	// RSP is done with the samples they are about to overwrite.
+	for (int i = 0; i < Mixer.num_channels; i++) {
+		if (Mixer.channels[i].ptr && !(Mixer.channels[i].flags & (CH_FLAGS_RESIDENT | CH_FLAGS_LOOP_CACHED)))
+			Mixer.ch_buf[i].last_round = last_round_id;
 	}
 
 	Mixer.ticks += num_samples;
@@ -1069,8 +1219,6 @@ void mixer_unthrottle(void) {
 
 static void mixer_poll_async(int16_t *out16, int num_samples) {
 	int32_t *out = (int32_t*)out16;
-
-	mixer_reclaim();
 
 	// Since the AI can only play an even number of samples,
 	// it's not possible to call this function with an odd number,
@@ -1122,10 +1270,8 @@ void mixer_try_play(void)
 	// to at least audio_get_num_buffers()-1, but fill completely, if there is
 	// only one free one left.
 	int free_buffers = audio_get_num_buffers() - audio_get_queued_buffers();
-	if (free_buffers <= 0) {
-		mixer_reclaim();
+	if (free_buffers <= 0)
 		return;
-	}
 
 	int buffers_to_fill = MAX(free_buffers - 1, 1);
 	while (buffers_to_fill-- > 0) {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -243,8 +243,26 @@ void __mixer_round_wait(uint32_t round_id) {
 	__mixer_profile_rsp += TICKS_READ() - t0;
 }
 
-uint32_t __mixer_round_current(void) {
-	return Mixer.round_next;
+uint32_t __mixer_round_producer(void) {
+	// ID of the mix round that will publish completion of highpri commands
+	// enqueued right now: the round being prepared (if inside mixer_exec),
+	// or the next one that will be issued. Note that the latter may never be
+	// issued: __mixer_dirty_wait handles that case by draining the queue.
+	if ((int32_t)(Mixer.round_next - Mixer.round_enqueued) > 0)
+		return Mixer.round_next;
+	return Mixer.round_next + 1;
+}
+
+bool __mixer_memmove_async(void *dst, void *src, int len) {
+	if (!mixer_initialized())
+		return false;
+	assert(((uint32_t)dst & 7) == 0 && ((uint32_t)src & 7) == 0 && (len & 7) == 0);
+	bool highpri = rspq_in_highpri();
+	if (!highpri) rspq_highpri_begin();
+	rspq_write(__mixer_overlay_id, 0x3,
+		PhysicalAddr(dst), PhysicalAddr(src), len);
+	if (!highpri) rspq_highpri_end();
+	return true;
 }
 
 void __mixer_dirty_wait(uint32_t round_id) {
@@ -270,8 +288,14 @@ void __mixer_dirty_wait(uint32_t round_id) {
 }
 
 void __mixer_wait_idle(void) {
+	if (!mixer_initialized())
+		return;
 	if (Mixer.round_enqueued)
 		__mixer_round_wait(Mixer.round_enqueued);
+	// Compaction memmoves can be enqueued after the last mix round (e.g. by
+	// mixer_reclaim at frame start): the round counter does not cover them,
+	// so drain the highpri queue before the caller frees/reuses memory.
+	rspq_highpri_sync();
 }
 
 static void mixer_settings_reclaim(void) {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -137,8 +137,7 @@ typedef struct mixer_channel_s {
 
 /** @brief Overlay saved-state layout (must match rsp_mixer.S) */
 typedef struct {
-	uint16_t xvol_l[MIXER_MAX_CHANNELS];
-	uint16_t xvol_r[MIXER_MAX_CHANNELS];
+	uint32_t xvol[MIXER_MAX_CHANNELS];      ///< [left:16][right:16]
 	uint32_t codebook[MIXER_MAX_CHANNELS];
 	uint32_t state[MIXER_MAX_CHANNELS];
 	uint32_t loop_state[MIXER_MAX_CHANNELS];

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -16,6 +16,8 @@
 #include "audio.h"
 #include "n64sys.h"
 #include "interrupt.h"
+#include "accounting_internal.h"
+#include "../rspq/rspq_internal.h"
 #include <memory.h>
 #include <stdlib.h>
 #include <math.h>
@@ -58,8 +60,14 @@
  */
 DEFINE_RSP_UCODE(rsp_mixer);
 
-/** @brief Size of the ucode state that is automatically persisted by rspq */
-#define MIXER_STATE_SIZE 128
+/** @brief Size of the ucode state that is automatically persisted by rspq.
+ * Layout must match RSPQ_BeginSavedState in rsp_mixer.S:
+ *   XVOL_L[32] + XVOL_R[32] (128 bytes) + COUNTER_RDRAM + pad (16 bytes).
+ */
+#define MIXER_STATE_SIZE 144
+
+/** @brief Number of in-flight settings slots for async mix rounds */
+#define MIXER_SETTINGS_SLOTS  16
 
 // NOTE: keep these in sync with rsp_mixer.S
 #define CH_FLAGS_BPS_SHIFT  	(3<<0)   ///< BPS shift value
@@ -124,7 +132,7 @@ typedef struct rsp_mixer_channel_s {
 _Static_assert(sizeof(rsp_mixer_channel_t) == 6*4);
 /// @endcond
 
-/** @brief Mixer ucode settings. 
+/** @brief Mixer ucode settings.
  *
  * This struct reflects the settings defined in rsp_mixer.S.
  */
@@ -134,7 +142,30 @@ typedef struct rsp_mixer_settings_s {
 	rsp_mixer_channel_t channels[MIXER_MAX_CHANNELS] __attribute__((aligned(16)));
 } rsp_mixer_settings_t;
 
-/** @brief Configured limits of a mixer channel. 
+/** @brief One settings ring slot tagged with the round that consumes it */
+typedef struct {
+	rsp_mixer_settings_t settings;
+	uint32_t round_id;
+	uint32_t pad[3];
+} __attribute__((aligned(16))) mixer_settings_slot_t;
+
+/** @brief RDRAM completion counter published by the mixer ucode */
+typedef struct {
+	uint32_t rounds_done;
+	uint32_t pad[3];
+} mixer_rdram_state_t;
+
+/** @brief Overlay saved-state layout (must match rsp_mixer.S) */
+typedef struct {
+	uint16_t xvol_l[MIXER_MAX_CHANNELS];
+	uint16_t xvol_r[MIXER_MAX_CHANNELS];
+	uint32_t counter_rdram;
+	uint32_t pad[3];
+} mixer_overlay_state_t;
+
+_Static_assert(sizeof(mixer_overlay_state_t) == MIXER_STATE_SIZE, "mixer overlay state size mismatch");
+
+/** @brief Configured limits of a mixer channel.
  *
  * This structure describes the playback limits for a mixer channel. The limits
  * are used to avoid over-allocating memory via sample buffers.
@@ -171,20 +202,127 @@ static struct {
 	mixer_fx15_t lvol[MIXER_MAX_CHANNELS];
 	mixer_fx15_t rvol[MIXER_MAX_CHANNELS];
 
-	rsp_mixer_settings_t ucode_settings __attribute__((aligned(16)));
+	volatile mixer_rdram_state_t *rstate;
+	uint32_t round_next;
+	uint32_t round_enqueued;
+
+	mixer_settings_slot_t *slot_ring;
+	int slot_head;
+	int slot_tail;
 
 } Mixer;
 
-/** @brief Count of ticks spent in mixer RSP, used for debugging purposes. */
+/** @brief Count of ticks spent waiting on mixer rounds (rare fallback path). */
 int64_t __mixer_profile_rsp = 0;
 
 uint32_t __mixer_overlay_id;
 
 static inline int mixer_initialized(void) { return Mixer.num_channels != 0; }
 
+bool __mixer_round_done(uint32_t round_id) {
+	// Before mixer_init (e.g. wav64 preload), nothing is in flight.
+	if (!Mixer.rstate)
+		return true;
+	return (int32_t)(Mixer.rstate->rounds_done - round_id) >= 0;
+}
+
+void __mixer_round_wait(uint32_t round_id) {
+	if (__mixer_round_done(round_id))
+		return;
+	// Waiting on a round whose mix command is not in the queue yet would
+	// deadlock: the counter is published by the mix command itself.
+	assertf((int32_t)(round_id - Mixer.round_enqueued) <= 0,
+		"mixer: wait on round %lx not yet enqueued (last enqueued: %lx)",
+		round_id, Mixer.round_enqueued);
+	rspq_flush();
+	uint32_t t0 = TICKS_READ();
+	ACCT_SCOPE(ACCT_CAT_RSP) RSP_WAIT_LOOP(500) {
+		if (__mixer_round_done(round_id))
+			break;
+	}
+	__mixer_profile_rsp += TICKS_READ() - t0;
+}
+
+uint32_t __mixer_round_current(void) {
+	return Mixer.round_next;
+}
+
+void __mixer_dirty_wait(uint32_t round_id) {
+	if (__mixer_round_done(round_id))
+		return;
+	if ((int32_t)(round_id - Mixer.round_enqueued) > 0) {
+		// The round that owns the dirty tail is the one currently being
+		// prepared: its mix command (which publishes the counter) is not in
+		// the queue yet, so waiting on the counter would deadlock. The
+		// producer commands (eg: VADPCM decodes) are already enqueued
+		// though, so drain the highpri queue instead. This happens only at
+		// a streamed-loop wrap, when waveform_read chains a second decode
+		// right after the undo, within the same mix round.
+		uint32_t t0 = TICKS_READ();
+		bool highpri = rspq_in_highpri();
+		if (highpri) rspq_highpri_end();
+		rspq_highpri_sync();
+		if (highpri) rspq_highpri_begin();
+		__mixer_profile_rsp += TICKS_READ() - t0;
+	} else {
+		__mixer_round_wait(round_id);
+	}
+}
+
+void __mixer_wait_idle(void) {
+	if (Mixer.round_enqueued)
+		__mixer_round_wait(Mixer.round_enqueued);
+}
+
+static void mixer_settings_reclaim(void) {
+	while (Mixer.slot_tail != Mixer.slot_head &&
+	       __mixer_round_done(Mixer.slot_ring[Mixer.slot_tail].round_id))
+		Mixer.slot_tail = (Mixer.slot_tail + 1) % MIXER_SETTINGS_SLOTS;
+}
+
+static rsp_mixer_settings_t *mixer_settings_acquire(uint32_t round_id) {
+	int next = (Mixer.slot_head + 1) % MIXER_SETTINGS_SLOTS;
+	if (next == Mixer.slot_tail) {
+		// Ring full: rare fallback. Wait for the oldest in-flight round.
+		__mixer_round_wait(Mixer.slot_ring[Mixer.slot_tail].round_id);
+		mixer_settings_reclaim();
+		next = (Mixer.slot_head + 1) % MIXER_SETTINGS_SLOTS;
+		assertf(next != Mixer.slot_tail, "mixer settings ring still full after wait");
+	}
+	Mixer.slot_ring[Mixer.slot_head].round_id = round_id;
+	rsp_mixer_settings_t *s = &Mixer.slot_ring[Mixer.slot_head].settings;
+	Mixer.slot_head = next;
+	return s;
+}
+
+static void mixer_reclaim(void) {
+	mixer_settings_reclaim();
+	for (int i = 0; i < Mixer.num_channels; i++) {
+		samplebuffer_t *sbuf = &Mixer.ch_buf[i];
+		mixer_channel_t *ch = &Mixer.channels[i];
+		if (!samplebuffer_is_inited(sbuf) || !ch->ptr)
+			continue;
+		// Fully-cachable loop: the loop must stay resident in the buffer
+		// forever (the RSP plays it straight from the cache, and wrapped
+		// positions jump backwards to the loop start). There is nothing to
+		// reclaim: compaction (if any) is handled by the loop-align discard
+		// in mixer_exec, which runs at most once per waveform.
+		int bps_fx64 = (ch->flags & CH_FLAGS_BPS_SHIFT) + MIXER_FX64_FRAC;
+		int loop_len = ch->loop_len >> bps_fx64;
+		if (loop_len && loop_len < sbuf->size)
+			continue;
+		if (!__mixer_round_done(sbuf->last_round))
+			continue;
+		if (sbuf->wdirty && __mixer_round_done(sbuf->dirty_round))
+			sbuf->wdirty = 0;
+		// Free consumed samples now so mid-frame appends rarely need to
+		// compact while rounds are still in flight.
+		samplebuffer_discard(sbuf, sbuf->wpos + sbuf->ridx);
+	}
+}
+
 void mixer_init(int num_channels) {
 	memset(&Mixer, 0, sizeof(Mixer));
-	data_cache_hit_writeback_invalidate(&Mixer.ucode_settings, sizeof(Mixer.ucode_settings));
 
 	Mixer.num_channels = num_channels;
 	Mixer.sample_rate = audio_get_frequency();  // actual sample rate obtained via DAC clock
@@ -196,12 +334,21 @@ void mixer_init(int num_channels) {
 		mixer_ch_set_limits(ch, 16, Mixer.sample_rate, 0);
 	}
 
-	void *mixer_state = rspq_overlay_get_state(&rsp_mixer);
-	memset(mixer_state, 0, MIXER_STATE_SIZE);
-	data_cache_hit_writeback(mixer_state, MIXER_STATE_SIZE);
+	Mixer.rstate = malloc_uncached(sizeof(*Mixer.rstate));
+	assertf(Mixer.rstate, "Out of memory");
+	memset((void*)Mixer.rstate, 0, sizeof(*Mixer.rstate));
+
+	Mixer.slot_ring = malloc_uncached(sizeof(mixer_settings_slot_t) * MIXER_SETTINGS_SLOTS);
+	assertf(Mixer.slot_ring, "Out of memory");
+	memset(Mixer.slot_ring, 0, sizeof(mixer_settings_slot_t) * MIXER_SETTINGS_SLOTS);
 
 	rspq_init();
-    __mixer_overlay_id = rspq_overlay_register(&rsp_mixer);
+	__mixer_overlay_id = rspq_overlay_register(&rsp_mixer);
+
+	mixer_overlay_state_t *mixer_state = rspq_overlay_get_state(&rsp_mixer);
+	memset(mixer_state, 0, sizeof(*mixer_state));
+	mixer_state->counter_rdram = PhysicalAddr((void*)Mixer.rstate);
+	data_cache_hit_writeback(mixer_state, sizeof(*mixer_state));
 }
 
 static int mixer_calc_buffer_size(int ch, int nchannels)
@@ -235,6 +382,8 @@ void mixer_set_vol(float vol) {
 void mixer_close(void) {
 	assert(mixer_initialized());
 
+	__mixer_wait_idle();
+
 	rspq_overlay_unregister(__mixer_overlay_id);
 	__mixer_overlay_id = 0;
 
@@ -242,6 +391,15 @@ void mixer_close(void) {
 	{
 		if (samplebuffer_is_inited(&Mixer.ch_buf[i]))
 			samplebuffer_close(&Mixer.ch_buf[i]);
+	}
+
+	if (Mixer.slot_ring) {
+		free_uncached(Mixer.slot_ring);
+		Mixer.slot_ring = NULL;
+	}
+	if (Mixer.rstate) {
+		free_uncached((void*)Mixer.rstate);
+		Mixer.rstate = NULL;
 	}
 
 	Mixer.num_channels = 0;
@@ -407,11 +565,15 @@ void mixer_ch_play(int ch, waveform_t *wave)
 
 	// If we're going to play a stereo waveform on a channel that was allocated
 	// for mono, we need to reallocate the buffer.
-	if (wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC))
+	if (wave->channels == 2 && !(c->flags & CH_FLAGS_STEREO_ALLOC)) {
+		__mixer_wait_idle();
 		samplebuffer_close(sbuf);
+	}
 	// Check if the state buffer is big enough, otherwise we need to reallocate
-	if (sbuf->state_size < wave->state_size)
+	if (sbuf->state_size < wave->state_size) {
+		__mixer_wait_idle();
 		samplebuffer_close(sbuf);
+	}
 
 	if (!samplebuffer_is_inited(sbuf)) {
 		// If we have not yet allocated the memory for the sample buffers,
@@ -565,6 +727,7 @@ void mixer_ch_set_limits(int ch, int max_bits, float max_frequency, int max_buf_
 	// Free the memory immediately, as it doesn't match the new limits anymore.
 	// We will reallocate it later lazily if needed.
 	if (samplebuffer_is_inited(&Mixer.ch_buf[ch])) {
+		__mixer_wait_idle();
 		samplebuffer_close(&Mixer.ch_buf[ch]);
 		Mixer.channels[ch].flags &= ~CH_FLAGS_STEREO_ALLOC;
 	}
@@ -573,6 +736,9 @@ void mixer_ch_set_limits(int ch, int max_bits, float max_frequency, int max_buf_
 static void mixer_exec(int32_t *out, int num_samples) {
 	tracef("mixer_exec: 0x%x samples\n", num_samples);
 
+	uint32_t round_id = ++Mixer.round_next;
+	rsp_mixer_settings_t *settings = mixer_settings_acquire(round_id);
+	rsp_mixer_channel_t *rsp_wv = settings->channels;
 	uint32_t fake_loop = 0;
 
 	for (int i=0; i<Mixer.num_channels; i++) {
@@ -670,11 +836,9 @@ static void mixer_exec(int32_t *out, int num_samples) {
 			void* ptr = samplebuffer_get(sbuf, wpos, &wlen);
 			assert(ptr);
 			ch->ptr = (uint8_t*)ptr - (wpos<<bps);
+			sbuf->last_round = round_id;
 		}
 	}
-
-	volatile rsp_mixer_settings_t *settings = UncachedAddr(&Mixer.ucode_settings);
-	volatile rsp_mixer_channel_t *rsp_wv = settings->channels;
 
 	for (int ch=0;ch<Mixer.num_channels;ch++) {
 		mixer_channel_t *c = &Mixer.channels[ch];
@@ -771,23 +935,33 @@ static void mixer_exec(int32_t *out, int num_samples) {
 		gvol *= (FADE_OUT_TIME - MIN(elapsed, FADE_OUT_TIME)) / FADE_OUT_TIME;
 	}
 
-	uint32_t t0 = TICKS_READ();
 	rspq_highpri_begin();
 	rspq_write(__mixer_overlay_id, 0,
 		(((uint32_t)MIXER_FX16(gvol)) & 0xFFFF),
 		(num_samples << 16) | Mixer.num_channels,
 		PhysicalAddr(out),
-		PhysicalAddr(&Mixer.ucode_settings));
+		PhysicalAddr(settings),
+		round_id);
 	rspq_highpri_end();
+	Mixer.round_enqueued = round_id;
 
-	rspq_highpri_sync();
-
-	__mixer_profile_rsp += TICKS_READ() - t0;
-
+	// CPU-authoritative position update. The RSP advances pos by step per
+	// output sample and wraps by loop_len when past len; we compute the same
+	// value in 64-bit fixed point. For RSP-visible loops, both sides are
+	// congruent mod loop_len (the exact wrap count may differ depending on
+	// fetch boundaries); the next round's wpos normalization handles that.
+	// Fake/unrolled loops keep growing pos; existing wrap logic above rebases.
 	for (int i=0;i<Mixer.num_channels;i++) {
 		mixer_channel_t *ch = &Mixer.channels[i];
-		if (ch->ptr)
-			ch->pos += (uint64_t)rsp_wv[i].pos - (uint64_t)(ch->pos & 0x7FFFFFFF);
+		if (!ch->ptr || (ch->flags & CH_FLAGS_STEREO_SUB))
+			continue;
+
+		ch->pos += ch->step * (uint64_t)num_samples;
+
+		if (ch->loop_len && !(fake_loop & (1<<i))) {
+			while (ch->pos >= ch->len)
+				ch->pos -= ch->loop_len;
+		}
 	}
 
 	Mixer.ticks += num_samples;
@@ -831,8 +1005,10 @@ void mixer_unthrottle(void) {
 	Mixer.throttled = false;
 }
 
-void mixer_poll(int16_t *out16, int num_samples) {
+static void mixer_poll_async(int16_t *out16, int num_samples) {
 	int32_t *out = (int32_t*)out16;
+
+	mixer_reclaim();
 
 	// Since the AI can only play an even number of samples,
 	// it's not possible to call this function with an odd number,
@@ -870,19 +1046,30 @@ void mixer_poll(int16_t *out16, int num_samples) {
 	}
 }
 
-void mixer_try_play()
+void mixer_poll(int16_t *out16, int num_samples) {
+	mixer_poll_async(out16, num_samples);
+	// Preserve the synchronous contract for direct callers (user-owned
+	// buffer / legacy audio_set_buffer_callback). One sync per poll instead
+	// of one per mixer_exec.
+	rspq_highpri_sync();
+}
+
+void mixer_try_play(void)
 {
 	// To smooth out the pacing for mixer and wav64 decodes, we fill buffers
 	// to at least audio_get_num_buffers()-1, but fill completely, if there is
 	// only one free one left.
 	int free_buffers = audio_get_num_buffers() - audio_get_queued_buffers();
-	if (free_buffers <= 0)
+	if (free_buffers <= 0) {
+		mixer_reclaim();
 		return;
+	}
 
 	int buffers_to_fill = MAX(free_buffers - 1, 1);
 	while (buffers_to_fill-- > 0) {
 		short *buf = audio_write_begin();
-		mixer_poll(buf, audio_get_buffer_length());
+		mixer_poll_async(buf, audio_get_buffer_length());
 		audio_write_end();
 	}
+	rspq_flush();
 }

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -84,10 +84,9 @@ DEFINE_RSP_UCODE(rsp_mixer);
 #define CH_FLAGS_LOOP_CACHED    (1<<10)  ///< Streamed loop pinned in the samplebuffer; RSP wraps
 #define CH_FLAGS_STEREO_ALLOC	(1<<9)   ///< The channel has a buffer sized for stereo (CPU-side only)
 
-/** @brief rspq command IDs for rsp_mixer.S */
-#define MIXER_CMD_CHANNEL     0x0
-#define MIXER_CMD_SETCHANNEL  0x1
-#define MIXER_CMD_FLUSH       0x2
+#define MIXER_CMD_CHANNEL     0x0        ///< rspq command ID for channel setup
+#define MIXER_CMD_SETCHANNEL  0x1        ///< rspq command ID for setting a channel
+#define MIXER_CMD_FLUSH       0x2        ///< rspq command ID for flushing the mixer
 
 /// @brief Fixed point value used in waveform position calculations.
 /// This is a signed 64-bit integer with the fractional part using

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -32,28 +32,4 @@ enum {
 /** @brief Register mixer profile slots with #profile_init. */
 void __mixer_profile_init(void);
 
-/**
- * @brief Return true if the RSP has fully executed the given mix round.
- *
- * Round IDs are issued by mixer_exec; when round R is done, every command
- * enqueued before its mix is done too.
- */
-bool __mixer_round_done(uint32_t round_id);
-
-/**
- * @brief Wait until the given mix round has completed (bounded spinwait).
- *
- * Used as a rare fallback when CPU needs to reclaim memory still referenced
- * by in-flight RSP work. Prefer arranging for the wait to be a no-op.
- */
-void __mixer_round_wait(uint32_t round_id);
-
-/**
- * @brief Wait until every issued mix round has completed.
- *
- * Cold-path helper for free/realloc of uncached buffers that in-flight
- * rounds may still reference.
- */
-void __mixer_wait_idle(void);
-
 #endif

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -28,12 +28,27 @@ bool __mixer_round_done(uint32_t round_id);
 void __mixer_round_wait(uint32_t round_id);
 
 /**
- * @brief Round ID of the mix currently being prepared (0 if none yet).
+ * @brief Round ID that covers highpri commands enqueued right now.
  *
- * samplebuffer uses this to tag dirty tails created by samplebuffer_undo
- * so later appends can wait for the matching producer commands.
+ * Returns the ID of the mix round whose completion guarantees that any
+ * highpri command enqueued at this moment (VADPCM decodes, compaction
+ * memmoves) has executed: the round being prepared if inside mixer_exec,
+ * or the next round to be issued otherwise. samplebuffer uses this to tag
+ * dirty tails and pending compactions.
  */
-uint32_t __mixer_round_current(void);
+uint32_t __mixer_round_producer(void);
+
+/**
+ * @brief Enqueue an RSP-side backward memmove (dst < src) in the highpri queue.
+ *
+ * Used by samplebuffer_discard to compact sample buffers in-order with the
+ * decode/mix commands that reference them, without CPU waits. dst/src must be
+ * 8-byte aligned, len a multiple of 8.
+ *
+ * @return false if the mixer is not initialized (caller must fall back to
+ *         a synchronous CPU copy).
+ */
+bool __mixer_memmove_async(void *dst, void *src, int len);
 
 /**
  * @brief Wait until the producers of a dirty tail tagged with round_id are done.

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -11,6 +11,27 @@
 /** @brief RSPQ overlay ID assigned to the mixer ucode */
 extern uint32_t __mixer_overlay_id;
 
+/** @brief Profile slots for mixer / xm64 / vadpcm (see #__mixer_profile_init). */
+enum {
+	PS_MIXER = 0,       ///< mixer_try_play
+	PS_XM_TICK,         ///< xm64 tick callback (sequencing + channel sync)
+	PS_XM_GETPOS,       ///< xm64: sync sample_position from mixer
+	PS_XM_LIBXM,        ///< xm64: xm_tick (libxm sequencer)
+	PS_XM_SYNC,         ///< xm64: play/pos/freq/vol sync to mixer
+	PS_MIXER_EXEC,      ///< mixer_exec
+	PS_MIXER_PREP,      ///< update_loops + refresh_chtbl + round_length
+	PS_MIXER_EMIT,      ///< mixer_emit_round (rspq write + fetch)
+	PS_SBUF_GET,        ///< samplebuffer_get
+	PS_VADPCM_READ,     ///< waveform_vadpcm_read_compressed
+	PS_VADPCM_HUFF,     ///< huffv_decompress
+	PS_VADPCM_IO,       ///< plain VADPCM DMA/read
+	PS_MIXER_ADVANCE,   ///< mixer_advance
+	PS_MIXER_SEEK,      ///< mixer_ch_seek
+};
+
+/** @brief Register mixer profile slots with #profile_init. */
+void __mixer_profile_init(void);
+
 /**
  * @brief Return true if the RSP has fully executed the given mix round.
  *

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -14,8 +14,8 @@ extern uint32_t __mixer_overlay_id;
 /**
  * @brief Return true if the RSP has fully executed the given mix round.
  *
- * Round IDs are issued by mixer_exec; when round R is done, every highpri
- * command enqueued before that mix (including VADPCM/Opus decode) is done too.
+ * Round IDs are issued by mixer_exec; when round R is done, every command
+ * enqueued before its mix is done too.
  */
 bool __mixer_round_done(uint32_t round_id);
 
@@ -26,39 +26,6 @@ bool __mixer_round_done(uint32_t round_id);
  * by in-flight RSP work. Prefer arranging for the wait to be a no-op.
  */
 void __mixer_round_wait(uint32_t round_id);
-
-/**
- * @brief Round ID that covers highpri commands enqueued right now.
- *
- * Returns the ID of the mix round whose completion guarantees that any
- * highpri command enqueued at this moment (VADPCM decodes, compaction
- * memmoves) has executed: the round being prepared if inside mixer_exec,
- * or the next round to be issued otherwise. samplebuffer uses this to tag
- * dirty tails and pending compactions.
- */
-uint32_t __mixer_round_producer(void);
-
-/**
- * @brief Enqueue an RSP-side backward memmove (dst < src) in the highpri queue.
- *
- * Used by samplebuffer_discard to compact sample buffers in-order with the
- * decode/mix commands that reference them, without CPU waits. dst/src must be
- * 8-byte aligned, len a multiple of 8.
- *
- * @return false if the mixer is not initialized (caller must fall back to
- *         a synchronous CPU copy).
- */
-bool __mixer_memmove_async(void *dst, void *src, int len);
-
-/**
- * @brief Wait until the producers of a dirty tail tagged with round_id are done.
- *
- * Like #__mixer_round_wait, but also handles the case where round_id is the
- * round currently being prepared (whose mix command is not enqueued yet):
- * in that case it drains the highpri queue, which already contains the
- * producer commands (eg: VADPCM decodes).
- */
-void __mixer_dirty_wait(uint32_t round_id);
 
 /**
  * @brief Wait until every issued mix round has completed.

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -29,6 +29,18 @@ enum {
 	PS_MIXER_SEEK,      ///< mixer_ch_seek
 };
 
+/** @brief Codec side-data for #WAVEFORM_FORMAT_VADPCM waveforms. */
+typedef struct {
+	/** Predictor codebook in RDRAM (must stay valid for the waveform lifetime). */
+	void *codebook;
+	/**
+	 * Decoder state at the loop start (16-byte vector), or NULL if the
+	 * waveform does not loop / loop state is unknown. Used by the RSP on
+	 * cached-loop wraps.
+	 */
+	void *loop_state;
+} waveform_vadpcm_t;
+
 /** @brief Register mixer profile slots with #profile_init. */
 void __mixer_profile_init(void);
 

--- a/src/audio/mixer_internal.h
+++ b/src/audio/mixer_internal.h
@@ -6,8 +6,51 @@
 #define LIBDRAGON_MIXER_INTERNAL_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /** @brief RSPQ overlay ID assigned to the mixer ucode */
 extern uint32_t __mixer_overlay_id;
+
+/**
+ * @brief Return true if the RSP has fully executed the given mix round.
+ *
+ * Round IDs are issued by mixer_exec; when round R is done, every highpri
+ * command enqueued before that mix (including VADPCM/Opus decode) is done too.
+ */
+bool __mixer_round_done(uint32_t round_id);
+
+/**
+ * @brief Wait until the given mix round has completed (bounded spinwait).
+ *
+ * Used as a rare fallback when CPU needs to reclaim memory still referenced
+ * by in-flight RSP work. Prefer arranging for the wait to be a no-op.
+ */
+void __mixer_round_wait(uint32_t round_id);
+
+/**
+ * @brief Round ID of the mix currently being prepared (0 if none yet).
+ *
+ * samplebuffer uses this to tag dirty tails created by samplebuffer_undo
+ * so later appends can wait for the matching producer commands.
+ */
+uint32_t __mixer_round_current(void);
+
+/**
+ * @brief Wait until the producers of a dirty tail tagged with round_id are done.
+ *
+ * Like #__mixer_round_wait, but also handles the case where round_id is the
+ * round currently being prepared (whose mix command is not enqueued yet):
+ * in that case it drains the highpri queue, which already contains the
+ * producer commands (eg: VADPCM decodes).
+ */
+void __mixer_dirty_wait(uint32_t round_id);
+
+/**
+ * @brief Wait until every issued mix round has completed.
+ *
+ * Cold-path helper for free/realloc of uncached buffers that in-flight
+ * rounds may still reference.
+ */
+void __mixer_wait_idle(void);
 
 #endif

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -55,6 +55,11 @@
 # Max output samples that fit in ACCUM (stereo int16). Must match mixer.c.
 #define MAX_SAMPLES_PER_ROUND     512
 
+# Extra ACCUM slots the mono resampler is allowed to overshoot into. Sized so
+# that ACCUM+padding is a whole number of 64-byte clear blocks.
+#define ACCUM_PAD_SAMPLES         16
+#define ACCUM_CLEAR_BLOCKS        (((MAX_SAMPLES_PER_ROUND + ACCUM_PAD_SAMPLES) * 4) / 64)
+
 # Number of fractional bits used in the fixed point numbers that specify
 # the waveform position, step, length and loop length.
 # NOTE: This must be the same of MIXER_FX64_FRAC in mixer.c.
@@ -69,9 +74,8 @@
 # Zero ACCUM before mixing (first MIX_CHANNEL of a round; ACCUM is in .bss).
 #define CH_FLAGS_CLEAR_ACCUM      (1<<7)
 
-# Resample staging (8 samples) and volume spill during VADPCM decode
-# (4 vectors).
-#define DMEM_SCRATCH_SIZE         64
+# Resample staging (8 samples) for the stereo and VADPCM paths.
+#define DMEM_SCRATCH_SIZE         16
 
 # Sample DMA cache (must be <= MIXER_LOOP_OVERREAD in mixer.c).
 #define SAMPLE_CACHE_SIZE         64
@@ -87,15 +91,21 @@
 	################################
 
 	#define v_zero        $v00
-	#define v_shift8      $v29
 	#define v_shift       $v30
 	#define v_const1      $v31
 
 	#define k_0000        v_zero
-	#define k_8000        v_shift8.e0
-	#define k_ffff        v_const1.e0
 	#define k_alpha       v_const1.e1
 	#define k_1malpha     v_const1.e2
+	# k_half:  0.5 as a 0.16 unsigned fraction. Multiplying by it with vmudl
+	#          is a logical shift right by one (vsrl cannot be used here: it
+	#          needs the RSPQ shift table in $v31, which holds VCONST_1).
+	# k_one:   integer one. vmudh by it loads a vector into the accumulator
+	#          unshifted, to start a vmadm chain.
+	# k_eight: integer eight, one group of the mono resampler.
+	#define k_half        v_const1.e3
+	#define k_one         v_const1.e4
+	#define k_eight       v_const1.e5
 
 
 	.data
@@ -113,6 +123,16 @@ VCONST_1:
 	.half 0x7FFF
 	.half 0xe076      #   (0.9837**8) fixed 0.16
 	.half 0x1f8a      # 1-(0.9837**8) fixed 0.16
+	.half 0x8000      # 0.5 fixed 0.16
+	.half 1           # integer one
+	.half 8           # integer eight
+
+	# Lane -> output sample mapping used by the mono resampler. The eight
+	# results come out interleaved this way so that the .q0/.q1 swizzles
+	# feed the LRLRLRLR layout of ACCUM without any further shuffling.
+	.align 4
+PERM8:
+	.half 0, 4, 1, 5, 2, 6, 3, 7
 
 	.align 4
 BANNER0:    .ascii "Dragon RSP Audio"
@@ -123,9 +143,11 @@ BANNER1:    .ascii " Coded by Rasky "
 	# Layout must match mixer_overlay_state_t in mixer.c.
 	# ================================================================
 	RSPQ_BeginSavedState
+	# One-tap volume filter state, [left:16][right:16] per channel. Kept
+	# interleaved so it can be splatted into the [L,R,L,R,...] vector the
+	# mixing loops use with a single word load.
 	.align 4
-XVOL_L:                   .dcb.w MAX_CHANNELS
-XVOL_R:                   .dcb.w MAX_CHANNELS
+XVOL:                     .dcb.l MAX_CHANNELS
 	# Per-channel VADPCM pointers, written by MIX_SETCHANNEL. They only
 	# change when a new waveform is played, so the CPU sends them once
 	# instead of inlining them in every MIX_CHANNEL.
@@ -146,14 +168,37 @@ IDENTITY:  .half  1<<11,1<<11,1<<11,1<<11, 1<<11,1<<11,1<<11,1<<11
 	# highpri burst of this overlay, so no overlay switch can clobber it
 	# mid-round. Cleared by the first MIX_CHANNEL (CH_FLAGS_CLEAR_ACCUM)
 	# and again by MIX_FLUSH after DMA-out.
+	# The mono resampler emits whole groups of 8 samples, so it can write up
+	# to 7 samples past the end of the round. ACCUM_PAD absorbs them; it is
+	# never DMA'd out, but it is cleared together with ACCUM so that the
+	# accumulation never saturates on leftovers.
 	.align 4
 ACCUM:                    .dcb.w (MAX_SAMPLES_PER_ROUND * 2)
+ACCUM_PAD:                .dcb.w (ACCUM_PAD_SAMPLES * 2)
 
-	# Temporary cache of samples fetched by DMA for resampling.
-	.align 3
+	# Temporary cache of samples fetched by DMA for resampling. Each cache is
+	# followed by a window of four zero samples: the mono resampler parks the
+	# lanes it must discard there, so they interpolate to silence instead of
+	# needing a separate mask (MonoLoop). Both caches are 16-byte aligned
+	# because they are written/read with sqv/lqv.
+	.align 4
 DMEM_SAMPLE_CACHE:        .dcb.b SAMPLE_CACHE_SIZE
+DMEM_SAMPLE_CACHE_ZERO:   .dcb.b 16
 
-	# Contiguous resample staging, plus volume spill during VADPCM decode.
+	# 8-bit samples widened to int16 after each DMA, so that one inner loop
+	# serves both PCM formats.
+	.align 4
+DMEM_SAMPLE_CACHE16:      .dcb.b SAMPLE_CACHE_SIZE * 2
+DMEM_SAMPLE_CACHE16_ZERO: .dcb.b 16
+
+	# Per-lane tap addresses produced by the mono resampler, and the
+	# scratch used to transpose the eight gathered 4-tap groups.
+	.align 4
+DMEM_ADDRS:               .dcb.b 16
+	.align 4
+DMEM_TRANSPOSE:           .dcb.b 128
+
+	# Contiguous resample staging (stereo and VADPCM paths).
 	.align 4
 DMEM_SCRATCH:             .dcb.b DMEM_SCRATCH_SIZE
 
@@ -199,6 +244,10 @@ CH_VADPCM_RA:             .long  0
 CH_ACC_PTR:               .long  0
 # Volume-filter step countdown, preserved across frame decodes.
 CH_K1:                    .half  0
+# Per-sample step of the mono resampler, split the same way as the position:
+# fraction as 0.16, plus whole samples.
+CH_STEPF:                 .half  0
+CH_STEPI:                 .half  0
                           .half  0
 
 
@@ -243,6 +292,56 @@ CH_K1:                    .half  0
 	#define is_stereo      v0
 	#define acc_ptr        s8
 	#define ch_idx         k0
+
+	# Volumes, as [L,R,L,R,L,R,L,R] to match the ACCUM layout. $v24/$v25
+	# are outside the range the VADPCM decoder uses, so they survive a
+	# frame decode untouched.
+	#define v_xvol         $v24
+	#define v_chvol        $v25
+
+	# Mono resampler state, live across MonoLoop iterations:
+	#   v_frac  fraction of the sample position, 0.16 unsigned
+	#   v_idx   DMEM index of tap y0, in units of 2 bytes
+	#   v_kmono broadcast scalars of the loop, see k_* below
+	#define v_frac         $v26
+	#define v_idx          $v27
+	#define v_kmono        $v29
+	# k_limit  first tap address that would read past the cache
+	# k_zaddr  address of the window of four zero samples
+	# k_step8f 8-sample step, fractional part
+	# k_step8i 8-sample step, whole samples
+	#define k_limit        v_kmono.e0
+	#define k_zaddr        v_kmono.e1
+	#define k_step8f       v_kmono.e2
+	#define k_step8i       v_kmono.e3
+	# Transient within one MonoLoop iteration.
+	#define v_addr         $v01
+	#define v_x2           $v02
+	#define v_x05          $v03
+	#define v_x205         $v04
+	#define v_x3           $v05
+	#define v_x305         $v06
+	#define v_res          $v07
+	#define v_y0n          $v09
+	#define v_y1n          $v10
+	#define v_y2n          $v11
+	#define v_y3n          $v12
+	#define v_cnt          $v13
+	#define v_acc0         $v14
+	#define v_acc1         $v15
+	#define v_y0           $v16
+	#define v_y1           $v17
+	#define v_y2           $v18
+	#define v_y3           $v19
+	#define v_tmp          $v20
+
+	#define addr_ptr       v0
+	#define tr_ptr         a0
+	#define bps            a1
+	#define cache_half     a2
+	#define frac_shift     a3
+	#define mask           v1
+	#define k_ff           s5
 
 	.func MIX_CHANNEL
 MIX_CHANNEL:
@@ -291,7 +390,7 @@ MIX_CHANNEL:
 	andi t0, CH_FLAGS_CLEAR_ACCUM
 	beqz t0, MIX_CHANNEL_NoClear
 	li s4, %lo(ACCUM)
-	li t0, (MAX_SAMPLES_PER_ROUND * 4) / 64 - 1
+	li t0, ACCUM_CLEAR_BLOCKS - 1
 1:	sqv v_zero, 0x00,s4
 	sqv v_zero, 0x10,s4
 	sqv v_zero, 0x20,s4
@@ -301,24 +400,24 @@ MIX_CHANNEL:
 	addi t0, -1
 
 MIX_CHANNEL_NoClear:
-	# Load current filtered volumes for this channel into vector regs
-	# (kept in $v13/$v14 for the duration of the command).
+	# Splat the current filtered volume and the target volume of this
+	# channel into [L,R,L,R,L,R,L,R] vectors. Both are stored as adjacent
+	# halfword pairs in DMEM, so one word replicated four times does it.
+	li s0, %lo(DMEM_SCRATCH)
 	lh ch_idx, %lo(CH_IDX)
-	sll t0, ch_idx, 1
-	lh t1, %lo(XVOL_L)(t0)
-	lh t2, %lo(XVOL_R)(t0)
-	mtc2 t1, $v13.e0               # v_xvol_l
-	mtc2 t2, $v14.e0               # v_xvol_r
-	vor $v13, v_zero, $v13.e0
-	vor $v14, v_zero, $v14.e0
-
-	# Target volumes
-	lh t1, %lo(CH_LVOL)
-	lh t2, %lo(CH_RVOL)
-	mtc2 t1, $v15.e0               # v_chvol_l
-	mtc2 t2, $v16.e0               # v_chvol_r
-	vor $v15, v_zero, $v15.e0
-	vor $v16, v_zero, $v16.e0
+	sll t0, ch_idx, 2
+	lw t1, %lo(XVOL)(t0)
+	lw t2, %lo(CH_LVOL)             # CH_RVOL is the next halfword
+	sw t1, 0x00(s0)
+	sw t1, 0x04(s0)
+	sw t1, 0x08(s0)
+	sw t1, 0x0C(s0)
+	lqv v_xvol, 0x00,s0
+	sw t2, 0x00(s0)
+	sw t2, 0x04(s0)
+	sw t2, 0x08(s0)
+	sw t2, 0x0C(s0)
+	lqv v_chvol, 0x00,s0
 
 	lh ticks, %lo(CH_NSAMPLES)
 	beqz ticks, MIX_CHANNEL_Done
@@ -343,6 +442,9 @@ MIX_CHANNEL_NoClear:
 	andi is_stereo_sub, t0, CH_FLAGS_STEREO_SUB
 	andi t1, t0, CH_FLAGS_VADPCM
 	bnez t1, VadpcmSetup
+	or t1, is_stereo, is_stereo_sub
+	beqz t1, MonoSetup
+	nop
 
 	li dma_cache_end, %lo(DMEM_SAMPLE_CACHE+SAMPLE_CACHE_SIZE)
 	sll dma_cache_end, WAVEFORM_POS_FRAC_BITS
@@ -366,114 +468,12 @@ WaveDmaFetch:
 	sll wv_pos_to_dmem, WAVEFORM_POS_FRAC_BITS
 	sll wv_step_8x, wv_step, 3
 
-	# Route to the correct resampling path. Stereo and stereo-sub share the
-	# interleaved fetch; sub extracts the R sample.
-	bnez is_stereo_sub, WaveGoStereo
+	# Stereo and stereo-sub share the interleaved fetch; sub extracts R.
 	sub wv_pos, wv_pos_to_dmem
-	bnez is_stereo, WaveGoStereo
-	nop
-	bnez is_16bit, WaveLoop16_8x
-	nop
-	j WaveLoop8_8x
-	nop
-
-WaveGoStereo:
 	bnez is_16bit, WaveLoop16_Stereo_8x
 	nop
 	j WaveLoop8StereoChecks
 	nop
-
-	############################################################
-	# Mono 8-bit
-	############################################################
-
-WaveLoop8_8x:
-	add t0, wv_pos, wv_step_8x
-	bgt t0, dma_cache_end, WaveLoop8Checks
-	li t0, 8
-	blt ticks, t0, WaveLoop8Checks
-
-	li out_ptr, %lo(DMEM_SCRATCH)
-	li t1, 8
-1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, 0(out_ptr)
-	addi out_ptr, 1
-	addi t1, -1
-	bnez t1, 1b
-	nop
-
-	jal MixBatch8bit
-	li t0, 8
-	addi ticks, -8
-	j WaveLoop8_8x
-	addi acc_ptr, 8*4
-
-WaveLoop8:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	# sign extend and mix one sample
-	sll t0, 8
-	mtc2 t0, $v01.e0
-	jal MixOne
-	nop
-	addi ticks, -1
-	addi acc_ptr, 4
-WaveLoop8Checks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop8
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
-
-	############################################################
-	# Mono 16-bit
-	############################################################
-
-WaveLoop16_8x:
-	add t0, wv_pos, wv_step_8x
-	bgt t0, dma_cache_end, WaveLoop16Checks
-	li t0, 8
-	blt ticks, t0, WaveLoop16Checks
-
-	li out_ptr, %lo(DMEM_SCRATCH)
-	li t1, 8
-1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, 0(out_ptr)
-	addi out_ptr, 2
-	addi t1, -1
-	bnez t1, 1b
-	nop
-
-	jal MixBatch16bit
-	nop
-	addi ticks, -8
-	j WaveLoop16_8x
-	addi acc_ptr, 8*4
-
-WaveLoop16:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	mtc2 t0, $v01.e0
-	jal MixOne
-	nop
-	addi ticks, -1
-	addi acc_ptr, 4
-WaveLoop16Checks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop16
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
 
 	############################################################
 	# Stereo 8-bit (owner extracts L, sub extracts R)
@@ -562,6 +562,288 @@ WaveLoop16StereoChecks:
 	j WaveStart
 	add wv_pos, wv_pos_to_dmem
 
+	############################################################
+	# Mono 8/16-bit: 4-tap Catmull-Rom (Hermite) resampling
+	#
+	# Eight output samples are produced per iteration, one per vector lane.
+	# Lane k carries output sample PERM8[k] = [0,4,1,5,2,6,3,7], so that the
+	# .q0/.q1 swizzles of the interpolated vector line up with the LRLRLRLR
+	# layout of ACCUM without any further shuffling.
+	#
+	# The sample position is split across two vectors: v_frac holds the
+	# fraction as 0.16 and v_idx the DMEM index of the first tap, in units
+	# of 2 bytes. Advancing eight samples is then vaddc+vadd, because the
+	# carry out of the fraction is exactly the carry into the sample index.
+	#
+	# With taps y0..y3 and x the fraction, the spline is evaluated in the
+	# central interval, between y1 and y2:
+	#
+	#   out = y1 + x*(y2-y0)/2
+	#            + x^2*(y0 - 5*y1/2 + 2*y2 - y3/2)
+	#            + x^3*(-y0/2 + 3*y1/2 - 3*y2/2 + y3/2)
+	#
+	# so the output lags the nominal position by one sample. That keeps the
+	# tap window at [pos, pos+3] and no sample before pos is ever needed —
+	# which matters because the sample cache is DMA'd starting exactly at
+	# pos, and for a streamed waveform the samples before it may no longer
+	# be in RDRAM.
+	#
+	# Lanes whose tap window runs past the end of the cache are parked on a
+	# window of four zero samples: they interpolate to silence and, since
+	# ACCUM is accumulated in place, leave it untouched. Being always the
+	# last ones in output order, they are simply counted and replayed after
+	# the next DMA.
+	#
+	# The mono path reuses the register names of the stereo dispatch for its
+	# own purposes (see the #defines above); is_16bit/is_stereo are dead here.
+	############################################################
+
+MonoSetup:
+	# A sample is always 2 bytes in DMEM: 8-bit waveforms are widened after
+	# each DMA so that a single inner loop serves both PCM formats.
+	#   bps         0 for 8-bit source samples, 1 for 16-bit
+	#   cache_half  DMEM address of the int16 cache, in units of 2 bytes
+	#   frac_shift  left shift turning wv_pos into a 0.16 sample fraction
+	lh t0, %lo(CH_FLAGS)
+	andi bps, t0, CH_FLAGS_BPS_SHIFT
+	li cache_half, %lo(DMEM_SAMPLE_CACHE16)
+	li t1, %lo(DMEM_SAMPLE_CACHE16_ZERO)
+	li frac_shift, 4
+	li t0, SAMPLE_CACHE_SIZE
+	beqz bps, 1f
+	nop
+	li cache_half, %lo(DMEM_SAMPLE_CACHE)
+	li t1, %lo(DMEM_SAMPLE_CACHE_ZERO)
+	li frac_shift, 3
+	srl t0, 1
+1:
+	# The window of four zero samples the rejected lanes are parked on. It
+	# sits right after the cache, so it also fails the "tap window inside
+	# the cache" test and a single comparison covers both cases.
+	sw zero, 0(t1)
+	sw zero, 4(t1)
+
+	# Assemble the loop scalars in DMEM and splat them in one load.
+	li s0, %lo(DMEM_SCRATCH)
+	sh t1, 0x02(s0)                          # k_zaddr
+	sll t0, 1                                # cache size in bytes
+	add t0, cache_half
+	addi t0, -3*2                            # y3 must stay inside the cache
+	sh t0, 0x00(s0)                          # k_limit
+	srl cache_half, 1                        # byte address -> DMEM index
+	sll t2, wv_step, 3
+	sllv t0, t2, frac_shift
+	sh t0, 0x04(s0)                          # k_step8f
+	srl t0, t2, WAVEFORM_POS_FRAC_BITS
+	srlv t0, t0, bps
+	sh t0, 0x06(s0)                          # k_step8i
+	# Same split for one sample, needed to seed the eight lanes.
+	sllv t0, wv_step, frac_shift
+	sh t0, %lo(CH_STEPF)
+	srl t0, wv_step, WAVEFORM_POS_FRAC_BITS
+	srlv t0, t0, bps
+	sh t0, %lo(CH_STEPI)
+	lqv v_kmono, 0x00,s0
+
+	li addr_ptr, %lo(DMEM_ADDRS)
+	li tr_ptr, %lo(DMEM_TRANSPOSE)
+	li k_ff, 0xFF
+
+MonoWaveStart:
+	bltu wv_pos, wv_len, MonoDmaFetch
+	nop
+	beqz wv_loop_len, MIX_CHANNEL_SilenceLeft
+	nop
+	j MonoWaveStart
+	sub wv_pos, wv_loop_len
+
+MonoDmaFetch:
+	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS
+	add s0, s2, wv_addr
+	li s4, %lo(DMEM_SAMPLE_CACHE)
+	andi s2, s0, 7                           # DMA rounds down to 8 bytes
+	jal DMAIn
+	li t0, DMA_SIZE(SAMPLE_CACHE_SIZE, 1)
+	sll wv_step_8x, wv_step, 3               # DMAExec clobbers t2
+
+	# Widen the 8-bit cache to int16: lpv shifts each byte into the high
+	# half of a lane, which is exactly the <<8 scaling the mixer expects.
+	bnez bps, MonoRefill
+	li s1, %lo(DMEM_SAMPLE_CACHE)
+	li s3, %lo(DMEM_SAMPLE_CACHE16)
+	lpv $v08, 0x00,s1
+	lpv $v09, 0x08,s1
+	lpv $v10, 0x10,s1
+	lpv $v11, 0x18,s1
+	lpv $v12, 0x20,s1
+	lpv $v13, 0x28,s1
+	lpv $v14, 0x30,s1
+	lpv $v15, 0x38,s1
+	sqv $v08, 0x00,s3
+	sqv $v09, 0x10,s3
+	sqv $v10, 0x20,s3
+	sqv $v11, 0x30,s3
+	sqv $v12, 0x40,s3
+	sqv $v13, 0x50,s3
+	sqv $v14, 0x60,s3
+	sqv $v15, 0x70,s3
+
+MonoRefill:
+	# Seed the eight lanes: lane k plays output sample PERM8[k], so it
+	# starts at wv_pos + PERM8[k]*step. The whole-sample carry of that
+	# product comes out of the accumulator, hence the vmudn/vsar pair.
+	li t1, %lo(PERM8)
+	lqv $v16, 0x00,t1
+	lh t0, %lo(CH_STEPF)
+	mtc2 t0, $v21.e0
+	lh t0, %lo(CH_STEPI)
+	mtc2 t0, $v22.e0
+	srlv t0, s2, bps                         # DMA misalignment -> index of
+	add t0, cache_half                       #   wv_pos inside the cache
+	mtc2 t0, $v23.e0
+	sllv t0, wv_pos, frac_shift              # fraction of wv_pos, 0.16
+	mtc2 t0, $v20.e0
+	# vmudn reads vs unsigned, so the step fraction must be the one splatted
+	# into a full vector: it is a 0.16 value and can have bit 15 set.
+	vor   $v18, v_zero, $v21.e0
+	vmudn v_frac, $v18, $v16                 # PERM8*step: fraction...
+	vsar  $v17, COP2_ACC_MD                  # ...and whole samples
+	vmudh v_idx, $v16, $v22.e0
+	vaddc v_frac, v_frac, $v20.e0
+	vadd  v_idx, v_idx, $v17                 # + carry out of the fraction
+	vadd  v_idx, v_idx, $v23.e0
+
+	.balign 8
+MonoLoop:
+	# Reject the lanes whose 4-tap window is not fully inside the cache,
+	# parking them on the zero window; VCC records the survivors.
+	vsll  v_addr, v_idx,  1                  # tap index -> DMEM address
+	vmudl v_x2,   v_frac, v_frac             # x^2
+	vmudl v_x05,  v_frac, k_half             # x/2
+	vlt   v_tmp,  v_addr, k_limit
+	vmudl v_x3,   v_x2,   v_frac             # x^3
+	vmrg  v_addr, v_addr, k_zaddr
+	vmudl v_x205, v_x2,   k_half             # x^2/2
+	vaddc v_frac, v_frac, k_step8f           # advance the eight positions:
+	vadd  v_idx,  v_idx,  k_step8i           #   the carry crosses over
+	vmudl v_x305, v_x3,   k_half             # x^3/2
+	cfc2 mask, COP2_CTRL_VCC
+	sqv v_addr, 0x00,addr_ptr
+
+	# Gather the four taps of each output sample, then transpose the eight
+	# 4-tap groups into four vectors holding one tap of all eight samples.
+	lhu s0, 0x00(addr_ptr)
+	lhu s1, 0x02(addr_ptr)
+	lhu s2, 0x04(addr_ptr)
+	lhu s3, 0x06(addr_ptr)
+	lhu s4, 0x08(addr_ptr)
+	lhu s6, 0x0A(addr_ptr)
+	lhu s7, 0x0C(addr_ptr)
+	lhu t0, 0x0E(addr_ptr)
+	ldv $v08, 0x00,s0
+	ldv $v09, 0x00,s1
+	ldv $v10, 0x00,s2
+	ldv $v11, 0x00,s3
+	ldv $v12, 0x00,s4
+	ldv $v13, 0x00,s6
+	ldv $v14, 0x00,s7
+	ldv $v15, 0x00,t0
+	stv $v08.e0, 0x00,tr_ptr
+	stv $v08.e1, 0x10,tr_ptr
+	stv $v08.e2, 0x20,tr_ptr
+	stv $v08.e3, 0x30,tr_ptr
+	stv $v08.e4, 0x40,tr_ptr
+	stv $v08.e5, 0x50,tr_ptr
+	stv $v08.e6, 0x60,tr_ptr
+	stv $v08.e7, 0x70,tr_ptr
+	ltv $v16.e0, 0x00,tr_ptr
+	ltv $v16.e7, 0x10,tr_ptr
+	ltv $v16.e6, 0x20,tr_ptr
+	ltv $v16.e5, 0x30,tr_ptr
+	ltv $v16.e4, 0x40,tr_ptr
+	ltv $v16.e3, 0x50,tr_ptr
+	ltv $v16.e2, 0x60,tr_ptr
+	ltv $v16.e1, 0x70,tr_ptr
+
+	# ACCUM is accumulated in place. acc_ptr is only 4-byte aligned once a
+	# partial group has been replayed, so the two quads are read and
+	# written with the unaligned lqv/lrv and sqv/srv pairs.
+	lqv v_acc0, 0x00,acc_ptr
+	lrv v_acc0, 0x10,acc_ptr
+	lqv v_acc1, 0x10,acc_ptr
+	lrv v_acc1, 0x20,acc_ptr
+
+	# Negated taps: the coefficients are fed to the accumulator one unit at
+	# a time (vmadm saturates its output but not the accumulator), so the
+	# subtractions of the polynomial are done on the taps instead.
+	vsub v_y0n, v_zero, v_y0
+	vsub v_y1n, v_zero, v_y1
+	vsub v_y2n, v_zero, v_y2
+	vsub v_y3n, v_zero, v_y3
+
+	vmudh v_res, v_y1,  k_one                # y1
+	vmadm v_res, v_y2,  v_x05                # + x  * (y2 - y0)/2
+	vmadm v_res, v_y0n, v_x05
+	vmadm v_res, v_y0,  v_x2                 # + x^2 * (y0 - 5*y1/2
+	vmadm v_res, v_y1n, v_x2                 #          + 2*y2 - y3/2)
+	vmadm v_res, v_y1n, v_x2
+	vmadm v_res, v_y1n, v_x205
+	vmadm v_res, v_y2,  v_x2
+	vmadm v_res, v_y2,  v_x2
+	vmadm v_res, v_y3n, v_x205
+	vmadm v_res, v_y0n, v_x305               # + x^3 * (-y0/2 + 3*y1/2
+	vmadm v_res, v_y1,  v_x3                 #          - 3*y2/2 + y3/2)
+	vmadm v_res, v_y1,  v_x305
+	vmadm v_res, v_y2n, v_x3
+	vmadm v_res, v_y2n, v_x305
+	vmadm v_res, v_y3,  v_x305
+
+	# .q0/.q1 duplicate each result into the L and R slot of one ACCUM
+	# entry, so the interleaved volume vector applies both gains at once.
+	vmudh v_acc0, v_acc0, k_one
+	vmacf v_acc0, v_xvol, v_res.q0
+	vmudh v_acc1, v_acc1, k_one
+	vmacf v_acc1, v_xvol, v_res.q1
+#if VOLUME_FILTER
+	vmudm v_xvol, v_xvol,  k_alpha
+	vmadm v_xvol, v_chvol, k_1malpha
+#endif
+	sqv v_acc0, 0x00,acc_ptr
+	srv v_acc0, 0x10,acc_ptr
+	sqv v_acc1, 0x10,acc_ptr
+	srv v_acc1, 0x20,acc_ptr
+
+	addi acc_ptr, 8*4
+	addi ticks, -8
+	bne mask, k_ff, MonoPartial
+	add wv_pos, wv_step_8x
+	bgtz ticks, MonoLoop
+	nop
+	j MIX_CHANNEL_Done
+	nop
+
+MonoPartial:
+	# Some lanes were parked: they contributed nothing to ACCUM, so give
+	# their ticks, ACCUM slots and positions back and replay them once the
+	# cache has been refilled.
+	vmrg  v_cnt, v_zero, k_one               # 1 for each rejected lane
+	vadd  v_cnt, v_cnt, v_cnt.q1
+	vadd  v_cnt, v_cnt, v_cnt.h2
+	vadd  v_cnt, v_cnt, v_cnt.e4
+	mfc2  t0, v_cnt.e0
+	add ticks, t0
+	sll t1, t0, 2
+	sub acc_ptr, t1
+	beqz t0, 2f
+	nop
+1:	addi t0, -1
+	bnez t0, 1b
+	sub wv_pos, wv_step
+2:	bgtz ticks, MonoWaveStart
+	nop
+	j MIX_CHANNEL_Done
+	nop
+
 ############################################################
 # Mono VADPCM path: decode one frame at a time into MIX_VADPCM_PCM,
 # then point-resample like 16-bit PCM. State is written back at epilog.
@@ -614,16 +896,8 @@ VadpcmHavePos:
 	lw t2, %lo(CH_VCUR_FRAME)
 	beq t1, t2, VadpcmResample
 	sw t1, %lo(ROUND_SCRATCH)                # wanted frame
-	# A frame decode clobbers $v13-$v16 (filtered/target volumes) and may
-	# clobber k1. Spill them to DMEM_SCRATCH (unused in the VADPCM path) so
-	# the post-decode reload in VadpcmDecodeCur resumes the volume filter
-	# from the current value instead of the command-start one (which would
-	# stall the filter convergence).
-	li t0, %lo(DMEM_SCRATCH)
-	sqv $v13, 0x00,t0
-	sqv $v14, 0x10,t0
-	sqv $v15, 0x20,t0
-	sqv $v16, 0x30,t0
+	# A frame decode may clobber k1 (the volumes live in $v24/$v25, which
+	# the decoder does not touch).
 	sh k1, %lo(CH_K1)
 VadpcmCatchUp:
 	lw t2, %lo(CH_VNEXT_FRAME)
@@ -668,15 +942,9 @@ VadpcmDecodeCur:
 	lw t1, %lo(CH_VNEXT_FRAME)
 	addi t1, -1                              # frame just decoded
 	sw t1, %lo(CH_VCUR_FRAME)
-	# Decode clobbers $v31 (vsra8 uses vshift8). Reload mixer constants
-	# and unspill the volumes saved in VadpcmHavePos before resampling.
+	# Decode clobbers $v31 (vsra8 uses vshift8): reload mixer constants.
 	li t0, %lo(VCONST_1)
 	lqv v_const1, 0,t0
-	li t0, %lo(DMEM_SCRATCH)
-	lqv $v13, 0x00,t0
-	lqv $v14, 0x10,t0
-	lqv $v15, 0x20,t0
-	lqv $v16, 0x30,t0
 	lh k1, %lo(CH_K1)                      # resume volume-filter countdown
 	# fall through to resample
 
@@ -709,10 +977,8 @@ VadpcmResample:
 	bgtz k1, 1f
 	nop
 	li k1, 8
-	vmudm $v13, $v13, k_alpha
-	vmadm $v13, $v15, k_1malpha
-	vmudm $v14, $v14, k_alpha
-	vmadm $v14, $v16, k_1malpha
+	vmudm v_xvol, v_xvol,  k_alpha
+	vmadm v_xvol, v_chvol, k_1malpha
 1:
 #endif
 	addi ticks, -1
@@ -758,10 +1024,8 @@ SilenceLoop:
 1:
 #if VOLUME_FILTER
 	# xvol = xvol*alpha + chvol*(1-alpha)
-	vmudm $v13, $v13, k_alpha
-	vmadm $v13, $v15, k_1malpha
-	vmudm $v14, $v14, k_alpha
-	vmadm $v14, $v16, k_1malpha
+	vmudm v_xvol, v_xvol,  k_alpha
+	vmadm v_xvol, v_chvol, k_1malpha
 #endif
 	sub ticks, t0
 	sll t1, t0, 2                  # each sample = 4 bytes in ACCUM
@@ -771,11 +1035,13 @@ SilenceLoop:
 MIX_CHANNEL_Done:
 	# Store updated xvol for this channel
 	lh ch_idx, %lo(CH_IDX)
-	sll t0, ch_idx, 1
-	mfc2 t1, $v13.e0
-	mfc2 t2, $v14.e0
-	sh t1, %lo(XVOL_L)(t0)
-	sh t2, %lo(XVOL_R)(t0)
+	sll t0, ch_idx, 2
+	mfc2 t1, v_xvol.e0
+	mfc2 t2, v_xvol.e1
+	sll t1, 16
+	andi t2, 0xFFFF
+	or t1, t2
+	sw t1, %lo(XVOL)(t0)
 	j RSPQ_Loop
 	nop
 	.endfunc
@@ -786,8 +1052,7 @@ MIX_CHANNEL_Done:
 # into ACCUM at acc_ptr, then update the volume filter.
 #
 # DMEM_SCRATCH holds: s0 s1 s2 s3 s4 s5 s6 s7 (halfwords)
-# $v13/$v14 = xvol_l / xvol_r (broadcast)
-# $v15/$v16 = chvol_l / chvol_r (broadcast)
+# v_xvol / v_chvol = filtered / target volume, as [L,R,L,R,...]
 ###############################################################
 
 	.func MixBatch16bit
@@ -795,77 +1060,22 @@ MixBatch16bit:
 	move ra2, ra
 	li s0, %lo(DMEM_SCRATCH)
 	lqv $v01, 0,s0                 # 8 samples
-
-	# Apply volumes
-	vmulf $v02, $v01, $v13         # left  = sample * xvol_l
-	vmulf $v03, $v01, $v14         # right = sample * xvol_r
-
-	# Interleave L/R into two vectors matching ACCUM layout and add.
-	# Build L0 R0 L1 R1 L2 R2 L3 R3 in $v04 via even/odd merge.
-	li t0, 0x5555
-	ctc2 t0, COP2_CTRL_VCC
-	vcopy $v04, $v02.q0            # L0 L0 L2 L2 L4 L4 L6 L6
-	vcopy $v05, $v02.q1            # L1 L1 L3 L3 L5 L5 L7 L7
-	vmrg $v04, $v04, $v03.q0       # L0 R0 L2 R2 L4 R4 L6 R6
-	vmrg $v05, $v05, $v03.q1       # L1 R1 L3 R3 L5 R5 L7 R7
-
-	# $v04 has even pairs, $v05 odd pairs – store via slv like VADPCM deint,
-	# but we need A0 B0 A1 B1 order. Rebuild with a temp buffer instead
-	# (clearer and not too expensive for 8 samples).
-	ssv $v02.e0,  0,s0
-	ssv $v03.e0,  2,s0
-	ssv $v02.e1,  4,s0
-	ssv $v03.e1,  6,s0
-	ssv $v02.e2,  8,s0
-	ssv $v03.e2, 10,s0
-	ssv $v02.e3, 12,s0
-	ssv $v03.e3, 14,s0
-	ssv $v02.e4, 16,s0
-	ssv $v03.e4, 18,s0
-	ssv $v02.e5, 20,s0
-	ssv $v03.e5, 22,s0
-	ssv $v02.e6, 24,s0
-	ssv $v03.e6, 26,s0
-	ssv $v02.e7, 28,s0
-	ssv $v03.e7, 30,s0
-
-	lqv $v04, 0x00,s0
-	lqv $v05, 0x10,s0
 	lqv $v06, 0x00,acc_ptr
 	lqv $v07, 0x10,acc_ptr
-	vadd $v06, $v06, $v04
-	vadd $v07, $v07, $v05
+
+	# .q0/.q1 duplicate each sample into the L and R slot of one ACCUM
+	# entry, so the interleaved volume vector applies both gains at once.
+	vmudh $v06, $v06, k_one
+	vmacf $v06, v_xvol, $v01.q0
+	vmudh $v07, $v07, k_one
+	vmacf $v07, v_xvol, $v01.q1
+#if VOLUME_FILTER
+	vmudm v_xvol, v_xvol,  k_alpha
+	vmadm v_xvol, v_chvol, k_1malpha
+#endif
 	sqv $v06, 0x00,acc_ptr
 	sqv $v07, 0x10,acc_ptr
-
-#if VOLUME_FILTER
-	vmudm $v13, $v13, k_alpha
-	vmadm $v13, $v15, k_1malpha
-	vmudm $v14, $v14, k_alpha
-	vmadm $v14, $v16, k_1malpha
-#endif
 	jr ra2
-	nop
-	.endfunc
-
-
-###############################################################
-# MixBatch8bit – promote 8 signed bytes in DMEM_SCRATCH[0..7]
-# to (sample<<8) halfwords, then mix via MixBatch16bit.
-###############################################################
-
-	.func MixBatch8bit
-MixBatch8bit:
-	move t9, ra
-	li s0, %lo(DMEM_SCRATCH)
-	# lpv places each byte into bits 15..8 of a lane (= sample<<8),
-	# matching the legacy mixer which stored 8-bit samples as the high
-	# byte of a cleared halfword.
-	lpv $v01, 0,s0
-	sqv $v01, 0,s0
-	jal MixBatch16bit
-	nop
-	jr t9
 	nop
 	.endfunc
 
@@ -879,15 +1089,15 @@ MixBatch8bit:
 
 	.func MixOne
 MixOne:
-	vmulf $v02, $v01, $v13
-	vmulf $v03, $v01, $v14
-	lsv $v04.e0, 0,acc_ptr
-	lsv $v05.e0, 2,acc_ptr
-	vadd $v04, $v04, $v02
-	vadd $v05, $v05, $v03
+	lsv $v04.e0, 0,acc_ptr         # lane 0 = left, lane 1 = right
+	lsv $v04.e1, 2,acc_ptr
+	nop
+	nop
+	vmudh $v04, $v04, k_one
+	vmacf $v04, v_xvol, $v01.e0
 	ssv $v04.e0, 0,acc_ptr
 	jr ra
-	ssv $v05.e0, 2,acc_ptr
+	ssv $v04.e1, 2,acc_ptr
 	.endfunc
 
 
@@ -915,7 +1125,7 @@ MIX_FLUSH:
 	li s4, %lo(ACCUM)
 
 	li s4, %lo(ACCUM)
-	li t0, (MAX_SAMPLES_PER_ROUND * 4) / 64 - 1
+	li t0, ACCUM_CLEAR_BLOCKS - 1
 	vxor v_zero, v_zero, v_zero
 1:	sqv v_zero, 0x00,s4
 	sqv v_zero, 0x10,s4

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -31,11 +31,12 @@
 	# Loop wraps (pos -= loop_len, reload loop_state) are handled here when
 	# the CPU pins a stable loop region (resident or loop-cached).
 	#
-	# Resampling is point-sampling with a fixed-point step (WAVEFORM_POS_FRAC_BITS).
-	# PCM samples are fetched from RDRAM into a small DMEM cache; VADPCM frames
-	# are DMA'd compressed, decoded into a DMEM window, then resampled the same
-	# way. Staging goes into DMEM_SCRATCH and is mixed into ACCUM with the
-	# current filtered volume. The volume filter runs once every 8 samples.
+	# PCM resampling is 4-tap Catmull-Rom (Hermite) with a fixed-point step
+	# (WAVEFORM_POS_FRAC_BITS). Stereo PCM is two MIX_CHANNELs (owner=L,
+	# STEREO_SUB=R) that share the same interleaved cache and the same loop
+	# body as mono; only the post-transpose tap shuffle differs. VADPCM frames
+	# are DMA'd compressed, decoded into a DMEM window, then point-resampled.
+	# The volume filter runs once every 8 samples.
 	#
 	####################################################################
 
@@ -77,8 +78,15 @@
 # Resample staging (8 samples) for the stereo and VADPCM paths.
 #define DMEM_SCRATCH_SIZE         16
 
-# Sample DMA cache (must be <= MIXER_LOOP_OVERREAD in mixer.c).
+# Sample DMA cache. A transfer may never end more than SAMPLE_CACHE_SIZE bytes
+# past the end of the RDRAM window (that is #MIXER_LOOP_OVERREAD in mixer.c,
+# the only part of the overread that is guaranteed to hold valid samples), but
+# it may well be larger than that when the window is far from its end. The
+# mono resampler exploits this to fetch SAMPLE_CACHE_SAMPLES samples at a
+# time, whatever the PCM format: refilling costs about as much as mixing a
+# cacheful, so it is worth spending most of the spare DMEM on the window.
 #define SAMPLE_CACHE_SIZE         64
+#define SAMPLE_CACHE_SAMPLES      128
 
 # In-mixer VADPCM: one decoded frame in DMEM (16 samples). Enough for
 # point resampling within the frame; the next frame is decoded on demand.
@@ -172,24 +180,29 @@ IDENTITY:  .half  1<<11,1<<11,1<<11,1<<11, 1<<11,1<<11,1<<11,1<<11
 	# to 7 samples past the end of the round. ACCUM_PAD absorbs them; it is
 	# never DMA'd out, but it is cleared together with ACCUM so that the
 	# accumulation never saturates on leftovers.
+	# ACCUM_PRE is the mirror image of that: entering the mono resampler
+	# costs one pass over the group before the first real one. The pass only
+	# adds zero, but it does read and write the slots, which on the very
+	# first group are the ones right before ACCUM.
 	.align 4
+ACCUM_PRE:                .dcb.w (8 * 2)
 ACCUM:                    .dcb.w (MAX_SAMPLES_PER_ROUND * 2)
 ACCUM_PAD:                .dcb.w (ACCUM_PAD_SAMPLES * 2)
 
-	# Temporary cache of samples fetched by DMA for resampling. Each cache is
-	# followed by a window of four zero samples: the mono resampler parks the
-	# lanes it must discard there, so they interpolate to silence instead of
-	# needing a separate mask (MonoLoop). Both caches are 16-byte aligned
-	# because they are written/read with sqv/lqv.
+	# Temporary cache of samples fetched by DMA for resampling.
+	#
+	# The mono resampler sees it as a window of SAMPLE_CACHE_SAMPLES int16
+	# samples: 8-bit waveforms are DMA'd into its upper half and widened in
+	# place to fill it, so that one inner loop serves both PCM formats. The
+	# stereo and VADPCM paths use the first SAMPLE_CACHE_SIZE bytes only.
+	#
+	# The window is followed by four zero samples: the mono resampler parks
+	# the lanes it must discard there, so they interpolate to silence
+	# instead of needing a separate mask (MonoLoop). It is 16-byte aligned
+	# because it is written/read with sqv/lqv.
 	.align 4
-DMEM_SAMPLE_CACHE:        .dcb.b SAMPLE_CACHE_SIZE
+DMEM_SAMPLE_CACHE:        .dcb.b SAMPLE_CACHE_SAMPLES * 2
 DMEM_SAMPLE_CACHE_ZERO:   .dcb.b 16
-
-	# 8-bit samples widened to int16 after each DMA, so that one inner loop
-	# serves both PCM formats.
-	.align 4
-DMEM_SAMPLE_CACHE16:      .dcb.b SAMPLE_CACHE_SIZE * 2
-DMEM_SAMPLE_CACHE16_ZERO: .dcb.b 16
 
 	# Per-lane tap addresses produced by the mono resampler, and the
 	# scratch used to transpose the eight gathered 4-tap groups.
@@ -283,13 +296,7 @@ CH_STEPI:                 .half  0
 	#define wv_len         t6
 	#define wv_loop_len    t7
 	#define wv_addr        t8
-	#define dma_cache_end  s7
-	#define out_ptr        s5
-	#define wv_pos_to_dmem s6
 	#define wv_step_8x     t2
-	#define is_stereo_sub  a0
-	#define is_16bit       a1
-	#define is_stereo      v0
 	#define acc_ptr        s8
 	#define ch_idx         k0
 
@@ -314,34 +321,50 @@ CH_STEPI:                 .half  0
 	#define k_zaddr        v_kmono.e1
 	#define k_step8f       v_kmono.e2
 	#define k_step8i       v_kmono.e3
-	# Transient within one MonoLoop iteration.
-	#define v_addr         $v01
-	#define v_x2           $v02
-	#define v_x05          $v03
-	#define v_x205         $v04
-	#define v_x3           $v05
-	#define v_x305         $v06
-	#define v_res          $v07
-	#define v_y0n          $v09
-	#define v_y1n          $v10
-	#define v_y2n          $v11
-	#define v_y3n          $v12
-	#define v_cnt          $v13
-	#define v_acc0         $v14
-	#define v_acc1         $v15
+
+	# Registers of one MonoLoop iteration. The powers of x are the only
+	# values that must survive from one iteration to the next (they are
+	# computed for the group that the next iteration interpolates), so they
+	# are kept away from $v08-$v23, which the gather and the transpose
+	# rewrite wholesale.
+	#
+	# The taps sit in the transpose destination bank (v16-v23): after the
+	# gather + transpose, y0..y3 of the plane being mixed are in v16..v19.
+	# Negated taps live in v20..v23 (the half of the bank the 4-tap gather
+	# leaves unused).
+	#define v_x2           $v01
+	#define v_x05          $v02
+	#define v_x205         $v03
+	#define v_x3           $v04
+	#define v_x305         $v05
+	#define v_res          $v06
+	#define v_acc0         $v07
+	#define v_acc1         $v28
+	#define v_addr         $v07     /* dead by the time v_acc0 is loaded */
+	#define v_tmp          $v15     /* vlt result, only VCC is of interest */
 	#define v_y0           $v16
 	#define v_y1           $v17
 	#define v_y2           $v18
 	#define v_y3           $v19
-	#define v_tmp          $v20
+	#define v_y0n          $v20
+	#define v_y1n          $v21
+	#define v_y2n          $v22
+	#define v_y3n          $v23
+	#define v_cnt          $v20
 
 	#define addr_ptr       v0
 	#define tr_ptr         a0
 	#define bps            a1
 	#define cache_half     a2
 	#define frac_shift     a3
-	#define mask           v1
+	#define mask           v1        /* mask of the group being mixed */
 	#define k_ff           s5
+	#define partial        t9        /* < 0 once a group has been rejected */
+	# stereo_shift lives in k1 (free on the PCM path; VADPCM uses it as the
+	# volume-filter countdown). is16 / stereo_sub are reloaded from CH_FLAGS
+	# at the few sites that need them — they must not alias wv_len / wv_addr.
+	#define stereo_shift   k1        /* 0 = mono, 1 = stereo: v_idx unit is a
+	                                    sample (2 B) or a frame (4 B) */
 
 	.func MIX_CHANNEL
 MIX_CHANNEL:
@@ -437,133 +460,13 @@ MIX_CHANNEL_NoClear:
 	lw wv_loop_len, %lo(CH_LOOP_LEN)
 
 	lh t0, %lo(CH_FLAGS)
-	andi is_16bit, t0, CH_FLAGS_16BIT
-	andi is_stereo, t0, CH_FLAGS_STEREO
-	andi is_stereo_sub, t0, CH_FLAGS_STEREO_SUB
 	andi t1, t0, CH_FLAGS_VADPCM
 	bnez t1, VadpcmSetup
-	or t1, is_stereo, is_stereo_sub
-	beqz t1, MonoSetup
 	nop
-
-	li dma_cache_end, %lo(DMEM_SAMPLE_CACHE+SAMPLE_CACHE_SIZE)
-	sll dma_cache_end, WAVEFORM_POS_FRAC_BITS
-
-WaveStart:
-	bltu wv_pos, wv_len, WaveDmaFetch
-	nop
-	beqz wv_loop_len, MIX_CHANNEL_SilenceLeft
-	nop
-	j WaveStart
-	sub wv_pos, wv_loop_len
-
-WaveDmaFetch:
-	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS
-	add s0, s2, wv_addr
-	li s4, %lo(DMEM_SAMPLE_CACHE)
-	jal DMAIn
-	li t0, DMA_SIZE(SAMPLE_CACHE_SIZE, 1)
-
-	sub wv_pos_to_dmem, s2, s4
-	sll wv_pos_to_dmem, WAVEFORM_POS_FRAC_BITS
-	sll wv_step_8x, wv_step, 3
-
-	# Stereo and stereo-sub share the interleaved fetch; sub extracts R.
-	sub wv_pos, wv_pos_to_dmem
-	bnez is_16bit, WaveLoop16_Stereo_8x
-	nop
-	j WaveLoop8StereoChecks
-	nop
+	# PCM mono and stereo share the Hermite path below.
 
 	############################################################
-	# Stereo 8-bit (owner extracts L, sub extracts R)
-	############################################################
-
-WaveLoop8Stereo:
-	beqz is_stereo_sub, 1f
-	nop
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t0, 1(t0)
-	j 2f
-	add wv_pos, wv_step
-1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-2:	sll t0, 8
-	mtc2 t0, $v01.e0
-	jal MixOne
-	nop
-	addi ticks, -1
-	addi acc_ptr, 4
-WaveLoop8StereoChecks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop8Stereo
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
-
-	############################################################
-	# Stereo 16-bit (owner extracts L, sub extracts R)
-	############################################################
-
-WaveLoop16_Stereo_8x:
-	add t0, wv_pos, wv_step_8x
-	bgt t0, dma_cache_end, WaveLoop16StereoChecks
-	li t0, 8
-	blt ticks, t0, WaveLoop16StereoChecks
-
-	li out_ptr, %lo(DMEM_SCRATCH)
-	li t1, 8
-WaveLoop16StereoUnroll:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	beqz is_stereo_sub, 1f
-	nop
-	lhu t0, 2(t0)                  # R sample
-	j 2f
-	add wv_pos, wv_step
-1:	lhu t0, 0(t0)                  # L sample
-	add wv_pos, wv_step
-2:	sh t0, 0(out_ptr)
-	addi out_ptr, 2
-	addi t1, -1
-	bnez t1, WaveLoop16StereoUnroll
-	nop
-
-	jal MixBatch16bit
-	nop
-	addi ticks, -8
-	j WaveLoop16_Stereo_8x
-	addi acc_ptr, 8*4
-
-WaveLoop16Stereo:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	beqz is_stereo_sub, 1f
-	nop
-	lhu t0, 2(t0)
-	j 2f
-	add wv_pos, wv_step
-1:	lhu t0, 0(t0)
-	add wv_pos, wv_step
-2:	mtc2 t0, $v01.e0
-	jal MixOne
-	nop
-	addi ticks, -1
-	addi acc_ptr, 4
-WaveLoop16StereoChecks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop16Stereo
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
-
-	############################################################
-	# Mono 8/16-bit: 4-tap Catmull-Rom (Hermite) resampling
+	# PCM 8/16-bit mono and stereo: 4-tap Catmull-Rom (Hermite)
 	#
 	# Eight output samples are produced per iteration, one per vector lane.
 	# Lane k carries output sample PERM8[k] = [0,4,1,5,2,6,3,7], so that the
@@ -588,56 +491,66 @@ WaveLoop16StereoChecks:
 	# pos, and for a streamed waveform the samples before it may no longer
 	# be in RDRAM.
 	#
+	# Stereo PCM is interleaved in the cache as [L,R,L,R,...]. The gather
+	# loads the four taps of the plane this MIX_CHANNEL owns with lsv
+	# (owner = L at +0/+4/+8/+12, STEREO_SUB = R at +2/+6/+10/+14), so the
+	# transpose lands on the same y0..y3 layout the mono path uses. The
+	# owner/sub volume split is unchanged.
+	#
 	# Lanes whose tap window runs past the end of the cache are parked on a
 	# window of four zero samples: they interpolate to silence and, since
 	# ACCUM is accumulated in place, leave it untouched. Being always the
 	# last ones in output order, they are simply counted and replayed after
 	# the next DMA.
 	#
-	# The mono path reuses the register names of the stereo dispatch for its
-	# own purposes (see the #defines above); is_16bit/is_stereo are dead here.
+	# The loop is software pipelined over two stages: each iteration gathers
+	# the taps of one group while interpolating and mixing the group gathered
+	# by the previous one. That is what allows the 32 memory accesses of the
+	# gather to run in the shadow of the 36 vector operations of the spline.
+	# Consequently the powers of x and the mask of accepted lanes are
+	# computed one iteration ahead of the group they belong to, and the loop
+	# has to be entered through MonoPrime, which fills the first stage.
 	############################################################
 
 MonoSetup:
-	# A sample is always 2 bytes in DMEM: 8-bit waveforms are widened after
-	# each DMA so that a single inner loop serves both PCM formats.
-	#   bps         0 for 8-bit source samples, 1 for 16-bit
-	#   cache_half  DMEM address of the int16 cache, in units of 2 bytes
-	#   frac_shift  left shift turning wv_pos into a 0.16 sample fraction
+	# A sample (mono) or stereo frame is always stored as int16 in DMEM:
+	# 8-bit waveforms are widened after each DMA so that a single inner
+	# loop serves every PCM format.
+	#   bps           log2(bytes per sample/frame) in the source waveform
+	#   stereo_shift  0 mono / 1 stereo (halfwords per source unit)
+	#   cache_half    DMEM address of the int16 cache, in units of 2 bytes
+	#   frac_shift    left shift turning wv_pos into a 0.16 unit fraction
 	lh t0, %lo(CH_FLAGS)
 	andi bps, t0, CH_FLAGS_BPS_SHIFT
-	li cache_half, %lo(DMEM_SAMPLE_CACHE16)
-	li t1, %lo(DMEM_SAMPLE_CACHE16_ZERO)
-	li frac_shift, 4
-	li t0, SAMPLE_CACHE_SIZE
-	beqz bps, 1f
-	nop
+	andi stereo_shift, t0, CH_FLAGS_STEREO
+	srl stereo_shift, 3                      # bit 3 → 0 or 1
 	li cache_half, %lo(DMEM_SAMPLE_CACHE)
 	li t1, %lo(DMEM_SAMPLE_CACHE_ZERO)
-	li frac_shift, 3
-	srl t0, 1
-1:
-	# The window of four zero samples the rejected lanes are parked on. It
-	# sits right after the cache, so it also fails the "tap window inside
-	# the cache" test and a single comparison covers both cases.
+	li frac_shift, 4
+	sub frac_shift, bps
+
+	# The window of four zero samples (mono) / four zero frames (stereo)
+	# the rejected lanes are parked on. It sits right after the cache, so
+	# it also fails the "tap window inside the cache" test and a single
+	# comparison covers both cases. 16 bytes is exactly one lqv.
 	sw zero, 0(t1)
 	sw zero, 4(t1)
+	sw zero, 8(t1)
+	sw zero, 12(t1)
 
-	# Assemble the loop scalars in DMEM and splat them in one load.
+	# Assemble the loop scalars in DMEM and splat them in one load. k_limit
+	# depends on the size of each transfer, so it is filled in by
+	# MonoDmaFetch before the loop ever runs.
 	li s0, %lo(DMEM_SCRATCH)
 	sh t1, 0x02(s0)                          # k_zaddr
-	sll t0, 1                                # cache size in bytes
-	add t0, cache_half
-	addi t0, -3*2                            # y3 must stay inside the cache
-	sh t0, 0x00(s0)                          # k_limit
 	srl cache_half, 1                        # byte address -> DMEM index
 	sll t2, wv_step, 3
 	sllv t0, t2, frac_shift
 	sh t0, 0x04(s0)                          # k_step8f
 	srl t0, t2, WAVEFORM_POS_FRAC_BITS
-	srlv t0, t0, bps
+	srlv t0, t0, bps                         # samples / frames (v_idx units)
 	sh t0, 0x06(s0)                          # k_step8i
-	# Same split for one sample, needed to seed the eight lanes.
+	# Same split for one sample/frame, needed to seed the eight lanes.
 	sllv t0, wv_step, frac_shift
 	sh t0, %lo(CH_STEPF)
 	srl t0, wv_step, WAVEFORM_POS_FRAC_BITS
@@ -658,19 +571,58 @@ MonoWaveStart:
 	sub wv_pos, wv_loop_len
 
 MonoDmaFetch:
-	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS
+	# Fetch as many source units as fill the int16 window (SAMPLE_CACHE_SAMPLES
+	# halfwords: that is SAMPLE_CACHE_SAMPLES samples mono, or half that many
+	# stereo frames), unless the transfer would end further than
+	# SAMPLE_CACHE_SIZE bytes past the RDRAM window: beyond that point the
+	# waveform is not guaranteed to continue.
+	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS   # byte offset of the position
+	srl s1, wv_len, WAVEFORM_POS_FRAC_BITS
+	sub s1, s2                               # bytes left in the window,
+	addi s1, SAMPLE_CACHE_SIZE               #   plus the guaranteed overread
+	li t0, SAMPLE_CACHE_SAMPLES
+	srlv t0, t0, stereo_shift                # samples / frames that fit
+	sllv t0, t0, bps                         # ...as a transfer size
+	sltu s3, s1, t0
+	beqz s3, 1f
+	nop
+	move t0, s1
+1:
+	# The tap window of the last accepted lane must stay within the units
+	# that were really fetched. v_idx is in samples (mono) or frames
+	# (stereo); the byte address is that times 2<<stereo_shift.
+	srlv t1, t0, bps                         # samples / frames in the cache
+	sll t1, 1                                # → bytes if mono
+	sllv t1, t1, stereo_shift                # → bytes if stereo (×4 per frame)
+	sll s3, cache_half, 1                    # cache base, back to a byte address
+	add t1, s3
+	li s3, 3*2
+	sllv s3, s3, stereo_shift                # y3 must stay inside the cache
+	sub t1, s3
+	mtc2 t1, k_limit
+
+	# 8-bit waveforms are DMA'd into the upper half of the window and
+	# widened downwards into the whole of it.
 	add s0, s2, wv_addr
 	li s4, %lo(DMEM_SAMPLE_CACHE)
+	lh t1, %lo(CH_FLAGS)
+	andi t1, CH_FLAGS_16BIT
+	bnez t1, 1f
 	andi s2, s0, 7                           # DMA rounds down to 8 bytes
-	jal DMAIn
-	li t0, DMA_SIZE(SAMPLE_CACHE_SIZE, 1)
+	addi s4, SAMPLE_CACHE_SAMPLES            # = half of the window, in bytes
+1:	jal DMAIn
+	addi t0, -1                              # = DMA_SIZE(t0, 1)
 	sll wv_step_8x, wv_step, 3               # DMAExec clobbers t2
 
 	# Widen the 8-bit cache to int16: lpv shifts each byte into the high
 	# half of a lane, which is exactly the <<8 scaling the mixer expects.
-	bnez bps, MonoRefill
-	li s1, %lo(DMEM_SAMPLE_CACHE)
-	li s3, %lo(DMEM_SAMPLE_CACHE16)
+	# The first half is widened first, so that its source (which is the
+	# second half of the destination) is read before being overwritten.
+	lh t1, %lo(CH_FLAGS)
+	andi t1, CH_FLAGS_16BIT
+	bnez t1, MonoRefill
+	li s1, %lo(DMEM_SAMPLE_CACHE+SAMPLE_CACHE_SAMPLES)
+	li s3, %lo(DMEM_SAMPLE_CACHE)
 	lpv $v08, 0x00,s1
 	lpv $v09, 0x08,s1
 	lpv $v10, 0x10,s1
@@ -687,145 +639,253 @@ MonoDmaFetch:
 	sqv $v13, 0x50,s3
 	sqv $v14, 0x60,s3
 	sqv $v15, 0x70,s3
+	lpv $v08, 0x40,s1
+	lpv $v09, 0x48,s1
+	lpv $v10, 0x50,s1
+	lpv $v11, 0x58,s1
+	lpv $v12, 0x60,s1
+	lpv $v13, 0x68,s1
+	lpv $v14, 0x70,s1
+	lpv $v15, 0x78,s1
+	sqv $v08, 0x00,s1
+	sqv $v09, 0x10,s1
+	sqv $v10, 0x20,s1
+	sqv $v11, 0x30,s1
+	sqv $v12, 0x40,s1
+	sqv $v13, 0x50,s1
+	sqv $v14, 0x60,s1
+	sqv $v15, 0x70,s1
 
 MonoRefill:
 	# Seed the eight lanes: lane k plays output sample PERM8[k], so it
 	# starts at wv_pos + PERM8[k]*step. The whole-sample carry of that
 	# product comes out of the accumulator, hence the vmudn/vsar pair.
 	li t1, %lo(PERM8)
-	lqv $v16, 0x00,t1
 	lh t0, %lo(CH_STEPF)
+	lh s0, %lo(CH_STEPI)
+	lqv $v16, 0x00,t1
+	# v_idx is in samples (mono) or frames (stereo). The cache base in those
+	# units is cache_half >> stereo_shift (halfwords vs halfwords/2).
+	srlv s1, s2, bps                         # DMA misalignment -> v_idx units
+	srlv s3, cache_half, stereo_shift
 	mtc2 t0, $v21.e0
-	lh t0, %lo(CH_STEPI)
-	mtc2 t0, $v22.e0
-	srlv t0, s2, bps                         # DMA misalignment -> index of
-	add t0, cache_half                       #   wv_pos inside the cache
-	mtc2 t0, $v23.e0
+	add s1, s3
 	sllv t0, wv_pos, frac_shift              # fraction of wv_pos, 0.16
-	mtc2 t0, $v20.e0
+	mtc2 s0, $v22.e0
+	mtc2 s1, $v23.e0
 	# vmudn reads vs unsigned, so the step fraction must be the one splatted
 	# into a full vector: it is a 0.16 value and can have bit 15 set.
 	vor   $v18, v_zero, $v21.e0
+	mtc2 t0, $v20.e0
 	vmudn v_frac, $v18, $v16                 # PERM8*step: fraction...
 	vsar  $v17, COP2_ACC_MD                  # ...and whole samples
 	vmudh v_idx, $v16, $v22.e0
+	# The priming pass below interpolates a group of zero taps, so zero them
+	# here, in the shadow of the seeding.
+	vxor  $v19, $v19, $v19
+	vxor  $v18, $v18, $v18
 	vaddc v_frac, v_frac, $v20.e0
 	vadd  v_idx, v_idx, $v17                 # + carry out of the fraction
+	vxor  $v17, $v17, $v17
+	vxor  $v16, $v16, $v16
 	vadd  v_idx, v_idx, $v23.e0
+
+MonoPrime:
+	# Fill the first stage of the pipeline: gather the first group of the
+	# new cache without mixing anything. This is the first half of the loop
+	# body, minus the transpose read-back, and it is lent the group of ACCUM
+	# slots that the loop advances past at its end. The zero taps make the
+	# pass it makes over them add nothing.
+	beqz  stereo_shift, 1f
+	li    mask, 0xFF                         # nothing to give back yet
+	vsll  v_addr, v_idx, 2                   # stereo: frames → bytes
+	j     2f
+	addi  acc_ptr, -8*4
+1:	vsll  v_addr, v_idx, 1                   # mono: samples → bytes
+	addi  acc_ptr, -8*4
+2:	vlt   v_tmp,  v_addr, k_limit
+	vmrg  v_addr, v_addr, k_zaddr
+	j     MonoLoopGather
+	sqv   v_addr, 0x00,addr_ptr
 
 	.balign 8
 MonoLoop:
-	# Reject the lanes whose 4-tap window is not fully inside the cache,
-	# parking them on the zero window; VCC records the survivors.
-	vsll  v_addr, v_idx,  1                  # tap index -> DMEM address
-	vmudl v_x2,   v_frac, v_frac             # x^2
-	vmudl v_x05,  v_frac, k_half             # x/2
-	vlt   v_tmp,  v_addr, k_limit
-	vmudl v_x3,   v_x2,   v_frac             # x^3
-	vmrg  v_addr, v_addr, k_zaddr
-	vmudl v_x205, v_x2,   k_half             # x^2/2
-	vaddc v_frac, v_frac, k_step8f           # advance the eight positions:
-	vadd  v_idx,  v_idx,  k_step8i           #   the carry crosses over
-	vmudl v_x305, v_x3,   k_half             # x^3/2
-	cfc2 mask, COP2_CTRL_VCC
-	sqv v_addr, 0x00,addr_ptr
+	# Mono: ~50 cycles/iter (8 samples) → 6.3 cyc/sample including the
+	# stereo_shift test. Stereo: a few more for the lsv gather; a stereo
+	# waveform is two MIX_CHANNEL commands (owner=L, STEREO_SUB=R).
+	#
+	# v_idx is in samples (mono) or frames (stereo); byte address ×2 or ×4.
+	beqz  stereo_shift, MonoLoopMono
+	nop
+	vsll  v_addr, v_idx, 2
+	j     MonoLoopCommon
+	nop
 
-	# Gather the four taps of each output sample, then transpose the eight
-	# 4-tap groups into four vectors holding one tap of all eight samples.
-	lhu s0, 0x00(addr_ptr)
-	lhu s1, 0x02(addr_ptr)
-	lhu s2, 0x04(addr_ptr)
-	lhu s3, 0x06(addr_ptr)
-	lhu s4, 0x08(addr_ptr)
-	lhu s6, 0x0A(addr_ptr)
-	lhu s7, 0x0C(addr_ptr)
-	lhu t0, 0x0E(addr_ptr)
-	ldv $v08, 0x00,s0
-	ldv $v09, 0x00,s1
-	ldv $v10, 0x00,s2
-	ldv $v11, 0x00,s3
-	ldv $v12, 0x00,s4
-	ldv $v13, 0x00,s6
-	ldv $v14, 0x00,s7
-	ldv $v15, 0x00,t0
-	stv $v08.e0, 0x00,tr_ptr
-	stv $v08.e1, 0x10,tr_ptr
-	stv $v08.e2, 0x20,tr_ptr
-	stv $v08.e3, 0x30,tr_ptr
-	stv $v08.e4, 0x40,tr_ptr
-	stv $v08.e5, 0x50,tr_ptr
-	stv $v08.e6, 0x60,tr_ptr
-	stv $v08.e7, 0x70,tr_ptr
-	ltv $v16.e0, 0x00,tr_ptr
-	ltv $v16.e7, 0x10,tr_ptr
-	ltv $v16.e6, 0x20,tr_ptr
-	ltv $v16.e5, 0x30,tr_ptr
-	ltv $v16.e4, 0x40,tr_ptr
-	ltv $v16.e3, 0x50,tr_ptr
-	ltv $v16.e2, 0x60,tr_ptr
-	ltv $v16.e1, 0x70,tr_ptr
+	.balign 8
+MonoLoopMono:
+	vsll  v_addr, v_idx, 1
+MonoLoopCommon:
+	# Read back the taps gathered by the previous iteration, one tap of all
+	# eight output samples per register, while the DMEM addresses of the
+	# group gathered by this one are computed. Lanes whose 4-tap window is
+	# not fully inside the cache are parked on the zero window; VCC records
+	# the survivors and is left untouched until the bottom of the body,
+	# where it becomes the mask of the group the next iteration will mix.
+	#
+	# The eight ltv leave the SU no room for anything else, so this is where
+	# the vector operations that depend on neither the taps nor the powers
+	# of x are parked.
+	                                         ltv $v16.e0, 0x00,tr_ptr
+	                                         ltv $v16.e7, 0x10,tr_ptr
+	                                         ltv $v16.e6, 0x20,tr_ptr
+	                                         ltv $v16.e5, 0x30,tr_ptr
+	vlt   v_tmp,  v_addr, k_limit;           ltv $v16.e4, 0x40,tr_ptr
+	vmrg  v_addr, v_addr, k_zaddr;           ltv $v16.e3, 0x50,tr_ptr
+#if VOLUME_FILTER
+	vmudm v_xvol, v_xvol,  k_alpha;          ltv $v16.e2, 0x60,tr_ptr
+	vmadm v_xvol, v_chvol, k_1malpha;        ltv $v16.e1, 0x70,tr_ptr
+#else
+	                                         ltv $v16.e2, 0x60,tr_ptr
+	                                         ltv $v16.e1, 0x70,tr_ptr
+#endif
+	                                         add wv_pos, wv_step_8x
+	                                         addi ticks, -8
+	                                         sqv v_addr, 0x00,addr_ptr
+
+MonoLoopGather:
+	# Negated taps: the coefficients are fed to the accumulator one unit    # Gather the taps of each of
+	# at a time (vmadm saturates its output but not the accumulator), so    # the eight output samples of
+	# the subtractions of the polynomial are done on the taps instead.      # the next group.
+	#
+	# Mono uses ldv (8 bytes = 4 contiguous taps). Stereo taps of one plane
+	# are every other halfword, so four lsv per lane build the same e0..e3
+	# layout; vector loads wrap inside a 16-byte DMEM line, and a lone lsv
+	# of an aligned halfword never wraps.
+	vsub  v_y0n, v_zero, v_y0;               lhu s0, 0x00(addr_ptr)
+	vsub  v_y1n, v_zero, v_y1;               lhu s1, 0x02(addr_ptr)
+	vsub  v_y2n, v_zero, v_y2;               lhu s2, 0x04(addr_ptr)
+	vsub  v_y3n, v_zero, v_y3;               lhu s3, 0x06(addr_ptr)
+	vmudh v_res, v_y1,  k_one;               lhu s4, 0x08(addr_ptr)     # y1
+	vmadm v_res, v_y2,  v_x05;               lhu s6, 0x0A(addr_ptr)     # + x * (y2 - y0)/2
+	vmadm v_res, v_y0n, v_x05;               lhu s7, 0x0C(addr_ptr)
+	vmadm v_res, v_y0,  v_x2;                lhu t0, 0x0E(addr_ptr)     # + x^2 * (y0 - 5*y1/2
+	bnez  stereo_shift, MonoGatherStereo
+	nop
+	vmadm v_res, v_y1n, v_x2;                ldv $v08, 0x00,s0          #          + 2*y2 - y3/2)
+	vmadm v_res, v_y1n, v_x2;                ldv $v09, 0x00,s1
+	vmadm v_res, v_y1n, v_x205;              ldv $v10, 0x00,s2
+	vmadm v_res, v_y2,  v_x2;                ldv $v11, 0x00,s3
+	vmadm v_res, v_y2,  v_x2;                ldv $v12, 0x00,s4
+	vmadm v_res, v_y3n, v_x205;              ldv $v13, 0x00,s6
+	vmadm v_res, v_y0n, v_x305;              ldv $v14, 0x00,s7          # + x^3 * (-y0/2 + 3*y1/2
+	vmadm v_res, v_y1,  v_x3;                ldv $v15, 0x00,t0          #          - 3*y2/2 + y3/2)
 
 	# ACCUM is accumulated in place. acc_ptr is only 4-byte aligned once a
 	# partial group has been replayed, so the two quads are read and
-	# written with the unaligned lqv/lrv and sqv/srv pairs.
-	lqv v_acc0, 0x00,acc_ptr
-	lrv v_acc0, 0x10,acc_ptr
-	lqv v_acc1, 0x10,acc_ptr
-	lrv v_acc1, 0x20,acc_ptr
+	# written with the unaligned lqv/lrv and sqv/srv pairs. The stv can only
+	# start four cycles after the last gather load anyway.
+	vmadm v_res, v_y1,  v_x305;              lqv v_acc0, 0x00,acc_ptr
+	vmadm v_res, v_y2n, v_x3;                lrv v_acc0, 0x10,acc_ptr
+	vmadm v_res, v_y2n, v_x305;              lqv v_acc1, 0x10,acc_ptr
+	vmadm v_res, v_y3,  v_x305;              lrv v_acc1, 0x20,acc_ptr
 
-	# Negated taps: the coefficients are fed to the accumulator one unit at
-	# a time (vmadm saturates its output but not the accumulator), so the
-	# subtractions of the polynomial are done on the taps instead.
-	vsub v_y0n, v_zero, v_y0
-	vsub v_y1n, v_zero, v_y1
-	vsub v_y2n, v_zero, v_y2
-	vsub v_y3n, v_zero, v_y3
+MonoGatherMix:
 
-	vmudh v_res, v_y1,  k_one                # y1
-	vmadm v_res, v_y2,  v_x05                # + x  * (y2 - y0)/2
-	vmadm v_res, v_y0n, v_x05
-	vmadm v_res, v_y0,  v_x2                 # + x^2 * (y0 - 5*y1/2
-	vmadm v_res, v_y1n, v_x2                 #          + 2*y2 - y3/2)
-	vmadm v_res, v_y1n, v_x2
-	vmadm v_res, v_y1n, v_x205
-	vmadm v_res, v_y2,  v_x2
-	vmadm v_res, v_y2,  v_x2
-	vmadm v_res, v_y3n, v_x205
-	vmadm v_res, v_y0n, v_x305               # + x^3 * (-y0/2 + 3*y1/2
-	vmadm v_res, v_y1,  v_x3                 #          - 3*y2/2 + y3/2)
-	vmadm v_res, v_y1,  v_x305
-	vmadm v_res, v_y2n, v_x3
-	vmadm v_res, v_y2n, v_x305
-	vmadm v_res, v_y3,  v_x305
+	# One test for both exits: the ticks left, forced negative if any lane
+	# of the group just mixed was rejected. It is computed here, and not at
+	# the bottom, because a store stalls when it lands exactly two cycles
+	# after a load: these two are what keeps the stv block clear of the
+	# vector loads above.
+	vmudl v_x05,  v_frac, k_half;            sub partial, mask, k_ff    # powers of x of the group being
+	vmudl v_x2,   v_frac, v_frac;            or s0, partial, ticks      #   gathered, for the next iteration
 
-	# .q0/.q1 duplicate each result into the L and R slot of one ACCUM
-	# entry, so the interleaved volume vector applies both gains at once.
-	vmudh v_acc0, v_acc0, k_one
-	vmacf v_acc0, v_xvol, v_res.q0
-	vmudh v_acc1, v_acc1, k_one
-	vmacf v_acc1, v_xvol, v_res.q1
-#if VOLUME_FILTER
-	vmudm v_xvol, v_xvol,  k_alpha
-	vmadm v_xvol, v_chvol, k_1malpha
-#endif
-	sqv v_acc0, 0x00,acc_ptr
-	srv v_acc0, 0x10,acc_ptr
-	sqv v_acc1, 0x10,acc_ptr
-	srv v_acc1, 0x20,acc_ptr
+	# .q0/.q1 duplicate each result into the L and R slot of one ACCUM      # ...and spill them, so that they
+	# entry, so the interleaved volume vector applies both gains at once.   # can be read back transposed.
+	vmudh v_acc0, v_acc0, k_one;             stv $v08.e0, 0x00,tr_ptr
+	vmacf v_acc0, v_xvol, v_res.q0;          stv $v08.e1, 0x10,tr_ptr
+	vmudh v_acc1, v_acc1, k_one;             stv $v08.e2, 0x20,tr_ptr
+	vmacf v_acc1, v_xvol, v_res.q1;          stv $v08.e3, 0x30,tr_ptr
+	vmudl v_x305, v_x2,   v_x05;             stv $v08.e4, 0x40,tr_ptr   # x^3/2 = x^2 * (x/2)
+	vmudl v_x3,   v_x2,   v_frac;            stv $v08.e5, 0x50,tr_ptr   # x^3
+	vmudl v_x205, v_x2,   k_half;            stv $v08.e6, 0x60,tr_ptr   # x^2/2
+	                                         stv $v08.e7, 0x70,tr_ptr
+	                                         sqv v_acc0, 0x00,acc_ptr
+	vaddc v_frac, v_frac, k_step8f;          srv v_acc0, 0x10,acc_ptr   # advance the eight positions:
+	vadd  v_idx,  v_idx,  k_step8i;          sqv v_acc1, 0x10,acc_ptr   #   the carry crosses over
+	                                         srv v_acc1, 0x20,acc_ptr
 
+	# VCC still holds the verdict of the vlt at the top: read it only now
+	# that "partial" has consumed the mask of the group just mixed. It is
+	# also the one spot where the cfc2, which counts as both a load and a
+	# store, has neither two cycles before nor after it.
+	                                         cfc2 mask, COP2_CTRL_VCC
+	bgtz s0, MonoLoop
 	addi acc_ptr, 8*4
-	addi ticks, -8
-	bne mask, k_ff, MonoPartial
-	add wv_pos, wv_step_8x
-	bgtz ticks, MonoLoop
+	bltz partial, MonoPartial
 	nop
 	j MIX_CHANNEL_Done
 	nop
 
+MonoGatherStereo:
+	# Build y0..y3 of this plane into e0..e3 of each gather register, matching
+	# the mono ldv layout. STEREO_SUB starts one halfword later (the R sample).
+	lh    t1, %lo(CH_FLAGS)
+	andi  t1, CH_FLAGS_STEREO_SUB
+	beqz  t1, 1f
+	nop
+	addi  s0, 2
+	addi  s1, 2
+	addi  s2, 2
+	addi  s3, 2
+	addi  s4, 2
+	addi  s6, 2
+	addi  s7, 2
+	addi  t0, 2
+1:	vmadm v_res, v_y1n, v_x2;                lsv $v08.e0, 0x00,s0
+	vmadm v_res, v_y1n, v_x2;                lsv $v08.e1, 0x04,s0
+	vmadm v_res, v_y1n, v_x205;              lsv $v08.e2, 0x08,s0
+	vmadm v_res, v_y2,  v_x2;                lsv $v08.e3, 0x0C,s0
+	vmadm v_res, v_y2,  v_x2;                lsv $v09.e0, 0x00,s1
+	vmadm v_res, v_y3n, v_x205;              lsv $v09.e1, 0x04,s1
+	vmadm v_res, v_y0n, v_x305;              lsv $v09.e2, 0x08,s1
+	vmadm v_res, v_y1,  v_x3;                lsv $v09.e3, 0x0C,s1
+	vmadm v_res, v_y1,  v_x305;              lsv $v10.e0, 0x00,s2
+	vmadm v_res, v_y2n, v_x3;                lsv $v10.e1, 0x04,s2
+	vmadm v_res, v_y2n, v_x305;              lsv $v10.e2, 0x08,s2
+	vmadm v_res, v_y3,  v_x305;              lsv $v10.e3, 0x0C,s2
+	                                         lsv $v11.e0, 0x00,s3
+	                                         lsv $v11.e1, 0x04,s3
+	                                         lsv $v11.e2, 0x08,s3
+	                                         lsv $v11.e3, 0x0C,s3
+	                                         lsv $v12.e0, 0x00,s4
+	                                         lsv $v12.e1, 0x04,s4
+	                                         lsv $v12.e2, 0x08,s4
+	                                         lsv $v12.e3, 0x0C,s4
+	                                         lsv $v13.e0, 0x00,s6
+	                                         lsv $v13.e1, 0x04,s6
+	                                         lsv $v13.e2, 0x08,s6
+	                                         lsv $v13.e3, 0x0C,s6
+	                                         lsv $v14.e0, 0x00,s7
+	                                         lsv $v14.e1, 0x04,s7
+	                                         lsv $v14.e2, 0x08,s7
+	                                         lsv $v14.e3, 0x0C,s7
+	                                         lsv $v15.e0, 0x00,t0
+	                                         lsv $v15.e1, 0x04,t0
+	                                         lsv $v15.e2, 0x08,t0
+	                                         lsv $v15.e3, 0x0C,t0
+	                                         lqv v_acc0, 0x00,acc_ptr
+	                                         lrv v_acc0, 0x10,acc_ptr
+	                                         lqv v_acc1, 0x10,acc_ptr
+	j     MonoGatherMix
+	                                         lrv v_acc1, 0x20,acc_ptr
+
 MonoPartial:
 	# Some lanes were parked: they contributed nothing to ACCUM, so give
 	# their ticks, ACCUM slots and positions back and replay them once the
-	# cache has been refilled.
+	# cache has been refilled. Their mask is what the loop turned into
+	# "partial", and VCC has since moved on to the group being gathered.
+	addi t0, partial, 0xFF
+	ctc2 t0, COP2_CTRL_VCC
 	vmrg  v_cnt, v_zero, k_one               # 1 for each rejected lane
 	vadd  v_cnt, v_cnt, v_cnt.q1
 	vadd  v_cnt, v_cnt, v_cnt.h2
@@ -1003,9 +1063,6 @@ VadpcmEpilog:
 	j MIX_CHANNEL_Silence
 	nop
 
-WaveBeforeEpilog:
-	# If ticks remain (past end of non-looping sample), treat as silence
-	# so volume still ramps.
 MIX_CHANNEL_SilenceLeft:
 	blez ticks, MIX_CHANNEL_Done
 	nop
@@ -1048,43 +1105,9 @@ MIX_CHANNEL_Done:
 
 
 ###############################################################
-# MixBatch16bit – mix 8 mono int16 samples from DMEM_SCRATCH
-# into ACCUM at acc_ptr, then update the volume filter.
-#
-# DMEM_SCRATCH holds: s0 s1 s2 s3 s4 s5 s6 s7 (halfwords)
-# v_xvol / v_chvol = filtered / target volume, as [L,R,L,R,...]
-###############################################################
-
-	.func MixBatch16bit
-MixBatch16bit:
-	move ra2, ra
-	li s0, %lo(DMEM_SCRATCH)
-	lqv $v01, 0,s0                 # 8 samples
-	lqv $v06, 0x00,acc_ptr
-	lqv $v07, 0x10,acc_ptr
-
-	# .q0/.q1 duplicate each sample into the L and R slot of one ACCUM
-	# entry, so the interleaved volume vector applies both gains at once.
-	vmudh $v06, $v06, k_one
-	vmacf $v06, v_xvol, $v01.q0
-	vmudh $v07, $v07, k_one
-	vmacf $v07, v_xvol, $v01.q1
-#if VOLUME_FILTER
-	vmudm v_xvol, v_xvol,  k_alpha
-	vmadm v_xvol, v_chvol, k_1malpha
-#endif
-	sqv $v06, 0x00,acc_ptr
-	sqv $v07, 0x10,acc_ptr
-	jr ra2
-	nop
-	.endfunc
-
-
-###############################################################
 # MixOne – mix a single sample in $v01.e0 into ACCUM at acc_ptr.
-# Used for the <8-sample tail of a resampling batch. Does NOT
-# update the volume filter (the next full batch or silence ramp
-# will); tails are rare and short.
+# Used by the VADPCM point-resampler. Does NOT update the volume
+# filter (the caller advances it every 8 samples).
 ###############################################################
 
 	.func MixOne
@@ -1167,15 +1190,10 @@ MIX_SETCHANNEL:
 	#undef wv_len
 	#undef wv_loop_len
 	#undef wv_addr
-	#undef dma_cache_end
-	#undef out_ptr
-	#undef wv_pos_to_dmem
 	#undef wv_step_8x
-	#undef is_stereo_sub
-	#undef is_16bit
-	#undef is_stereo
 	#undef acc_ptr
 	#undef ch_idx
+	#undef stereo_shift
 
 
 

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -176,7 +176,7 @@
 	.data
 
 	RSPQ_BeginOverlayHeader
-		RSPQ_DefineCommand command_exec, 16				# 0x0
+		RSPQ_DefineCommand command_exec, 20				# 0x0
 		RSPQ_DefineCommand VADPCM_Decompress, 16		# 0x1
 		RSPQ_DefineCommand VADPCM_SetState, 8			# 0x2
 	RSPQ_EndOverlayHeader
@@ -206,6 +206,13 @@ BANNER1:    .ascii " Coded by Rasky "
 	.align 4
 XVOL_L:                   .dcb.w MAX_CHANNELS
 XVOL_R:                   .dcb.w MAX_CHANNELS
+	# RDRAM address of the round completion counter (written by CPU at init).
+	# Must stay in saved state so it survives overlay swaps.
+	.align 4
+COUNTER_RDRAM:            .long  0
+	                      .long  0
+	                      .long  0
+	                      .long  0
 	RSPQ_EndSavedState
 
 	.align 4
@@ -267,6 +274,12 @@ CHANNEL_BUFFER:  .dcb.w (MAX_SAMPLES_PER_LOOP * MAX_CHANNELS)
 	.align 4  # for human visual debugging, 3 would be sufficient (for DMA)
 OUTPUT_AREA:     .dcb.w MAX_SAMPLES_PER_LOOP*2
 
+	# Scratch used to DMA the round id out to COUNTER_RDRAM. 8-byte aligned
+	# for RSP DMA; only the first word is meaningful.
+	.align 3
+ROUND_SCRATCH:            .long  0
+	                      .long  0
+
 	.text 1
 
 	# Number of samples that will be processed in the current loop.
@@ -291,10 +304,10 @@ command_exec:
 	andi a1, 0xFFFF
 	sh a1, %lo(NUM_CHANNELS)
 
-	lw a2, CMD_ADDR(0x8, 0x10)
+	lw a2, CMD_ADDR(0x8, 0x14)
 	sw a2, %lo(OUTPUT_RDRAM)
 
-	# Load settings
+	# Load settings (input-only; positions are CPU-authoritative, no writeback)
 	jal DMASettings
 	li t2, DMA_IN
 
@@ -371,27 +384,31 @@ End:
 	jal EndMixer
 	nop
 
-	jal DMASettings
-	li t2, DMA_OUT_ASYNC
-
-	# Wait for the last out transfer to be finished
-	jal_and_j DMAWaitIdle, RSPQ_Loop
+	# Publish the round id to RDRAM. Settings are no longer written back:
+	# the CPU advances channel positions itself. Completing this DMA is the
+	# signal that every command enqueued before this mix (VADPCM/Opus
+	# decodes included) has finished, because the highpri queue is FIFO.
+	lw t0, CMD_ADDR(0x10, 0x14)
+	sw t0, %lo(ROUND_SCRATCH)
+	li s4, %lo(ROUND_SCRATCH)
+	lw s0, %lo(COUNTER_RDRAM)
+	li t0, DMA_SIZE(8, 1)
+	jal_and_j DMAOutAsync, RSPQ_Loop
 
 	#undef samples_left
 	#undef outptr
 
 
 ###############################################################
-# DMASettings - Load/save the settings via DMA.
+# DMASettings - Load the settings via DMA.
 #
 # Arguments:
-#   t2:  DMA_* flag for DMAExec
+#   t2:  DMA_* flag for DMAExec (always DMA_IN for command_exec)
 ###############################################################
 
 	.func DMASettings
 DMASettings:
-	# Save settings
-	lw s0, CMD_ADDR(0xC, 0x10)
+	lw s0, CMD_ADDR(0xC, 0x14)
 	li s4, %lo(SETTINGS_START)
 	j DMAExec
 	li t0, DMA_SIZE((SETTINGS_END - SETTINGS_START), 1)

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -69,17 +69,9 @@
 # Zero ACCUM before mixing (first MIX_CHANNEL of a round; ACCUM is in .bss).
 #define CH_FLAGS_CLEAR_ACCUM      (1<<7)
 
-# Resample staging (8 samples) and volume spill during VADPCM decode.
-#define DMEM_SCRATCH_SIZE         128
-
-# Bytes of ACCUM staged per DMA when the output pointer is not 8-byte aligned.
-# Must be a multiple of 8, so that every chunk keeps the same misalignment,
-# and must leave room in DMEM_SCRATCH for the word preceding the chunk plus
-# the 8-byte rounding of the transfer.
-#define FLUSH_CHUNK               (DMEM_SCRATCH_SIZE - 8)
-.if (FLUSH_CHUNK % 8) != 0 || (FLUSH_CHUNK + 8) > DMEM_SCRATCH_SIZE
-.error "FLUSH_CHUNK must be a multiple of 8 and fit in DMEM_SCRATCH"
-.endif
+# Resample staging (8 samples) and volume spill during VADPCM decode
+# (4 vectors).
+#define DMEM_SCRATCH_SIZE         64
 
 # Sample DMA cache (must be <= MIXER_LOOP_OVERREAD in mixer.c).
 #define SAMPLE_CACHE_SIZE         64
@@ -903,75 +895,25 @@ MixOne:
 # MIX_FLUSH – DMA ACCUM to RDRAM and clear ACCUM.
 #
 # a0: [nsamples:16][pad:16]
-# a1: output RDRAM pointer (physical)
+# a1: output RDRAM pointer (physical, 8-byte aligned)
+#
+# The DMA engine ignores the low 3 bits of both addresses, so ACCUM can only
+# be sent as-is to an 8-byte aligned pointer. The CPU guarantees that: the
+# output buffer is aligned and every round mixes an even number of stereo
+# samples (see mixer_round_length).
 ###############################################################
 
 	.func MIX_FLUSH
 MIX_FLUSH:
 	andi t4, a0, 0xFFFF            # nsamples
-	move s1, a1                    # output rdram
-
 	beqz t4, RSPQ_Loop
-	nop
+	move s0, a1                    # output rdram
 
-	# Handle 4-byte-but-not-8-byte aligned output. The DMA engine ignores the
-	# low 3 bits of both addresses, so data must sit at an odd word offset in
-	# DMEM to land on an odd word offset in RDRAM: ACCUM (8-byte aligned)
-	# cannot be sent as-is and has to be staged through DMEM_SCRATCH, in
-	# chunks of FLUSH_CHUNK bytes. Every transfer also rewrites the word that
-	# precedes its chunk: for the first one that is memory outside our buffer,
-	# so it is read back from RDRAM first; for the others it is the last word
-	# of the previous chunk, still known here.
-	andi t1, s1, 7
-	beqz t1, MIX_FLUSH_Dma
-
-	move s0, s1                    # rdram cursor (stays 4 mod 8: chunks are 8-byte multiples)
-	li s4, %lo(DMEM_SCRATCH)
-	jal DMAIn
-	li t0, DMA_SIZE(8, 1)
-	li t5, %lo(ACCUM)              # accum cursor
-	sll t6, t4, 2                  # bytes left
-	lw t7, %lo(DMEM_SCRATCH)       # word preceding the chunk
-
-MIX_FLUSH_Stage:
-	move t3, t6                    # this chunk: MIN(bytes left, FLUSH_CHUNK)
-	li t2, FLUSH_CHUNK
-	bltu t6, t2, 1f
-	nop
-	move t3, t2
-1:	li t2, %lo(DMEM_SCRATCH)
-	sw t7, 0(t2)
-	addi t2, 4
-	add t8, t2, t3
-2:	lw t7, 0(t5)                   # exits holding the last word staged
-	addi t5, 4
-	sw t7, 0(t2)
-	addi t2, 4
-	bne t2, t8, 2b
-	nop
-
-	li s4, %lo(DMEM_SCRATCH+4)     # aligned down by the DMA engine
-	move s0, s1
-	addi t0, t3, 3                 # +4 bytes of prefix - 1 for DMA_SIZE
-	jal DMAOut
-	nop
-
-	add s1, t3
-	sub t6, t3
-	bgtz t6, MIX_FLUSH_Stage
-	nop
-	j MIX_FLUSH_Clear
-	nop
-
-MIX_FLUSH_Dma:
-	li s4, %lo(ACCUM)
-	move s0, s1
 	sll t0, t4, 2
 	addi t0, -1
 	jal DMAOut
-	nop
+	li s4, %lo(ACCUM)
 
-MIX_FLUSH_Clear:
 	li s4, %lo(ACCUM)
 	li t0, (MAX_SAMPLES_PER_ROUND * 4) / 64 - 1
 	vxor v_zero, v_zero, v_zero

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -31,12 +31,13 @@
 	# Loop wraps (pos -= loop_len, reload loop_state) are handled here when
 	# the CPU pins a stable loop region (resident or loop-cached).
 	#
-	# PCM resampling is 4-tap Catmull-Rom (Hermite) with a fixed-point step
-	# (WAVEFORM_POS_FRAC_BITS). Stereo PCM is two MIX_CHANNELs (owner=L,
-	# STEREO_SUB=R) that share the same interleaved cache and the same loop
-	# body as mono; only the post-transpose tap shuffle differs. VADPCM frames
-	# are DMA'd compressed, decoded into a DMEM window, then point-resampled.
-	# The volume filter runs once every 8 samples.
+	# PCM and VADPCM resampling is 4-tap Catmull-Rom (Hermite) with a
+	# fixed-point step (WAVEFORM_POS_FRAC_BITS). Stereo PCM is two MIX_CHANNELs
+	# (owner=L, STEREO_SUB=R) that share the same interleaved cache and loop
+	# body as mono; only the gather differs. VADPCM frames are DMA'd compressed,
+	# decoded into DMEM_SAMPLE_CACHE, then Hermite-resampled by that same loop.
+	# Stereo VADPCM is two independent mono MIX_CHANNELs. The volume filter
+	# runs once every 8 samples.
 	#
 	####################################################################
 
@@ -88,9 +89,9 @@
 #define SAMPLE_CACHE_SIZE         64
 #define SAMPLE_CACHE_SAMPLES      128
 
-# In-mixer VADPCM: one decoded frame in DMEM (16 samples). Enough for
-# point resampling within the frame; the next frame is decoded on demand.
-#define VADPCM_WIN_FRAMES         1
+# In-mixer VADPCM: decode up to this many frames into DMEM_SAMPLE_CACHE
+# (16 samples each). 8 frames = SAMPLE_CACHE_SAMPLES.
+#define VADPCM_WIN_FRAMES         8
 #define VADPCM_WIN_SAMPLES        (VADPCM_WIN_FRAMES * 16)
 
 
@@ -98,6 +99,11 @@
 	# Global register allocations
 	################################
 
+	# $v00 is zeroed once per command and must stay zero for the whole of it:
+	# it is the vs operand of the vor/vsub that build the splats of the mono
+	# resampler, and vs cannot be swizzled, so no element of another vector
+	# can stand in for it. Nothing else in this file may write to it, VADPCM
+	# decoder included (see v____).
 	#define v_zero        $v00
 	#define v_shift       $v30
 	#define v_const1      $v31
@@ -193,13 +199,17 @@ ACCUM_PAD:                .dcb.w (ACCUM_PAD_SAMPLES * 2)
 	#
 	# The mono resampler sees it as a window of SAMPLE_CACHE_SAMPLES int16
 	# samples: 8-bit waveforms are DMA'd into its upper half and widened in
-	# place to fill it, so that one inner loop serves both PCM formats. The
-	# stereo and VADPCM paths use the first SAMPLE_CACHE_SIZE bytes only.
+	# place to fill it, so that one inner loop serves both PCM formats.
+	# VADPCM decodes directly into this window (up to VADPCM_WIN_FRAMES).
 	#
 	# The window is followed by four zero samples: the mono resampler parks
 	# the lanes it must discard there, so they interpolate to silence
 	# instead of needing a separate mask (MonoLoop). It is 16-byte aligned
 	# because it is written/read with sqv/lqv.
+	#
+	# The pipelined VADPCM decoder spills one stale vector 16 bytes below the
+	# window before its first real store: that lands in the tail of ACCUM_PAD,
+	# which is never DMA'd out.
 	.align 4
 DMEM_SAMPLE_CACHE:        .dcb.b SAMPLE_CACHE_SAMPLES * 2
 DMEM_SAMPLE_CACHE_ZERO:   .dcb.b 16
@@ -223,12 +233,12 @@ MIX_VADPCM_CODEBOOK:      .space 128
 MIX_VADPCM_STATE:         .space 16
 	.align 4
 MIX_VADPCM_STATE_BEFORE:  .space 16
+	# Compressed frames of one fill, plus room for the 8-byte lookahead of
+	# the decoder priming and for the DMA rounding up to 8 bytes.
 	.align 3
-MIX_VADPCM_COMP:          .space (VADPCM_WIN_FRAMES * 9 + 8)
-	.align 4
-MIX_VADPCM_PCM:           .space (VADPCM_WIN_SAMPLES * 2)
+MIX_VADPCM_COMP:          .space (VADPCM_WIN_FRAMES * 9 + 24)
 
-	# Scratch for the VADPCM catch-up path (wanted frame index).
+	# Frame index the current fill starts at.
 	.align 3
 ROUND_SCRATCH:            .long  0
 	                      .long  0
@@ -249,18 +259,22 @@ CH_LVOL:                  .half  0
 CH_RVOL:                  .half  0
 CH_NSAMPLES:              .half  0
 CH_ACC_OFF:               .half  0
-# Frame index currently in MIX_VADPCM_PCM; -1 = none.
+# First frame currently decoded into DMEM_SAMPLE_CACHE; -1 = none.
 CH_VCUR_FRAME:            .long  0
 # Frame index that MIX_VADPCM_STATE is ready to decode next.
 CH_VNEXT_FRAME:           .long  0
 CH_VADPCM_RA:             .long  0
-CH_ACC_PTR:               .long  0
-# Volume-filter step countdown, preserved across frame decodes.
-CH_K1:                    .half  0
+# Frames of the current fill, and frames the next decode call will produce
+# (they differ while the decoder is catching up to the start of the fill).
+CH_VNFRAMES:              .half  0
+CH_VDECN:                 .half  0
+# k_limit of the current fill, computed before the decode clobbers it.
+CH_VLIMIT:                .half  0
 # Per-sample step of the mono resampler, split the same way as the position:
 # fraction as 0.16, plus whole samples.
 CH_STEPF:                 .half  0
 CH_STEPI:                 .half  0
+                          .half  0
                           .half  0
 
 
@@ -283,11 +297,13 @@ CH_STEPI:                 .half  0
 # MIX_SETCHANNEL.
 #
 # Positions for CH_FLAGS_VADPCM are in *samples* (not bytes). ptr points to
-# compressed 9-byte frames; frame i starts at ptr + i*9.
+# compressed 9-byte frames; frame i starts at ptr + i*9. VADPCM is decoded
+# into DMEM_SAMPLE_CACHE and Hermite-resampled like PCM.
 #
-# Stereo owner (CH_FLAGS_STEREO): ptr points to interleaved LR samples;
+# Stereo PCM owner (CH_FLAGS_STEREO): ptr points to interleaved LR samples;
 # L is extracted and mixed with (lvol, rvol). The stereo-sub channel is
 # a separate MIX_CHANNEL with CH_FLAGS_STEREO_SUB that extracts R.
+# Stereo VADPCM is two mono MIX_CHANNELs (STEREO bit ignored by the ucode).
 ###############################################################
 
 	#define ticks          t3
@@ -401,8 +417,6 @@ MIX_CHANNEL:
 	sw t0, %lo(CH_STATE)
 	lw t0, %lo(CHTBL_LOOP_STATE)(t1)
 	sw t0, %lo(CH_LOOP_STATE)
-	li t0, -1
-	sw t0, %lo(CH_VCUR_FRAME)
 
 	li t0, %lo(VCONST_1)
 	lqv v_const1, 0,t0
@@ -522,7 +536,13 @@ MonoSetup:
 	#   frac_shift    left shift turning wv_pos into a 0.16 unit fraction
 	lh t0, %lo(CH_FLAGS)
 	andi bps, t0, CH_FLAGS_BPS_SHIFT
+	# A VADPCM command decodes one plane into an int16 cache, so its units are
+	# mono samples however the STEREO bit (which the owner still carries) reads.
 	andi stereo_shift, t0, CH_FLAGS_STEREO
+	andi t1, t0, CH_FLAGS_VADPCM
+	srl t1, 2                                # VADPCM bit -> STEREO bit
+	nor t1, t1, zero
+	and stereo_shift, t1
 	srl stereo_shift, 3                      # bit 3 → 0 or 1
 	li cache_half, %lo(DMEM_SAMPLE_CACHE)
 	li t1, %lo(DMEM_SAMPLE_CACHE_ZERO)
@@ -563,6 +583,11 @@ MonoSetup:
 	li k_ff, 0xFF
 
 MonoWaveStart:
+	# VADPCM refills by decoding into the sample cache, not by DMA of PCM.
+	lh t0, %lo(CH_FLAGS)
+	andi t0, CH_FLAGS_VADPCM
+	bnez t0, VadpcmWaveStart
+	nop
 	bltu wv_pos, wv_len, MonoDmaFetch
 	nop
 	beqz wv_loop_len, MIX_CHANNEL_SilenceLeft
@@ -823,7 +848,7 @@ MonoGatherMix:
 	addi acc_ptr, 8*4
 	bltz partial, MonoPartial
 	nop
-	j MIX_CHANNEL_Done
+	j MonoExit
 	nop
 
 MonoGatherStereo:
@@ -901,12 +926,21 @@ MonoPartial:
 	sub wv_pos, wv_step
 2:	bgtz ticks, MonoWaveStart
 	nop
+	# fall through
+
+MonoExit:
+	# VADPCM must write decoder state back before finishing.
+	lh t0, %lo(CH_FLAGS)
+	andi t0, CH_FLAGS_VADPCM
+	bnez t0, VadpcmEpilog
+	nop
 	j MIX_CHANNEL_Done
 	nop
 
 ############################################################
-# Mono VADPCM path: decode one frame at a time into MIX_VADPCM_PCM,
-# then point-resample like 16-bit PCM. State is written back at epilog.
+# VADPCM path: decode into DMEM_SAMPLE_CACHE, then Hermite (MonoLoop).
+# Positions are in samples (not bytes). STEREO on the wire is ignored —
+# stereo VADPCM is two independent mono MIX_CHANNELs.
 ############################################################
 
 VadpcmSetup:
@@ -916,27 +950,25 @@ VadpcmSetup:
 	jal DMAInAsync
 	li t0, DMA_SIZE(128, 1)
 
-	# DMA decoder state. next_frame = floor(pos/16).
+	# DMA decoder state. next_frame = floor(pos/16); the cache is empty.
 	lw s0, %lo(CH_STATE)
 	li s4, %lo(MIX_VADPCM_STATE)
 	jal DMAIn
 	li t0, DMA_SIZE(16, 1)
 
-	lw t0, %lo(CH_POS)
-	srl t0, WAVEFORM_POS_FRAC_BITS
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
 	srl t0, 4
 	sw t0, %lo(CH_VNEXT_FRAME)
 	li t0, -1
+	j MonoSetup                              # bps = 0, stereo_shift = 0
 	sw t0, %lo(CH_VCUR_FRAME)
-	li k1, 8                       # volume-filter step countdown (samples)
-	# fall through
 
 VadpcmWaveStart:
-	bltu wv_pos, wv_len, VadpcmHavePos
+	bltu wv_pos, wv_len, VadpcmFillCache
 	nop
 	beqz wv_loop_len, VadpcmEpilog
 	sub wv_pos, wv_loop_len
-	# Cached-loop wrap: reload loop-start state and invalidate window.
+	# Cached-loop wrap: reload loop-start state and invalidate the window.
 	lw s0, %lo(CH_LOOP_STATE)
 	beqz s0, 1f
 	li s4, %lo(MIX_VADPCM_STATE)
@@ -946,115 +978,128 @@ VadpcmWaveStart:
 	srl t0, 4
 	sw t0, %lo(CH_VNEXT_FRAME)
 	li t0, -1
-	sw t0, %lo(CH_VCUR_FRAME)
 	j VadpcmWaveStart
-	nop
+	sw t0, %lo(CH_VCUR_FRAME)
 
-VadpcmHavePos:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS   # sample
-	srl t1, t0, 4                            # frame needed
-	lw t2, %lo(CH_VCUR_FRAME)
-	beq t1, t2, VadpcmResample
-	sw t1, %lo(ROUND_SCRATCH)                # wanted frame
-	# A frame decode may clobber k1 (the volumes live in $v24/$v25, which
-	# the decoder does not touch).
-	sh k1, %lo(CH_K1)
-VadpcmCatchUp:
-	lw t2, %lo(CH_VNEXT_FRAME)
-	lw t1, %lo(ROUND_SCRATCH)
-	beq t2, t1, VadpcmDecodeCur
-	nop
-	slt t0, t1, t2
-	bnez t0, VadpcmDecodeCur
-	nop
-	# Decode-discard one frame (large step skipped past it)
+VadpcmFillCache:
+	# Decode min(VADPCM_WIN_FRAMES, frames left) frames of 16 samples into the
+	# sample cache, then let MonoLoop resample them like 16-bit mono PCM.
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	srl t1, t0, 4                            # start_frame
+	sw t1, %lo(ROUND_SCRATCH)
+	srl t0, wv_len, WAVEFORM_POS_FRAC_BITS
+	addi t0, 15
+	srl t0, 4                                # frames covered by the waveform
+	sub t0, t1
+	blez t0, VadpcmEpilog
+	li t2, VADPCM_WIN_FRAMES
+	# While more frames follow, only lanes with all four taps inside the
+	# decoded window are accepted (the rest are replayed after the next fill).
+	# At the end of the waveform there is nothing left to replay, so the taps
+	# past the last sample are taken from four zero samples appended below.
+	slt t9, t2, t0
+	bnez t9, 1f
+	li t1, -3*2
+	move t2, t0
+	li t1, 0
+1:	sh t2, %lo(CH_VNFRAMES)
+	sll t0, t2, 5                            # nframes * 16 samples * 2 bytes
+	addi t0, %lo(DMEM_SAMPLE_CACHE)
+	sw zero, 0(t0)                           # four zero samples past the end
+	sw zero, 4(t0)
+	add t1, t0
+	sh t1, %lo(CH_VLIMIT)
 	sh ticks, %lo(CH_NSAMPLES)
 	sw wv_pos, %lo(CH_POS)
-	sw acc_ptr, %lo(CH_ACC_PTR)
-	jal VadpcmDecodeFrame
+
+	# Bring MIX_VADPCM_STATE, which decodes CH_VNEXT_FRAME, to start_frame.
+	# Every fill but the first starts a few frames back, because the taps of
+	# the last samples of the previous window were rejected and replayed;
+	# rewinding is free, since the state of a frame is just the eight samples
+	# before it and those are still in the cache. Decoding forward is only
+	# needed when the position jumped past the window.
+VadpcmAlignState:
+	lw t2, %lo(CH_VNEXT_FRAME)
+	lw t1, %lo(ROUND_SCRATCH)
+	beq t2, t1, VadpcmAligned
+	lw t0, %lo(CH_VCUR_FRAME)
+	slt t9, t1, t2
+	beqz t9, VadpcmCatchUp
+	sub t9, t1, t0                           # frames of the window to keep
+	li s0, %lo(MIX_VADPCM_STATE_BEFORE)
+	beqz t9, 1f
+	sll t9, 5
+	addi t9, %lo(DMEM_SAMPLE_CACHE)
+	addi s0, t9, -16
+1:	li s1, %lo(MIX_VADPCM_STATE)
+	lqv $v01, 0,s0
+	sqv $v01, 0,s1
+	j VadpcmAligned
+	sw t1, %lo(CH_VNEXT_FRAME)
+
+VadpcmCatchUp:
+	li t0, 1
+	sh t0, %lo(CH_VDECN)
+1:	lw t2, %lo(CH_VNEXT_FRAME)
+	lw t1, %lo(ROUND_SCRATCH)
+	beq t2, t1, VadpcmAligned
 	nop
-	lh ticks, %lo(CH_NSAMPLES)
-	lw wv_pos, %lo(CH_POS)
-	lw acc_ptr, %lo(CH_ACC_PTR)
-	lw wv_step, %lo(CH_STEP)
-	lw wv_len, %lo(CH_LEN)
-	lw wv_loop_len, %lo(CH_LOOP_LEN)
-	j VadpcmCatchUp
+	jal VadpcmDecodeFrames
+	nop
+	j 1b
 	nop
 
-VadpcmDecodeCur:
-	# Snapshot state before decoding the frame we will resample from.
+VadpcmAligned:
+	# Snapshot the state that decodes start_frame: the epilog needs it if the
+	# command ends before a single frame has been consumed.
 	li s0, %lo(MIX_VADPCM_STATE)
 	li s1, %lo(MIX_VADPCM_STATE_BEFORE)
 	lqv $v01, 0,s0
 	sqv $v01, 0,s1
-	sh ticks, %lo(CH_NSAMPLES)
-	sw wv_pos, %lo(CH_POS)
-	sw acc_ptr, %lo(CH_ACC_PTR)
-	jal VadpcmDecodeFrame
-	nop
+	lw t1, %lo(ROUND_SCRATCH)
+	lh t0, %lo(CH_VNFRAMES)
+	sw t1, %lo(CH_VCUR_FRAME)
+	jal VadpcmDecodeFrames
+	sh t0, %lo(CH_VDECN)
+
+	# The decoder clobbers ticks/pos/len/loop_len/addr, k_ff, s2, $v01-$v23
+	# and $v31 (which it needs as the shift table of vsra8).
 	lh ticks, %lo(CH_NSAMPLES)
 	lw wv_pos, %lo(CH_POS)
-	lw acc_ptr, %lo(CH_ACC_PTR)
-	lw wv_step, %lo(CH_STEP)
 	lw wv_len, %lo(CH_LEN)
 	lw wv_loop_len, %lo(CH_LOOP_LEN)
-	lw t1, %lo(CH_VNEXT_FRAME)
-	addi t1, -1                              # frame just decoded
-	sw t1, %lo(CH_VCUR_FRAME)
-	# Decode clobbers $v31 (vsra8 uses vshift8): reload mixer constants.
+	lw wv_addr, %lo(CH_PTR)
 	li t0, %lo(VCONST_1)
 	lqv v_const1, 0,t0
-	lh k1, %lo(CH_K1)                      # resume volume-filter countdown
-	# fall through to resample
-
-VadpcmResample:
-	blez ticks, VadpcmEpilog
-	nop
-	# Ensure the current sample's frame is loaded. Go through VadpcmWaveStart
-	# so that a position that just ran past the end wraps the loop (a short
-	# loop can be crossed several times within one round).
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	srl t1, t0, 4
-	lw t2, %lo(CH_VCUR_FRAME)
-	bne t1, t2, VadpcmWaveStart
-	nop
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	andi t0, 15
-	sll t0, 1
-	li s1, %lo(MIX_VADPCM_PCM)
-	add t0, s1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	mtc2 t0, $v01.e0
-	jal MixOne
-	nop
-#if VOLUME_FILTER
-	# MixOne does not advance the volume filter. Apply the same 8-sample
-	# coefficient the PCM MixBatch path uses, once every 8 output samples.
-	addi k1, -1
-	bgtz k1, 1f
-	nop
-	li k1, 8
-	vmudm v_xvol, v_xvol,  k_alpha
-	vmadm v_xvol, v_chvol, k_1malpha
-1:
-#endif
-	addi ticks, -1
-	j VadpcmResample
-	addi acc_ptr, 4
+	lh t1, %lo(CH_VLIMIT)
+	mtc2 t1, k_limit
+	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS
+	andi s2, 15                              # offset of wv_pos in the cache
+	sll wv_step_8x, wv_step, 3
+	j MonoRefill
+	li k_ff, 0xFF
 
 VadpcmEpilog:
-	# Write back state for frame at wv_pos. STATE_BEFORE = ready for
-	# CH_VCUR_FRAME; STATE = ready for CH_VNEXT_FRAME.
+	# The state that decodes frame F is just the eight samples before it, so
+	# once the cache holds F it can be written back straight out of it. Only
+	# the two ends need the snapshots: nothing decoded yet (STATE, as loaded)
+	# or nothing consumed yet (STATE_BEFORE, taken at CH_VCUR_FRAME).
 	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	srl t0, 4
+	srl t0, 4                                # end_frame
 	lw t1, %lo(CH_VCUR_FRAME)
 	li s4, %lo(MIX_VADPCM_STATE)
-	bne t0, t1, 1f
-	nop
-	li s4, %lo(MIX_VADPCM_STATE_BEFORE)
+	bltz t1, 1f
+	sub t0, t1                               # frames consumed
+	blez t0, 2f
+	lw t2, %lo(CH_VNEXT_FRAME)
+	sub t2, t1                               # frames decoded
+	slt t9, t2, t0
+	bnez t9, 1f
+	sll t0, 5
+	addi t0, %lo(DMEM_SAMPLE_CACHE)
+	j 1f
+	addi s4, t0, -16                         # eight samples before end_frame
+2:	li s4, %lo(MIX_VADPCM_STATE_BEFORE)
 1:	lw s0, %lo(CH_STATE)
 	jal DMAOut
 	li t0, DMA_SIZE(16, 1)
@@ -1101,26 +1146,6 @@ MIX_CHANNEL_Done:
 	sw t1, %lo(XVOL)(t0)
 	j RSPQ_Loop
 	nop
-	.endfunc
-
-
-###############################################################
-# MixOne – mix a single sample in $v01.e0 into ACCUM at acc_ptr.
-# Used by the VADPCM point-resampler. Does NOT update the volume
-# filter (the caller advances it every 8 samples).
-###############################################################
-
-	.func MixOne
-MixOne:
-	lsv $v04.e0, 0,acc_ptr         # lane 0 = left, lane 1 = right
-	lsv $v04.e1, 2,acc_ptr
-	nop
-	nop
-	vmudh $v04, $v04, k_one
-	vmacf $v04, v_xvol, $v01.e0
-	ssv $v04.e0, 0,acc_ptr
-	jr ra
-	ssv $v04.e1, 2,acc_ptr
 	.endfunc
 
 
@@ -1236,10 +1261,19 @@ MIX_SETCHANNEL:
 #define vstate2 $v20
 #define vstate3 $v21
 #define vresult $v03
-#define v____   $v00
+# Destination of the vmudh/vmadh whose result is only wanted in the
+# accumulator. It must not be $v00: the mixer needs that one to stay zero
+# across the decode. $v04/$v05 are the two the decoder does not otherwise use,
+# and the mixer only keeps powers of x there, which it recomputes every group.
+#define v____   $v04
 
-	.func VadpcmDecodeFrame
-VadpcmDecodeFrame:
+	# Decode CH_VDECN frames starting at CH_VNEXT_FRAME into
+	# DMEM_SAMPLE_CACHE. Advances CH_VNEXT_FRAME by CH_VDECN.
+	# Clobbers t2, t3, t4, t6, t7, t8, t9, s0-s5 and $v01-$v23, $v31 ($v30 is
+	# rewritten with the shift table it already held). $v00 is deliberately
+	# left alone, see v____.
+	.func VadpcmDecodeFrames
+VadpcmDecodeFrames:
 	sw ra, %lo(CH_VADPCM_RA)
 
 	# MIX_CHANNEL keeps volume-filter constants in $v31 (v_const1), but
@@ -1248,7 +1282,7 @@ VadpcmDecodeFrame:
 	lpv vshift8, 0x00,zero
 	vsrl vshift, vshift8, 8
 
-	# RDRAM address of compressed frame: ptr + next_frame*9
+	# RDRAM address of first compressed frame: ptr + next_frame*9
 	lw t0, %lo(CH_VNEXT_FRAME)
 	sll t1, t0, 3
 	add t1, t0
@@ -1256,13 +1290,19 @@ VadpcmDecodeFrame:
 	add s0, t1
 	andi t9, s0, 7                        # misalignment (survives DMAIn)
 	sub s0, t9
+	lh nframes, %lo(CH_VDECN)
+	# nframes*9 bytes, plus the 8-byte lookahead and the misalignment that
+	# DMAIn folds into s4.
+	sll t0, nframes, 3
+	add t0, nframes
+	addi t0, 16
 	li s4, %lo(MIX_VADPCM_COMP)
 	jal DMAIn
-	li t0, DMA_SIZE(9+8, 1)
+	addi t0, -1                            # = DMA_SIZE(t0, 1)
 
 	li dmem_codebook, %lo(MIX_VADPCM_CODEBOOK)
 	li dmem_state, %lo(MIX_VADPCM_STATE)
-	li dmem_output, %lo(MIX_VADPCM_PCM)
+	li dmem_output, %lo(DMEM_SAMPLE_CACHE)
 	li dmem_input, %lo(MIX_VADPCM_COMP)
 	add dmem_input, t9
 	addiu dmem_input, 1
@@ -1270,8 +1310,7 @@ VadpcmDecodeFrame:
 	jal VADPCM_LoadIdentity
 	nop
 
-	li nframes, 1
-	li a2, 0                               # mono path in SaveState
+	lh nframes, %lo(CH_VDECN)
 	lqv vstate1, 0x00,dmem_state
 	li t1, 1
 	j VADPCM_Priming
@@ -1370,7 +1409,8 @@ VADPCM_DecodeLoop:
 VADPCM_SaveState:
 	sqv vstate1, 0x00,dmem_state
 	lw t0, %lo(CH_VNEXT_FRAME)
-	addi t0, 1
+	lh t1, %lo(CH_VDECN)
+	add t0, t1
 	sw t0, %lo(CH_VNEXT_FRAME)
 	lw ra, %lo(CH_VADPCM_RA)
 	jr ra

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -53,7 +53,7 @@
 #define VOLUME_FILTER             1
 
 # Max output samples that fit in ACCUM (stereo int16). Must match mixer.c.
-#define MAX_SAMPLES_PER_ROUND     256
+#define MAX_SAMPLES_PER_ROUND     512
 
 # Number of fractional bits used in the fixed point numbers that specify
 # the waveform position, step, length and loop length.
@@ -71,6 +71,15 @@
 
 # Resample staging (8 samples) and volume spill during VADPCM decode.
 #define DMEM_SCRATCH_SIZE         128
+
+# Bytes of ACCUM staged per DMA when the output pointer is not 8-byte aligned.
+# Must be a multiple of 8, so that every chunk keeps the same misalignment,
+# and must leave room in DMEM_SCRATCH for the word preceding the chunk plus
+# the 8-byte rounding of the transfer.
+#define FLUSH_CHUNK               (DMEM_SCRATCH_SIZE - 8)
+.if (FLUSH_CHUNK % 8) != 0 || (FLUSH_CHUNK + 8) > DMEM_SCRATCH_SIZE
+.error "FLUSH_CHUNK must be a multiple of 8 and fit in DMEM_SCRATCH"
+.endif
 
 # Sample DMA cache (must be <= MIXER_LOOP_OVERREAD in mixer.c).
 #define SAMPLE_CACHE_SIZE         64
@@ -912,31 +921,51 @@ MIX_FLUSH:
 	beqz t4, MIX_FLUSH_Publish
 	nop
 
-	# Handle 4-byte-but-not-8-byte aligned output: fetch the 8-byte DMA
-	# transfer so the leading 4 bytes (before our buffer) are preserved,
-	# then splice ACCUM starting at the misaligned offset.
+	# Handle 4-byte-but-not-8-byte aligned output. The DMA engine ignores the
+	# low 3 bits of both addresses, so data must sit at an odd word offset in
+	# DMEM to land on an odd word offset in RDRAM: ACCUM (8-byte aligned)
+	# cannot be sent as-is and has to be staged through DMEM_SCRATCH, in
+	# chunks of FLUSH_CHUNK bytes. Every transfer also rewrites the word that
+	# precedes its chunk: for the first one that is memory outside our buffer,
+	# so it is read back from RDRAM first; for the others it is the last word
+	# of the previous chunk, still known here.
 	andi t1, s1, 7
 	beqz t1, MIX_FLUSH_Dma
 
-	move s0, s1
+	move s0, s1                    # rdram cursor (stays 4 mod 8: chunks are 8-byte multiples)
 	li s4, %lo(DMEM_SCRATCH)
 	jal DMAIn
 	li t0, DMA_SIZE(8, 1)
-	# s4 points at the first requested byte. Copy ACCUM over it.
-	li t0, %lo(ACCUM)
-	sll t2, t4, 2
-1:	lw t3, 0(t0)
-	sw t3, 0(s4)
-	addi t0, 4
-	addi s4, 4
-	addi t2, -4
-	bgtz t2, 1b
+	li t5, %lo(ACCUM)              # accum cursor
+	sll t6, t4, 2                  # bytes left
+	lw t7, %lo(DMEM_SCRATCH)       # word preceding the chunk
+
+MIX_FLUSH_Stage:
+	move t3, t6                    # this chunk: MIN(bytes left, FLUSH_CHUNK)
+	li t2, FLUSH_CHUNK
+	bltu t6, t2, 1f
 	nop
-	li s4, %lo(DMEM_SCRATCH)
+	move t3, t2
+1:	li t2, %lo(DMEM_SCRATCH)
+	sw t7, 0(t2)
+	addi t2, 4
+	add t8, t2, t3
+2:	lw t7, 0(t5)                   # exits holding the last word staged
+	addi t5, 4
+	sw t7, 0(t2)
+	addi t2, 4
+	bne t2, t8, 2b
+	nop
+
+	li s4, %lo(DMEM_SCRATCH+4)     # aligned down by the DMA engine
 	move s0, s1
-	sll t0, t4, 2
-	addi t0, 3                     # +4 bytes of prefix - 1 for DMA_SIZE
+	addi t0, t3, 3                 # +4 bytes of prefix - 1 for DMA_SIZE
 	jal DMAOut
+	nop
+
+	add s1, t3
+	sub t6, t3
+	bgtz t6, MIX_FLUSH_Stage
 	nop
 	j MIX_FLUSH_Clear
 	nop

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -8,26 +8,26 @@
 	# Architecture (per-channel commands)
 	# ===================================
 	#
-# Mixing is driven by three RSPQ commands:
-#
-#   MIX_SETCHANNEL – record the VADPCM codebook/state pointers of one channel
-#                  into a per-channel DMEM table.
-#   MIX_CHANNEL  – resample one channel for up to MAX_SAMPLES_PER_ROUND
-#                  output ticks and accumulate into a stereo DMEM buffer
-#                  (ACCUM) in .bss. Optionally decode mono VADPCM frames
-#                  into a DMEM window first (CH_FLAGS_VADPCM). Stereo
-#                  VADPCM is two independent mono MIX_CHANNELs (L/R planes).
-#   MIX_FLUSH    – DMA ACCUM out to RDRAM, clear it, publish the round id.
-#
-# All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one highpri burst
-# of this overlay so ACCUM (in .bss) cannot be clobbered mid-round. XVOL_L/R
-# (one-tap volume filter state) and the per-channel VADPCM table live in
-# saved state, so they survive overlay swaps.
-#
-# Per-round channel parameters travel inline in the MIX_CHANNEL command; the
-# VADPCM pointers, which only change when a new waveform starts, are sent by
-# MIX_SETCHANNEL. Sample data comes from
-# either resident RDRAM or a CPU-side ring FIFO (no RSP compaction).
+	# Mixing is driven by three RSPQ commands:
+	#
+	#   MIX_SETCHANNEL – record the VADPCM codebook/state pointers of one channel
+	#                  into a per-channel DMEM table.
+	#   MIX_CHANNEL  – resample one channel for up to MAX_SAMPLES_PER_ROUND
+	#                  output ticks and accumulate into a stereo DMEM buffer
+	#                  (ACCUM) in .bss. Optionally decode mono VADPCM frames
+	#                  into a DMEM window first (CH_FLAGS_VADPCM). Stereo
+	#                  VADPCM is two independent mono MIX_CHANNELs (L/R planes).
+	#   MIX_FLUSH    – DMA ACCUM out to RDRAM and clear it.
+	#
+	# All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one highpri burst
+	# of this overlay so ACCUM (in .bss) cannot be clobbered mid-round. XVOL_L/R
+	# (one-tap volume filter state) and the per-channel VADPCM table live in
+	# saved state, so they survive overlay swaps.
+	#
+	# Per-round channel parameters travel inline in the MIX_CHANNEL command; the
+	# VADPCM pointers, which only change when a new waveform starts, are sent by
+	# MIX_SETCHANNEL. Sample data comes from
+	# either resident RDRAM or a CPU-side samplebuffer (no RSP compaction).
 	# Loop wraps (pos -= loop_len, reload loop_state) are handled here when
 	# the CPU pins a stable loop region (resident or loop-cached).
 	#
@@ -111,7 +111,7 @@
 	RSPQ_BeginOverlayHeader
 		RSPQ_DefineCommand MIX_CHANNEL,       32		# 0x0
 		RSPQ_DefineCommand MIX_SETCHANNEL,    16		# 0x1
-		RSPQ_DefineCommand MIX_FLUSH,         12		# 0x2
+		RSPQ_DefineCommand MIX_FLUSH,          8		# 0x2
 	RSPQ_EndOverlayHeader
 
 ############################################################################
@@ -134,15 +134,10 @@ BANNER1:    .ascii " Coded by Rasky "
 	.align 4
 XVOL_L:                   .dcb.w MAX_CHANNELS
 XVOL_R:                   .dcb.w MAX_CHANNELS
-	.align 4
-COUNTER_RDRAM:            .long  0
-	                      .long  0
-	                      .long  0
-	                      .long  0
 	# Per-channel VADPCM pointers, written by MIX_SETCHANNEL. They only
 	# change when a new waveform is played, so the CPU sends them once
 	# instead of inlining them in every MIX_CHANNEL.
-	.align 2
+	.align 4
 CHTBL_CODEBOOK:           .dcb.l MAX_CHANNELS
 CHTBL_STATE:              .dcb.l MAX_CHANNELS
 CHTBL_LOOP_STATE:         .dcb.l MAX_CHANNELS
@@ -183,7 +178,7 @@ MIX_VADPCM_COMP:          .space (VADPCM_WIN_FRAMES * 9 + 8)
 	.align 4
 MIX_VADPCM_PCM:           .space (VADPCM_WIN_SAMPLES * 2)
 
-	# Scratch used to DMA the round id out to COUNTER_RDRAM.
+	# Scratch for the VADPCM catch-up path (wanted frame index).
 	.align 3
 ROUND_SCRATCH:            .long  0
 	                      .long  0
@@ -905,20 +900,18 @@ MixOne:
 
 
 ###############################################################
-# MIX_FLUSH – DMA ACCUM to RDRAM, clear ACCUM, publish round id.
+# MIX_FLUSH – DMA ACCUM to RDRAM and clear ACCUM.
 #
 # a0: [nsamples:16][pad:16]
 # a1: output RDRAM pointer (physical)
-# a2: round_id
 ###############################################################
 
 	.func MIX_FLUSH
 MIX_FLUSH:
 	andi t4, a0, 0xFFFF            # nsamples
 	move s1, a1                    # output rdram
-	move k1, a2                    # round_id
 
-	beqz t4, MIX_FLUSH_Publish
+	beqz t4, RSPQ_Loop
 	nop
 
 	# Handle 4-byte-but-not-8-byte aligned output. The DMA engine ignores the
@@ -990,12 +983,8 @@ MIX_FLUSH_Clear:
 	bnez t0, 1b
 	addi t0, -1
 
-MIX_FLUSH_Publish:
-	sw k1, %lo(ROUND_SCRATCH)
-	li s4, %lo(ROUND_SCRATCH)
-	lw s0, %lo(COUNTER_RDRAM)
-	li t0, DMA_SIZE(8, 1)
-	jal_and_j DMAOutAsync, RSPQ_Loop
+	j RSPQ_Loop
+	nop
 	.endfunc
 
 

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -179,6 +179,7 @@
 		RSPQ_DefineCommand command_exec, 20				# 0x0
 		RSPQ_DefineCommand VADPCM_Decompress, 16		# 0x1
 		RSPQ_DefineCommand VADPCM_SetState, 8			# 0x2
+		RSPQ_DefineCommand command_memmove, 12			# 0x3
 	RSPQ_EndOverlayHeader
 
 ############################################################################
@@ -397,6 +398,70 @@ End:
 
 	#undef samples_left
 	#undef outptr
+
+
+###############################################################
+# command_memmove
+#
+# Backward move of bytes in RDRAM (dst < src), enqueued by
+# samplebuffer_discard to compact a sample buffer. Being a regular
+# queue command, it executes in-order with the decode/mix commands
+# that reference the buffer, so the CPU does not need to wait for
+# them before compacting.
+#
+# dst/src must be 8-byte aligned and len must be a multiple of 8
+# (the CPU falls back to a synchronous copy otherwise): unlike
+# OPUS_memmove, we cannot copy a few extra bytes, because the bytes
+# just after the moved region belong to the append area that the
+# CPU may be writing concurrently.
+#
+# Chunks are staged through CHANNEL_BUFFER, which is scratch space
+# only used within a single command_exec.
+#
+# Input:
+#   a0: 0..23: RDRAM destination pointer
+#   a1: 0..23: RDRAM source pointer
+#   a2:        number of bytes to move
+###############################################################
+
+	#define MEMMOVE_CHUNK  (MAX_SAMPLES_PER_LOOP * MAX_CHANNELS * 2)
+
+	.func command_memmove
+command_memmove:
+	#if RSPQ_DEBUG
+	andi t0, a0, 7
+	assert_eq t0, 0, 0x8601
+	andi t0, a1, 7
+	assert_eq t0, 0, 0x8601
+	andi t0, a2, 7
+	assert_eq t0, 0, 0x8601
+	#endif
+
+MemmoveLoop:
+	move t4, a2
+	ble t4, MEMMOVE_CHUNK, 1f
+	nop
+	li t4, MEMMOVE_CHUNK
+1:
+	move s0, a1
+	li s4, %lo(CHANNEL_BUFFER)
+	jal DMAIn
+	addiu t0, t4, -1
+
+	move s0, a0
+	li s4, %lo(CHANNEL_BUFFER)
+	jal DMAOut
+	addiu t0, t4, -1
+
+	add a0, t4
+	add a1, t4
+	sub a2, t4
+	bgtz a2, MemmoveLoop
+	nop
+
+	j RSPQ_Loop
+	nop
+	.endfunc
 
 
 ###############################################################

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -687,11 +687,13 @@ VadpcmDecodeCur:
 VadpcmResample:
 	blez ticks, VadpcmEpilog
 	nop
-	# Ensure the current sample's frame is loaded.
+	# Ensure the current sample's frame is loaded. Go through VadpcmWaveStart
+	# so that a position that just ran past the end wraps the loop (a short
+	# loop can be crossed several times within one round).
 	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
 	srl t1, t0, 4
 	lw t2, %lo(CH_VCUR_FRAME)
-	bne t1, t2, VadpcmHavePos
+	bne t1, t2, VadpcmWaveStart
 	nop
 
 	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -8,20 +8,28 @@
 	# Architecture (per-channel commands)
 	# ===================================
 	#
-	# Mixing is driven by two RSPQ commands:
-	#
-	#   MIX_CHANNEL  – resample one channel for up to MAX_SAMPLES_PER_ROUND
-	#                  output ticks and accumulate into a stereo DMEM buffer
-	#                  (ACCUM) in .bss. Optionally decode mono VADPCM frames
-	#                  into a DMEM window first (CH_FLAGS_VADPCM).
-	#   MIX_FLUSH    – DMA ACCUM out to RDRAM, clear it, publish the round id.
-	#
-	# All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one highpri burst
-	# of this overlay so ACCUM cannot be clobbered mid-round. XVOL_L/R (one-tap
-	# volume filter state) live in saved state so volume ramps survive swaps.
-	#
-	# Channel parameters travel inline in the MIX_CHANNEL command – there is
-	# no settings DMA ring. VADPCM channels also pass codebook/state/loop_state.
+# Mixing is driven by three RSPQ commands:
+#
+#   MIX_SETCHANNEL – record the VADPCM codebook/state pointers of one channel
+#                  into a per-channel DMEM table.
+#   MIX_CHANNEL  – resample one channel for up to MAX_SAMPLES_PER_ROUND
+#                  output ticks and accumulate into a stereo DMEM buffer
+#                  (ACCUM) in .bss. Optionally decode mono VADPCM frames
+#                  into a DMEM window first (CH_FLAGS_VADPCM). Stereo
+#                  VADPCM is two independent mono MIX_CHANNELs (L/R planes).
+#   MIX_FLUSH    – DMA ACCUM out to RDRAM, clear it, publish the round id.
+#
+# All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one highpri burst
+# of this overlay so ACCUM (in .bss) cannot be clobbered mid-round. XVOL_L/R
+# (one-tap volume filter state) and the per-channel VADPCM table live in
+# saved state, so they survive overlay swaps.
+#
+# Per-round channel parameters travel inline in the MIX_CHANNEL command; the
+# VADPCM pointers, which only change when a new waveform starts, are sent by
+# MIX_SETCHANNEL. Sample data comes from
+# either resident RDRAM or a CPU-side ring FIFO (no RSP compaction).
+	# Loop wraps (pos -= loop_len, reload loop_state) are handled here when
+	# the CPU pins a stable loop region (resident or loop-cached).
 	#
 	# Resampling is point-sampling with a fixed-point step (WAVEFORM_POS_FRAC_BITS).
 	# PCM samples are fetched from RDRAM into a small DMEM cache; VADPCM frames
@@ -61,9 +69,8 @@
 # Zero ACCUM before mixing (first MIX_CHANNEL of a round; ACCUM is in .bss).
 #define CH_FLAGS_CLEAR_ACCUM      (1<<7)
 
-# Scratch size for memmove bounce buffer / resample staging. Must be a
-# multiple of 8 and large enough for useful memmove chunks.
-#define DMEM_SCRATCH_SIZE         1536
+# Resample staging (8 samples) and volume spill during VADPCM decode.
+#define DMEM_SCRATCH_SIZE         128
 
 # Sample DMA cache (must be <= MIXER_LOOP_OVERREAD in mixer.c).
 #define SAMPLE_CACHE_SIZE         64
@@ -93,11 +100,9 @@
 	.data
 
 	RSPQ_BeginOverlayHeader
-		RSPQ_DefineCommand MIX_CHANNEL,       48		# 0x0
-		RSPQ_DefineCommand VADPCM_Decompress, 16		# 0x1
-		RSPQ_DefineCommand VADPCM_SetState,    8		# 0x2
-		RSPQ_DefineCommand command_memmove,   12		# 0x3
-		RSPQ_DefineCommand MIX_FLUSH,         12		# 0x4
+		RSPQ_DefineCommand MIX_CHANNEL,       32		# 0x0
+		RSPQ_DefineCommand MIX_SETCHANNEL,    16		# 0x1
+		RSPQ_DefineCommand MIX_FLUSH,         12		# 0x2
 	RSPQ_EndOverlayHeader
 
 ############################################################################
@@ -125,6 +130,13 @@ COUNTER_RDRAM:            .long  0
 	                      .long  0
 	                      .long  0
 	                      .long  0
+	# Per-channel VADPCM pointers, written by MIX_SETCHANNEL. They only
+	# change when a new waveform is played, so the CPU sends them once
+	# instead of inlining them in every MIX_CHANNEL.
+	.align 2
+CHTBL_CODEBOOK:           .dcb.l MAX_CHANNELS
+CHTBL_STATE:              .dcb.l MAX_CHANNELS
+CHTBL_LOOP_STATE:         .dcb.l MAX_CHANNELS
 	RSPQ_EndSavedState
 
 	.align 4
@@ -133,7 +145,7 @@ IDENTITY:  .half  1<<11,1<<11,1<<11,1<<11, 1<<11,1<<11,1<<11,1<<11
 	.bss
 
 	# Stereo int16 accumulator for one mix round (LRLR...). Lives in .bss
-	# (not saved state) so the DMEM budget still fits the VADPCM bssovl1
+	# (not saved state) — kept out of the ACCUM bank
 	# bank. All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one
 	# highpri burst of this overlay, so no overlay switch can clobber it
 	# mid-round. Cleared by the first MIX_CHANNEL (CH_FLAGS_CLEAR_ACCUM)
@@ -145,15 +157,14 @@ ACCUM:                    .dcb.w (MAX_SAMPLES_PER_ROUND * 2)
 	.align 3
 DMEM_SAMPLE_CACHE:        .dcb.b SAMPLE_CACHE_SIZE
 
-	# Contiguous resample staging (8 samples) plus bounce buffer for
-	# command_memmove.
+	# Contiguous resample staging, plus volume spill during VADPCM decode.
 	.align 4
 DMEM_SCRATCH:             .dcb.b DMEM_SCRATCH_SIZE
 
-	# In-mixer VADPCM staging (mono). Lives in .bss with ACCUM; not used by
-	# the legacy VADPCM_Decompress path (which uses the bssovl1 bank).
+	# In-mixer VADPCM staging (mono codebook = 8 vectors = 128 bytes).
+	# Stereo VADPCM uses two MIX_CHANNEL commands, each with its own half.
 	.align 4
-MIX_VADPCM_CODEBOOK:      .space 256
+MIX_VADPCM_CODEBOOK:      .space 128
 	.align 4
 MIX_VADPCM_STATE:         .space 16
 	.align 4
@@ -188,8 +199,6 @@ CH_ACC_OFF:               .half  0
 CH_VCUR_FRAME:            .long  0
 # Frame index that MIX_VADPCM_STATE is ready to decode next.
 CH_VNEXT_FRAME:           .long  0
-# Nonzero: VADPCM_SaveState returns to VadpcmDecodeFrame instead of DMA-out.
-CH_VADPCM_MIXRET:         .long  0
 CH_VADPCM_RA:             .long  0
 CH_ACC_PTR:               .long  0
 # Volume-filter step countdown, preserved across frame decodes.
@@ -202,7 +211,7 @@ CH_K1:                    .half  0
 ###############################################################
 # MIX_CHANNEL – resample one channel and accumulate into ACCUM.
 #
-# Command words (48 bytes):
+# Command words (32 bytes):
 #   a0: [ovl+cmd:8][ch_idx:8][flags:8][pad:8]   (24-bit payload)
 #   a1: [lvol:16][rvol:16]
 #   a2: pos   (fixed point, WAVEFORM_POS_FRAC_BITS)
@@ -211,10 +220,9 @@ CH_K1:                    .half  0
 #   +20: loop_len
 #   +24: ptr  (0 = silence: only ramp volume toward target)
 #   +28: [acc_offset:16][nsamples:16]
-#   +32: codebook   (VADPCM; 0 for PCM)
-#   +36: state      (VADPCM decoder state in RDRAM)
-#   +40: loop_state (VADPCM state at loop start; 0 if none)
-#   +44: pad
+#
+# VADPCM codebook/state/loop_state come from the per-channel table filled by
+# MIX_SETCHANNEL.
 #
 # Positions for CH_FLAGS_VADPCM are in *samples* (not bytes). ptr points to
 # compressed 9-byte frames; frame i starts at ptr + i*9.
@@ -256,21 +264,24 @@ MIX_CHANNEL:
 	sh t0, %lo(CH_RVOL)
 	sw a2, %lo(CH_POS)
 	sw a3, %lo(CH_STEP)
-	lw t0, CMD_ADDR(0x10, 0x30)
+	lw t0, CMD_ADDR(0x10, 0x20)
 	sw t0, %lo(CH_LEN)
-	lw t0, CMD_ADDR(0x14, 0x30)
+	lw t0, CMD_ADDR(0x14, 0x20)
 	sw t0, %lo(CH_LOOP_LEN)
-	lw t0, CMD_ADDR(0x18, 0x30)
+	lw t0, CMD_ADDR(0x18, 0x20)
 	sw t0, %lo(CH_PTR)
-	lw t0, CMD_ADDR(0x1C, 0x30)
+	lw t0, CMD_ADDR(0x1C, 0x20)
 	sh t0, %lo(CH_NSAMPLES)
 	srl t0, 16
 	sh t0, %lo(CH_ACC_OFF)
-	lw t0, CMD_ADDR(0x20, 0x30)
+	# VADPCM pointers: fetch this channel's entry from the table.
+	lh t1, %lo(CH_IDX)
+	sll t1, 2
+	lw t0, %lo(CHTBL_CODEBOOK)(t1)
 	sw t0, %lo(CH_CODEBOOK)
-	lw t0, CMD_ADDR(0x24, 0x30)
+	lw t0, %lo(CHTBL_STATE)(t1)
 	sw t0, %lo(CH_STATE)
-	lw t0, CMD_ADDR(0x28, 0x30)
+	lw t0, %lo(CHTBL_LOOP_STATE)(t1)
 	sw t0, %lo(CH_LOOP_STATE)
 	li t0, -1
 	sw t0, %lo(CH_VCUR_FRAME)
@@ -565,7 +576,7 @@ VadpcmSetup:
 	lw s0, %lo(CH_CODEBOOK)
 	li s4, %lo(MIX_VADPCM_CODEBOOK)
 	jal DMAInAsync
-	li t0, DMA_SIZE(256, 1)
+	li t0, DMA_SIZE(128, 1)
 
 	# DMA decoder state. next_frame = floor(pos/16).
 	lw s0, %lo(CH_STATE)
@@ -958,53 +969,24 @@ MIX_FLUSH_Publish:
 
 
 ###############################################################
-# command_memmove
+# MIX_SETCHANNEL – record the VADPCM pointers of one channel.
 #
-# Backward move of bytes in RDRAM (dst < src). Chunks staged
-# through DMEM_SCRATCH.
-#
-# a0: RDRAM destination
-# a1: RDRAM source
-# a2: byte count (multiple of 8)
+# Command words (16 bytes):
+#   a0: [ovl+cmd:8][ch_idx:8][pad:16]
+#   a1: codebook
+#   a2: state       (VADPCM decoder state in RDRAM)
+#   a3: loop_state  (VADPCM state at loop start; 0 if none)
 ###############################################################
 
-	#define MEMMOVE_CHUNK  DMEM_SCRATCH_SIZE
-
-	.func command_memmove
-command_memmove:
-	#if RSPQ_DEBUG
-	andi t0, a0, 7
-	assert_eq t0, 0, 0x8601
-	andi t0, a1, 7
-	assert_eq t0, 0, 0x8601
-	andi t0, a2, 7
-	assert_eq t0, 0, 0x8601
-	#endif
-
-MemmoveLoop:
-	move t4, a2
-	ble t4, MEMMOVE_CHUNK, 1f
-	nop
-	li t4, MEMMOVE_CHUNK
-1:
-	move s0, a1
-	li s4, %lo(DMEM_SCRATCH)
-	jal DMAIn
-	addiu t0, t4, -1
-
-	move s0, a0
-	li s4, %lo(DMEM_SCRATCH)
-	jal DMAOut
-	addiu t0, t4, -1
-
-	add a0, t4
-	add a1, t4
-	sub a2, t4
-	bgtz a2, MemmoveLoop
-	nop
-
+	.func MIX_SETCHANNEL
+MIX_SETCHANNEL:
+	srl t0, a0, 16
+	andi t0, 0xFF
+	sll t0, 2
+	sw a1, %lo(CHTBL_CODEBOOK)(t0)
+	sw a2, %lo(CHTBL_STATE)(t0)
 	j RSPQ_Loop
-	nop
+	sw a3, %lo(CHTBL_LOOP_STATE)(t0)
 	.endfunc
 
 	#undef ticks
@@ -1024,43 +1006,13 @@ MemmoveLoop:
 	#undef ch_idx
 
 
-############################################################################
-# VADPCM decompressor
-############################################################################
 
-	########################################
-	# VADPCM_Decompress
-	#
-	# Args:
-	#   a0: pointer to input buffer
-	#   a1: pointer to output buffer (+ numframes-1 in MSB)
-	#   a2: pointer to state buffer  (+ bit 31 set if stereo)
-	#   a3: pointer to codebook
-	#
-	########################################
+############################################################################
+# Mono VADPCM decode (MIX_CHANNEL / VadpcmDecodeFrame)
+############################################################################
 
 #define VADPCM_ORDER_SHIFT    1
 #define VADPCM_ORDER          (1<<VADPCM_ORDER_SHIFT)
-
-	# VADPCM State and Codebook
-#define VADPCM_CODEBOOK_SIZE  8
-
-#define MAX_VADPCM_FRAMES     94
-
-	.section .bssovl1
-
-					# Codebook must be aligned to allow for xor trick
-					# to switch channels
-					.balign VADPCM_CODEBOOK_SIZE*16 
-VADPCM_CODEBOOK:   	.space VADPCM_CODEBOOK_SIZE*16*2
-
-					.align 4
-VADPCM_STATE:    	.space 16*2   # state, left/right
-VADPCM_BUFFER:      .space MAX_VADPCM_FRAMES*16*2		
-VADPCM_BUFFER_END:	.space 8    # Extra 8 bytes for misalignment
-
-
-	.text
 
 #define scaling    			t8
 #define predictor  			t7
@@ -1069,16 +1021,9 @@ VADPCM_BUFFER_END:	.space 8    # Extra 8 bytes for misalignment
 #define dmem_codebook       s2
 #define dmem_output         s3
 #define dmem_input          s5
-#define buffer_in_size      v0
-#define buffer_out_size     v1
-#define stereo_toggle       k1
-#define rdram_input		    a0
-#define rdram_output	    a1
-#define cb_xor              t2   // codebook toggle: 0 (mono) / VADPCM_CODEBOOK_SIZE*16 (stereo)
-#define slot_xor            t3   // scratch-slot toggle: 0 (mono) / 16 (stereo)
-#define slot_ptr            t4   // pointer into RSPQ_SCRATCH_MEM (2x 16-byte channel state slots)
-#define db_base             t5   // stereo deinterleave: buffer base (saved before decode loop)
-#define db_count            t9   // stereo deinterleave: number of L/R pairs
+#define cb_xor              t2
+#define slot_xor            t3
+#define slot_ptr            t4
 
 #define vscale  $v01
 #define vstatef $v02
@@ -1094,36 +1039,15 @@ VADPCM_BUFFER_END:	.space 8    # Extra 8 bytes for misalignment
 #define pred1h  $v15
 #define vres0    $v16
 #define vres1    $v17
-
-#define next_vres0 $v22   // upcoming frame's residuals, sign-extended: even lanes
-#define next_vres1 $v23   // (next_vres0) and odd lanes (next_vres1), pre-scaling
-
+#define next_vres0 $v22
+#define next_vres1 $v23
 #define vstate0 $v18
 #define vstate1 $v19
 #define vstate2 $v20
 #define vstate3 $v21
-#define vresult $v03   // current frame's decoded second sub-block (samples 8..15);
-                       // also becomes the input state for the next same-channel frame
+#define vresult $v03
+#define v____   $v00
 
-#define v____ 	$v29
-
-	// Stereo deinterleave scratch: two banks of 4 registers that are dead by the
-	// time the deinterleave runs. Bank A (v_il*) holds the pair being stored; bank
-	// B (v_ib*) holds the next pair being computed (software-pipelined).
-#define v_il0   $v06
-#define v_il1   $v07
-#define v_il2   $v08
-#define v_il3   $v09
-#define v_ib0   $v10
-#define v_ib1   $v11
-#define v_ib2   $v12
-#define v_ib3   $v13
-
-###############################################################
-# VadpcmDecodeFrame – decode CH_VNEXT_FRAME into MIX_VADPCM_PCM.
-# Reuses VADPCM_DecodeLoop / VADPCM_SaveState via CH_VADPCM_MIXRET.
-# Clobbers: most SU/VU temps used by the VADPCM decompressor.
-###############################################################
 	.func VadpcmDecodeFrame
 VadpcmDecodeFrame:
 	sw ra, %lo(CH_VADPCM_RA)
@@ -1158,8 +1082,6 @@ VadpcmDecodeFrame:
 
 	li nframes, 1
 	li a2, 0                               # mono path in SaveState
-	li t0, 1
-	sw t0, %lo(CH_VADPCM_MIXRET)
 	lqv vstate1, 0x00,dmem_state
 	li t1, 1
 	j VADPCM_Priming
@@ -1181,139 +1103,17 @@ VADPCM_LoadIdentity:
 	ltv pred1a.e0, 0,s0
 	.endfunc
 
-	.func VADPCM_Decompress
-VADPCM_Decompress:
-	# CH_VADPCM_MIXRET lives in .bss (not cleared between commands): make
-	# sure VADPCM_SaveState takes the DMA-out path, not the in-mixer return.
-	sw zero, %lo(CH_VADPCM_MIXRET)
-	li dmem_codebook, %lo(VADPCM_CODEBOOK)
-	li dmem_state, %lo(VADPCM_STATE)
-
-	# Fetch the codebook
-	move s4, dmem_codebook
-	move s0, a3
-	jal DMAInAsync
-	li t0, DMA_SIZE(VADPCM_CODEBOOK_SIZE*16*2, 1)
-
-	# Fetch the state
-	move s4, dmem_state
-	move s0, a2
-	jal DMAInAsync
-	li t0, DMA_SIZE(16*2, 1)
-
-	jal VADPCM_LoadIdentity
-	nop
-
-	srl nframes, a1, 24
-	bgez a2, 1f
-	 addiu nframes, 1
-	sll nframes, 1
-
-1:	# Calculate offset of input buffer inside the output buffer
-	li dmem_output, %lo(VADPCM_BUFFER)
-	and rdram_input, 0x00FFFFFF
-	and a1, 0x00FFFFFF
-	sub t0, rdram_input, rdram_output
-	add dmem_input, t0, dmem_output
-
-	# Shift buffer by output misalignment
-	andi t1, rdram_output, 7
-	add dmem_output, t1
-	add dmem_input, t1
-
-	beqz t1, 1f
- 	 sll buffer_out_size, nframes, 5		# buffer_out_size = nframes*32
-	addiu buffer_out_size, 8
-1:
-
-	sll buffer_in_size, nframes, 3			# buffer_in_size = nframes*8
-	andi t1, rdram_input, 7
-	beqz t1, 1f	
-	 add buffer_in_size, nframes             #  + nframes
-	addiu buffer_in_size, 8
-1:
-
-	#ifndef NDEBUG
-	# Check that dmem_input and RDRAM input have the same misalignment
-	andi t3, dmem_input, 7
-	andi t2, rdram_input, 7
-	assert_eq t3, t2, 0x1234
-	#endif
-
-	# Fetch the input buffer. Calculate size as nframes*9+misalignemnt
-	move s0, rdram_input
-	addiu t0, buffer_in_size, -1
-	jal DMAIn
-	 move s4, dmem_input
-
-	move stereo_toggle, a2
-	lqv vstate1, 0x00,dmem_state
-	lqv vstate3, 0x10,dmem_state
-	addiu dmem_input, 1
-	li t1, 1                          # loop-invariant: base for (1<<scaling)
-
-	##################################################################
-
-	# ---- VADPCM decode ----
-	# VADPCM packs audio in 9-byte frames that each decode to 16 samples. A frame
-	# is a control byte (high nibble = scaling shift, low nibble = predictor index
-	# into the codebook) followed by 16 packed 4-bit residuals. The 16 samples are
-	# produced as two sub-blocks of 8 (samples 0..7 then 8..15), each an order-2
-	# linear prediction. Calling p0,p1 = codebook[2*index + 0,1] the two predictor
-	# vectors and s[] the 8 samples of the PREVIOUS sub-block, sub-block sample j is
-	#
-	#   out[j] = p0[j]*s[6] + p1[j]*s[7]                 (state feedback, order 2)
-	#          + (r[j] << 11)                            (this residual, Q11)
-	#          + sum_{k<j} r[k] * v[j-1-k]               (residual convolution)
-	#
-	# where r[k] = ext4(residual_k) << scaling is the signed, scaled residual and
-	# v = p1 is the predictor's second vector. Fixed point is Q11 throughout: the
-	# codebook coefficients and the residual's own term (the "<< 11" identity) are
-	# 1.0 = 2048, samples accumulate in Q11 in the 48-bit vector accumulator, and
-	# the final step recovers the integer sample as clamp16(acc >> 11).
-	#
-	# This is evaluated as a matrix-vector product. pred1a..pred1h are the 8
-	# columns of the residual->sample matrix (a lower-triangular Toeplitz matrix:
-	# 2048 on the diagonal, v on the sub-diagonals); pred0,pred1 hold p0,p1 for the
-	# state feedback. Even residuals live in vres0, odd residuals in vres1, already
-	# multiplied by 2^scaling. A frame is decoded as: block 0 (samples 0..7) ->
-	# combine 0 (extract+round) -> block 1 (samples 8..15) -> combine 1.
-	#
-	# The same loop decodes mono and stereo; they differ only in two parameters:
-	#   cb_xor   - 0 (mono) / VADPCM_CODEBOOK_SIZE*16 (stereo). Stereo interleaves
-	#              frames L0 R0 L1 R1 ...; XORing dmem_codebook by cb_xor each frame
-	#              selects the L or R codebook for that frame.
-	#   slot_xor - 0 (mono) / 16 (stereo). The per-channel input state lives in two
-	#              16-byte slots of RSPQ_SCRATCH_MEM. Each frame reads its state from
-	#              slot[cur^slot_xor] and writes its result to slot[cur]. For mono
-	#              (xor 0) this is one slot carrying the running state; for stereo
-	#              the two slots alternate, so each frame sees its own channel's
-	#              previous frame (two frames back in the interleaved stream).
-	# Stereo emits per-frame L/R blocks, so a deinterleave pass at the end turns
-	# L0 R0 L1 R1 ... into sample-interleaved output.
-
-	# ---- Priming for frame 0 (shared by both modes) ----
-	# On entry the loop body expects the frame's residuals already scaled into
-	# vres0/vres1 and its full convolution matrix already in pred0/pred1/pred1a..h.
-	# This block establishes that for frame 0: read the control byte, sign-extend
-	# the residuals, build vscale = 2^scaling and the predictor address, load the
-	# matrix, and scale the residuals. (Frame 0 is the left channel for stereo, so
-	# the base codebook address is correct.)
 VADPCM_Priming:
 	lbu t0, -1(dmem_input)
 	lpv next_vres0, 0,dmem_input
 	lpv next_vres1, 0,dmem_input
 	srl scaling, t0, 4
 	andi predictor, t0, 0xF
-	sllv scaling, t1, scaling				
+	sllv scaling, t1, scaling
 	mtc2 scaling, vscale.e0;					vsra8 next_vres0, next_vres0, 12
 	sll predictor, VADPCM_ORDER_SHIFT + 4;      vsll  next_vres1, next_vres1, 4
-	add predictor, dmem_codebook;				vsra8 next_vres1, next_vres1, 12			# next_vres1 = residual * 2^scaling
-	
-	# Load the whole convolution matrix for frame 0: pred0/pred1 are the two
-	# predictor vectors p0,p1; pred1a.e1..pred1g.e7 fill the Toeplitz sub-diagonals
-	# with v=p1 at increasing element offsets (the diagonal already holds the 2048
-	# identity from init).
+	add predictor, dmem_codebook;				vsra8 next_vres1, next_vres1, 12
+
 	lqv pred0.e0,  0x00,predictor
 	lqv pred1.e0,  0x10,predictor
 	lqv pred1a.e1, 0x10,predictor
@@ -1323,78 +1123,35 @@ VADPCM_Priming:
 	lqv pred1e.e5, 0x10,predictor
 	lqv pred1f.e6, 0x10,predictor
 	lqv pred1g.e7, 0x10,predictor
-	# Scale frame 0's residuals: vres0/vres1 = residual * 2^scaling.
 	vmudh vres0, next_vres0, vscale.e0
 	vmudh vres1, next_vres1, vscale.e0
 
-	# Per-mode parameters and initial channel state. The loop carries each frame's
-	# result in vresult and writes it to slot[cur] for the next same-channel frame
-	# to read as input state. To make frame 0 read a valid initial state, vresult
-	# is primed with the channel's incoming state (loaded earlier from dmem_state):
-	# the left state for mono, the right state for stereo (frame 0 is left, so it
-	# must read the left state from the other slot, seeded directly below).
-	# db_base/db_count record the buffer base and L/R pair count for the stereo
-	# deinterleave pass.
 	li slot_ptr, %lo(RSPQ_SCRATCH_MEM)
-	lqv vresult, 0x00,dmem_state      # mono: initial state = left  (delay slot, always runs)
+	lqv vresult, 0x00,dmem_state
 	li slot_xor, 0
-	bgez a2, VADPCM_DecodeLoop
-	 li cb_xor, 0
-	li slot_xor, 16
-	li cb_xor, VADPCM_CODEBOOK_SIZE*16
-	lqv vresult, 0x10,dmem_state       # stereo: initial state = right
-	move db_base, dmem_output          # buffer base for the deinterleave
-	srl db_count, nframes, 1           # number of L/R pairs
-	sqv vstate1, 16,slot_ptr           # slot[1] = left initial state (read by frame 0)
+	li cb_xor, 0
 
-	# ---- Decode loop: one frame (16 samples) per iteration ----
-	# This loop runs at 35 cycles/frame (2.187 cycles/sample)
 	.balign 8
 VADPCM_DecodeLoop:
-	# ---- block 0: samples 0..7 = matrix * residuals + state feedback ----
-	# The VU accumulates the 8 residual terms (even residuals from vres0.e0..e3,
-	# odd from vres1.e0..e3, each times its convolution-matrix column) and the two
-	# state-feedback terms (pred0*s[6] + pred1*s[7], where s = vstate1 is the
-	# previous sub-block of this channel). The accumulator is exact, so term order
-	# is free. In parallel the SU advances the per-frame bookkeeping:
-	#   vresult holds the previous frame's result; store it to its channel slot
-	#   (where the next same-channel frame reads it) and to the output buffer,
-	#   select this frame's slot, load this frame's input state into vstate1, then
-	#   read the next frame's control byte and residual nibbles.
-	vmudh v____,  pred1a, vres0.e0;    sqv vresult, 0,slot_ptr         # prev result -> this frame's channel slot
-	vmadh v____,  pred1c, vres0.e1;    xor slot_ptr, slot_xor          # select this frame's channel slot
-	vmadh v____,  pred1e, vres0.e2;    sqv vresult, -16,dmem_output    # prev result -> output (samples 8..15)
-	vmadh v____,  pred1g, vres0.e3;    lqv vstate1, 0,slot_ptr         # input state = prev same-channel frame's samples 8..15
+	vmudh v____,  pred1a, vres0.e0;    sqv vresult, 0,slot_ptr
+	vmadh v____,  pred1c, vres0.e1;    xor slot_ptr, slot_xor
+	vmadh v____,  pred1e, vres0.e2;    sqv vresult, -16,dmem_output
+	vmadh v____,  pred1g, vres0.e3;    lqv vstate1, 0,slot_ptr
 	vmadh v____,  pred1b, vres1.e0;    srv vresult, 0x00,dmem_output
-	vmadh v____,  pred1d, vres1.e1;    addiu dmem_input, 9             # advance to next frame (9 bytes)
-	vmadh v____,  pred1f, vres1.e2;    lbu t0, -1(dmem_input)          # next frame's control byte
-	vmadh v____,  pred1h, vres1.e3;    lpv next_vres0, 0,dmem_input    # next frame's residual nibbles
+	vmadh v____,  pred1d, vres1.e1;    addiu dmem_input, 9
+	vmadh v____,  pred1f, vres1.e2;    lbu t0, -1(dmem_input)
+	vmadh v____,  pred1h, vres1.e3;    lpv next_vres0, 0,dmem_input
 	vmadh v____,  pred0,  vstate1.e6;  lpv next_vres1, 0,dmem_input
 	vmadh v____,  pred1,  vstate1.e7;  addiu nframes, -1
 
-	# ---- combine 0 -> vstate0 (samples 0..7) ----
-	# Round the Q11 accumulator to integer samples: read the mid/high accumulator
-	# words (acc >> 16) and multiply by 2^5 (vshift.e2 = K32), giving acc >> 11;
-	# the vmadh saturates to signed 16-bit, i.e. clamp16. vstate0 = samples 0..7.
-	# The SU decodes the next frame's header (scaling shift and predictor index ->
-	# vscale and predictor address, toggling the codebook for stereo via cb_xor),
-	# and unpacks its residuals: even nibbles into next_vres0 (sign-extend by >>12
-	# after lpv put each nibble pair in the high byte), odd nibbles into next_vres1
-	# (shift left 4 first, then sign-extend).
-	vsar  vstatef, COP2_ACC_MD;        srl scaling, t0, 4              # scaling shift = control >> 4
-	vsar  vstate0, COP2_ACC_HI;        andi predictor, t0, 0xF         # predictor index = control & 15
-	vsra8 next_vres0, next_vres0, 12;  xor dmem_codebook, cb_xor       # select this channel's codebook
+	vsar  vstatef, COP2_ACC_MD;        srl scaling, t0, 4
+	vsar  vstate0, COP2_ACC_HI;        andi predictor, t0, 0xF
+	vsra8 next_vres0, next_vres0, 12;  xor dmem_codebook, cb_xor
 	vsll  next_vres1, next_vres1, 4;   sll predictor, VADPCM_ORDER_SHIFT + 4
-	vmudn v____, vstatef, vshift.e2;   add predictor, dmem_codebook    # &codebook[2*index]
-	vmadh vstate0, vstate0, vshift.e2; sllv scaling, t1, scaling       # vscale source = 1 << shift
+	vmudn v____, vstatef, vshift.e2;   add predictor, dmem_codebook
+	vmadh vstate0, vstate0, vshift.e2; sllv scaling, t1, scaling
 
-	# ---- block 1: samples 8..15 = matrix * residuals + state feedback ----
-	# Same product as block 0 but for the second sub-block: residuals from lanes
-	# e4..e7 of vres0/vres1, and the state feedback now comes from vstate0.e6/e7
-	# (samples 6,7 just produced by this frame's first sub-block). The SU builds
-	# the next frame's matrix: mtc2 loads its vscale, and the lqv's fill the
-	# Toeplitz sub-diagonals (v at offsets e1..e7) from its predictor address.
-	vmudh v____,  pred1a, vres0.e4;    mtc2 scaling, vscale.e0         # next frame's vscale = 1 << shift
+	vmudh v____,  pred1a, vres0.e4;    mtc2 scaling, vscale.e0
 	vmadh v____,  pred1b, vres1.e4;    lqv pred1a.e1, 0x10,predictor
 	vmadh v____,  pred1c, vres0.e5;    lqv pred1b.e2, 0x10,predictor
 	vmadh v____,  pred1d, vres1.e5;    lqv pred1c.e3, 0x10,predictor
@@ -1405,248 +1162,26 @@ VADPCM_DecodeLoop:
 	vmadh v____,  pred0,  vstate0.e6
 	vmadh v____,  pred1,  vstate0.e7
 
-	# ---- combine 1 -> vresult (samples 8..15) ----
-	# Round the accumulator to samples 8..15 exactly as combine 0 (acc >> 11 with
-	# clamp16) into vresult. The SU writes this frame's first sub-block (vstate0,
-	# samples 0..7) to the output buffer, loads the next frame's predictor vectors
-	# pred0/pred1, scales the next frame's residuals into vres0/vres1, and advances
-	# the output pointer by 32 bytes (16 samples).
 	vsar  vstatef, COP2_ACC_MD;         sqv vstate0, 0x00,dmem_output
 	vsar  vresult, COP2_ACC_HI;         srv vstate0, 0x10,dmem_output
 	vsra8 next_vres1, next_vres1, 12;   lqv pred0.e0, 0x00,predictor
-	vmudh vres0, next_vres0, vscale.e0; lqv pred1.e0, 0x10,predictor   # next frame's even residuals scaled
+	vmudh vres0, next_vres0, vscale.e0; lqv pred1.e0, 0x10,predictor
 	vmudn v____, vstatef, vshift.e2;    addiu dmem_output, 32
 	vmadh vresult, vresult, vshift.e2;  bgtz nframes, VADPCM_DecodeLoop
-	 vmudh vres1, next_vres1, vscale.e0                                # next frame's odd residuals scaled
+	 vmudh vres1, next_vres1, vscale.e0
 
-	# ---- End of decode loop ----
-
-	# The loop writes each frame's result one iteration after producing it, so the
-	# last frame's result is still only in vresult: write it to the output buffer
-	# (samples 8..15) and to its channel slot. slot_ptr still selects that slot.
 	sqv vresult, -16,dmem_output
 	srv vresult, 0x00,dmem_output
 	sqv vresult, 0,slot_ptr
 
-	# The saved state for the next call is each channel's last sub-block. For mono
-	# that is slot[0] (vstate1 currently holds unrelated data, so reload it).
-	# vstate3 is unused for mono. Stereo first deinterleaves the per-frame L/R
-	# blocks into sample order, then reloads both channels' final states.
 	li slot_ptr, %lo(RSPQ_SCRATCH_MEM)
-	bgez a2, VADPCM_SaveState
-	 lqv vstate1, 0,slot_ptr           # mono: left final state = slot[0]
-
-	# ---- Stereo deinterleave: per-frame L/R blocks -> sample-interleaved ----
-	# The loop emitted each L/R pair as a 16-sample left block (L0..L15) followed
-	# by a 16-sample right block (R0..R15), 64 bytes per pair. Rewrite each pair in
-	# place to sample-interleaved order L0 R0 L1 R1 ... L15 R15.
-	#
-	# The duplicate swizzles .q0 = [0,0,2,2,4,4,6,6] and .q1 = [1,1,3,3,5,5,7,7]
-	# gather the even/odd lanes of a vector. Merging L.q0 (even lanes) with R.q0
-	# (odd lanes, via VCC = 0x55) yields the even-sample L/R pairs interleaved
-	# [L0 R0 L2 R2 L4 R4 L6 R6]; .q1 yields the odd-sample pairs [L1 R1 L3 R3 ...].
-	# Each lane-pair (e0,e2,e4,e6) is one finished [Lk Rk] output word; slv scatters
-	# them to their interleaved byte offsets (even samples at 0,8,..; odd at 4,12,..).
-	#
-	# Software-pipelined: each iteration stores the previous pair (bank A, v_il*)
-	# while loading and computing the current pair (bank B, v_ib*); bank B is then
-	# copied into bank A for the next store. The stores read bank A and the loads
-	# write the next 64-byte block, so an iteration's stores and the next pair's
-	# compute are independent and the abundant VU work folds under the slv stores.
-	li t0, 0x55
-	ctc2 t0, COP2_CTRL_VCC              # vmrg mask: even lanes <- L, odd lanes <- R
-	move dmem_output, db_base
-	# Prologue: compute the first pair into bank A (v_il*).
-	lqv vstate0, 0x00,dmem_output
-	lrv vstate0, 0x10,dmem_output
-	lqv vstate1, 0x10,dmem_output
-	lrv vstate1, 0x20,dmem_output
-	lqv vstate2, 0x20,dmem_output;     vcopy v_il0, vstate0.q0
-	lrv vstate2, 0x30,dmem_output;     vcopy v_il1, vstate0.q1
-	lqv vstate3, 0x30,dmem_output;     vcopy v_il2, vstate1.q0
-	lrv vstate3, 0x40,dmem_output;     vcopy v_il3, vstate1.q1
-	vmrg v_il0, v_il0, vstate2.q0                            # L0 R0 L2 R2 ..
-	vmrg v_il1, v_il1, vstate2.q1                            # L1 R1 L3 R3 ..
-	vmrg v_il2, v_il2, vstate3.q0                            # L8 R8 L10 R10 ..
-	vmrg v_il3, v_il3, vstate3.q1                            # L9 R9 L11 R11 ..
-	addiu db_count, -1
-	blez db_count, VADPCM_DeintLast    # only one pair: store it directly
-	 nop
-	# This loop is 30 cycles per 8 stereo-samples / 16 samples = 1.875 cycles/sample
-	.balign 8
-VADPCM_Deinterleave:
-	# Store bank A (current pair) while loading + computing the next pair (bank B).
-	slv v_il0.e0, 0x00,dmem_output
-	lqv vstate0,  0x40,dmem_output
-	slv v_il1.e0, 0x04,dmem_output
-	lrv vstate0,  0x50,dmem_output
-	slv v_il0.e2, 0x08,dmem_output
-	lqv vstate1,  0x50,dmem_output
-	slv v_il1.e2, 0x0C,dmem_output
-	lrv vstate1,  0x60,dmem_output
-	slv v_il0.e4, 0x10,dmem_output
-	lqv vstate2,  0x60,dmem_output
-	slv v_il1.e4, 0x14,dmem_output
-	lrv vstate2,  0x70,dmem_output
-	slv v_il0.e6, 0x18,dmem_output
-	lqv vstate3,  0x70,dmem_output
-	slv v_il1.e6, 0x1C,dmem_output
-	lrv vstate3,  0x80,dmem_output
-	slv v_il2.e0, 0x20,dmem_output;    vcopy v_ib0, vstate0.q0
-	slv v_il3.e0, 0x24,dmem_output;    vcopy v_ib1, vstate0.q1
-	slv v_il2.e2, 0x28,dmem_output;    vcopy v_ib2, vstate1.q0
-	slv v_il3.e2, 0x2C,dmem_output;    vcopy v_ib3, vstate1.q1
-	slv v_il2.e4, 0x30,dmem_output;    vmrg v_ib0, v_ib0, vstate2.q0
-	slv v_il3.e4, 0x34,dmem_output;    vmrg v_ib1, v_ib1, vstate2.q1
-	slv v_il2.e6, 0x38,dmem_output;    vmrg v_ib2, v_ib2, vstate3.q0
-	slv v_il3.e6, 0x3C,dmem_output;    vmrg v_ib3, v_ib3, vstate3.q1
-	vcopy v_il0, v_ib0;                addiu dmem_output, 64
-	vcopy v_il1, v_ib1;                addiu db_count, -1
-	vcopy v_il2, v_ib2;                bgtz db_count, VADPCM_Deinterleave
-	 vcopy v_il3, v_ib3
-VADPCM_DeintLast:
-	# Epilogue: store the last computed pair (bank A).
-	slv v_il0.e0, 0x00,dmem_output
-	slv v_il1.e0, 0x04,dmem_output
-	slv v_il0.e2, 0x08,dmem_output
-	slv v_il1.e2, 0x0C,dmem_output
-	slv v_il0.e4, 0x10,dmem_output
-	slv v_il1.e4, 0x14,dmem_output
-	slv v_il0.e6, 0x18,dmem_output
-	slv v_il1.e6, 0x1C,dmem_output
-	slv v_il2.e0, 0x20,dmem_output
-	slv v_il3.e0, 0x24,dmem_output
-	slv v_il2.e2, 0x28,dmem_output
-	slv v_il3.e2, 0x2C,dmem_output
-	slv v_il2.e4, 0x30,dmem_output
-	slv v_il3.e4, 0x34,dmem_output
-	slv v_il2.e6, 0x38,dmem_output
-	slv v_il3.e6, 0x3C,dmem_output
-
-	# Reload the final per-channel states (the deinterleave reused vstate1/3).
-	# Left frames write slot[1], right frames write slot[0], so each slot now holds
-	# its channel's last decoded sub-block.
-	li slot_ptr, %lo(RSPQ_SCRATCH_MEM)
-	lqv vstate1, 16,slot_ptr           # slot[1] = left  final state
-	lqv vstate3, 0,slot_ptr            # slot[0] = right final state
+	lqv vstate1, 0,slot_ptr
 
 VADPCM_SaveState:
-	##################################################################
-
-	# Save back state
 	sqv vstate1, 0x00,dmem_state
-
-	# In-mixer path: keep state in DMEM and return to VadpcmDecodeFrame.
-	# MIX_VADPCM_STATE is only 16 bytes (mono) — do not store vstate3.
-	lw t0, %lo(CH_VADPCM_MIXRET)
-	beqz t0, 1f
-	sw zero, %lo(CH_VADPCM_MIXRET)
 	lw t0, %lo(CH_VNEXT_FRAME)
 	addi t0, 1
 	sw t0, %lo(CH_VNEXT_FRAME)
 	lw ra, %lo(CH_VADPCM_RA)
 	jr ra
 	nop
-1:
-	sqv vstate3, 0x10,dmem_state
-	move s4, dmem_state
-	move s0, a2
-	jal DMAOutAsync
-	li t0, DMA_SIZE(32, 1)
-
-	# Check if the output buffer is misaligned
-	and t0, rdram_output, 7
-    beqz t0, VADPM_OutputDma
-    nop
-
-    # Handle unaligned output buffer: we need to fetch and merge
-    # existing samples on misaligned addresses. Use dmem_state
-	# as scratch buffer
-    move s0, rdram_output
-    jal DMAIn
-    move s4, dmem_state
-
-    li s0, %lo(VADPCM_BUFFER)
-	move s4, dmem_state
-VADPCM_OutputMergeLoop:
-    lhu t1, 0(s4)
-    addiu s4, 2
-    addiu t0, -2
-    sh t1, 0(s0)
-    bnez t0, VADPCM_OutputMergeLoop
-    addiu s0, 2
-
-VADPM_OutputDma:
-	# Save back output buffer
-	li s4, %lo(VADPCM_BUFFER)
-	move s0, rdram_output
-	addiu t0, buffer_out_size, -1
-	jal_and_j DMAOutAsync, RSPQ_Loop
-
-	.endfunc
-
-	#undef v_out_l
-	#undef v_out_r
-	#undef v_sample_0
-	#undef v_sample_1
-	#undef v_sample_2
-	#undef v_sample_3
-	#undef v_mix_l
-	#undef v_mix_r
-	#undef vscale
-	#undef vstatef
-	#undef pred0
-	#undef pred1
-	#undef pred1a
-	#undef pred1b
-	#undef pred1c
-	#undef pred1d
-	#undef pred1e
-	#undef pred1f
-	#undef pred1g
-	#undef pred1h
-	#undef vres0
-	#undef vres1
-	#undef vstate0
-	#undef vstate1
-	#undef vstate2
-	#undef vstate3
-	#undef v____
-	#undef scaling
-	#undef predictor
-	#undef nframes
-	#undef dmem_state
-	#undef dmem_codebook
-	#undef dmem_output
-	#undef dmem_input
-	#undef buffer_in_size
-	#undef buffer_out_size
-	#undef stereo_toggle
-	#undef rdram_input
-	#undef rdram_output
-
-
-	########################################
-	# VADPCM_SetState
-	#
-	# Args:
-	#   a0: pointer to RDRAM state (destination)
-	#   a1: pointer to RDRAM buffer with source state
-    #       or 0 if state must be cleared
-	########################################
-
-	.func VADPCM_SetState
-VADPCM_SetState:
-	li s4, %lo(VADPCM_STATE)
-	sqv vzero, 0x00,s4
-	sqv vzero, 0x10,s4
-	beqz a1, VADPCM_SetState_Write
-	 li t0, DMA_SIZE(16*2, 1)
-	jal DMAIn
-	 move s0, a1
-
-VADPCM_SetState_Write:
-	move s0, a0
-	jal_and_j DMAOut, RSPQ_Loop
-
-	.endfunc

--- a/src/audio/rsp_mixer.S
+++ b/src/audio/rsp_mixer.S
@@ -4,103 +4,30 @@
 	#
 	# Authors: Giovanni Bajo <giovannibajo@gmail.com>
 	####################################################################
-
-	##############################################################
 	#
-	# This ucode implements a mixer, for 32 channels of digital samples,
-	# with per-channel resampling (mixing channels of different frequencies),
-	# per-channel 16-bit volume and 16-bit panning control,
-	# and full 16-bit stereo output with no loss of precision.
+	# Architecture (per-channel commands)
+	# ===================================
 	#
-	# The C code that drives this ucode is in mixer.c (mixer_poll).
-	# The input for the ucode is the channel parameters, that describe
-	# the playback configuration and where to find the actual samples
-	# in RDRAM.
+	# Mixing is driven by two RSPQ commands:
 	#
-	# The ucode fetches the samples from RDRAM via DMA, resample them 
-	# (that is, operating a frequency change using point sampling),
-	# apply volume/panning, and mix them together. The final output
-	# samples are sent to RDRAM via DMA.
+	#   MIX_CHANNEL  – resample one channel for up to MAX_SAMPLES_PER_ROUND
+	#                  output ticks and accumulate into a stereo DMEM buffer
+	#                  (ACCUM) in .bss. Optionally decode mono VADPCM frames
+	#                  into a DMEM window first (CH_FLAGS_VADPCM).
+	#   MIX_FLUSH    – DMA ACCUM out to RDRAM, clear it, publish the round id.
 	#
-	# Given the limited space in DMEM, this happens in loops where a small
-	# amount of samples per each channel is processed (MAX_SAMPLES_PER_LOOP).
+	# All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one highpri burst
+	# of this overlay so ACCUM cannot be clobbered mid-round. XVOL_L/R (one-tap
+	# volume filter state) live in saved state so volume ramps survive swaps.
 	#
-	# RESAMPLING
-	# **********
+	# Channel parameters travel inline in the MIX_CHANNEL command – there is
+	# no settings DMA ring. VADPCM channels also pass codebook/state/loop_state.
 	#
-	# Resampling is implemented by the function UpdateAndFetch. As the name
-	# describes, this functions fetches samples from RDRAM via DMA into a
-	# temporary buffer in DMEM (DMEM_SAMPLE_CACHE), and then resample them
-	# into a buffer called CHANNEL_BUFFER, which holds the resampled samples
-	# for all channels.
-	#
-	# Resampling means doing a point sampling on the input sample,
-	# according to the resampling frequency. The channel configuration
-	# already contains a fixed-point "step" value for each channel, that
-	# is used as increment in the loop. For instance, if the step is 2, it
-	# means that every other sample will be skipped, thus achieving a 0.5x
-	# resampling (= playing a 88Khz sample on a 44Khz output).
-	#
-	# Resampling requires thus copying one sample at at time from DMEM_SAMPLE_CACHE
-	# into CHANNEL_BUFFER, with a fixed-point increment. This is actually
-	# quite slow and cannot be vectorized; it is by far the slowest part of
-	# the whole ucode. To achieve reasonable performance, the inner resampling
-	# loop has been painstakingly optimized by having specific version for 8-bit
-	# and 16-bit input samples, and with manual loop unrolling to increase
-	# performance. The final version takes 4,88 cycles/sample for 8-bit channels,
-	# and 5,88 cycles/samples for 16-bit channels. TODO: handle also stereo
-	# waveforms spanning 2 channels. This would allow the mixer to support
-	# interleaved stereo waveforms.
-	#
-	# The DMEM_SAMPLE_CACHE area is a temporary 64-byte buffer that is used to
-	# hold the original samples fetched via DMA (before resampling). Since the
-	# ucode doesn't know how many samples will be needed (the exact number
-	# depends on the resampling step and would require a division to be
-	# calculated), the DMA always fills this area in full, so we define it
-	# small-ish to avoid wasting too much time fetching useless samples. On
-	# the other hand, in the rare cases in which there is a high resampling
-	# step, multiple DMA transfers might be needed.
-	#
-	#
-	# MIXER
-	# *****
-	#
-	# The mixer is actually made of two cores: one that mixes up to 32 channels
-	# and runs at 16 cycles/sample, and one that mixes up to 8 channels
-	# and runs at 11 cycles/sample. The 8 channels core is only
-	# 32% faster because the 32 channels core better exploit vector
-	# instruction parallelism.
-	#
-	# The 8-channel mixer is automatically selected whenever no more than 8
-	# channels are configured. TODO: this could be improved by actually looking
-	# at channel status; a channel might be configured but be currently turned 
-	# off or otherwise silent. 
-	#
-	# The mixer fetches the samples from CHANNEL_BUFFER, apply volume and
-	# panning, mix them, and write the output stream in a buffer called
-	# OUTPUT_AREA. The main loop will then DMA this buffer back to RDRAM.
-	#
-	# The mixer cores also implement a one-tap volume filter to
-	# smooth out sudden volume changes to avoid clicks in the output.
-	# This is common for instance with XM modules, and in fact most
-	# XM players implement filters to achieve a similar effect.
-	# To avoid taxing too much the core, the filter runs at 1/8th
-	# of the output rate. With the filter turned on, the 32-channel
-	# core runs at 18 cycles/samples, while the 8-channel core
-	# runs at 11.5 cycles/samples. The filter can be turned off at compile
-	# time (VOLUME_FILTER). TODO: make this a runtime option.
-	#
-	# Even with the filter overhead, the mixer is still very fast.
-	# For 32 channel mixing at 44100Hz, it uses only the 1.65% of the
-	# available frame time, while 8-channel mixing takes 1.10%. In
-	# general, resampling takes much more time than mixing. Because of this,
-	# the volume filter is on by default.
-	#
-	####################################################################
-	#
-	# Glossary:
-	#    * Sample: a single 8-bit / 16-bit amplitude value
-	#    * Waveform: a sequence of samples that can be played (eg: a WAV file)
+	# Resampling is point-sampling with a fixed-point step (WAVEFORM_POS_FRAC_BITS).
+	# PCM samples are fetched from RDRAM into a small DMEM cache; VADPCM frames
+	# are DMA'd compressed, decoded into a DMEM window, then resampled the same
+	# way. Staging goes into DMEM_SCRATCH and is mixed into ACCUM with the
+	# current filtered volume. The volume filter runs once every 8 samples.
 	#
 	####################################################################
 
@@ -110,105 +37,89 @@
 .set noreorder
 .set at
 
-# Maximum number of channels supported by this ucode. You can't really increase
-# this without modifying the code.
-#define MAX_CHANNELS           32
+# Maximum number of channels supported by this ucode.
+#define MAX_CHANNELS              32
 
 # Activate one-tap filter on volume changes, to smooth out sudden changes
 # that can cause clicks.
-#define VOLUME_FILTER           1
+#define VOLUME_FILTER             1
 
-# How many sample to process in a mixing loop. This can be tuned to use more/less
-# DMEM. Obviously, more samples per loop is better for performance.
-#define MAX_SAMPLES_PER_LOOP   32
+# Max output samples that fit in ACCUM (stereo int16). Must match mixer.c.
+#define MAX_SAMPLES_PER_ROUND     256
 
 # Number of fractional bits used in the fixed point numbers that specify
 # the waveform position, step, length and loop length.
-# NOTE: This must be the same of MIXER_FX32_FRAC in mixer.c.
-#define WAVEFORM_POS_FRAC_BITS  12
+# NOTE: This must be the same of MIXER_FX64_FRAC in mixer.c.
+#define WAVEFORM_POS_FRAC_BITS    12
 
 # Waveform flags. Keep these in sync with mixer.c
-#define CH_FLAGS_16BIT      (1<<2)
-#define CH_FLAGS_STEREO     (1<<3)
+#define CH_FLAGS_BPS_SHIFT        (3<<0)
+#define CH_FLAGS_16BIT            (1<<2)
+#define CH_FLAGS_STEREO           (1<<3)
+#define CH_FLAGS_STEREO_SUB       (1<<4)
+#define CH_FLAGS_VADPCM           (1<<5)
+# Zero ACCUM before mixing (first MIX_CHANNEL of a round; ACCUM is in .bss).
+#define CH_FLAGS_CLEAR_ACCUM      (1<<7)
 
-#define MAX_CHANNELS_VOFF  (MAX_CHANNELS*2)
+# Scratch size for memmove bounce buffer / resample staging. Must be a
+# multiple of 8 and large enough for useful memmove chunks.
+#define DMEM_SCRATCH_SIZE         1536
+
+# Sample DMA cache (must be <= MIXER_LOOP_OVERREAD in mixer.c).
+#define SAMPLE_CACHE_SIZE         64
+
+# In-mixer VADPCM: one decoded frame in DMEM (16 samples). Enough for
+# point resampling within the frame; the next frame is decoded on demand.
+#define VADPCM_WIN_FRAMES         1
+#define VADPCM_WIN_SAMPLES        (VADPCM_WIN_FRAMES * 16)
 
 
 	################################
-	# Global register allocations, valid in the whole ucode
+	# Global register allocations
 	################################
 
 	#define v_zero        $v00
-
-	# Current volume left/right for each channel. This is the volume
-	# that's being ramped up to the final volume.
-	#define v_xvol_l_0    $v13
-	#define v_xvol_r_0    $v14
-	#define v_xvol_l_1    $v15
-	#define v_xvol_r_1    $v16
-	#define v_xvol_l_2    $v17
-	#define v_xvol_r_2    $v18
-	#define v_xvol_l_3    $v19
-	#define v_xvol_r_3    $v20
-
-	# Final volume left/right (basic volume * panning * global volume),
-	# pre-multiplied by 1-alpha.
-	#define v_chvol_l_0   $v21
-	#define v_chvol_r_0   $v22
-	#define v_chvol_l_1   $v23
-	#define v_chvol_r_1   $v24
-	#define v_chvol_l_2   $v25
-	#define v_chvol_r_2   $v26
-	#define v_chvol_l_3   $v27
-	#define v_chvol_r_3   $v28
-
-	# Shift registers
 	#define v_shift8      $v29
 	#define v_shift       $v30
-
-	# Misc constants
 	#define v_const1      $v31
 
 	#define k_0000        v_zero
 	#define k_8000        v_shift8.e0
+	#define k_ffff        v_const1.e0
+	#define k_alpha       v_const1.e1
+	#define k_1malpha     v_const1.e2
 
 
 	.data
 
 	RSPQ_BeginOverlayHeader
-		RSPQ_DefineCommand command_exec, 20				# 0x0
+		RSPQ_DefineCommand MIX_CHANNEL,       48		# 0x0
 		RSPQ_DefineCommand VADPCM_Decompress, 16		# 0x1
-		RSPQ_DefineCommand VADPCM_SetState, 8			# 0x2
-		RSPQ_DefineCommand command_memmove, 12			# 0x3
+		RSPQ_DefineCommand VADPCM_SetState,    8		# 0x2
+		RSPQ_DefineCommand command_memmove,   12		# 0x3
+		RSPQ_DefineCommand MIX_FLUSH,         12		# 0x4
 	RSPQ_EndOverlayHeader
 
 ############################################################################
 
-	# Misc constants
 	.align 4
 VCONST_1:
 	.half 0x7FFF
 	.half 0xe076      #   (0.9837**8) fixed 0.16
 	.half 0x1f8a      # 1-(0.9837**8) fixed 0.16
 
-	#define k_ffff      v_const1.e0
-	#define k_alpha     v_const1.e1
-	#define k_1malpha   v_const1.e2
-
 	.align 4
 BANNER0:    .ascii "Dragon RSP Audio"
 BANNER1:    .ascii " Coded by Rasky "
 
+	# ================================================================
+	# Overlay saved state – survives RSPQ overlay swaps.
+	# Layout must match mixer_overlay_state_t in mixer.c.
+	# ================================================================
 	RSPQ_BeginSavedState
-	# Current volume state for each channel. This might differ from CHANNEL_VOLUMES
-	# when the volume filter is turned on: this is the actual current value that
-	# is being interpolated to CHANNEL_VOLUMES, which is the requested target
-	# volume to reach.
 	.align 4
 XVOL_L:                   .dcb.w MAX_CHANNELS
 XVOL_R:                   .dcb.w MAX_CHANNELS
-	# RDRAM address of the round completion counter (written by CPU at init).
-	# Must stay in saved state so it survives overlay swaps.
 	.align 4
 COUNTER_RDRAM:            .long  0
 	                      .long  0
@@ -221,210 +132,843 @@ IDENTITY:  .half  1<<11,1<<11,1<<11,1<<11, 1<<11,1<<11,1<<11,1<<11
 
 	.bss
 
-############################################################################
-# UCODE INPUT DATA
-############################################################################
-
-# Output RDRAM buffer where to store mixed samples (16-bit, stereo)
-OUTPUT_RDRAM:             .long  0
-# Global volume of playback
-GLOBAL_VOLUME:            .half  0
-# Number of samples to resample/mix on each channel
-NUM_SAMPLES:              .half  0
-# Number of configured channels
-NUM_CHANNELS:             .half  0
-
-# Requested volumes for each channel. If VOLUME_FILTER is on, these are the
-# values requested by the user, but the current value for each channel might
-# be different (as the filter is running).
+	# Stereo int16 accumulator for one mix round (LRLR...). Lives in .bss
+	# (not saved state) so the DMEM budget still fits the VADPCM bssovl1
+	# bank. All MIX_CHANNEL + MIX_FLUSH of a round are enqueued in one
+	# highpri burst of this overlay, so no overlay switch can clobber it
+	# mid-round. Cleared by the first MIX_CHANNEL (CH_FLAGS_CLEAR_ACCUM)
+	# and again by MIX_FLUSH after DMA-out.
 	.align 4
-SETTINGS_START:
-CHANNEL_VOLUMES_L:        .dcb.w MAX_CHANNELS
-CHANNEL_VOLUMES_R:        .dcb.w MAX_CHANNELS
+ACCUM:                    .dcb.w (MAX_SAMPLES_PER_ROUND * 2)
 
-# Array of structures rsp_mixer_channel_s. See mixer.c. 6 words for each
-# channel with the following content:
-#
-#   0: pos:      absolute waveform position (as fixed point, WAVEFORM_POS_FRAC_BITS)
-#   1: step:     resampling increment of position for each output sample (fixed point)
-#   2: len:      length of the waveform (fixed point)
-#   3: loop_len: length of the loop from the end of the waveform (or 0 if no loop)
-#   4: ptr:      pointer to the beginning of the waveform
-#   5: flags:    channel flags (see CH_FLAGS_ macros in mixer.c)
-#
-	.align 4
-WAVEFORM_SETTINGS:        .dcb.l (6*MAX_CHANNELS)
-SETTINGS_END:
-
-	# Temporary cache of samples fetched by DMA. Notice that this must be
-	# less or equal than MIXER_LOOP_OVERREAD (mixer.c), because the
-	# RSP will over-read up to this amount of bytes after waveform's end.
+	# Temporary cache of samples fetched by DMA for resampling.
 	.align 3
-	#define SAMPLE_CACHE_SIZE  64
-DMEM_SAMPLE_CACHE:		  .dcb.b SAMPLE_CACHE_SIZE
+DMEM_SAMPLE_CACHE:        .dcb.b SAMPLE_CACHE_SIZE
 
+	# Contiguous resample staging (8 samples) plus bounce buffer for
+	# command_memmove.
+	.align 4
+DMEM_SCRATCH:             .dcb.b DMEM_SCRATCH_SIZE
 
-	# CHANNEL_BUFFER holds the resampled samples for all the channels.
-	# Samples of different channels are interleaved, so that they can
-	# be mixed with vector instructions.
-	.align 4  # for human visual debugging 
-CHANNEL_BUFFER:  .dcb.w (MAX_SAMPLES_PER_LOOP * MAX_CHANNELS)
+	# In-mixer VADPCM staging (mono). Lives in .bss with ACCUM; not used by
+	# the legacy VADPCM_Decompress path (which uses the bssovl1 bank).
+	.align 4
+MIX_VADPCM_CODEBOOK:      .space 256
+	.align 4
+MIX_VADPCM_STATE:         .space 16
+	.align 4
+MIX_VADPCM_STATE_BEFORE:  .space 16
+	.align 3
+MIX_VADPCM_COMP:          .space (VADPCM_WIN_FRAMES * 9 + 8)
+	.align 4
+MIX_VADPCM_PCM:           .space (VADPCM_WIN_SAMPLES * 2)
 
-	# OUTPUT_AREA holds the final mixed stereo samples, that will be copied
-	# to RDRAM via DMA.
-	.align 4  # for human visual debugging, 3 would be sufficient (for DMA)
-OUTPUT_AREA:     .dcb.w MAX_SAMPLES_PER_LOOP*2
-
-	# Scratch used to DMA the round id out to COUNTER_RDRAM. 8-byte aligned
-	# for RSP DMA; only the first word is meaningful.
+	# Scratch used to DMA the round id out to COUNTER_RDRAM.
 	.align 3
 ROUND_SCRATCH:            .long  0
 	                      .long  0
 
+	# Stashed MIX_CHANNEL parameters (command buffer may be overwritten).
+	.align 2
+CH_POS:                   .long  0
+CH_STEP:                  .long  0
+CH_LEN:                   .long  0
+CH_LOOP_LEN:              .long  0
+CH_PTR:                   .long  0
+CH_CODEBOOK:              .long  0
+CH_STATE:                 .long  0
+CH_LOOP_STATE:            .long  0
+CH_FLAGS:                 .half  0
+CH_IDX:                   .half  0
+CH_LVOL:                  .half  0
+CH_RVOL:                  .half  0
+CH_NSAMPLES:              .half  0
+CH_ACC_OFF:               .half  0
+# Frame index currently in MIX_VADPCM_PCM; -1 = none.
+CH_VCUR_FRAME:            .long  0
+# Frame index that MIX_VADPCM_STATE is ready to decode next.
+CH_VNEXT_FRAME:           .long  0
+# Nonzero: VADPCM_SaveState returns to VadpcmDecodeFrame instead of DMA-out.
+CH_VADPCM_MIXRET:         .long  0
+CH_VADPCM_RA:             .long  0
+CH_ACC_PTR:               .long  0
+# Volume-filter step countdown, preserved across frame decodes.
+CH_K1:                    .half  0
+                          .half  0
+
+
 	.text 1
 
-	# Number of samples that will be processed in the current loop.
-	#define num_samples     k1
+###############################################################
+# MIX_CHANNEL – resample one channel and accumulate into ACCUM.
+#
+# Command words (48 bytes):
+#   a0: [ovl+cmd:8][ch_idx:8][flags:8][pad:8]   (24-bit payload)
+#   a1: [lvol:16][rvol:16]
+#   a2: pos   (fixed point, WAVEFORM_POS_FRAC_BITS)
+#   a3: step
+#   +16: len
+#   +20: loop_len
+#   +24: ptr  (0 = silence: only ramp volume toward target)
+#   +28: [acc_offset:16][nsamples:16]
+#   +32: codebook   (VADPCM; 0 for PCM)
+#   +36: state      (VADPCM decoder state in RDRAM)
+#   +40: loop_state (VADPCM state at loop start; 0 if none)
+#   +44: pad
+#
+# Positions for CH_FLAGS_VADPCM are in *samples* (not bytes). ptr points to
+# compressed 9-byte frames; frame i starts at ptr + i*9.
+#
+# Stereo owner (CH_FLAGS_STEREO): ptr points to interleaved LR samples;
+# L is extracted and mixed with (lvol, rvol). The stereo-sub channel is
+# a separate MIX_CHANNEL with CH_FLAGS_STEREO_SUB that extracts R.
+###############################################################
 
+	#define ticks          t3
+	#define wv_pos         t4
+	#define wv_step        t5
+	#define wv_len         t6
+	#define wv_loop_len    t7
+	#define wv_addr        t8
+	#define dma_cache_end  s7
+	#define out_ptr        s5
+	#define wv_pos_to_dmem s6
+	#define wv_step_8x     t2
+	#define is_stereo_sub  a0
+	#define is_16bit       a1
+	#define is_stereo      v0
+	#define acc_ptr        s8
+	#define ch_idx         k0
 
-command_exec:
-	#define samples_left    t4
-	#define outptr          s8
+	.func MIX_CHANNEL
+MIX_CHANNEL:
+	# Stash command parameters into DMEM.
+	# a0 bits[23:16]=ch_idx, bits[15:8]=flags (bits[31:24]=ovl+cmd).
+	srl t0, a0, 16
+	andi t0, 0xFF                  # ch_idx
+	sh t0, %lo(CH_IDX)
+	srl t0, a0, 8
+	andi t0, 0xFF                  # flags
+	sh t0, %lo(CH_FLAGS)
+	srl t0, a1, 16                 # lvol
+	sh t0, %lo(CH_LVOL)
+	andi t0, a1, 0xFFFF            # rvol
+	sh t0, %lo(CH_RVOL)
+	sw a2, %lo(CH_POS)
+	sw a3, %lo(CH_STEP)
+	lw t0, CMD_ADDR(0x10, 0x30)
+	sw t0, %lo(CH_LEN)
+	lw t0, CMD_ADDR(0x14, 0x30)
+	sw t0, %lo(CH_LOOP_LEN)
+	lw t0, CMD_ADDR(0x18, 0x30)
+	sw t0, %lo(CH_PTR)
+	lw t0, CMD_ADDR(0x1C, 0x30)
+	sh t0, %lo(CH_NSAMPLES)
+	srl t0, 16
+	sh t0, %lo(CH_ACC_OFF)
+	lw t0, CMD_ADDR(0x20, 0x30)
+	sw t0, %lo(CH_CODEBOOK)
+	lw t0, CMD_ADDR(0x24, 0x30)
+	sw t0, %lo(CH_STATE)
+	lw t0, CMD_ADDR(0x28, 0x30)
+	sw t0, %lo(CH_LOOP_STATE)
+	li t0, -1
+	sw t0, %lo(CH_VCUR_FRAME)
 
-	vxor v_zero, v_zero, v_zero
 	li t0, %lo(VCONST_1)
 	lqv v_const1, 0,t0
+	vxor v_zero, v_zero, v_zero
 
-	# Extract command parameters
-	andi a0, 0xFFFF
-	sh a0, %lo(GLOBAL_VOLUME)
-
-	srl t1, a1, 16
-	sh t1, %lo(NUM_SAMPLES)
-
-	andi a1, 0xFFFF
-	sh a1, %lo(NUM_CHANNELS)
-
-	lw a2, CMD_ADDR(0x8, 0x14)
-	sw a2, %lo(OUTPUT_RDRAM)
-
-	# Load settings (input-only; positions are CPU-authoritative, no writeback)
-	jal DMASettings
-	li t2, DMA_IN
-
-	jal SetupMixer
-	nop
-
-MainLoop:
-	lh samples_left, %lo(NUM_SAMPLES)
-	beqz samples_left, End
-
-	# Fetch output RDRAM pointer and set t1=1 if it's not 8-byte aligned.
-	# We expect the pointer to be 32-bit aligned (since it's a buffer of 16-bit
-	# stereo samples), but it might not be 64-bit aligned.
-	lw t1, %lo(OUTPUT_RDRAM)
-	andi t1, 7
-	slt t1, zero, t1
-
-	# The maximum number of samples that we want to generate
-	# in a single loop is MAX_SAMPLES_PER_LOOP. Subtract 
-	# 1 from this number if RDRAM buffer is not aligned so
-	# that after this loop we're 8-byte aligned again.
-	li num_samples, MAX_SAMPLES_PER_LOOP
-	sub num_samples, t1
-
-	# num_samples = MIN(num_samples, MAX_SAMPLES_PER_LOOP[-1])
-	bgt samples_left, num_samples, CheckDMAAlignment
-	nop
-	move num_samples, samples_left
-CheckDMAAlignment:
-	# If the output buffer is not aligned, fetch one DMA line (8 bytes)
-	# so that we preserve the 4 bytes that come before the buffer we were
-	# given (which would be overwritten by the RSP DMA).
-	beqz t1, DoLoop
-	li outptr, %lo(OUTPUT_AREA)
-
-	lw s0, %lo(OUTPUT_RDRAM)
-	li s4, %lo(OUTPUT_AREA)
-	jal DMAIn
-	li t0, DMA_SIZE(8,1)
-	addi outptr, 4
-
-DoLoop:
-	# Update number of samples left, subtracting the number of samples
-	# that will be calculated in this loop.
-	sub samples_left, num_samples
-	sh samples_left, %lo(NUM_SAMPLES)
-
-	# Fetch the samples and do resampling
-	jal UpdateAndFetch
-	lhu k0, %lo(NUM_CHANNELS)
-
-	# Mix the samples
-	jal Mixer
-	move s4, outptr
-
-	# Update the output pointer in RDRAM for next loop.
-	sll t0, num_samples, 2
-	lw s0, %lo(OUTPUT_RDRAM)
-	add s1, s0, t0
-	sw s1, %lo(OUTPUT_RDRAM)
-
-	# DMA the output buffer into RDRAM (s0 is the output pointer before update).
-	# We can do the transfer in background because it will surely be finished
-	# by the time we start filling the output area again.
+	# Optionally clear ACCUM (first channel of a round).
+	lh t0, %lo(CH_FLAGS)
+	andi t0, CH_FLAGS_CLEAR_ACCUM
+	beqz t0, MIX_CHANNEL_NoClear
+	li s4, %lo(ACCUM)
+	li t0, (MAX_SAMPLES_PER_ROUND * 4) / 64 - 1
+1:	sqv v_zero, 0x00,s4
+	sqv v_zero, 0x10,s4
+	sqv v_zero, 0x20,s4
+	sqv v_zero, 0x30,s4
+	addi s4, 64
+	bnez t0, 1b
 	addi t0, -1
-	jal DMAOutAsync
-	li s4, %lo(OUTPUT_AREA)
 
-	j MainLoop
+MIX_CHANNEL_NoClear:
+	# Load current filtered volumes for this channel into vector regs
+	# (kept in $v13/$v14 for the duration of the command).
+	lh ch_idx, %lo(CH_IDX)
+	sll t0, ch_idx, 1
+	lh t1, %lo(XVOL_L)(t0)
+	lh t2, %lo(XVOL_R)(t0)
+	mtc2 t1, $v13.e0               # v_xvol_l
+	mtc2 t2, $v14.e0               # v_xvol_r
+	vor $v13, v_zero, $v13.e0
+	vor $v14, v_zero, $v14.e0
+
+	# Target volumes
+	lh t1, %lo(CH_LVOL)
+	lh t2, %lo(CH_RVOL)
+	mtc2 t1, $v15.e0               # v_chvol_l
+	mtc2 t2, $v16.e0               # v_chvol_r
+	vor $v15, v_zero, $v15.e0
+	vor $v16, v_zero, $v16.e0
+
+	lh ticks, %lo(CH_NSAMPLES)
+	beqz ticks, MIX_CHANNEL_Done
+
+	# Accumulator write pointer: ACCUM + acc_offset * sizeof(stereo int16)
+	li acc_ptr, %lo(ACCUM)
+	lh t0, %lo(CH_ACC_OFF)
+	sll t0, 2
+	add acc_ptr, t0
+
+	lw wv_addr, %lo(CH_PTR)
+	beqz wv_addr, MIX_CHANNEL_Silence
+
+	lw wv_pos, %lo(CH_POS)
+	lw wv_step, %lo(CH_STEP)
+	lw wv_len, %lo(CH_LEN)
+	lw wv_loop_len, %lo(CH_LOOP_LEN)
+
+	lh t0, %lo(CH_FLAGS)
+	andi is_16bit, t0, CH_FLAGS_16BIT
+	andi is_stereo, t0, CH_FLAGS_STEREO
+	andi is_stereo_sub, t0, CH_FLAGS_STEREO_SUB
+	andi t1, t0, CH_FLAGS_VADPCM
+	bnez t1, VadpcmSetup
+
+	li dma_cache_end, %lo(DMEM_SAMPLE_CACHE+SAMPLE_CACHE_SIZE)
+	sll dma_cache_end, WAVEFORM_POS_FRAC_BITS
+
+WaveStart:
+	bltu wv_pos, wv_len, WaveDmaFetch
+	nop
+	beqz wv_loop_len, MIX_CHANNEL_SilenceLeft
+	nop
+	j WaveStart
+	sub wv_pos, wv_loop_len
+
+WaveDmaFetch:
+	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS
+	add s0, s2, wv_addr
+	li s4, %lo(DMEM_SAMPLE_CACHE)
+	jal DMAIn
+	li t0, DMA_SIZE(SAMPLE_CACHE_SIZE, 1)
+
+	sub wv_pos_to_dmem, s2, s4
+	sll wv_pos_to_dmem, WAVEFORM_POS_FRAC_BITS
+	sll wv_step_8x, wv_step, 3
+
+	# Route to the correct resampling path. Stereo and stereo-sub share the
+	# interleaved fetch; sub extracts the R sample.
+	bnez is_stereo_sub, WaveGoStereo
+	sub wv_pos, wv_pos_to_dmem
+	bnez is_stereo, WaveGoStereo
+	nop
+	bnez is_16bit, WaveLoop16_8x
+	nop
+	j WaveLoop8_8x
 	nop
 
-End:
-	# Store the current channel volume in DMEM (permanent state)
-	jal EndMixer
+WaveGoStereo:
+	bnez is_16bit, WaveLoop16_Stereo_8x
+	nop
+	j WaveLoop8StereoChecks
 	nop
 
-	# Publish the round id to RDRAM. Settings are no longer written back:
-	# the CPU advances channel positions itself. Completing this DMA is the
-	# signal that every command enqueued before this mix (VADPCM/Opus
-	# decodes included) has finished, because the highpri queue is FIFO.
-	lw t0, CMD_ADDR(0x10, 0x14)
-	sw t0, %lo(ROUND_SCRATCH)
+	############################################################
+	# Mono 8-bit
+	############################################################
+
+WaveLoop8_8x:
+	add t0, wv_pos, wv_step_8x
+	bgt t0, dma_cache_end, WaveLoop8Checks
+	li t0, 8
+	blt ticks, t0, WaveLoop8Checks
+
+	li out_ptr, %lo(DMEM_SCRATCH)
+	li t1, 8
+1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	lbu t0, 0(t0)
+	add wv_pos, wv_step
+	sb t0, 0(out_ptr)
+	addi out_ptr, 1
+	addi t1, -1
+	bnez t1, 1b
+	nop
+
+	jal MixBatch8bit
+	li t0, 8
+	addi ticks, -8
+	j WaveLoop8_8x
+	addi acc_ptr, 8*4
+
+WaveLoop8:
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	lbu t0, 0(t0)
+	add wv_pos, wv_step
+	# sign extend and mix one sample
+	sll t0, 8
+	mtc2 t0, $v01.e0
+	jal MixOne
+	nop
+	addi ticks, -1
+	addi acc_ptr, 4
+WaveLoop8Checks:
+	blez ticks, WaveBeforeEpilog
+	slt t0, wv_pos, dma_cache_end
+	bnez t0, WaveLoop8
+	nop
+	j WaveStart
+	add wv_pos, wv_pos_to_dmem
+
+	############################################################
+	# Mono 16-bit
+	############################################################
+
+WaveLoop16_8x:
+	add t0, wv_pos, wv_step_8x
+	bgt t0, dma_cache_end, WaveLoop16Checks
+	li t0, 8
+	blt ticks, t0, WaveLoop16Checks
+
+	li out_ptr, %lo(DMEM_SCRATCH)
+	li t1, 8
+1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
+	sll t0, 1
+	lhu t0, 0(t0)
+	add wv_pos, wv_step
+	sh t0, 0(out_ptr)
+	addi out_ptr, 2
+	addi t1, -1
+	bnez t1, 1b
+	nop
+
+	jal MixBatch16bit
+	nop
+	addi ticks, -8
+	j WaveLoop16_8x
+	addi acc_ptr, 8*4
+
+WaveLoop16:
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
+	sll t0, 1
+	lhu t0, 0(t0)
+	add wv_pos, wv_step
+	mtc2 t0, $v01.e0
+	jal MixOne
+	nop
+	addi ticks, -1
+	addi acc_ptr, 4
+WaveLoop16Checks:
+	blez ticks, WaveBeforeEpilog
+	slt t0, wv_pos, dma_cache_end
+	bnez t0, WaveLoop16
+	nop
+	j WaveStart
+	add wv_pos, wv_pos_to_dmem
+
+	############################################################
+	# Stereo 8-bit (owner extracts L, sub extracts R)
+	############################################################
+
+WaveLoop8Stereo:
+	beqz is_stereo_sub, 1f
+	nop
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
+	sll t0, 1
+	lbu t0, 1(t0)
+	j 2f
+	add wv_pos, wv_step
+1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
+	sll t0, 1
+	lbu t0, 0(t0)
+	add wv_pos, wv_step
+2:	sll t0, 8
+	mtc2 t0, $v01.e0
+	jal MixOne
+	nop
+	addi ticks, -1
+	addi acc_ptr, 4
+WaveLoop8StereoChecks:
+	blez ticks, WaveBeforeEpilog
+	slt t0, wv_pos, dma_cache_end
+	bnez t0, WaveLoop8Stereo
+	nop
+	j WaveStart
+	add wv_pos, wv_pos_to_dmem
+
+	############################################################
+	# Stereo 16-bit (owner extracts L, sub extracts R)
+	############################################################
+
+WaveLoop16_Stereo_8x:
+	add t0, wv_pos, wv_step_8x
+	bgt t0, dma_cache_end, WaveLoop16StereoChecks
+	li t0, 8
+	blt ticks, t0, WaveLoop16StereoChecks
+
+	li out_ptr, %lo(DMEM_SCRATCH)
+	li t1, 8
+WaveLoop16StereoUnroll:
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
+	sll t0, 2
+	beqz is_stereo_sub, 1f
+	nop
+	lhu t0, 2(t0)                  # R sample
+	j 2f
+	add wv_pos, wv_step
+1:	lhu t0, 0(t0)                  # L sample
+	add wv_pos, wv_step
+2:	sh t0, 0(out_ptr)
+	addi out_ptr, 2
+	addi t1, -1
+	bnez t1, WaveLoop16StereoUnroll
+	nop
+
+	jal MixBatch16bit
+	nop
+	addi ticks, -8
+	j WaveLoop16_Stereo_8x
+	addi acc_ptr, 8*4
+
+WaveLoop16Stereo:
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
+	sll t0, 2
+	beqz is_stereo_sub, 1f
+	nop
+	lhu t0, 2(t0)
+	j 2f
+	add wv_pos, wv_step
+1:	lhu t0, 0(t0)
+	add wv_pos, wv_step
+2:	mtc2 t0, $v01.e0
+	jal MixOne
+	nop
+	addi ticks, -1
+	addi acc_ptr, 4
+WaveLoop16StereoChecks:
+	blez ticks, WaveBeforeEpilog
+	slt t0, wv_pos, dma_cache_end
+	bnez t0, WaveLoop16Stereo
+	nop
+	j WaveStart
+	add wv_pos, wv_pos_to_dmem
+
+############################################################
+# Mono VADPCM path: decode one frame at a time into MIX_VADPCM_PCM,
+# then point-resample like 16-bit PCM. State is written back at epilog.
+############################################################
+
+VadpcmSetup:
+	# DMA codebook once per command.
+	lw s0, %lo(CH_CODEBOOK)
+	li s4, %lo(MIX_VADPCM_CODEBOOK)
+	jal DMAInAsync
+	li t0, DMA_SIZE(256, 1)
+
+	# DMA decoder state. next_frame = floor(pos/16).
+	lw s0, %lo(CH_STATE)
+	li s4, %lo(MIX_VADPCM_STATE)
+	jal DMAIn
+	li t0, DMA_SIZE(16, 1)
+
+	lw t0, %lo(CH_POS)
+	srl t0, WAVEFORM_POS_FRAC_BITS
+	srl t0, 4
+	sw t0, %lo(CH_VNEXT_FRAME)
+	li t0, -1
+	sw t0, %lo(CH_VCUR_FRAME)
+	li k1, 8                       # volume-filter step countdown (samples)
+	# fall through
+
+VadpcmWaveStart:
+	bltu wv_pos, wv_len, VadpcmHavePos
+	nop
+	beqz wv_loop_len, VadpcmEpilog
+	sub wv_pos, wv_loop_len
+	# Cached-loop wrap: reload loop-start state and invalidate window.
+	lw s0, %lo(CH_LOOP_STATE)
+	beqz s0, 1f
+	li s4, %lo(MIX_VADPCM_STATE)
+	jal DMAIn
+	li t0, DMA_SIZE(16, 1)
+1:	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	srl t0, 4
+	sw t0, %lo(CH_VNEXT_FRAME)
+	li t0, -1
+	sw t0, %lo(CH_VCUR_FRAME)
+	j VadpcmWaveStart
+	nop
+
+VadpcmHavePos:
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS   # sample
+	srl t1, t0, 4                            # frame needed
+	lw t2, %lo(CH_VCUR_FRAME)
+	beq t1, t2, VadpcmResample
+	sw t1, %lo(ROUND_SCRATCH)                # wanted frame
+	# A frame decode clobbers $v13-$v16 (filtered/target volumes) and may
+	# clobber k1. Spill them to DMEM_SCRATCH (unused in the VADPCM path) so
+	# the post-decode reload in VadpcmDecodeCur resumes the volume filter
+	# from the current value instead of the command-start one (which would
+	# stall the filter convergence).
+	li t0, %lo(DMEM_SCRATCH)
+	sqv $v13, 0x00,t0
+	sqv $v14, 0x10,t0
+	sqv $v15, 0x20,t0
+	sqv $v16, 0x30,t0
+	sh k1, %lo(CH_K1)
+VadpcmCatchUp:
+	lw t2, %lo(CH_VNEXT_FRAME)
+	lw t1, %lo(ROUND_SCRATCH)
+	beq t2, t1, VadpcmDecodeCur
+	nop
+	slt t0, t1, t2
+	bnez t0, VadpcmDecodeCur
+	nop
+	# Decode-discard one frame (large step skipped past it)
+	sh ticks, %lo(CH_NSAMPLES)
+	sw wv_pos, %lo(CH_POS)
+	sw acc_ptr, %lo(CH_ACC_PTR)
+	jal VadpcmDecodeFrame
+	nop
+	lh ticks, %lo(CH_NSAMPLES)
+	lw wv_pos, %lo(CH_POS)
+	lw acc_ptr, %lo(CH_ACC_PTR)
+	lw wv_step, %lo(CH_STEP)
+	lw wv_len, %lo(CH_LEN)
+	lw wv_loop_len, %lo(CH_LOOP_LEN)
+	j VadpcmCatchUp
+	nop
+
+VadpcmDecodeCur:
+	# Snapshot state before decoding the frame we will resample from.
+	li s0, %lo(MIX_VADPCM_STATE)
+	li s1, %lo(MIX_VADPCM_STATE_BEFORE)
+	lqv $v01, 0,s0
+	sqv $v01, 0,s1
+	sh ticks, %lo(CH_NSAMPLES)
+	sw wv_pos, %lo(CH_POS)
+	sw acc_ptr, %lo(CH_ACC_PTR)
+	jal VadpcmDecodeFrame
+	nop
+	lh ticks, %lo(CH_NSAMPLES)
+	lw wv_pos, %lo(CH_POS)
+	lw acc_ptr, %lo(CH_ACC_PTR)
+	lw wv_step, %lo(CH_STEP)
+	lw wv_len, %lo(CH_LEN)
+	lw wv_loop_len, %lo(CH_LOOP_LEN)
+	lw t1, %lo(CH_VNEXT_FRAME)
+	addi t1, -1                              # frame just decoded
+	sw t1, %lo(CH_VCUR_FRAME)
+	# Decode clobbers $v31 (vsra8 uses vshift8). Reload mixer constants
+	# and unspill the volumes saved in VadpcmHavePos before resampling.
+	li t0, %lo(VCONST_1)
+	lqv v_const1, 0,t0
+	li t0, %lo(DMEM_SCRATCH)
+	lqv $v13, 0x00,t0
+	lqv $v14, 0x10,t0
+	lqv $v15, 0x20,t0
+	lqv $v16, 0x30,t0
+	lh k1, %lo(CH_K1)                      # resume volume-filter countdown
+	# fall through to resample
+
+VadpcmResample:
+	blez ticks, VadpcmEpilog
+	nop
+	# Ensure the current sample's frame is loaded.
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	srl t1, t0, 4
+	lw t2, %lo(CH_VCUR_FRAME)
+	bne t1, t2, VadpcmHavePos
+	nop
+
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	andi t0, 15
+	sll t0, 1
+	li s1, %lo(MIX_VADPCM_PCM)
+	add t0, s1
+	lhu t0, 0(t0)
+	add wv_pos, wv_step
+	mtc2 t0, $v01.e0
+	jal MixOne
+	nop
+#if VOLUME_FILTER
+	# MixOne does not advance the volume filter. Apply the same 8-sample
+	# coefficient the PCM MixBatch path uses, once every 8 output samples.
+	addi k1, -1
+	bgtz k1, 1f
+	nop
+	li k1, 8
+	vmudm $v13, $v13, k_alpha
+	vmadm $v13, $v15, k_1malpha
+	vmudm $v14, $v14, k_alpha
+	vmadm $v14, $v16, k_1malpha
+1:
+#endif
+	addi ticks, -1
+	j VadpcmResample
+	addi acc_ptr, 4
+
+VadpcmEpilog:
+	# Write back state for frame at wv_pos. STATE_BEFORE = ready for
+	# CH_VCUR_FRAME; STATE = ready for CH_VNEXT_FRAME.
+	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
+	srl t0, 4
+	lw t1, %lo(CH_VCUR_FRAME)
+	li s4, %lo(MIX_VADPCM_STATE)
+	bne t0, t1, 1f
+	nop
+	li s4, %lo(MIX_VADPCM_STATE_BEFORE)
+1:	lw s0, %lo(CH_STATE)
+	jal DMAOut
+	li t0, DMA_SIZE(16, 1)
+	blez ticks, MIX_CHANNEL_Done
+	nop
+	j MIX_CHANNEL_Silence
+	nop
+
+WaveBeforeEpilog:
+	# If ticks remain (past end of non-looping sample), treat as silence
+	# so volume still ramps.
+MIX_CHANNEL_SilenceLeft:
+	blez ticks, MIX_CHANNEL_Done
+	nop
+	# fall through to silence ramp for remaining ticks
+
+	############################################################
+	# Silence path: ramp volume toward target, advance acc_ptr
+	############################################################
+MIX_CHANNEL_Silence:
+SilenceLoop:
+	blez ticks, MIX_CHANNEL_Done
+	li t0, 8
+	blt ticks, t0, 1f
+	nop
+	li t0, 8
+1:
+#if VOLUME_FILTER
+	# xvol = xvol*alpha + chvol*(1-alpha)
+	vmudm $v13, $v13, k_alpha
+	vmadm $v13, $v15, k_1malpha
+	vmudm $v14, $v14, k_alpha
+	vmadm $v14, $v16, k_1malpha
+#endif
+	sub ticks, t0
+	sll t1, t0, 2                  # each sample = 4 bytes in ACCUM
+	j SilenceLoop
+	add acc_ptr, t1
+
+MIX_CHANNEL_Done:
+	# Store updated xvol for this channel
+	lh ch_idx, %lo(CH_IDX)
+	sll t0, ch_idx, 1
+	mfc2 t1, $v13.e0
+	mfc2 t2, $v14.e0
+	sh t1, %lo(XVOL_L)(t0)
+	sh t2, %lo(XVOL_R)(t0)
+	j RSPQ_Loop
+	nop
+	.endfunc
+
+
+###############################################################
+# MixBatch16bit – mix 8 mono int16 samples from DMEM_SCRATCH
+# into ACCUM at acc_ptr, then update the volume filter.
+#
+# DMEM_SCRATCH holds: s0 s1 s2 s3 s4 s5 s6 s7 (halfwords)
+# $v13/$v14 = xvol_l / xvol_r (broadcast)
+# $v15/$v16 = chvol_l / chvol_r (broadcast)
+###############################################################
+
+	.func MixBatch16bit
+MixBatch16bit:
+	move ra2, ra
+	li s0, %lo(DMEM_SCRATCH)
+	lqv $v01, 0,s0                 # 8 samples
+
+	# Apply volumes
+	vmulf $v02, $v01, $v13         # left  = sample * xvol_l
+	vmulf $v03, $v01, $v14         # right = sample * xvol_r
+
+	# Interleave L/R into two vectors matching ACCUM layout and add.
+	# Build L0 R0 L1 R1 L2 R2 L3 R3 in $v04 via even/odd merge.
+	li t0, 0x5555
+	ctc2 t0, COP2_CTRL_VCC
+	vcopy $v04, $v02.q0            # L0 L0 L2 L2 L4 L4 L6 L6
+	vcopy $v05, $v02.q1            # L1 L1 L3 L3 L5 L5 L7 L7
+	vmrg $v04, $v04, $v03.q0       # L0 R0 L2 R2 L4 R4 L6 R6
+	vmrg $v05, $v05, $v03.q1       # L1 R1 L3 R3 L5 R5 L7 R7
+
+	# $v04 has even pairs, $v05 odd pairs – store via slv like VADPCM deint,
+	# but we need A0 B0 A1 B1 order. Rebuild with a temp buffer instead
+	# (clearer and not too expensive for 8 samples).
+	ssv $v02.e0,  0,s0
+	ssv $v03.e0,  2,s0
+	ssv $v02.e1,  4,s0
+	ssv $v03.e1,  6,s0
+	ssv $v02.e2,  8,s0
+	ssv $v03.e2, 10,s0
+	ssv $v02.e3, 12,s0
+	ssv $v03.e3, 14,s0
+	ssv $v02.e4, 16,s0
+	ssv $v03.e4, 18,s0
+	ssv $v02.e5, 20,s0
+	ssv $v03.e5, 22,s0
+	ssv $v02.e6, 24,s0
+	ssv $v03.e6, 26,s0
+	ssv $v02.e7, 28,s0
+	ssv $v03.e7, 30,s0
+
+	lqv $v04, 0x00,s0
+	lqv $v05, 0x10,s0
+	lqv $v06, 0x00,acc_ptr
+	lqv $v07, 0x10,acc_ptr
+	vadd $v06, $v06, $v04
+	vadd $v07, $v07, $v05
+	sqv $v06, 0x00,acc_ptr
+	sqv $v07, 0x10,acc_ptr
+
+#if VOLUME_FILTER
+	vmudm $v13, $v13, k_alpha
+	vmadm $v13, $v15, k_1malpha
+	vmudm $v14, $v14, k_alpha
+	vmadm $v14, $v16, k_1malpha
+#endif
+	jr ra2
+	nop
+	.endfunc
+
+
+###############################################################
+# MixBatch8bit – promote 8 signed bytes in DMEM_SCRATCH[0..7]
+# to (sample<<8) halfwords, then mix via MixBatch16bit.
+###############################################################
+
+	.func MixBatch8bit
+MixBatch8bit:
+	move t9, ra
+	li s0, %lo(DMEM_SCRATCH)
+	# lpv places each byte into bits 15..8 of a lane (= sample<<8),
+	# matching the legacy mixer which stored 8-bit samples as the high
+	# byte of a cleared halfword.
+	lpv $v01, 0,s0
+	sqv $v01, 0,s0
+	jal MixBatch16bit
+	nop
+	jr t9
+	nop
+	.endfunc
+
+
+###############################################################
+# MixOne – mix a single sample in $v01.e0 into ACCUM at acc_ptr.
+# Used for the <8-sample tail of a resampling batch. Does NOT
+# update the volume filter (the next full batch or silence ramp
+# will); tails are rare and short.
+###############################################################
+
+	.func MixOne
+MixOne:
+	vmulf $v02, $v01, $v13
+	vmulf $v03, $v01, $v14
+	lsv $v04.e0, 0,acc_ptr
+	lsv $v05.e0, 2,acc_ptr
+	vadd $v04, $v04, $v02
+	vadd $v05, $v05, $v03
+	ssv $v04.e0, 0,acc_ptr
+	jr ra
+	ssv $v05.e0, 2,acc_ptr
+	.endfunc
+
+
+###############################################################
+# MIX_FLUSH – DMA ACCUM to RDRAM, clear ACCUM, publish round id.
+#
+# a0: [nsamples:16][pad:16]
+# a1: output RDRAM pointer (physical)
+# a2: round_id
+###############################################################
+
+	.func MIX_FLUSH
+MIX_FLUSH:
+	andi t4, a0, 0xFFFF            # nsamples
+	move s1, a1                    # output rdram
+	move k1, a2                    # round_id
+
+	beqz t4, MIX_FLUSH_Publish
+	nop
+
+	# Handle 4-byte-but-not-8-byte aligned output: fetch the 8-byte DMA
+	# transfer so the leading 4 bytes (before our buffer) are preserved,
+	# then splice ACCUM starting at the misaligned offset.
+	andi t1, s1, 7
+	beqz t1, MIX_FLUSH_Dma
+
+	move s0, s1
+	li s4, %lo(DMEM_SCRATCH)
+	jal DMAIn
+	li t0, DMA_SIZE(8, 1)
+	# s4 points at the first requested byte. Copy ACCUM over it.
+	li t0, %lo(ACCUM)
+	sll t2, t4, 2
+1:	lw t3, 0(t0)
+	sw t3, 0(s4)
+	addi t0, 4
+	addi s4, 4
+	addi t2, -4
+	bgtz t2, 1b
+	nop
+	li s4, %lo(DMEM_SCRATCH)
+	move s0, s1
+	sll t0, t4, 2
+	addi t0, 3                     # +4 bytes of prefix - 1 for DMA_SIZE
+	jal DMAOut
+	nop
+	j MIX_FLUSH_Clear
+	nop
+
+MIX_FLUSH_Dma:
+	li s4, %lo(ACCUM)
+	move s0, s1
+	sll t0, t4, 2
+	addi t0, -1
+	jal DMAOut
+	nop
+
+MIX_FLUSH_Clear:
+	li s4, %lo(ACCUM)
+	li t0, (MAX_SAMPLES_PER_ROUND * 4) / 64 - 1
+	vxor v_zero, v_zero, v_zero
+1:	sqv v_zero, 0x00,s4
+	sqv v_zero, 0x10,s4
+	sqv v_zero, 0x20,s4
+	sqv v_zero, 0x30,s4
+	addi s4, 64
+	bnez t0, 1b
+	addi t0, -1
+
+MIX_FLUSH_Publish:
+	sw k1, %lo(ROUND_SCRATCH)
 	li s4, %lo(ROUND_SCRATCH)
 	lw s0, %lo(COUNTER_RDRAM)
 	li t0, DMA_SIZE(8, 1)
 	jal_and_j DMAOutAsync, RSPQ_Loop
-
-	#undef samples_left
-	#undef outptr
+	.endfunc
 
 
 ###############################################################
 # command_memmove
 #
-# Backward move of bytes in RDRAM (dst < src), enqueued by
-# samplebuffer_discard to compact a sample buffer. Being a regular
-# queue command, it executes in-order with the decode/mix commands
-# that reference the buffer, so the CPU does not need to wait for
-# them before compacting.
+# Backward move of bytes in RDRAM (dst < src). Chunks staged
+# through DMEM_SCRATCH.
 #
-# dst/src must be 8-byte aligned and len must be a multiple of 8
-# (the CPU falls back to a synchronous copy otherwise): unlike
-# OPUS_memmove, we cannot copy a few extra bytes, because the bytes
-# just after the moved region belong to the append area that the
-# CPU may be writing concurrently.
-#
-# Chunks are staged through CHANNEL_BUFFER, which is scratch space
-# only used within a single command_exec.
-#
-# Input:
-#   a0: 0..23: RDRAM destination pointer
-#   a1: 0..23: RDRAM source pointer
-#   a2:        number of bytes to move
+# a0: RDRAM destination
+# a1: RDRAM source
+# a2: byte count (multiple of 8)
 ###############################################################
 
-	#define MEMMOVE_CHUNK  (MAX_SAMPLES_PER_LOOP * MAX_CHANNELS * 2)
+	#define MEMMOVE_CHUNK  DMEM_SCRATCH_SIZE
 
 	.func command_memmove
 command_memmove:
@@ -444,12 +988,12 @@ MemmoveLoop:
 	li t4, MEMMOVE_CHUNK
 1:
 	move s0, a1
-	li s4, %lo(CHANNEL_BUFFER)
+	li s4, %lo(DMEM_SCRATCH)
 	jal DMAIn
 	addiu t0, t4, -1
 
 	move s0, a0
-	li s4, %lo(CHANNEL_BUFFER)
+	li s4, %lo(DMEM_SCRATCH)
 	jal DMAOut
 	addiu t0, t4, -1
 
@@ -463,787 +1007,21 @@ MemmoveLoop:
 	nop
 	.endfunc
 
-
-###############################################################
-# DMASettings - Load the settings via DMA.
-#
-# Arguments:
-#   t2:  DMA_* flag for DMAExec (always DMA_IN for command_exec)
-###############################################################
-
-	.func DMASettings
-DMASettings:
-	lw s0, CMD_ADDR(0xC, 0x14)
-	li s4, %lo(SETTINGS_START)
-	j DMAExec
-	li t0, DMA_SIZE((SETTINGS_END - SETTINGS_START), 1)
-	.endfunc
-
-
-
-###############################################################
-# UpdateAndFetch - Resampling loop.
-#
-# This function goes through all active channels, fetch
-# the samples of current waveforms via DMA, and apply the
-# required resampling (frequency change) for a specified
-# number of ticks (output samples).
-#
-# All channels parameters are fetched from WAVEFORM_SETTINGS.
-#
-# Arguments:
-#
-#  k0:  number of active channels
-#
-# Global state:
-#
-#  num_samples:  number of ticks to resample
-#
-###############################################################
-
-	#define ticks          t3
-	#define waveform_ptr   s1
-	#define wv_pos         t4
-	#define wv_step        t5
-	#define wv_len         t6
-	#define wv_loop_len    t7
-	#define wv_addr        t8
-	#define wv_dma_addr    v0
-	#define nchan          v1
-	#define dma_cache_end  s7
-	#define out_ptr        s5
-	#define wv_pos_to_dmem s6
-	#define wv_step_8x     t2
-	#define is_stereo      a0
-	#define is_16bit       a1
-
-	.func UpdateAndFetch
-UpdateAndFetch:
-	move ra2, ra
-
-	li out_ptr, %lo(CHANNEL_BUFFER)
-	li t0, (MAX_SAMPLES_PER_LOOP * MAX_CHANNELS * 2) / 64 - 1
-ClearLoop:
-	sqv v_zero, 0x00,out_ptr
-	sqv v_zero, 0x10,out_ptr
-	sqv v_zero, 0x20,out_ptr
-	sqv v_zero, 0x30,out_ptr
-	addi out_ptr, 64
-	bnez t0, ClearLoop
-	addi t0, -1
-
-	li waveform_ptr, %lo(WAVEFORM_SETTINGS)
-	li nchan, 0
-
-	li dma_cache_end, %lo(DMEM_SAMPLE_CACHE+SAMPLE_CACHE_SIZE)
-	sll dma_cache_end, WAVEFORM_POS_FRAC_BITS
-
-	# main update loop: will be done once per channel.
-UpdateLoop:
-	# Fetch waveform parameters. Notice that if the RDRAM
-	# address is zero, no waveform was configured in this channel,
-	# so we can skip directly to next channel.
-	lw wv_addr,     16(waveform_ptr)
-	beqz wv_addr, WaveLoopEpilog2
-	lw wv_pos,       0(waveform_ptr)
-	lw wv_step,      4(waveform_ptr)
-	lw wv_len,       8(waveform_ptr)
-	lw wv_loop_len, 12(waveform_ptr)
-
-	# Prepare output pointer
-	addi out_ptr, nchan, %lo(CHANNEL_BUFFER)
-	add out_ptr, nchan
-	move ticks, num_samples
-
-	# Flags: isolate 16-bit flag (bit 2) and stereo flags (bit 3)
-	lw t0, 20(waveform_ptr)
-	andi is_stereo, t0, CH_FLAGS_STEREO
-	andi is_16bit, t0, CH_FLAGS_16BIT
-WaveStart:
-	# Check if we reached end of sample.
-	bltu wv_pos, wv_len, WaveDmaFetch
-	nop
-
-	# End of sample. Check if the waveform loops
-	beqz wv_loop_len, WaveLoopEpilog
-	nop
-
-	# Apply loop to current position and loop again (until wv_pos < wv_len).
-	# We need to iterate in case during a single UpdateLoop we moved wv_pos
-	# more than wv_loop_len bytes, so subtracting just once is not sufficient.
-	j WaveStart
-	sub wv_pos, wv_loop_len
-
-WaveDmaFetch:
-	# Fetch SAMPLE_CACHE_SIZE bytes of the current waveform
-	# into DMEM_SAMPLE_CACHE, from the current position.
-	# Notice that DMA is 8-byte aligned, and DMAIn will adjust
-	# s4 to point to the actual byte in DMEM containing the
-	# first requested sample.
-	srl s2, wv_pos, WAVEFORM_POS_FRAC_BITS
-	add s0, s2, wv_addr
-	li s4, %lo(DMEM_SAMPLE_CACHE)
-	jal DMAIn
-	li t0, DMA_SIZE(SAMPLE_CACHE_SIZE, 1)
-
-	# Calculate an offset that converts wv_pos from a (fixed point) RDRAM
-	# pointer into a (fixed point) DMEM pointer. This will be used because
-	# the inner loop will use wv_pos adjusted to be a DMEM pointer
-	# rather than a RDRAM pointer, for performance.
-	sub wv_pos_to_dmem, s2, s4
-	sll wv_pos_to_dmem, WAVEFORM_POS_FRAC_BITS
-
-	# Compute wv_step_8x
-	sll wv_step_8x, wv_step, 3
-
-	############################################################
-	#       His Royal Majesty The Resampling Loop.
-	############################################################
-	# This is where 80% of the RSP time is spent. Any clock
-	# cycle counts!
-	#
-	# We need to go through the samples fetched in DMEM and
-	# resample them into the output buffer (aka: copying them
-	# going through with specified step).
-	#
-	# For performance, this loop assumes that all samples in
-	# DMEM are valid (that is, they were not fetched more than 
-	# waveform length). To make sure this is always true,
-	# the C code has prepared all samples with an overread
-	# buffer at the end (see XM_WAVEFORM_OVERREAD).
-	#
-	# The loop is available in four different versions:
-	# 8-bit and 16-bits, and 1x and 8x (unrolled). The unrolled
-	# version automatically fallbacks to the 1x version when
-	# required.
-	############################################################
-
-	# Adjust wv_pos to become a DMEM pointer, and then 
-	# jump to the 8-bit or 16-bit resampling loop.
-	bnez is_stereo, WaveLoopStereo
-	sub wv_pos, wv_pos_to_dmem
-
-	############################################################
-	#       Mono
-	############################################################
-
-	bnez is_16bit, WaveLoop16_8x
-
-	############################################################
-	#       Mono - 8 bit
-	############################################################
-
-WaveLoop8_8x:
-	add t0, wv_pos, wv_step_8x                 # check if pos+step*8 is still in the DMEM cache
-	bgt t0, dma_cache_end, WaveLoop8Checks
-	li t0, 8                                   # check if we need to process at least 8 samples
-	blt ticks, t0, WaveLoop8Checks
-
-	# Process 8 samples
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS    # Get raw DMEM pointer (integer part of wv_pos)
-	lbu t0, 0(t0)                              # Fetch the sample
-	add wv_pos, wv_step                        # Update wv_pos (load cycle delay)
-	sb t0, (0*MAX_CHANNELS*2+0)(out_ptr)       # Store the sample
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (1*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (2*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (3*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (4*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (5*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (6*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS
-	lbu t0, 0(t0)
-	add wv_pos, wv_step
-	sb t0, (7*MAX_CHANNELS*2+0)(out_ptr)
-
-	# Update output pointer and ticks counter, and loop.
-	add out_ptr, 8*MAX_CHANNELS*2
-	j WaveLoop8_8x
-	addi ticks, -8
-
-WaveLoop8:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS        # Get the raw DMEM pointer
-	lbu t0, 0(t0)                                  # Fetch the 8-bit sample
-	add wv_pos, wv_step                            # Update the pointer using the resampling step 
-	sb t0, 0(out_ptr)                              # Store to output as 16-bit
-	addi out_ptr, MAX_CHANNELS*2                   # Update output pointer
-	addi ticks, -1
-WaveLoop8Checks:
-	blez ticks, WaveBeforeEpilog                   # Check if we're finished
-	slt t0, wv_pos, dma_cache_end                  # Loop if we've not reached the end of DMEM buffer
-	bnez t0, WaveLoop8
-	nop
-	j WaveStart                                    # End of buffer: fetch some more samples
-	add wv_pos, wv_pos_to_dmem
-
-	############################################################
-	#       Mono - 16 bit
-	############################################################
-
-WaveLoop16_8x:
-	add t0, wv_pos, wv_step_8x
-	bgt t0, dma_cache_end, WaveLoop16Checks
-	li t0, 8
-	blt ticks, t0, WaveLoop16Checks
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (0*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (1*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (2*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (3*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (4*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (5*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (6*MAX_CHANNELS*2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, (7*MAX_CHANNELS*2)(out_ptr)
-
-	add out_ptr, 8*MAX_CHANNELS*2
-	j WaveLoop16_8x
-	addi ticks, -8
-
-WaveLoop16:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lhu t0, 0(t0)
-	add wv_pos, wv_step
-	sh t0, 0(out_ptr)
-	addi out_ptr, MAX_CHANNELS*2
-	addi ticks, -1
-WaveLoop16Checks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop16
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
-
-
-	############################################################
-	#       Stereo
-	############################################################
-
-WaveLoopStereo:
-	bnez is_16bit, WaveLoop16_Stereo_8x
-
-	############################################################
-	#       Stereo - 8 bit
-	############################################################
-
-WaveLoop8_Stereo_8x:
-	add t0, wv_pos, wv_step_8x
-	bgt t0, dma_cache_end, WaveLoop8StereoChecks
-	li t0, 8
-	blt ticks, t0, WaveLoop8StereoChecks
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (0*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (0*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (1*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (1*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (2*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (2*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (3*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (3*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (4*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (4*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (5*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (5*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (6*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (6*MAX_CHANNELS*2+2)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, (7*MAX_CHANNELS*2+0)(out_ptr)
-	sb t0, (7*MAX_CHANNELS*2+2)(out_ptr)
-
-	add out_ptr, 8*MAX_CHANNELS*2
-	j WaveLoop8_Stereo_8x
-	addi ticks, -8
-
-WaveLoop8Stereo:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+1
-	sll t0, 1
-	lbu t1, 0(t0)
-	lbu t0, 1(t0)
-	add wv_pos, wv_step
-	sb t1, 0(out_ptr)
-	sb t0, 2(out_ptr)
-
-	addi out_ptr, MAX_CHANNELS*2
-	addi ticks, -1
-WaveLoop8StereoChecks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop8Stereo
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
-
-
-	############################################################
-	#       Stereo - 16 bit
-	############################################################
-
-WaveLoop16_Stereo_8x:
-	add t0, wv_pos, wv_step_8x
-	bgt t0, dma_cache_end, WaveLoop16StereoChecks
-	li t0, 8
-	blt ticks, t0, WaveLoop16StereoChecks
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (0*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (1*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (2*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (3*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (4*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (5*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (6*MAX_CHANNELS*2+0)(out_ptr)
-
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, (7*MAX_CHANNELS*2+0)(out_ptr)
-
-	add out_ptr, 8*MAX_CHANNELS*2
-	j WaveLoop16_Stereo_8x
-	addi ticks, -8
-
-WaveLoop16Stereo:
-	srl t0, wv_pos, WAVEFORM_POS_FRAC_BITS+2
-	sll t0, 2
-	lw t0, 0(t0)
-	add wv_pos, wv_step
-	sw t0, 0(out_ptr)
-
-	addi out_ptr, MAX_CHANNELS*2
-	addi ticks, -1
-WaveLoop16StereoChecks:
-	blez ticks, WaveBeforeEpilog
-	slt t0, wv_pos, dma_cache_end
-	bnez t0, WaveLoop16Stereo
-	nop
-	j WaveStart
-	add wv_pos, wv_pos_to_dmem
-
-WaveBeforeEpilog:
-	add wv_pos, wv_pos_to_dmem
-
-WaveLoopEpilog:
-	beqz is_stereo, WaveLoopEpilog2
-	sw wv_pos, 0(waveform_ptr)   # store updated wv_pos in DMEM
-
-	# For stereo, we need to skip 1 channel
-	addi nchan, 1
-	addi waveform_ptr, 6*4
-
-WaveLoopEpilog2:
-	addi nchan, 1
-	bne nchan, k0, UpdateLoop
-	addi waveform_ptr, 6*4
-
-	jr ra2
-	nop
-	.endfunc
-
-
-
-##############################################################
-# SetupMixer: load left/right volumes for each channel
-# into the global registers (v_chvol_l/r), so that they're 
-# available for mixing.
-##############################################################
-
-	#define v_glvol       $v01
-
-	.func SetupMixer
-SetupMixer:
-	# Load global volume (into all lanes)
-	lh t0, %lo(GLOBAL_VOLUME)
-	mtc2 t0, v_glvol.e0
-	vor v_glvol, v_zero, v_glvol.e0
-
-	li s0, %lo(CHANNEL_VOLUMES_L)
-	li s1, %lo(XVOL_L)
-
-	# Load channel volumes (left / right)
-	lqv v_chvol_l_0,     0*MAX_CHANNELS_VOFF+0x00,s0
-	lqv v_chvol_l_1,     0*MAX_CHANNELS_VOFF+0x10,s0
-	lqv v_chvol_l_2,     0*MAX_CHANNELS_VOFF+0x20,s0
-	lqv v_chvol_l_3,     0*MAX_CHANNELS_VOFF+0x30,s0
-
-	lqv v_chvol_r_0,     1*MAX_CHANNELS_VOFF+0x00,s0
-	lqv v_chvol_r_1,     1*MAX_CHANNELS_VOFF+0x10,s0
-	lqv v_chvol_r_2,     1*MAX_CHANNELS_VOFF+0x20,s0
-	lqv v_chvol_r_3,     1*MAX_CHANNELS_VOFF+0x30,s0
-
-	# Apply global volume to obtain the final volume for each channel
-	vmudl v_chvol_l_0, v_chvol_l_0, v_glvol
-	vmudl v_chvol_r_0, v_chvol_r_0, v_glvol
-	vmudl v_chvol_l_1, v_chvol_l_1, v_glvol
-	vmudl v_chvol_r_1, v_chvol_r_1, v_glvol
-	vmudl v_chvol_l_2, v_chvol_l_2, v_glvol
-	vmudl v_chvol_r_2, v_chvol_r_2, v_glvol
-	vmudl v_chvol_l_3, v_chvol_l_3, v_glvol
-	vmudl v_chvol_r_3, v_chvol_r_3, v_glvol
-
-#if VOLUME_FILTER
-	# Load actual volumes levels
-	lqv v_xvol_l_0,      0*MAX_CHANNELS_VOFF+0x00,s1
-	lqv v_xvol_l_1,      0*MAX_CHANNELS_VOFF+0x10,s1
-	lqv v_xvol_l_2,      0*MAX_CHANNELS_VOFF+0x20,s1
-	lqv v_xvol_l_3,      0*MAX_CHANNELS_VOFF+0x30,s1
-
-	lqv v_xvol_r_0,      1*MAX_CHANNELS_VOFF+0x00,s1
-	lqv v_xvol_r_1,      1*MAX_CHANNELS_VOFF+0x10,s1
-	lqv v_xvol_r_2,      1*MAX_CHANNELS_VOFF+0x20,s1
-	lqv v_xvol_r_3,      1*MAX_CHANNELS_VOFF+0x30,s1
-#else
-	vor v_xvol_l_0, v_chvol_l_0, v_zero
-	vor v_xvol_l_1, v_chvol_l_1, v_zero
-	vor v_xvol_l_2, v_chvol_l_2, v_zero
-	vor v_xvol_l_3, v_chvol_l_3, v_zero
-
-	vor v_xvol_r_0, v_chvol_r_0, v_zero
-	vor v_xvol_r_1, v_chvol_r_1, v_zero
-	vor v_xvol_r_2, v_chvol_r_2, v_zero
-	vor v_xvol_r_3, v_chvol_r_3, v_zero
-#endif
-
-	jr ra
-	nop
-	.endfunc
-
-	#undef v_glvol 
-
-
-	.func EndMixer
-EndMixer:
-	li s1, %lo(XVOL_L)
-
-	sqv v_xvol_l_0,      0*MAX_CHANNELS_VOFF+0x00,s1
-	sqv v_xvol_l_1,      0*MAX_CHANNELS_VOFF+0x10,s1
-	sqv v_xvol_l_2,      0*MAX_CHANNELS_VOFF+0x20,s1
-	sqv v_xvol_l_3,      0*MAX_CHANNELS_VOFF+0x30,s1
-
-	sqv v_xvol_r_0,      1*MAX_CHANNELS_VOFF+0x00,s1
-	sqv v_xvol_r_1,      1*MAX_CHANNELS_VOFF+0x10,s1
-	sqv v_xvol_r_2,      1*MAX_CHANNELS_VOFF+0x20,s1
-	sqv v_xvol_r_3,      1*MAX_CHANNELS_VOFF+0x30,s1
-
-	jr ra
-	nop
-
-	.endfunc
-
-
-##############################################################
-# Mixer
-#
-# Arguments:
-#    s4:  buffer into which the mixed samples will be stored
-#
-# Global state:
-#    num_samples:  number of samples to mix
-#
-##############################################################
-
-	#define v_out_l       $v01
-	#define v_out_r       $v02
-	#define v_sample_0    $v03
-	#define v_sample_1    $v04
-	#define v_sample_2    $v05
-	#define v_sample_3    $v06
-	#define v_mix_l       $v07
-	#define v_mix_r       $v08
-
-	.func Mixer
-Mixer:
-	# Load samples
-	li s0, %lo(CHANNEL_BUFFER)
-	move t1, num_samples
-
-	# Load initial samples
-	lqv v_sample_0, 0x00,s0
-	lqv v_sample_1, 0x10,s0
-	lqv v_sample_2, 0x20,s0
-	lqv v_sample_3, 0x30,s0
-
-	# For optimal pipelining, output is stored at the beginning of the loop. To avoid
-	# corrupting memory, load the output register with whatever is there now.
-	lsv v_out_l.e0, -4,s4
-	ble k0, 8, Mix8Start    # Optimized mixing loop for <= 8 channels
-	lsv v_out_r.e0, -2,s4
-
-Mix32Start:
-	blt t1, 8, Mix32Loop
-	move t0, t1
-	li t0, 8
-
-	############################################################################
-	#             VU                                          SU               #
-	############################################################################
-	.align 3
-Mix32Loop:
-	# Apply volume/panning to each channel sample.
-	# left channel:
-	vmulf v_mix_l, v_sample_0, v_xvol_l_0;
-	vmacf v_mix_l, v_sample_1, v_xvol_l_1;             # Store previous loop's output
-	vmacf v_mix_l, v_sample_2, v_xvol_l_2;             ssv v_out_l.e0, -4,s4
-	vmacf v_mix_l, v_sample_3, v_xvol_l_3;             ssv v_out_r.e0, -2,s4
-	# right channel:                                   # Updated counters
-	vmulf v_mix_r, v_sample_0, v_xvol_r_0;             add s0, 32*2
-	vmacf v_mix_r, v_sample_1, v_xvol_r_1;             addi t0, -1
-	vmacf v_mix_r, v_sample_2, v_xvol_r_2;             addi s4, 4
-	vmacf v_mix_r, v_sample_3, v_xvol_r_3;
-
-	# Mix all lanes together into the first lane       # Load next loop's samples
-	vadd v_out_l, v_mix_l, v_mix_l.q1;                 lqv v_sample_0.e0, 0x00,s0
-	vadd v_out_r, v_mix_r, v_mix_r.q1;                 lqv v_sample_1.e0, 0x10,s0
-	  # 1 cycle stall here
-	vadd v_out_l, v_out_l, v_out_l.h2;                 lqv v_sample_2.e0, 0x20,s0
-	vadd v_out_r, v_out_r, v_out_r.h2;                 lqv v_sample_3.e0, 0x30,s0
-	  # 1 cycle stall here
-	vadd v_out_l, v_out_l, v_out_l.e4;                 bnez t0, Mix32Loop
-	vadd v_out_r, v_out_r, v_out_r.e4;
-
-#if VOLUME_FILTER
-	# Apply volume ramp
-	vmudm v_xvol_l_0, v_xvol_l_0, k_alpha
-	vmadm v_xvol_l_0, v_chvol_l_0, k_1malpha
-
-	vmudm v_xvol_l_1, v_xvol_l_1, k_alpha
-	vmadm v_xvol_l_1, v_chvol_l_1, k_1malpha
-
-	vmudm v_xvol_l_2, v_xvol_l_2, k_alpha
-	vmadm v_xvol_l_2, v_chvol_l_2, k_1malpha
-
-	vmudm v_xvol_l_3, v_xvol_l_3, k_alpha
-	vmadm v_xvol_l_3, v_chvol_l_3, k_1malpha
-
-	vmudm v_xvol_r_0, v_xvol_r_0, k_alpha
-	vmadm v_xvol_r_0, v_chvol_r_0, k_1malpha
-
-	vmudm v_xvol_r_1, v_xvol_r_1, k_alpha
-	vmadm v_xvol_r_1, v_chvol_r_1, k_1malpha
-
-	vmudm v_xvol_r_2, v_xvol_r_2, k_alpha              # Next iteration
-	vmadm v_xvol_r_2, v_chvol_r_2, k_1malpha;          addi t1, -8
-
-	vmudm v_xvol_r_3, v_xvol_r_3, k_alpha;             bgtz t1, Mix32Start
-	vmadm v_xvol_r_3, v_chvol_r_3, k_1malpha           
-#else
-	addi t1, -8
-	bgtz t1, Mix32Start
-	nop
-#endif
-
-	# Store last loop's output and exit
-	ssv v_out_l.e0, -4,s4
-	jr ra
-	ssv v_out_r.e0, -2,s4
-
-
-Mix8Start:
-	blt t1, 8, Mix8Loop
-	move t0, t1
-	li t0, 8
-
-	############################################################################
-	#             VU                                          SU               #
-	############################################################################
-	.align 3
-Mix8Loop:
-	vmulf v_mix_l, v_sample_0, v_xvol_l_0;             ssv v_out_l.e0, -4,s4
-	vmulf v_mix_r, v_sample_0, v_xvol_r_0;             ssv v_out_r.e0, -2,s4
-	  # pipeline stall
-	vadd v_out_l, v_mix_l, v_mix_l.q1;                 addi t0, -1
-	vadd v_out_r, v_mix_r, v_mix_r.q1;                 add s0, 32*2
-	  # pipeline stall
-	vadd v_out_l, v_out_l, v_out_l.h2;                 addi s4, 4
-	vadd v_out_r, v_out_r, v_out_r.h2;                 lqv v_sample_0, 0,s0
-	  # pipeline stall
-	vadd v_out_l, v_out_l, v_out_l.e4;                 bnez t0, Mix8Loop
-	vadd v_out_r, v_out_r, v_out_r.e4;
-
-#if VOLUME_FILTER
-	# Apply volume ramp
-	vmudm v_xvol_l_0, v_xvol_l_0, k_alpha
-	vmadm v_xvol_l_0, v_chvol_l_0, k_1malpha;          addi t1, -8
-
-	vmudm v_xvol_r_0, v_xvol_r_0, k_alpha;             bgtz t1, Mix8Start
-	vmadm v_xvol_r_0, v_chvol_r_0, k_1malpha
-#else
-	addi t1, -8
-	bgtz t1, Mix8Start
-	nop 
-#endif
-
-	ssv v_out_l.e0, -4,s4
-	jr ra
-	ssv v_out_r.e0, -2,s4
-	.endfunc
-
-
-	#undef v_zero       
-	#undef v_xvol_l_0   
-	#undef v_xvol_r_0   
-	#undef v_xvol_l_1   
-	#undef v_xvol_r_1   
-	#undef v_xvol_l_2   
-	#undef v_xvol_r_2   
-	#undef v_xvol_l_3   
-	#undef v_xvol_r_3   
-	#undef v_chvol_l_0  
-	#undef v_chvol_r_0  
-	#undef v_chvol_l_1  
-	#undef v_chvol_r_1  
-	#undef v_chvol_l_2  
-	#undef v_chvol_r_2  
-	#undef v_chvol_l_3  
-	#undef v_chvol_r_3  
-	#undef v_shift8     
-	#undef v_shift      
-	#undef v_const1
-	#undef k_0000
-	#undef k_8000
+	#undef ticks
+	#undef wv_pos
+	#undef wv_step
+	#undef wv_len
+	#undef wv_loop_len
+	#undef wv_addr
+	#undef dma_cache_end
+	#undef out_ptr
+	#undef wv_pos_to_dmem
+	#undef wv_step_8x
+	#undef is_stereo_sub
+	#undef is_16bit
+	#undef is_stereo
+	#undef acc_ptr
+	#undef ch_idx
 
 
 ############################################################################
@@ -1341,8 +1119,73 @@ VADPCM_BUFFER_END:	.space 8    # Extra 8 bytes for misalignment
 #define v_ib2   $v12
 #define v_ib3   $v13
 
+###############################################################
+# VadpcmDecodeFrame – decode CH_VNEXT_FRAME into MIX_VADPCM_PCM.
+# Reuses VADPCM_DecodeLoop / VADPCM_SaveState via CH_VADPCM_MIXRET.
+# Clobbers: most SU/VU temps used by the VADPCM decompressor.
+###############################################################
+	.func VadpcmDecodeFrame
+VadpcmDecodeFrame:
+	sw ra, %lo(CH_VADPCM_RA)
+
+	# MIX_CHANNEL keeps volume-filter constants in $v31 (v_const1), but
+	# vsra8 needs the RSPQ shift table in vshift8 ($v31). Restore it the
+	# same way RSPQ_Loop does before each command; caller reloads VCONST_1.
+	lpv vshift8, 0x00,zero
+	vsrl vshift, vshift8, 8
+
+	# RDRAM address of compressed frame: ptr + next_frame*9
+	lw t0, %lo(CH_VNEXT_FRAME)
+	sll t1, t0, 3
+	add t1, t0
+	lw s0, %lo(CH_PTR)
+	add s0, t1
+	andi t9, s0, 7                        # misalignment (survives DMAIn)
+	sub s0, t9
+	li s4, %lo(MIX_VADPCM_COMP)
+	jal DMAIn
+	li t0, DMA_SIZE(9+8, 1)
+
+	li dmem_codebook, %lo(MIX_VADPCM_CODEBOOK)
+	li dmem_state, %lo(MIX_VADPCM_STATE)
+	li dmem_output, %lo(MIX_VADPCM_PCM)
+	li dmem_input, %lo(MIX_VADPCM_COMP)
+	add dmem_input, t9
+	addiu dmem_input, 1
+
+	jal VADPCM_LoadIdentity
+	nop
+
+	li nframes, 1
+	li a2, 0                               # mono path in SaveState
+	li t0, 1
+	sw t0, %lo(CH_VADPCM_MIXRET)
+	lqv vstate1, 0x00,dmem_state
+	li t1, 1
+	j VADPCM_Priming
+	nop
+	.endfunc
+
+	.func VADPCM_LoadIdentity
+VADPCM_LoadIdentity:
+	vxor pred1a, pred1a
+	vxor pred1b, pred1b
+	vxor pred1c, pred1c
+	vxor pred1d, pred1d
+	vxor pred1e, pred1e
+	vxor pred1f, pred1f
+	vxor pred1g, pred1g
+	vxor pred1h, pred1h
+	li s0, %lo(IDENTITY)
+	jr ra
+	ltv pred1a.e0, 0,s0
+	.endfunc
+
 	.func VADPCM_Decompress
 VADPCM_Decompress:
+	# CH_VADPCM_MIXRET lives in .bss (not cleared between commands): make
+	# sure VADPCM_SaveState takes the DMA-out path, not the in-mixer return.
+	sw zero, %lo(CH_VADPCM_MIXRET)
 	li dmem_codebook, %lo(VADPCM_CODEBOOK)
 	li dmem_state, %lo(VADPCM_STATE)
 
@@ -1358,18 +1201,8 @@ VADPCM_Decompress:
 	jal DMAInAsync
 	li t0, DMA_SIZE(16*2, 1)
 
-	# Create an identity matrix in pred1a-pred1h, zeroing the whole
-	# matrix, and then loading the identity in the diagonal
-	vxor pred1a, pred1a
-	vxor pred1b, pred1b
-	vxor pred1c, pred1c
-	vxor pred1d, pred1d
-	vxor pred1e, pred1e
-	vxor pred1f, pred1f
-	vxor pred1g, pred1g
-	vxor pred1h, pred1h
-	li s0, %lo(IDENTITY)
-	ltv pred1a.e0,    0,s0
+	jal VADPCM_LoadIdentity
+	nop
 
 	srl nframes, a1, 24
 	bgez a2, 1f
@@ -1466,6 +1299,7 @@ VADPCM_Decompress:
 	# the residuals, build vscale = 2^scaling and the predictor address, load the
 	# matrix, and scale the residuals. (Frame 0 is the left channel for stereo, so
 	# the base codebook address is correct.)
+VADPCM_Priming:
 	lbu t0, -1(dmem_input)
 	lpv next_vres0, 0,dmem_input
 	lpv next_vres1, 0,dmem_input
@@ -1701,6 +1535,19 @@ VADPCM_SaveState:
 
 	# Save back state
 	sqv vstate1, 0x00,dmem_state
+
+	# In-mixer path: keep state in DMEM and return to VadpcmDecodeFrame.
+	# MIX_VADPCM_STATE is only 16 bytes (mono) — do not store vstate3.
+	lw t0, %lo(CH_VADPCM_MIXRET)
+	beqz t0, 1f
+	sw zero, %lo(CH_VADPCM_MIXRET)
+	lw t0, %lo(CH_VNEXT_FRAME)
+	addi t0, 1
+	sw t0, %lo(CH_VNEXT_FRAME)
+	lw ra, %lo(CH_VADPCM_RA)
+	jr ra
+	nop
+1:
 	sqv vstate3, 0x10,dmem_state
 	move s4, dmem_state
 	move s0, a2

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -1,7 +1,7 @@
 /**
  * @file samplebuffer.c
  * @author Giovanni Bajo <giovannibajo@gmail.com>
- * @brief Sample buffer (ring FIFO)
+ * @brief Sample buffer
  * @ingroup mixer
  */
 
@@ -14,6 +14,7 @@
 #include "utils.h"
 #include "debug.h"
 #include "profile.h"
+#include "rspq.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -30,6 +31,17 @@ static inline uint8_t *samplebuffer_base(const samplebuffer_t *buf) {
 	return SAMPLES_PTR(buf);
 }
 
+/** Round a unit count so that count * unit_bytes is a multiple of 8. */
+static int samplebuffer_align_len(const samplebuffer_t *buf, int len) {
+	int ub = buf->unit_bytes;
+	assert(ub > 0);
+	if (ub & (ub - 1))
+		return ROUND_UP(len, 8);
+	// PCM: ub is 1, 2, or 4 → ROUND_UP(len << bps, 8) >> bps (no division).
+	int bps = ub == 1 ? 0 : (ub == 2 ? 1 : 2);
+	return ((len + ((8 >> bps) - 1)) >> (3 - bps)) << (3 - bps);
+}
+
 void samplebuffer_dma_wait(samplebuffer_t *buf) {
 	if (buf->dma_ticket) {
 		dma_wait_finished(buf->dma_ticket);
@@ -41,7 +53,7 @@ void samplebuffer_dma_wait(samplebuffer_t *buf) {
 static void samplebuffer_commit(samplebuffer_t *buf) {
 	if (buf->pending_len <= 0)
 		return;
-	int ub = samplebuffer_unit_bytes(buf);
+	int ub = buf->unit_bytes;
 	int ring = buf->size;
 	int slot = buf->pending_slot;
 	int len = buf->pending_len;
@@ -55,7 +67,7 @@ static void samplebuffer_commit(samplebuffer_t *buf) {
 		       n * ub);
 	} else if (slot + len > ring) {
 		samplebuffer_dma_wait(buf);
-		// Write crossed the ring end into the margin: mirror the overflow
+		// Write crossed the usable end into the margin: mirror the overflow
 		// back to the start (producer wrote into the margin area).
 		int overflow = slot + len - ring;
 		memcpy(samplebuffer_base(buf),
@@ -70,7 +82,7 @@ void samplebuffer_init(samplebuffer_t *buf, uint8_t* uncached_mem, int nbytes, i
 
 	assertf(UncachedAddr(uncached_mem) == uncached_mem,
 		"specified buffer must be in the uncached segment.\nTry using malloc_uncached() to allocate it");
-	buf->ptr_and_flags = (uint32_t)uncached_mem;
+	buf->ptr_and_flags = (uint32_t)(uintptr_t)uncached_mem;
 	assert((buf->ptr_and_flags & 7) == 0);
 	buf->size = nbytes;
 	buf->capacity_bytes = nbytes;
@@ -83,21 +95,49 @@ void samplebuffer_init(samplebuffer_t *buf, uint8_t* uncached_mem, int nbytes, i
 	buf->wnext = -1;
 }
 
-void samplebuffer_set_bps(samplebuffer_t *buf, int bits_per_sample) {
-	assert(bits_per_sample == 8 || bits_per_sample == 16 || bits_per_sample == 32);
-	assertf(buf->widx == 0 && buf->ridx == 0 && buf->wpos == 0,
-		"samplebuffer_set_bps can only be called on an empty samplebuffer");
+static int gcd(int a, int b) {
+	while (b) { int t = a % b; a = b; b = t; }
+	return a;
+}
 
-	int bps = bits_per_sample == 8 ? 0 : (bits_per_sample == 16 ? 1 : 2);
-	buf->unit_bytes = 0;
-	buf->ptr_and_flags = SAMPLES_PTR_MAKE(SAMPLES_PTR(buf), bps);
-	int ub = 1 << bps;
-	int margin_bytes = SAMPLEBUFFER_MARGIN_UNITS * ub;
-	int usable = buf->capacity_bytes - margin_bytes;
-	assertf(usable > 0, "samplebuffer too small for ring margin");
-	usable &= ~7;
-	buf->size = usable >> bps;
-	assert(buf->size > 0);
+/**
+ * Recompute the usable size in units, from the allocated bytes, the unit size
+ * and the append granularity. The samplebuffer must be empty.
+ */
+static void samplebuffer_recalc_size(samplebuffer_t *buf) {
+	int ub = buf->unit_bytes;
+	assert(ub > 0);
+	int usable = buf->capacity_bytes - SAMPLEBUFFER_MARGIN_UNITS * ub;
+	assertf(usable >= ub, "samplebuffer too small for margin");
+
+	// size * unit_bytes must be a multiple of 8, so that a waveform position
+	// keeps its byte phase when it wraps around the samplebuffer.
+	int n;
+	if ((ub & (ub - 1)) == 0) {
+		int bps = ub == 1 ? 0 : (ub == 2 ? 1 : 2);
+		n = (usable & ~7) >> bps;
+	} else {
+		n = usable / ub;
+		while (n > 0 && ((n * ub) & 7))
+			n--;
+	}
+	assertf(n >= SAMPLEBUFFER_MARGIN_UNITS, "samplebuffer too small");
+
+	// If the producer appends chunks that do not fit the tail margin, keep the
+	// size a multiple of the chunk (and of the byte phase above): the write
+	// cursor then wraps exactly at the end of the usable area, so a chunk is
+	// never split by the wrap and never needs the live window to be relocated.
+	// Smaller chunks always fit the margin, so they gain nothing from this.
+	// Give up if it would not leave room for two chunks.
+	int f = buf->append_units;
+	if (f > SAMPLEBUFFER_MARGIN_UNITS) {
+		int phase = 8 / gcd(ub, 8);
+		int step = f / gcd(f, phase) * phase;
+		if (n - n % step >= 2*f)
+			n -= n % step;
+	}
+
+	buf->size = n;
 }
 
 void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes) {
@@ -106,21 +146,17 @@ void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes) {
 		"samplebuffer_set_unit_bytes can only be called on an empty samplebuffer");
 
 	buf->unit_bytes = (uint8_t)unit_bytes;
-	buf->ptr_and_flags = SAMPLES_PTR_MAKE(SAMPLES_PTR(buf), 0);
-	int margin_bytes = SAMPLEBUFFER_MARGIN_UNITS * unit_bytes;
-	int usable = buf->capacity_bytes - margin_bytes;
-	assertf(usable >= unit_bytes, "samplebuffer too small for ring margin");
-	int ring = usable / unit_bytes;
-	while (ring > 0 && ((ring * unit_bytes) & 7))
-		ring--;
-	assertf(ring >= SAMPLEBUFFER_MARGIN_UNITS, "samplebuffer ring too small");
-	buf->size = ring;
+	samplebuffer_recalc_size(buf);
 }
 
 void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read) {
 	buf->wave = wave;
 	buf->wv_read = read;
 	assert(wave->state_size <= buf->state_size);
+
+	buf->append_units = wave->append_units;
+	if (buf->unit_bytes && buf->widx == 0 && buf->ridx == 0)
+		samplebuffer_recalc_size(buf);
 }
 
 bool samplebuffer_is_inited(samplebuffer_t *buf)
@@ -141,44 +177,56 @@ static inline int samplebuffer_slot(const samplebuffer_t *buf, int rel) {
 	return (buf->head + rel) % buf->size;
 }
 
-/** Move the live window [ridx, widx) to physical slot 0 (rare; large appends). */
-static void samplebuffer_relocate_live(samplebuffer_t *buf) {
-	int ub = samplebuffer_unit_bytes(buf);
+/**
+ * Move the live window [ridx, widx) to the start of the sample area, so that a
+ * following append of wlen units is contiguous (rare; only large appends).
+ *
+ * With a known append granularity, the window is placed so that the write
+ * cursor lands on a multiple of it: as the usable size is a multiple as well,
+ * from here on appends wrap exactly at the end of the samplebuffer and no
+ * further relocation is needed, until an undo or a seek breaks the phase again.
+ */
+static void samplebuffer_relocate_live(samplebuffer_t *buf, int wlen) {
+	int ub = buf->unit_bytes;
 	int ring = buf->size;
 	int live = buf->widx - buf->ridx;
 	uint8_t *base = samplebuffer_base(buf);
 
+	int dst = 0;
+	int f = buf->append_units;
+	if (f > SAMPLEBUFFER_MARGIN_UNITS && ring % f == 0 &&
+		ROUND_UP(live, f) + wlen <= ring)
+		dst = ROUND_UP(live, f) - live;
+
 	if (live > 0) {
 		samplebuffer_dma_wait(buf);
-		// RSP may still be reading this window from a prior mix round.
-		if (buf->last_round)
-			__mixer_round_wait(buf->last_round);
+		// RSP may still be reading this window from a prior mix round. With
+		// #waveform_t::append_units this path is rare (seek / undo that breaks
+		// the write phase), so a full highpri sync is acceptable.
+		rspq_highpri_sync();
 		int src = samplebuffer_slot(buf, buf->ridx);
-		if (src != 0) {
+		if (src != dst) {
 			int nbytes = live * ub;
 			if (src + live <= ring) {
-				memmove(base, base + src * ub, nbytes);
+				memmove(base + dst * ub, base + src * ub, nbytes);
 			} else {
 				int first = ring - src;
 				void *tmp = malloc(nbytes);
 				assert(tmp);
 				memcpy(tmp, base + src * ub, first * ub);
 				memcpy((uint8_t*)tmp + first * ub, base, (live - first) * ub);
-				memcpy(base, tmp, nbytes);
+				memcpy(base + dst * ub, tmp, nbytes);
 				free(tmp);
 			}
 		}
-		// Keep margin mirror coherent for any live bytes in [0, MARGIN).
-		if (live > 0 && live <= SAMPLEBUFFER_MARGIN_UNITS)
-			memcpy(base + ring * ub, base, live * ub);
-		else if (live > SAMPLEBUFFER_MARGIN_UNITS)
-			memcpy(base + ring * ub, base, SAMPLEBUFFER_MARGIN_UNITS * ub);
+		// Keep the margin mirror coherent with the new start of the sample area.
+		memcpy(base + ring * ub, base, SAMPLEBUFFER_MARGIN_UNITS * ub);
 	}
 
 	buf->wpos += buf->ridx;
 	buf->widx = live;
 	buf->ridx = 0;
-	buf->head = 0;
+	buf->head = dst;
 }
 
 /** @brief Units that #samplebuffer_prefetch keeps ready ahead of the mixer. */
@@ -196,15 +244,9 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 	PROFILE_SCOPE(PS_SBUF_GET) {
 	samplebuffer_commit(buf);
 
-	int ub = samplebuffer_unit_bytes(buf);
+	int ub = buf->unit_bytes;
 	int ring = buf->size;
-	int round_len = *wlen;
-	if (buf->unit_bytes) {
-		round_len = ROUND_UP(round_len, 8);
-	} else {
-		int bps = SAMPLES_BPS_SHIFT(buf);
-		round_len = ((round_len)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
-	}
+	int round_len = samplebuffer_align_len(buf, *wlen);
 
 	tracef("samplebuffer_get: wpos=%x wlen=%x\n", wpos, *wlen);
 
@@ -215,7 +257,8 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 		buf->wpos = wpos;
 		buf->head = 0;
 		int len = round_len;
-		if (!buf->unit_bytes && (buf->wpos * ub) & 1) {
+		// 8-bit PCM + odd wpos: dma_read needs a 2-byte aligned start.
+		if (ub == 1 && (buf->wpos & 1)) {
 			buf->wpos--; len++;
 		}
 		buf->wv_read(buf->wave->ctx, buf, buf->wpos, len, seeking);
@@ -227,13 +270,7 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 		if (reuse < *wlen) {
 			tracef("samplebuffer_get: read missing: reuse=%x wpos=%x wlen=%x\n", reuse, wpos, *wlen);
 			assertf(wpos+reuse == buf->wnext, "wpos:%x reuse:%x buf->wnext:%x", wpos, reuse, buf->wnext);
-			int missing = *wlen - reuse;
-			if (buf->unit_bytes)
-				missing = ROUND_UP(missing, 8);
-			else {
-				int bps = SAMPLES_BPS_SHIFT(buf);
-				missing = ((missing)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
-			}
+			int missing = samplebuffer_align_len(buf, *wlen - reuse);
 			// Free space without discarding past the live read cursor.
 			missing = MIN(missing, ring - (buf->widx - buf->ridx));
 			buf->wv_read(buf->wave->ctx, buf, wpos+reuse, missing, false);
@@ -254,7 +291,7 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 
 	int slot = samplebuffer_slot(buf, rel);
 	assertf(*wlen <= SAMPLEBUFFER_MARGIN_UNITS || slot + *wlen <= ring,
-		"samplebuffer_get: window %x not contiguous (slot=%x ring=%x)", *wlen, slot, ring);
+		"samplebuffer_get: window %x not contiguous (slot=%x size=%x)", *wlen, slot, ring);
 	ret = samplebuffer_base(buf) + slot * ub;
 	}
 	return ret;
@@ -266,8 +303,8 @@ void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen) {
 		return;
 	samplebuffer_commit(buf);
 
-	// Only extend the current stream: on a seek the ring is flushed, so
-	// anything fetched now would be thrown away.
+	// Only extend the current stream: on a seek the samplebuffer is flushed,
+	// so anything fetched now would be thrown away.
 	if (wpos < buf->wpos || wpos > buf->wnext)
 		return;
 	// Fill back up to the watermark, so that one transfer covers several rounds.
@@ -276,12 +313,7 @@ void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen) {
 	if (missing <= 0 ||
 		(ahead > SAMPLEBUFFER_PREFETCH_LOW_UNITS && ahead >= wlen))
 		return;
-	if (buf->unit_bytes)
-		missing = ROUND_UP(missing, 8);
-	else {
-		int bps = SAMPLES_BPS_SHIFT(buf);
-		missing = ((missing)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
-	}
+	missing = samplebuffer_align_len(buf, missing);
 	// Never ask for more than a margin: readers split bigger requests into
 	// several appends, and since a buffer tracks a single in-flight transfer,
 	// the second append would have to wait for the first one here.
@@ -301,9 +333,25 @@ void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen) {
 void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
 	samplebuffer_commit(buf);
 
-	int ub = samplebuffer_unit_bytes(buf);
+	// Learn the granularity of the large appends, for producers that do not
+	// declare it (or declare a divisor of the chunk they really use: one that
+	// fits the margin cannot save any relocate, so the chunk we are seeing is
+	// a better guess). The size can only be changed while the samplebuffer is
+	// empty, as it is the modulus of all the physical positions.
+	if (wlen > SAMPLEBUFFER_MARGIN_UNITS) {
+		int f = buf->append_units > SAMPLEBUFFER_MARGIN_UNITS
+			? gcd(buf->append_units, wlen) : wlen;
+		if (f != buf->append_units) {
+			buf->append_units = f;
+			if (buf->widx == 0 && buf->ridx == 0)
+				samplebuffer_recalc_size(buf);
+		}
+	}
+
+	int ub = buf->unit_bytes;
 	int ring = buf->size;
-	assertf(buf->unit_bytes || ((buf->wpos * ub) % 2) == 0, "buf->wpos:%x", buf->wpos);
+	// PCM: dma_read / dfs need an even byte offset into the sample area.
+	assertf((ub & (ub - 1)) != 0 || ((buf->wpos * ub) % 2) == 0, "buf->wpos:%x", buf->wpos);
 
 	// Make room by discarding the oldest units past the read cursor.
 	while (buf->widx + wlen > ring) {
@@ -318,19 +366,19 @@ void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
 	}
 
 	int slot = samplebuffer_slot(buf, buf->widx);
-	// Contiguous write: fit before ring end, or spill into the margin (≤MARGIN).
-	// Codecs that append full frames larger than the margin (Opus, YM) may need
-	// a one-shot relocate of the live window to physical 0 so the write is linear.
+	// Contiguous write: fit before the usable end, or spill into the margin
+	// (≤MARGIN). Codecs that append full frames larger than the margin (Opus,
+	// YM) may need a relocate of the live window so that the write is linear.
 	if (slot + wlen > ring && wlen > SAMPLEBUFFER_MARGIN_UNITS) {
 		assertf(buf->widx - buf->ridx + wlen <= ring,
 			"samplebuffer_append: buffer too small\n"
 			"live:%x wlen:%x size:%x", buf->widx - buf->ridx, wlen, ring);
-		samplebuffer_relocate_live(buf);
-		slot = buf->widx;
+		samplebuffer_relocate_live(buf, wlen);
+		slot = samplebuffer_slot(buf, buf->widx);
 		assert(slot + wlen <= ring);
 	} else if (slot + wlen > ring) {
 		assertf(wlen <= SAMPLEBUFFER_MARGIN_UNITS,
-			"samplebuffer_append: large append %x wraps ring (slot=%x)", wlen, slot);
+			"samplebuffer_append: large append %x wraps (slot=%x)", wlen, slot);
 	}
 
 	buf->pending_slot = slot;

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -1,7 +1,7 @@
 /**
  * @file samplebuffer.c
  * @author Giovanni Bajo <giovannibajo@gmail.com>
- * @brief Sample buffer
+ * @brief Sample buffer (ring FIFO)
  * @ingroup mixer
  */
 
@@ -12,36 +12,62 @@
 #include "n64types.h"
 #include "utils.h"
 #include "debug.h"
+#include <stdlib.h>
 #include <string.h>
 
 /** @brief Set to 1 to activate debug logs */
 #define MIXER_TRACE   0
 
 #if MIXER_TRACE
-/** @brief like debugf(), but writes only if #MIXER_TRACE is not 0 */
 #define tracef(fmt, ...)  debugf(fmt, ##__VA_ARGS__)
 #else
-/** @brief like debugf(), but writes only if #MIXER_TRACE is not 0 */
 #define tracef(fmt, ...)  ({ })
 #endif
+
+static inline uint8_t *samplebuffer_base(const samplebuffer_t *buf) {
+	return SAMPLES_PTR(buf);
+}
+
+/** Commit a pending append that may have spilled into the tail margin. */
+static void samplebuffer_commit(samplebuffer_t *buf) {
+	if (buf->pending_len <= 0)
+		return;
+	int ub = samplebuffer_unit_bytes(buf);
+	int ring = buf->size;
+	int slot = buf->pending_slot;
+	int len = buf->pending_len;
+	// Mirror bytes written into physical [0, MARGIN) out to the tail margin.
+	if (slot < SAMPLEBUFFER_MARGIN_UNITS) {
+		int n = MIN(len, SAMPLEBUFFER_MARGIN_UNITS - slot);
+		memcpy(samplebuffer_base(buf) + (ring + slot) * ub,
+		       samplebuffer_base(buf) + slot * ub,
+		       n * ub);
+	} else if (slot + len > ring) {
+		// Write crossed the ring end into the margin: mirror the overflow
+		// back to the start (producer wrote into the margin area).
+		int overflow = slot + len - ring;
+		memcpy(samplebuffer_base(buf),
+		       samplebuffer_base(buf) + ring * ub,
+		       overflow * ub);
+	}
+	buf->pending_len = 0;
+}
 
 void samplebuffer_init(samplebuffer_t *buf, uint8_t* uncached_mem, int nbytes, int state_size) {
 	memset(buf, 0, sizeof(samplebuffer_t));
 
-	// Store the buffer pointer as uncached address. We don't want to access
-	// it with CPU as we want to build samples with RSP, and all APIs assume
-	// that content is committed to RDRAM (not cache).
-	assertf(UncachedAddr(uncached_mem) == uncached_mem, 
+	assertf(UncachedAddr(uncached_mem) == uncached_mem,
 		"specified buffer must be in the uncached segment.\nTry using malloc_uncached() to allocate it");
 	buf->ptr_and_flags = (uint32_t)uncached_mem;
 	assert((buf->ptr_and_flags & 7) == 0);
 	buf->size = nbytes;
+	buf->capacity_bytes = nbytes;
 
 	if (state_size) {
 		buf->state = uncached_mem + nbytes;
 		buf->state_size = state_size;
-	} 
-		
+	}
+
 	buf->wnext = -1;
 }
 
@@ -50,12 +76,16 @@ void samplebuffer_set_bps(samplebuffer_t *buf, int bits_per_sample) {
 	assertf(buf->widx == 0 && buf->ridx == 0 && buf->wpos == 0,
 		"samplebuffer_set_bps can only be called on an empty samplebuffer");
 
-	int nbytes = buf->size * samplebuffer_unit_bytes(buf);
-
 	int bps = bits_per_sample == 8 ? 0 : (bits_per_sample == 16 ? 1 : 2);
 	buf->unit_bytes = 0;
 	buf->ptr_and_flags = SAMPLES_PTR_MAKE(SAMPLES_PTR(buf), bps);
-	buf->size = nbytes >> bps;
+	int ub = 1 << bps;
+	int margin_bytes = SAMPLEBUFFER_MARGIN_UNITS * ub;
+	int usable = buf->capacity_bytes - margin_bytes;
+	assertf(usable > 0, "samplebuffer too small for ring margin");
+	usable &= ~7;
+	buf->size = usable >> bps;
+	assert(buf->size > 0);
 }
 
 void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes) {
@@ -63,18 +93,21 @@ void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes) {
 	assertf(buf->widx == 0 && buf->ridx == 0 && buf->wpos == 0,
 		"samplebuffer_set_unit_bytes can only be called on an empty samplebuffer");
 
-	int nbytes = buf->size * samplebuffer_unit_bytes(buf);
 	buf->unit_bytes = (uint8_t)unit_bytes;
-	// Keep a dummy bps of 0 (1 byte) in the tagged pointer; real sizing
-	// comes from unit_bytes.
 	buf->ptr_and_flags = SAMPLES_PTR_MAKE(SAMPLES_PTR(buf), 0);
-	buf->size = nbytes / unit_bytes;
+	int margin_bytes = SAMPLEBUFFER_MARGIN_UNITS * unit_bytes;
+	int usable = buf->capacity_bytes - margin_bytes;
+	assertf(usable >= unit_bytes, "samplebuffer too small for ring margin");
+	int ring = usable / unit_bytes;
+	while (ring > 0 && ((ring * unit_bytes) & 7))
+		ring--;
+	assertf(ring >= SAMPLEBUFFER_MARGIN_UNITS, "samplebuffer ring too small");
+	buf->size = ring;
 }
 
 void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read) {
 	buf->wave = wave;
 	buf->wv_read = read;
-	buf->wave_uuid = wave->__uuid;
 	assert(wave->state_size <= buf->state_size);
 }
 
@@ -84,21 +117,61 @@ bool samplebuffer_is_inited(samplebuffer_t *buf)
 }
 
 void samplebuffer_close(samplebuffer_t *buf) {
-	// A pending RSP compaction still references the memory we're about to free.
-	if (buf->wmove_end > 0)
-		__mixer_dirty_wait(buf->move_round);
 	void *ptr = SAMPLES_PTR(buf);
 	if (ptr)
 		free_uncached(ptr);
 	memset(buf, 0, sizeof(samplebuffer_t));
 }
 
-void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
-	// Round up the requested length so the resulting byte span is a
-	// multiple of 8 (faster PI/RSP DMA). For power-of-two unit sizes this
-	// is the classic ROUNDUP8_BPS; for arbitrary unit_bytes (VADPCM frames)
-	// we round the unit count up to a multiple of 8.
+/** Physical slot for relative index `rel` (0 = wpos). */
+static inline int samplebuffer_slot(const samplebuffer_t *buf, int rel) {
+	return (buf->head + rel) % buf->size;
+}
+
+/** Move the live window [ridx, widx) to physical slot 0 (rare; large appends). */
+static void samplebuffer_relocate_live(samplebuffer_t *buf) {
 	int ub = samplebuffer_unit_bytes(buf);
+	int ring = buf->size;
+	int live = buf->widx - buf->ridx;
+	uint8_t *base = samplebuffer_base(buf);
+
+	if (live > 0) {
+		// RSP may still be reading this window from a prior mix round.
+		if (buf->last_round)
+			__mixer_round_wait(buf->last_round);
+		int src = samplebuffer_slot(buf, buf->ridx);
+		if (src != 0) {
+			int nbytes = live * ub;
+			if (src + live <= ring) {
+				memmove(base, base + src * ub, nbytes);
+			} else {
+				int first = ring - src;
+				void *tmp = malloc(nbytes);
+				assert(tmp);
+				memcpy(tmp, base + src * ub, first * ub);
+				memcpy((uint8_t*)tmp + first * ub, base, (live - first) * ub);
+				memcpy(base, tmp, nbytes);
+				free(tmp);
+			}
+		}
+		// Keep margin mirror coherent for any live bytes in [0, MARGIN).
+		if (live > 0 && live <= SAMPLEBUFFER_MARGIN_UNITS)
+			memcpy(base + ring * ub, base, live * ub);
+		else if (live > SAMPLEBUFFER_MARGIN_UNITS)
+			memcpy(base + ring * ub, base, SAMPLEBUFFER_MARGIN_UNITS * ub);
+	}
+
+	buf->wpos += buf->ridx;
+	buf->widx = live;
+	buf->ridx = 0;
+	buf->head = 0;
+}
+
+void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
+	samplebuffer_commit(buf);
+
+	int ub = samplebuffer_unit_bytes(buf);
+	int ring = buf->size;
 	int round_len = *wlen;
 	if (buf->unit_bytes) {
 		round_len = ROUND_UP(round_len, 8);
@@ -109,17 +182,18 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 
 	tracef("samplebuffer_get: wpos=%x wlen=%x\n", wpos, *wlen);
 
-	if (buf->widx == 0 || wpos < buf->wpos || wpos > buf->wpos+buf->widx) {
-		tracef("samplebuffer_get: flushing buffer: buf->widx=%x buf->wpos=%x buf->wnext=%x\n", buf->widx, buf->wpos, buf->wnext);
-		bool seeking = wpos != buf->wnext;	
+	if (buf->widx == 0 || wpos < buf->wpos || wpos > buf->wpos + buf->widx) {
+		tracef("samplebuffer_get: seek/flush wpos=%x (had %x+%x)\n", wpos, buf->wpos, buf->widx);
+		bool seeking = (buf->wnext < 0) || (wpos != buf->wnext);
 		samplebuffer_flush(buf);
 		buf->wpos = wpos;
+		buf->head = 0;
 		int len = round_len;
-		// For PCM, keep 2-byte phase so dma_read stays happy.
 		if (!buf->unit_bytes && (buf->wpos * ub) & 1) {
 			buf->wpos--; len++;
 		}
 		buf->wv_read(buf->wave->ctx, buf, buf->wpos, len, seeking);
+		samplebuffer_commit(buf);
 		buf->wnext = buf->wpos + buf->widx;
 	} else {
 		buf->ridx = wpos - buf->wpos;
@@ -135,191 +209,81 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 				missing = ((missing)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
 			}
 			buf->wv_read(buf->wave->ctx, buf, wpos+reuse, missing, false);
+			samplebuffer_commit(buf);
 			buf->wnext = buf->wpos + buf->widx;
 		}
 	}
 
-	assertf(wpos >= buf->wpos && wpos < buf->wpos+buf->widx, 
+	assertf(wpos >= buf->wpos && wpos < buf->wpos+buf->widx,
 		"samplebuffer_get: logic error\n"
 		"wpos:%x buf->wpos:%x buf->widx:%x", wpos, buf->wpos, buf->widx);
 
-	int idx = wpos - buf->wpos;
-	int len = buf->widx - idx;
+	int rel = wpos - buf->wpos;
+	buf->ridx = rel;
+	int len = buf->widx - rel;
 	if (len < *wlen)
 		*wlen = len;
 
-	return (uint8_t*)SAMPLES_PTR(buf) + idx * ub;
+	int slot = samplebuffer_slot(buf, rel);
+	assertf(*wlen <= SAMPLEBUFFER_MARGIN_UNITS || slot + *wlen <= ring,
+		"samplebuffer_get: window %x not contiguous (slot=%x ring=%x)", *wlen, slot, ring);
+	return samplebuffer_base(buf) + slot * ub;
 }
 
 void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
-	// If the requested number of samples doesn't fit the buffer, we
-	// need to make space for it by discarding older samples.
-	if (buf->widx + wlen > buf->size) {
-		// Make space in the buffer by discarding everything up to the
-		// ridx index, which is the first sample that we still need for playback.
-		assertf(buf->widx >= buf->ridx,
-			"samplebuffer_append: invalid consistency check\n"
-			"widx:%x ridx:%x\n", buf->widx, buf->ridx);
-
-		// Rollback ridx until it hits an 8-byte aligned position.
-		int ub = samplebuffer_unit_bytes(buf);
-		int ridx = buf->ridx;
-		while ((ridx * ub) & 7)
-			ridx--;
-		samplebuffer_discard(buf, buf->wpos+ridx);
-	}
+	samplebuffer_commit(buf);
 
 	int ub = samplebuffer_unit_bytes(buf);
-	// PCM buffers must keep a 2-byte phase between wpos and the buffer start
-	// so that dfs read() can DMA directly into it. Frame-based buffers
-	// (unit_bytes != 0, e.g. VADPCM) can legitimately reach any byte phase
-	// (a loop whose length is an odd number of frames does), and their read
-	// callbacks handle unaligned destinations.
+	int ring = buf->size;
 	assertf(buf->unit_bytes || ((buf->wpos * ub) % 2) == 0, "buf->wpos:%x", buf->wpos);
 
-	// If there is still not space in the buffer, it means that the
-	// buffer is too small for this append call. This is a logic error,
-	// so better assert right away.
-	// TODO: in principle, we could bubble this error up to the callers,
-	// let them fill less samples than requested, and obtain some cracks
-	// in the audio. Is it worth it?
-	assertf(buf->widx + wlen <= buf->size,
-		"samplebuffer_append: buffer too small\n"
-		"ridx:%x widx:%x wlen:%x size:%x", buf->ridx, buf->widx, wlen, buf->size);
-
-	// If an undo left a dirty tail that an in-flight RSP producer will still
-	// write, wait for those producers before CPU-writing into the same region.
-	if (buf->wdirty > buf->widx) {
-		__mixer_dirty_wait(buf->dirty_round);
-		buf->wdirty = 0;
+	// Make room by discarding the oldest units past the read cursor.
+	while (buf->widx + wlen > ring) {
+		int drop = buf->widx + wlen - ring;
+		assertf(drop <= buf->ridx,
+			"samplebuffer_append: buffer too small\n"
+			"ridx:%x widx:%x wlen:%x size:%x", buf->ridx, buf->widx, wlen, ring);
+		buf->wpos += drop;
+		buf->widx -= drop;
+		buf->ridx -= drop;
+		buf->head = (buf->head + drop) % ring;
 	}
 
-	// If an RSP-side compaction is pending, the CPU must not overwrite the
-	// stale source region [wmove_start, wmove_end) before the RSP has read
-	// it. Only gate when this append actually reaches into that region.
-	if (buf->wmove_end > 0 && buf->widx + wlen > buf->wmove_start) {
-		__mixer_dirty_wait(buf->move_round);
-		buf->wmove_end = 0;
+	int slot = samplebuffer_slot(buf, buf->widx);
+	// Contiguous write: fit before ring end, or spill into the margin (≤MARGIN).
+	// Codecs that append full frames larger than the margin (Opus, YM) may need
+	// a one-shot relocate of the live window to physical 0 so the write is linear.
+	if (slot + wlen > ring && wlen > SAMPLEBUFFER_MARGIN_UNITS) {
+		assertf(buf->widx - buf->ridx + wlen <= ring,
+			"samplebuffer_append: buffer too small\n"
+			"live:%x wlen:%x size:%x", buf->widx - buf->ridx, wlen, ring);
+		samplebuffer_relocate_live(buf);
+		slot = buf->widx;
+		assert(slot + wlen <= ring);
+	} else if (slot + wlen > ring) {
+		assertf(wlen <= SAMPLEBUFFER_MARGIN_UNITS,
+			"samplebuffer_append: large append %x wraps ring (slot=%x)", wlen, slot);
 	}
 
-	// Track the round that covers whatever producer will write the returned
-	// area (e.g. an RSP VADPCM decode enqueued right after this call).
-	buf->prod_round = __mixer_round_producer();
-
-	void *data = (uint8_t*)SAMPLES_PTR(buf) + buf->widx * ub;
+	buf->pending_slot = slot;
+	buf->pending_len = wlen;
 	buf->widx += wlen;
-	return data;
+	return samplebuffer_base(buf) + slot * ub;
 }
 
 void samplebuffer_undo(samplebuffer_t *buf, int wlen) {
-	tracef("samplebuffer_truncate: wlen=%x\n", wlen);
-	assertf(buf->widx >= wlen, "samplebuffer_append_undo: invalid wlen:%x widx:%x", wlen, buf->widx);
+	samplebuffer_commit(buf);
+	tracef("samplebuffer_undo: wlen=%x\n", wlen);
+	assertf(buf->widx >= wlen, "samplebuffer_undo: invalid wlen:%x widx:%x", wlen, buf->widx);
 	buf->widx -= wlen;
-	// Bytes above the new widx may still be written by an in-flight RSP
-	// producer (e.g. VADPCM decode). Tag them so append waits if needed.
-	buf->wdirty = MAX(buf->wdirty, buf->widx + wlen);
-	buf->dirty_round = __mixer_round_producer();
-}
-
-void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
-	// Compute the index of the first sample that will be preserved (and thus
-	// will be moved to position 0 of the buffer).
-	int idx = wpos - buf->wpos;
-	if (idx <= 0)
-		return;
-	if (idx > buf->widx)
-		idx = buf->widx;
-
-	int ub = samplebuffer_unit_bytes(buf);
-
-	// Align the discard position down so the byte offset is a multiple of 8.
-	// For power-of-two unit sizes this matches the legacy (8>>bps) mask; for
-	// arbitrary unit_bytes, step back one unit at a time.
-	if (buf->unit_bytes) {
-		while (idx > 0 && ((idx * ub) & 7))
-			idx--;
-	} else {
-		int bps = SAMPLES_BPS_SHIFT(buf);
-		idx &= ~((8 >> bps) - 1);
-	}
-	if (idx == 0)
-		return;
-
-	tracef("samplebuffer_discard: wpos=%x idx:%x buf->wpos=%x buf->widx=%x\n", wpos, idx, buf->wpos, buf->widx);
-	int kept_bytes = (buf->widx - idx) * ub;
-	if (kept_bytes > 0) {		
-		tracef("samplebuffer_discard: compacting buffer, moving 0x%x bytes\n", kept_bytes);
-
-		uint8_t *src = (uint8_t*)SAMPLES_PTR(buf) + idx * ub;
-		uint8_t *dst = SAMPLES_PTR(buf);
-		assert(((uint32_t)dst & 7) == 0);
-
-		// Fast path: enqueue an RSP-side memmove in the highpri queue. Being
-		// a regular queue command, it executes in-order after the in-flight
-		// decode/mix commands that still reference the old buffer layout, so
-		// no CPU wait is needed. It requires the kept size to be a multiple
-		// of 8 bytes (RSP DMA granularity): we cannot round it up like the
-		// CPU copy below does, because the bytes just after the kept region
-		// belong to the append area that the CPU may write in the meantime.
-		if ((kept_bytes & 7) == 0 && __mixer_memmove_async(dst, src, kept_bytes)) {
-			// Record the stale source region (in physical buffer slots):
-			// CPU appends must not overwrite it until the RSP executes the
-			// move (see samplebuffer_append).
-			int start = idx, end = buf->widx;
-			if (buf->wmove_end > 0) {
-				start = MIN(start, buf->wmove_start);
-				end = MAX(end, buf->wmove_end);
-			}
-			buf->wmove_start = start;
-			buf->wmove_end = end;
-			buf->move_round = __mixer_round_producer();
-		} else {
-			// Slow path (kept size not a multiple of 8 bytes, which can
-			// happen after samplebuffer_undo truncates the buffer): copy
-			// with the CPU. Wait until nothing in-flight references the
-			// buffer anymore: a pending compaction move, producers that may
-			// still be writing the kept region, and mix rounds that read
-			// the old layout.
-			if (buf->wmove_end > 0) {
-				__mixer_dirty_wait(buf->move_round);
-				buf->wmove_end = 0;
-			}
-			__mixer_dirty_wait(buf->prod_round);
-			__mixer_round_wait(buf->last_round);
-
-			// Optimized copy of samples. We work on uncached memory directly
-			// so that we don't need to flush, and use only 64-bits ops. We
-			// round up to a multiple of 8 the amount of bytes: it doesn't
-			// matter if we copy a bit more, because this copy is synchronous
-			// (nothing else can be writing the buffer while it runs).
-			// This has been benchmarked to be faster than memmove() + cache flush.
-			int copy_bytes = ROUND_UP(kept_bytes, 8);
-			u_uint64_t *src64 = (u_uint64_t*)src;
-			uint64_t *dst64 = (uint64_t*)dst;
-			for (int i=0;i<copy_bytes/8;i++)
-				*dst64++ = *src64++;
-		}
-	}
-
-	buf->wpos += idx;
-	buf->widx -= idx;
-	buf->ridx -= idx;
-	if (buf->ridx < 0)
-		buf->ridx = 0;
-	if (buf->wdirty > 0) {
-		buf->wdirty -= idx;
-		if (buf->wdirty < 0)
-			buf->wdirty = 0;
-	}
+	if (buf->wnext >= 0)
+		buf->wnext = buf->wpos + buf->widx;
 }
 
 void samplebuffer_flush(samplebuffer_t *buf) {
+	samplebuffer_commit(buf);
 	buf->wpos = buf->widx = buf->ridx = 0;
+	buf->head = 0;
 	buf->wnext = -1;
-	buf->wdirty = 0;
-	// A pending RSP compaction still reads/writes the whole [0, wmove_end)
-	// area: extend the protected region down to 0 so that the first append
-	// after the flush waits for the move to complete.
-	if (buf->wmove_end > 0)
-		buf->wmove_start = 0;
+	buf->pending_len = 0;
 }

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -13,6 +13,7 @@
 #include "dma.h"
 #include "utils.h"
 #include "debug.h"
+#include "profile.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -180,7 +181,19 @@ static void samplebuffer_relocate_live(samplebuffer_t *buf) {
 	buf->head = 0;
 }
 
+/** @brief Units that #samplebuffer_prefetch keeps ready ahead of the mixer. */
+#define SAMPLEBUFFER_PREFETCH_UNITS      SAMPLEBUFFER_MARGIN_UNITS
+
+/** @brief Units left ahead that trigger a refill.
+ *
+ * A WaveformRead costs mostly per call, so refilling late (in bigger chunks)
+ * is cheaper; refilling too late means the mixer has to fetch synchronously
+ * and wait for the transfer. */
+#define SAMPLEBUFFER_PREFETCH_LOW_UNITS  32
+
 void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
+	void *ret = NULL;
+	PROFILE_SCOPE(PS_SBUF_GET) {
 	samplebuffer_commit(buf);
 
 	int ub = samplebuffer_unit_bytes(buf);
@@ -221,6 +234,8 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 				int bps = SAMPLES_BPS_SHIFT(buf);
 				missing = ((missing)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
 			}
+			// Free space without discarding past the live read cursor.
+			missing = MIN(missing, ring - (buf->widx - buf->ridx));
 			buf->wv_read(buf->wave->ctx, buf, wpos+reuse, missing, false);
 			samplebuffer_commit(buf);
 			buf->wnext = buf->wpos + buf->widx;
@@ -240,7 +255,47 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 	int slot = samplebuffer_slot(buf, rel);
 	assertf(*wlen <= SAMPLEBUFFER_MARGIN_UNITS || slot + *wlen <= ring,
 		"samplebuffer_get: window %x not contiguous (slot=%x ring=%x)", *wlen, slot, ring);
-	return samplebuffer_base(buf) + slot * ub;
+	ret = samplebuffer_base(buf) + slot * ub;
+	}
+	return ret;
+}
+
+void samplebuffer_prefetch(samplebuffer_t *buf, int wpos, int wlen) {
+	if (!buf->wave || !buf->wv_read || !buf->wave->async_read ||
+		buf->widx == 0 || buf->wnext < 0)
+		return;
+	samplebuffer_commit(buf);
+
+	// Only extend the current stream: on a seek the ring is flushed, so
+	// anything fetched now would be thrown away.
+	if (wpos < buf->wpos || wpos > buf->wnext)
+		return;
+	// Fill back up to the watermark, so that one transfer covers several rounds.
+	int ahead = buf->wnext - wpos;
+	int missing = MAX(SAMPLEBUFFER_PREFETCH_UNITS, wlen) - ahead;
+	if (missing <= 0 ||
+		(ahead > SAMPLEBUFFER_PREFETCH_LOW_UNITS && ahead >= wlen))
+		return;
+	if (buf->unit_bytes)
+		missing = ROUND_UP(missing, 8);
+	else {
+		int bps = SAMPLES_BPS_SHIFT(buf);
+		missing = ((missing)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
+	}
+	// Never ask for more than a margin: readers split bigger requests into
+	// several appends, and since a buffer tracks a single in-flight transfer,
+	// the second append would have to wait for the first one here.
+	missing = MIN(missing, SAMPLEBUFFER_MARGIN_UNITS);
+	// Never fetch into space that a live window still needs.
+	missing = MIN(missing, buf->size - (buf->widx - buf->ridx));
+	if (missing <= 0)
+		return;
+
+	// Leave the transfer in flight: samplebuffer_get will commit and sync it.
+	PROFILE_SCOPE(PS_SBUF_GET) {
+		buf->wv_read(buf->wave->ctx, buf, buf->wnext, missing, false);
+	}
+	buf->wnext = buf->wpos + buf->widx;
 }
 
 void* samplebuffer_append(samplebuffer_t *buf, int wlen) {

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -10,6 +10,7 @@
 #include "samplebuffer.h"
 #include "n64sys.h"
 #include "n64types.h"
+#include "dma.h"
 #include "utils.h"
 #include "debug.h"
 #include <stdlib.h>
@@ -28,6 +29,13 @@ static inline uint8_t *samplebuffer_base(const samplebuffer_t *buf) {
 	return SAMPLES_PTR(buf);
 }
 
+void samplebuffer_dma_wait(samplebuffer_t *buf) {
+	if (buf->dma_ticket) {
+		dma_wait_finished(buf->dma_ticket);
+		buf->dma_ticket = 0;
+	}
+}
+
 /** Commit a pending append that may have spilled into the tail margin. */
 static void samplebuffer_commit(samplebuffer_t *buf) {
 	if (buf->pending_len <= 0)
@@ -36,13 +44,16 @@ static void samplebuffer_commit(samplebuffer_t *buf) {
 	int ring = buf->size;
 	int slot = buf->pending_slot;
 	int len = buf->pending_len;
-	// Mirror bytes written into physical [0, MARGIN) out to the tail margin.
+	// Mirror needs the DMA to have finished; otherwise leave the ticket for
+	// the mixer to wait on before the RSP consumes the window.
 	if (slot < SAMPLEBUFFER_MARGIN_UNITS) {
+		samplebuffer_dma_wait(buf);
 		int n = MIN(len, SAMPLEBUFFER_MARGIN_UNITS - slot);
 		memcpy(samplebuffer_base(buf) + (ring + slot) * ub,
 		       samplebuffer_base(buf) + slot * ub,
 		       n * ub);
 	} else if (slot + len > ring) {
+		samplebuffer_dma_wait(buf);
 		// Write crossed the ring end into the margin: mirror the overflow
 		// back to the start (producer wrote into the margin area).
 		int overflow = slot + len - ring;
@@ -117,6 +128,7 @@ bool samplebuffer_is_inited(samplebuffer_t *buf)
 }
 
 void samplebuffer_close(samplebuffer_t *buf) {
+	samplebuffer_dma_wait(buf);
 	void *ptr = SAMPLES_PTR(buf);
 	if (ptr)
 		free_uncached(ptr);
@@ -136,6 +148,7 @@ static void samplebuffer_relocate_live(samplebuffer_t *buf) {
 	uint8_t *base = samplebuffer_base(buf);
 
 	if (live > 0) {
+		samplebuffer_dma_wait(buf);
 		// RSP may still be reading this window from a prior mix round.
 		if (buf->last_round)
 			__mixer_round_wait(buf->last_round);
@@ -282,6 +295,7 @@ void samplebuffer_undo(samplebuffer_t *buf, int wlen) {
 
 void samplebuffer_flush(samplebuffer_t *buf) {
 	samplebuffer_commit(buf);
+	samplebuffer_dma_wait(buf);
 	buf->wpos = buf->widx = buf->ridx = 0;
 	buf->head = 0;
 	buf->wnext = -1;

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -70,6 +70,9 @@ bool samplebuffer_is_inited(samplebuffer_t *buf)
 }
 
 void samplebuffer_close(samplebuffer_t *buf) {
+	// A pending RSP compaction still references the memory we're about to free.
+	if (buf->wmove_end > 0)
+		__mixer_dirty_wait(buf->move_round);
 	void *ptr = SAMPLES_PTR(buf);
 	if (ptr)
 		free_uncached(ptr);
@@ -194,6 +197,18 @@ void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
 		buf->wdirty = 0;
 	}
 
+	// If an RSP-side compaction is pending, the CPU must not overwrite the
+	// stale source region [wmove_start, wmove_end) before the RSP has read
+	// it. Only gate when this append actually reaches into that region.
+	if (buf->wmove_end > 0 && buf->widx + wlen > buf->wmove_start) {
+		__mixer_dirty_wait(buf->move_round);
+		buf->wmove_end = 0;
+	}
+
+	// Track the round that covers whatever producer will write the returned
+	// area (e.g. an RSP VADPCM decode enqueued right after this call).
+	buf->prod_round = __mixer_round_producer();
+
 	void *data = SAMPLES_PTR(buf) + (buf->widx << SAMPLES_BPS_SHIFT(buf));
 	buf->widx += wlen;
 	return data;
@@ -206,7 +221,7 @@ void samplebuffer_undo(samplebuffer_t *buf, int wlen) {
 	// Bytes above the new widx may still be written by an in-flight RSP
 	// producer (e.g. VADPCM decode). Tag them so append waits if needed.
 	buf->wdirty = MAX(buf->wdirty, buf->widx + wlen);
-	buf->dirty_round = __mixer_round_current();
+	buf->dirty_round = __mixer_round_producer();
 }
 
 void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
@@ -218,46 +233,70 @@ void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
 	if (idx > buf->widx)
 		idx = buf->widx;
 
-	// Make sure moving this sample at the beginning of the buffer doesn't change
-	// the 2-byte phase of the waveform address. This is not strictly required,
-	// but it helps waveform implementations that want to use dma_read().
-	if ((idx << SAMPLES_BPS_SHIFT(buf)) & 1) {
-		idx--;
-		if (idx == 0)
-			return;
-	}
+	int bps = SAMPLES_BPS_SHIFT(buf);
+
+	// Align the discard position down to 8 bytes. This preserves the 2-byte
+	// phase of the waveform address (which helps waveform implementations
+	// that want to use dma_read()), and additionally keeps the source of the
+	// compaction move 8-byte aligned, as required by the RSP fast path below.
+	idx &= ~((8 >> bps) - 1);
+	if (idx == 0)
+		return;
 
 	tracef("samplebuffer_discard: wpos=%x idx:%x buf->wpos=%x buf->widx=%x\n", wpos, idx, buf->wpos, buf->widx);
-	int kept_bytes = (buf->widx - idx) << SAMPLES_BPS_SHIFT(buf);
+	int kept_bytes = (buf->widx - idx) << bps;
 	if (kept_bytes > 0) {		
 		tracef("samplebuffer_discard: compacting buffer, moving 0x%x bytes\n", kept_bytes);
 
-		// Bytes being moved may still be read by in-flight mix rounds (and
-		// written by in-flight decode commands). Wait until those rounds are
-		// done. Callers arrange for this to be virtually always a no-op
-		// (proactive compaction at frame start via mixer_reclaim).
-		__mixer_round_wait(buf->last_round);
-
-		// FIXME: this violates the zero-copy principle as we do a memmove here.
-		// The problem is that the RSP ucode doesn't fully support a circular
-		// buffer of samples (and also our samplebuffer_t isn't structured for
-		// this). Luckily, this is a rare chance and in most cases just a few
-		// samples are moved (in the normal playback case, it should be just 1,
-		// as in general a sample could be used more than once for resampling).
-		uint8_t *src = SAMPLES_PTR(buf) + (idx << SAMPLES_BPS_SHIFT(buf));
+		uint8_t *src = SAMPLES_PTR(buf) + (idx << bps);
 		uint8_t *dst = SAMPLES_PTR(buf);
 		assert(((uint32_t)dst & 7) == 0);
 
-		// Optimized copy of samples. We work on uncached memory directly
-		// so that we don't need to flush, and use only 64-bits ops. We round up
-		// to a multiple of 8 the amount of bytes, as it doesn't matter if we
-		// copy more, as long as we're fast.
-		// This has been benchmarked to be faster than memmove() + cache flush.
-		kept_bytes = ROUND_UP(kept_bytes, 8);
-		u_uint64_t *src64 = (u_uint64_t*)src;
-		uint64_t *dst64 = (uint64_t*)dst;
-		for (int i=0;i<kept_bytes/8;i++)
-			*dst64++ = *src64++;
+		// Fast path: enqueue an RSP-side memmove in the highpri queue. Being
+		// a regular queue command, it executes in-order after the in-flight
+		// decode/mix commands that still reference the old buffer layout, so
+		// no CPU wait is needed. It requires the kept size to be a multiple
+		// of 8 bytes (RSP DMA granularity): we cannot round it up like the
+		// CPU copy below does, because the bytes just after the kept region
+		// belong to the append area that the CPU may write in the meantime.
+		if ((kept_bytes & 7) == 0 && __mixer_memmove_async(dst, src, kept_bytes)) {
+			// Record the stale source region (in physical buffer slots):
+			// CPU appends must not overwrite it until the RSP executes the
+			// move (see samplebuffer_append).
+			int start = idx, end = buf->widx;
+			if (buf->wmove_end > 0) {
+				start = MIN(start, buf->wmove_start);
+				end = MAX(end, buf->wmove_end);
+			}
+			buf->wmove_start = start;
+			buf->wmove_end = end;
+			buf->move_round = __mixer_round_producer();
+		} else {
+			// Slow path (kept size not a multiple of 8 bytes, which can
+			// happen after samplebuffer_undo truncates the buffer): copy
+			// with the CPU. Wait until nothing in-flight references the
+			// buffer anymore: a pending compaction move, producers that may
+			// still be writing the kept region, and mix rounds that read
+			// the old layout.
+			if (buf->wmove_end > 0) {
+				__mixer_dirty_wait(buf->move_round);
+				buf->wmove_end = 0;
+			}
+			__mixer_dirty_wait(buf->prod_round);
+			__mixer_round_wait(buf->last_round);
+
+			// Optimized copy of samples. We work on uncached memory directly
+			// so that we don't need to flush, and use only 64-bits ops. We
+			// round up to a multiple of 8 the amount of bytes: it doesn't
+			// matter if we copy a bit more, because this copy is synchronous
+			// (nothing else can be writing the buffer while it runs).
+			// This has been benchmarked to be faster than memmove() + cache flush.
+			int copy_bytes = ROUND_UP(kept_bytes, 8);
+			u_uint64_t *src64 = (u_uint64_t*)src;
+			uint64_t *dst64 = (uint64_t*)dst;
+			for (int i=0;i<copy_bytes/8;i++)
+				*dst64++ = *src64++;
+		}
 	}
 
 	buf->wpos += idx;
@@ -276,4 +315,9 @@ void samplebuffer_flush(samplebuffer_t *buf) {
 	buf->wpos = buf->widx = buf->ridx = 0;
 	buf->wnext = -1;
 	buf->wdirty = 0;
+	// A pending RSP compaction still reads/writes the whole [0, wmove_end)
+	// area: extend the protected region down to 0 so that the first append
+	// after the flush waits for the move to complete.
+	if (buf->wmove_end > 0)
+		buf->wmove_start = 0;
 }

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -50,11 +50,25 @@ void samplebuffer_set_bps(samplebuffer_t *buf, int bits_per_sample) {
 	assertf(buf->widx == 0 && buf->ridx == 0 && buf->wpos == 0,
 		"samplebuffer_set_bps can only be called on an empty samplebuffer");
 
-	int nbytes = buf->size << SAMPLES_BPS_SHIFT(buf);
+	int nbytes = buf->size * samplebuffer_unit_bytes(buf);
 
 	int bps = bits_per_sample == 8 ? 0 : (bits_per_sample == 16 ? 1 : 2);
+	buf->unit_bytes = 0;
 	buf->ptr_and_flags = SAMPLES_PTR_MAKE(SAMPLES_PTR(buf), bps);
 	buf->size = nbytes >> bps;
+}
+
+void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes) {
+	assert(unit_bytes > 0);
+	assertf(buf->widx == 0 && buf->ridx == 0 && buf->wpos == 0,
+		"samplebuffer_set_unit_bytes can only be called on an empty samplebuffer");
+
+	int nbytes = buf->size * samplebuffer_unit_bytes(buf);
+	buf->unit_bytes = (uint8_t)unit_bytes;
+	// Keep a dummy bps of 0 (1 byte) in the tagged pointer; real sizing
+	// comes from unit_bytes.
+	buf->ptr_and_flags = SAMPLES_PTR_MAKE(SAMPLES_PTR(buf), 0);
+	buf->size = nbytes / unit_bytes;
 }
 
 void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read) {
@@ -80,64 +94,47 @@ void samplebuffer_close(samplebuffer_t *buf) {
 }
 
 void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
-	// ROUNDUP8_BPS rounds up the specified number of samples
-	// (given the bps shift) so that they span an exact multiple
-	// of 8 bytes. This will be applied to the number of samples
-	// requested to wv_read(), to make sure that we always
-	// keep the sample buffer filled with a multiple of 8 bytes.
-	// This is not strictly required because dma_read() can do wonders,
-	// but it results in slightly faster DMA transfers and its almost free
-	// to do here.
-	/// @cond
-	#define ROUNDUP8_BPS(nsamples, bps) \
-		(((nsamples)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps)))
-	/// @endcond
-
-	int bps = SAMPLES_BPS_SHIFT(buf);
+	// Round up the requested length so the resulting byte span is a
+	// multiple of 8 (faster PI/RSP DMA). For power-of-two unit sizes this
+	// is the classic ROUNDUP8_BPS; for arbitrary unit_bytes (VADPCM frames)
+	// we round the unit count up to a multiple of 8.
+	int ub = samplebuffer_unit_bytes(buf);
+	int round_len = *wlen;
+	if (buf->unit_bytes) {
+		round_len = ROUND_UP(round_len, 8);
+	} else {
+		int bps = SAMPLES_BPS_SHIFT(buf);
+		round_len = ((round_len)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
+	}
 
 	tracef("samplebuffer_get: wpos=%x wlen=%x\n", wpos, *wlen);
 
 	if (buf->widx == 0 || wpos < buf->wpos || wpos > buf->wpos+buf->widx) {
-		// If the requested position is totally outside
-		// the existing range (and not even consecutive),
-		// Flush the buffer and decode from scratch.
-		// Normally this is because of seeking, but might
-		// also be just because we discarded all the contents
-		// of the buffer, so be sure to set seeking only if
-		// the position is different from what we expected.
 		tracef("samplebuffer_get: flushing buffer: buf->widx=%x buf->wpos=%x buf->wnext=%x\n", buf->widx, buf->wpos, buf->wnext);
 		bool seeking = wpos != buf->wnext;	
 		samplebuffer_flush(buf);
 		buf->wpos = wpos;
-		// Avoid setting a position that is odd, because it would case a
-		// 2-byte phase change in the sample buffer, which would make 
-		// impossible to call dma_read.
-		int len = *wlen;
-		if ((buf->wpos << bps) & 1) {
+		int len = round_len;
+		// For PCM, keep 2-byte phase so dma_read stays happy.
+		if (!buf->unit_bytes && (buf->wpos * ub) & 1) {
 			buf->wpos--; len++;
 		}
-		buf->wv_read(buf->wave->ctx, buf, buf->wpos, ROUNDUP8_BPS(len, bps), seeking);
+		buf->wv_read(buf->wave->ctx, buf, buf->wpos, len, seeking);
 		buf->wnext = buf->wpos + buf->widx;
 	} else {
-		// Record first sample that we still need to keep in the sample
-		// buffer. This is important to do now because decoder_read might
-		// push more samples than required into the buffer and force
-		// to compact the buffer. We thus need to know which samples
-		// are still required.
 		buf->ridx = wpos - buf->wpos;
-
-		// Part of the requested samples are already in the sample buffer.
-		// Check how many we can reuse. For instance, if there's a waveform
-		// loop, the whole loop might already be in the sample buffer, so
-		// no further decoding is necessary.
 		int reuse = buf->wpos + buf->widx - wpos;
-
-		// If the existing samples are not enough, read the missing
-		// through the callback.
 		if (reuse < *wlen) {
 			tracef("samplebuffer_get: read missing: reuse=%x wpos=%x wlen=%x\n", reuse, wpos, *wlen);
 			assertf(wpos+reuse == buf->wnext, "wpos:%x reuse:%x buf->wnext:%x", wpos, reuse, buf->wnext);
-			buf->wv_read(buf->wave->ctx, buf, wpos+reuse, ROUNDUP8_BPS(*wlen-reuse, bps), false);
+			int missing = *wlen - reuse;
+			if (buf->unit_bytes)
+				missing = ROUND_UP(missing, 8);
+			else {
+				int bps = SAMPLES_BPS_SHIFT(buf);
+				missing = ((missing)+((8>>(bps))-1)) >> (3-(bps)) << (3-(bps));
+			}
+			buf->wv_read(buf->wave->ctx, buf, wpos+reuse, missing, false);
 			buf->wnext = buf->wpos + buf->widx;
 		}
 	}
@@ -147,15 +144,11 @@ void* samplebuffer_get(samplebuffer_t *buf, int wpos, int *wlen) {
 		"wpos:%x buf->wpos:%x buf->widx:%x", wpos, buf->wpos, buf->widx);
 
 	int idx = wpos - buf->wpos;
-
-	// If the sample buffer contains less samples than requested,
-	// report that by updating *wlen. This will cause cracks in the
-	// audio as silence will be inserted by the mixer.
 	int len = buf->widx - idx;
 	if (len < *wlen)
 		*wlen = len;
 
-	return SAMPLES_PTR(buf) + (idx << SAMPLES_BPS_SHIFT(buf));
+	return (uint8_t*)SAMPLES_PTR(buf) + idx * ub;
 }
 
 void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
@@ -168,17 +161,21 @@ void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
 			"samplebuffer_append: invalid consistency check\n"
 			"widx:%x ridx:%x\n", buf->widx, buf->ridx);
 
-		// Rollback ridx until it hit a 8-byte aligned position.
-		// This preserves the guarantee that samplebuffer_append
-		// will always return a 8-byte aligned pointer, which is
-		// good for DMA purposes.
+		// Rollback ridx until it hits an 8-byte aligned position.
+		int ub = samplebuffer_unit_bytes(buf);
 		int ridx = buf->ridx;
-		while ((ridx << SAMPLES_BPS_SHIFT(buf)) & 7)
+		while ((ridx * ub) & 7)
 			ridx--;
 		samplebuffer_discard(buf, buf->wpos+ridx);
 	}
 
-	assertf(((buf->wpos<< SAMPLES_BPS_SHIFT(buf)) % 2) == 0, "buf->wpos:%x", buf->wpos);
+	int ub = samplebuffer_unit_bytes(buf);
+	// PCM buffers must keep a 2-byte phase between wpos and the buffer start
+	// so that dfs read() can DMA directly into it. Frame-based buffers
+	// (unit_bytes != 0, e.g. VADPCM) can legitimately reach any byte phase
+	// (a loop whose length is an odd number of frames does), and their read
+	// callbacks handle unaligned destinations.
+	assertf(buf->unit_bytes || ((buf->wpos * ub) % 2) == 0, "buf->wpos:%x", buf->wpos);
 
 	// If there is still not space in the buffer, it means that the
 	// buffer is too small for this append call. This is a logic error,
@@ -209,7 +206,7 @@ void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
 	// area (e.g. an RSP VADPCM decode enqueued right after this call).
 	buf->prod_round = __mixer_round_producer();
 
-	void *data = SAMPLES_PTR(buf) + (buf->widx << SAMPLES_BPS_SHIFT(buf));
+	void *data = (uint8_t*)SAMPLES_PTR(buf) + buf->widx * ub;
 	buf->widx += wlen;
 	return data;
 }
@@ -233,22 +230,27 @@ void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
 	if (idx > buf->widx)
 		idx = buf->widx;
 
-	int bps = SAMPLES_BPS_SHIFT(buf);
+	int ub = samplebuffer_unit_bytes(buf);
 
-	// Align the discard position down to 8 bytes. This preserves the 2-byte
-	// phase of the waveform address (which helps waveform implementations
-	// that want to use dma_read()), and additionally keeps the source of the
-	// compaction move 8-byte aligned, as required by the RSP fast path below.
-	idx &= ~((8 >> bps) - 1);
+	// Align the discard position down so the byte offset is a multiple of 8.
+	// For power-of-two unit sizes this matches the legacy (8>>bps) mask; for
+	// arbitrary unit_bytes, step back one unit at a time.
+	if (buf->unit_bytes) {
+		while (idx > 0 && ((idx * ub) & 7))
+			idx--;
+	} else {
+		int bps = SAMPLES_BPS_SHIFT(buf);
+		idx &= ~((8 >> bps) - 1);
+	}
 	if (idx == 0)
 		return;
 
 	tracef("samplebuffer_discard: wpos=%x idx:%x buf->wpos=%x buf->widx=%x\n", wpos, idx, buf->wpos, buf->widx);
-	int kept_bytes = (buf->widx - idx) << bps;
+	int kept_bytes = (buf->widx - idx) * ub;
 	if (kept_bytes > 0) {		
 		tracef("samplebuffer_discard: compacting buffer, moving 0x%x bytes\n", kept_bytes);
 
-		uint8_t *src = SAMPLES_PTR(buf) + (idx << bps);
+		uint8_t *src = (uint8_t*)SAMPLES_PTR(buf) + idx * ub;
 		uint8_t *dst = SAMPLES_PTR(buf);
 		assert(((uint32_t)dst & 7) == 0);
 

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -21,11 +21,13 @@
 /** @brief Set to 1 to activate debug logs */
 #define MIXER_TRACE   0
 
+///@cond
 #if MIXER_TRACE
 #define tracef(fmt, ...)  debugf(fmt, ##__VA_ARGS__)
 #else
 #define tracef(fmt, ...)  ({ })
 #endif
+///@endcond
 
 static inline uint8_t *samplebuffer_base(const samplebuffer_t *buf) {
 	return SAMPLES_PTR(buf);

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -6,12 +6,11 @@
  */
 
 #include "mixer.h"
+#include "mixer_internal.h"
 #include "samplebuffer.h"
 #include "n64sys.h"
 #include "n64types.h"
 #include "utils.h"
-#include "rspq.h"
-#include "../rspq/rspq_internal.h"
 #include "debug.h"
 #include <string.h>
 
@@ -188,6 +187,13 @@ void* samplebuffer_append(samplebuffer_t *buf, int wlen) {
 		"samplebuffer_append: buffer too small\n"
 		"ridx:%x widx:%x wlen:%x size:%x", buf->ridx, buf->widx, wlen, buf->size);
 
+	// If an undo left a dirty tail that an in-flight RSP producer will still
+	// write, wait for those producers before CPU-writing into the same region.
+	if (buf->wdirty > buf->widx) {
+		__mixer_dirty_wait(buf->dirty_round);
+		buf->wdirty = 0;
+	}
+
 	void *data = SAMPLES_PTR(buf) + (buf->widx << SAMPLES_BPS_SHIFT(buf));
 	buf->widx += wlen;
 	return data;
@@ -197,6 +203,10 @@ void samplebuffer_undo(samplebuffer_t *buf, int wlen) {
 	tracef("samplebuffer_truncate: wlen=%x\n", wlen);
 	assertf(buf->widx >= wlen, "samplebuffer_append_undo: invalid wlen:%x widx:%x", wlen, buf->widx);
 	buf->widx -= wlen;
+	// Bytes above the new widx may still be written by an in-flight RSP
+	// producer (e.g. VADPCM decode). Tag them so append waits if needed.
+	buf->wdirty = MAX(buf->wdirty, buf->widx + wlen);
+	buf->dirty_round = __mixer_round_current();
 }
 
 void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
@@ -222,14 +232,11 @@ void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
 	if (kept_bytes > 0) {		
 		tracef("samplebuffer_discard: compacting buffer, moving 0x%x bytes\n", kept_bytes);
 
-		// Samples are normally generated via RSP. Before moving them with the CPU,
-		// we must be sure the RSP is done with.
-		// FIXME: this could be avoided with a RSP memmove command, but it remains
-		// to be seen what is more efficient.
-		bool highpri = rspq_in_highpri();
-		if (highpri) rspq_highpri_end();
-		rspq_highpri_sync();
-		if (highpri) rspq_highpri_begin();
+		// Bytes being moved may still be read by in-flight mix rounds (and
+		// written by in-flight decode commands). Wait until those rounds are
+		// done. Callers arrange for this to be virtually always a no-op
+		// (proactive compaction at frame start via mixer_reclaim).
+		__mixer_round_wait(buf->last_round);
 
 		// FIXME: this violates the zero-copy principle as we do a memmove here.
 		// The problem is that the RSP ucode doesn't fully support a circular
@@ -258,9 +265,15 @@ void samplebuffer_discard(samplebuffer_t *buf, int wpos) {
 	buf->ridx -= idx;
 	if (buf->ridx < 0)
 		buf->ridx = 0;
+	if (buf->wdirty > 0) {
+		buf->wdirty -= idx;
+		if (buf->wdirty < 0)
+			buf->wdirty = 0;
+	}
 }
 
 void samplebuffer_flush(samplebuffer_t *buf) {
 	buf->wpos = buf->widx = buf->ridx = 0;
 	buf->wnext = -1;
+	buf->wdirty = 0;
 }

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -35,9 +35,6 @@
 /** ID of a WAVX file (big-endian WAV) */
 #define WAV_RIFX_ID   "RIFX"
 
-/** @brief Profile of DMA usage by WAV64, used for debugging purposes. */
-int64_t __wav64_profile_dma = 0;
-
 /** @brief None compression init function */
 static void wav64_none_init(wav64_t *wav, int state_size);
 /** @brief None compression get_bitrate function */
@@ -60,13 +57,16 @@ static wav64_compression_t algos[WAV64_NUM_FORMATS] = {
 };
 
 static void raw_waveform_read(samplebuffer_t *sbuf, int current_fd, int wpos, int wlen, int bps) {
-	uint8_t* ram_addr = (uint8_t*)samplebuffer_append(sbuf, wlen);
-	int bytes = wlen << bps;
+	while (wlen > 0) {
+		int n = MIN(wlen, SAMPLEBUFFER_MARGIN_UNITS);
+		uint8_t* ram_addr = (uint8_t*)samplebuffer_append(sbuf, n);
+		int bytes = n << bps;
 
-	// FIXME: remove CachedAddr() when read() supports uncached addresses
-	uint32_t t0 = TICKS_READ();
-	read(current_fd, CachedAddr(ram_addr), bytes);
-	__wav64_profile_dma += TICKS_READ() - t0;
+		// FIXME: remove CachedAddr() when read() supports uncached addresses
+		read(current_fd, CachedAddr(ram_addr), bytes);
+		wlen -= n;
+		wpos += n;
+	}
 }
 
 static void wav64_none_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
@@ -79,21 +79,14 @@ static void wav64_none_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen,
 	raw_waveform_read(sbuf, wav->st->current_fd, wpos, wlen, bps);
 }
 
-static void wav64_none_read_memcopy(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
-	wav64_t *wav = (wav64_t*)sbuf->wave;
-	int bps = (wav->wave.bits == 8 ? 0 : 1) + (wav->wave.channels == 2 ? 1 : 0);
-	
-	uint8_t* src_addr = wav->st->samples + (wpos << bps);
-	uint8_t* dst_addr = (uint8_t*)samplebuffer_append(sbuf, wlen);
-	memcpy(dst_addr, src_addr, wlen << bps);
-}
-
 static void wav64_none_init(wav64_t *wav, int state_size) {
-	// Initialize none compression. Setup read callback
+	// Initialize none compression. Setup read callback for streaming;
+	// preloaded waveforms set wave->mem and need no read callback.
 	if (!wav->st->samples) {
 		wav->wave.read = wav64_none_read;
 	} else {
-		wav->wave.read = wav64_none_read_memcopy;
+		wav->wave.read = NULL;
+		wav->wave.mem = wav->st->samples;
 	}
 	// Also clear start callback (needed in the preloading codepath)
 	wav->wave.start = NULL;
@@ -137,7 +130,7 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 		assertf(0, "wav64 %s: invalid ID: %02x%02x%02x%02x\n",
 			file_name, head.id[0], head.id[1], head.id[2], head.id[3]);
 	}
-	assertf(head.version == 6, "wav64 %s: invalid version: %02x\n",
+	assertf(head.version == 7, "wav64 %s: invalid version: %02x\n",
 		file_name, head.version);
 	assertf(head.format < WAV64_NUM_FORMATS, "Unknown wav64 compression format %d; corrupted file?", head.format);
 	assertf(head.format < WAV64_NUM_FORMATS && algos[head.format].init != NULL,
@@ -145,14 +138,20 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 
 	int ext_size = head.start_offset - sizeof(wav64_header_t);
 	bool preload = parms->streaming_mode == WAV64_STREAMING_NONE;
-	// Mono VADPCM preloads stay compressed (9 bytes/frame); stereo still
-	// decompresses to PCM and is reinitialized as RAW.
-	bool preload_vadpcm_mono = preload && head.format == WAV64_FORMAT_VADPCM && head.channels == 1;
-	int preload_size = preload_vadpcm_mono
-		? ROUND_UP((head.len / 16) * 9, 16)
+	// VADPCM preloads stay compressed (9 bytes/frame/channel), laid out fully
+	// planar in RDRAM for direct MIX_CHANNEL addressing.
+	bool preload_vadpcm = preload && head.format == WAV64_FORMAT_VADPCM;
+	int nframes = head.len / 16;
+	int preload_size = preload_vadpcm
+		? ROUND_UP(nframes * 9 * head.channels, 16)
 		: ROUND_UP(head.len * head.channels * (head.nbits >> 3), 16);
+	if (preload && !preload_vadpcm) {
+		int ub = head.channels * (head.nbits >> 3);
+		preload_size += SAMPLEBUFFER_MARGIN_UNITS * ub;
+		preload_size = ROUND_UP(preload_size, 16);
+	}
 	int preload_extra_alloc = ROUND_UP(
-		(head.format == WAV64_FORMAT_RAW || preload_vadpcm_mono) ? 0 : 4096, 16);
+		(head.format == WAV64_FORMAT_RAW || preload_vadpcm) ? 0 : 4096, 16);
 	int state_size = ROUND_UP(head.state_size, 16);
 
 	// Calculate required allocation
@@ -160,7 +159,7 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 	heap_size += ROUND_UP(sizeof(wav64_state_t), 16);				// wav64_state_t
 
 	int heap_off_waveform = heap_size;
-	if (!wav) heap_size += ROUND_UP(sizeof(waveform_t), 16);		// Waveform
+	if (!wav) heap_size += ROUND_UP(sizeof(wav64_t), 16);		// wav64_t (wave + st)
 
 	int heap_off_name = heap_size;
 	heap_size += ROUND_UP(strlen(file_name) + 1, 16);				// Filename
@@ -212,25 +211,14 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 		data_cache_hit_invalidate(heap + heap_off_samples, preload_size + preload_extra_alloc + state_size);
 		wav->st->samples = UncachedAddr(heap + heap_off_samples);
 
-		samplebuffer_t sbuf;
-		samplebuffer_init(&sbuf, wav->st->samples, preload_size + preload_extra_alloc, state_size);
 		if (wav->wave.format == WAVEFORM_FORMAT_VADPCM) {
-			int nframes = wav->wave.len / 16;
-			int wlen = nframes;
-			// st->samples is the destination buffer; clear it while reading so the
-			// read callback streams from the file instead of memcpy'ing itself.
-			void *dst = wav->st->samples;
-			wav->st->samples = NULL;
-			samplebuffer_set_unit_bytes(&sbuf, 9);
-			samplebuffer_set_waveform(&sbuf, &wav->wave, wav->wave.read);
-			if (wav->wave.start) wav->wave.start(wav->wave.ctx, &sbuf);
-			samplebuffer_get(&sbuf, 0, &wlen);
-			assertf(wlen == nframes, "wav64: preload failed for %s: wlen=%x/%x", wav->wave.name, wlen, nframes);
-			wav->st->samples = dst;
-			// Drop Huffman tables (frames are plain now); keep ext for codebook.
+			wav64_vadpcm_preload(wav, wav->st->samples);
+			wav->wave.mem = wav->st->samples;
 			if (algos[wav->st->format].close)
 				algos[wav->st->format].close(wav);
 		} else {
+			samplebuffer_t sbuf;
+			samplebuffer_init(&sbuf, wav->st->samples, preload_size + preload_extra_alloc, state_size);
 			int wlen = wav->wave.len;
 			samplebuffer_set_bps(&sbuf, wav->wave.bits * wav->wave.channels);
 			samplebuffer_set_waveform(&sbuf, &wav->wave, wav->wave.read);

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -302,6 +302,10 @@ void wav64_close(wav64_t *wav)
 			mixer_ch_stop(i);
 	}
 
+	// Wait for in-flight mix/decode rounds that may still reference
+	// codebook/state/ext before freeing the heap.
+	__mixer_wait_idle();
+
 	if (algos[wav->st->format].close)
 		algos[wav->st->format].close(wav);
 

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -11,7 +11,6 @@
 #include "wav64_opus_internal.h"
 #include "wav64_ulc_internal.h"
 #include "mixer.h"
-#include "mixer_internal.h"
 #include "dragonfs.h"
 #include "n64sys.h"
 #include "dma.h"
@@ -327,7 +326,7 @@ void wav64_close(wav64_t *wav)
 
 	// Wait for in-flight mix/decode rounds that may still reference
 	// codebook/state/ext before freeing the heap.
-	__mixer_wait_idle();
+	rspq_highpri_sync();
 
 	if (algos[wav->st->format].close)
 		algos[wav->st->format].close(wav);

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -145,8 +145,14 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 
 	int ext_size = head.start_offset - sizeof(wav64_header_t);
 	bool preload = parms->streaming_mode == WAV64_STREAMING_NONE;
-	int preload_size = ROUND_UP(head.len * head.channels * (head.nbits >> 3), 16);
-	int preload_extra_alloc = ROUND_UP(head.format == WAV64_FORMAT_RAW ? 0 : 4096, 16);
+	// Mono VADPCM preloads stay compressed (9 bytes/frame); stereo still
+	// decompresses to PCM and is reinitialized as RAW.
+	bool preload_vadpcm_mono = preload && head.format == WAV64_FORMAT_VADPCM && head.channels == 1;
+	int preload_size = preload_vadpcm_mono
+		? ROUND_UP((head.len / 16) * 9, 16)
+		: ROUND_UP(head.len * head.channels * (head.nbits >> 3), 16);
+	int preload_extra_alloc = ROUND_UP(
+		(head.format == WAV64_FORMAT_RAW || preload_vadpcm_mono) ? 0 : 4096, 16);
 	int state_size = ROUND_UP(head.state_size, 16);
 
 	// Calculate required allocation
@@ -206,26 +212,43 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 		data_cache_hit_invalidate(heap + heap_off_samples, preload_size + preload_extra_alloc + state_size);
 		wav->st->samples = UncachedAddr(heap + heap_off_samples);
 
-		int wlen = wav->wave.len;
 		samplebuffer_t sbuf;
 		samplebuffer_init(&sbuf, wav->st->samples, preload_size + preload_extra_alloc, state_size);
-		samplebuffer_set_bps(&sbuf, wav->wave.bits);
-		samplebuffer_set_waveform(&sbuf, &wav->wave, wav->wave.read);
-		if (wav->wave.start) wav->wave.start(wav->wave.ctx, &sbuf);
-		samplebuffer_get(&sbuf, 0, &wlen);
-		rspq_highpri_sync();
-		assertf(wlen == wav->wave.len, "wav64: preload failed for %s: wlen=%x/%x", wav->wave.name, wlen, wav->wave.len);
+		if (wav->wave.format == WAVEFORM_FORMAT_VADPCM) {
+			int nframes = wav->wave.len / 16;
+			int wlen = nframes;
+			// st->samples is the destination buffer; clear it while reading so the
+			// read callback streams from the file instead of memcpy'ing itself.
+			void *dst = wav->st->samples;
+			wav->st->samples = NULL;
+			samplebuffer_set_unit_bytes(&sbuf, 9);
+			samplebuffer_set_waveform(&sbuf, &wav->wave, wav->wave.read);
+			if (wav->wave.start) wav->wave.start(wav->wave.ctx, &sbuf);
+			samplebuffer_get(&sbuf, 0, &wlen);
+			assertf(wlen == nframes, "wav64: preload failed for %s: wlen=%x/%x", wav->wave.name, wlen, nframes);
+			wav->st->samples = dst;
+			// Drop Huffman tables (frames are plain now); keep ext for codebook.
+			if (algos[wav->st->format].close)
+				algos[wav->st->format].close(wav);
+		} else {
+			int wlen = wav->wave.len;
+			samplebuffer_set_bps(&sbuf, wav->wave.bits * wav->wave.channels);
+			samplebuffer_set_waveform(&sbuf, &wav->wave, wav->wave.read);
+			if (wav->wave.start) wav->wave.start(wav->wave.ctx, &sbuf);
+			samplebuffer_get(&sbuf, 0, &wlen);
+			rspq_highpri_sync();
+			assertf(wlen == wav->wave.len, "wav64: preload failed for %s: wlen=%x/%x", wav->wave.name, wlen, wav->wave.len);
 
-		// Now remove the extra allocation
-		if (algos[wav->st->format].close)
-			algos[wav->st->format].close(wav);
+			if (algos[wav->st->format].close)
+				algos[wav->st->format].close(wav);
 
-		wav->st = realloc(wav->st, heap_off_preload_end);
-		wav->st->ext = NULL;
+			wav->st = realloc(wav->st, heap_off_preload_end);
+			wav->st->ext = NULL;
 
-		// Reinitialize as RAW format after preloading
-		wav->st->format = WAV64_FORMAT_RAW;
-		algos[wav->st->format].init(wav, head.state_size);
+			// Reinitialize as RAW format after preloading
+			wav->st->format = WAV64_FORMAT_RAW;
+			algos[wav->st->format].init(wav, head.state_size);
+		}
 	}
 
 	return wav;

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -65,6 +65,7 @@ static void raw_waveform_read(samplebuffer_t *sbuf, wav64_t *wav, int wpos, int 
 		uint32_t pi_addr = rom + wav->st->base_offset + (wpos << bps);
 
 		if (rom && !(((uint32_t)ram_addr ^ pi_addr) & 1)) {
+			samplebuffer_dma_wait(sbuf);
 			sbuf->dma_ticket = dma_read_async(ram_addr, pi_addr, bytes);
 		} else {
 			lseek(wav->st->current_fd, wav->st->base_offset + (wpos << bps), SEEK_SET);
@@ -88,8 +89,12 @@ static void wav64_none_init(wav64_t *wav, int state_size) {
 	// preloaded waveforms set wave->mem and need no read callback.
 	if (!wav->st->samples) {
 		wav->wave.read = wav64_none_read;
+		// Samples come straight from ROM via async PI DMA; a file on any other
+		// medium is read synchronously instead.
+		wav->wave.async_read = wav->st->rom_base != 0;
 	} else {
 		wav->wave.read = NULL;
+		wav->wave.async_read = false;
 		wav->wave.mem = wav->st->samples;
 	}
 	// Also clear start callback (needed in the preloading codepath)

--- a/src/audio/wav64.c
+++ b/src/audio/wav64.c
@@ -56,14 +56,21 @@ static wav64_compression_t algos[WAV64_NUM_FORMATS] = {
 	},
 };
 
-static void raw_waveform_read(samplebuffer_t *sbuf, int current_fd, int wpos, int wlen, int bps) {
+static void raw_waveform_read(samplebuffer_t *sbuf, wav64_t *wav, int wpos, int wlen, int bps) {
+	uint32_t rom = wav->st->rom_base;
 	while (wlen > 0) {
 		int n = MIN(wlen, SAMPLEBUFFER_MARGIN_UNITS);
 		uint8_t* ram_addr = (uint8_t*)samplebuffer_append(sbuf, n);
 		int bytes = n << bps;
+		uint32_t pi_addr = rom + wav->st->base_offset + (wpos << bps);
 
-		// FIXME: remove CachedAddr() when read() supports uncached addresses
-		read(current_fd, CachedAddr(ram_addr), bytes);
+		if (rom && !(((uint32_t)ram_addr ^ pi_addr) & 1)) {
+			sbuf->dma_ticket = dma_read_async(ram_addr, pi_addr, bytes);
+		} else {
+			lseek(wav->st->current_fd, wav->st->base_offset + (wpos << bps), SEEK_SET);
+			// FIXME: remove CachedAddr() when read() supports uncached addresses
+			read(wav->st->current_fd, CachedAddr(ram_addr), bytes);
+		}
 		wlen -= n;
 		wpos += n;
 	}
@@ -72,11 +79,8 @@ static void raw_waveform_read(samplebuffer_t *sbuf, int current_fd, int wpos, in
 static void wav64_none_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	wav64_t *wav = (wav64_t*)sbuf->wave;
 	int bps = (wav->wave.bits == 8 ? 0 : 1) + (wav->wave.channels == 2 ? 1 : 0);
-	
-	// Always seek to allow for simultaneous playback on multiple channels with
-	// a single file descriptor
-	lseek(wav->st->current_fd, wav->st->base_offset + (wpos << bps), SEEK_SET);
-	raw_waveform_read(sbuf, wav->st->current_fd, wpos, wlen, bps);
+	(void)ctx; (void)seeking;
+	raw_waveform_read(sbuf, wav, wpos, wlen, bps);
 }
 
 static void wav64_none_init(wav64_t *wav, int state_size) {
@@ -202,6 +206,8 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 	wav->st->current_fd = file_handle;
 	wav->st->base_offset = head.start_offset + start_offset;
 	wav->st->flags = owned_fd ? WAV64_FLAG_OWNED_FD : 0;
+	wav->st->rom_base = 0;
+	ioctl(file_handle, IODFS_GET_ROM_BASE, &wav->st->rom_base);
 
 	// Initialize the compression algorithm
 	algos[wav->st->format].init(wav, head.state_size);
@@ -224,6 +230,7 @@ static wav64_t* internal_open(wav64_t *wav, int file_handle, const char *file_na
 			samplebuffer_set_waveform(&sbuf, &wav->wave, wav->wave.read);
 			if (wav->wave.start) wav->wave.start(wav->wave.ctx, &sbuf);
 			samplebuffer_get(&sbuf, 0, &wlen);
+			samplebuffer_dma_wait(&sbuf);
 			rspq_highpri_sync();
 			assertf(wlen == wav->wave.len, "wav64: preload failed for %s: wlen=%x/%x", wav->wave.name, wlen, wav->wave.len);
 

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -5,6 +5,8 @@
 #ifndef __LIBDRAGON_WAV64_INTERNAL_H
 #define __LIBDRAGON_WAV64_INTERNAL_H
 
+#include "mixer.h"
+
 #define WAV64_ID            "WV64"    ///< WAV64 file identifier
 #define WAV64_FORMAT_RAW    0         ///< Raw audio format
 #define WAV64_FORMAT_VADPCM 1         ///< VADPCM compressed format
@@ -45,6 +47,8 @@ typedef struct wav64_state_s {
 	int base_offset;		 ///< Start of Wav64 data (as offset from start of the file)
 	int nsimul;				 ///< Number of maximum simultaneous playbacks
 	uint8_t flags;           ///< Misc flags
+	/** Codec side-data for in-mixer VADPCM mono (#waveform_t::codec). */
+	waveform_vadpcm_t vadpcm;
 } wav64_state_t;
 
 /** @brief WAV64 pluggable compression algorithm */

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -45,7 +45,6 @@ typedef struct wav64_state_s {
 	void *samples;           ///< Pointer to the preloaded samples (if streaming is disabled)
 	int current_fd;			 ///< File descriptor for the wav64 file
 	int base_offset;		 ///< Start of Wav64 data (as offset from start of the file)
-	int nsimul;				 ///< Number of maximum simultaneous playbacks
 	uint8_t flags;           ///< Misc flags
 	/** Codec side-data for in-mixer VADPCM mono (#waveform_t::codec). */
 	waveform_vadpcm_t vadpcm;

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -5,7 +5,7 @@
 #ifndef __LIBDRAGON_WAV64_INTERNAL_H
 #define __LIBDRAGON_WAV64_INTERNAL_H
 
-#include "mixer.h"
+#include "mixer_internal.h"
 
 #define WAV64_ID            "WV64"    ///< WAV64 file identifier
 #define WAV64_FORMAT_RAW    0         ///< Raw audio format
@@ -48,7 +48,7 @@ typedef struct wav64_state_s {
 	/** PI bus address of file start (0 if not a DFS file / async DMA unavailable). */
 	uint32_t rom_base;
 	uint8_t flags;           ///< Misc flags
-	/** Codec side-data for in-mixer VADPCM mono (#waveform_t::codec). */
+	/** Codec side-data for in-mixer VADPCM mono (will be stored in waveform_t::codec). */
 	waveform_vadpcm_t vadpcm;
 } wav64_state_t;
 

--- a/src/audio/wav64_internal.h
+++ b/src/audio/wav64_internal.h
@@ -45,6 +45,8 @@ typedef struct wav64_state_s {
 	void *samples;           ///< Pointer to the preloaded samples (if streaming is disabled)
 	int current_fd;			 ///< File descriptor for the wav64 file
 	int base_offset;		 ///< Start of Wav64 data (as offset from start of the file)
+	/** PI bus address of file start (0 if not a DFS file / async DMA unavailable). */
+	uint32_t rom_base;
 	uint8_t flags;           ///< Misc flags
 	/** Codec side-data for in-mixer VADPCM mono (#waveform_t::codec). */
 	waveform_vadpcm_t vadpcm;

--- a/src/audio/wav64_opus.c
+++ b/src/audio/wav64_opus.c
@@ -104,9 +104,8 @@ static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wl
     uint8_t alignas(16) buf[ext->max_cmp_frame_size + 1];
     int nframes = DIVIDE_CEIL(wlen + intra_skip, ext->frame_size);
 
-    // Make space for the decoded samples. Call samplebuffer_append once as we
-    // use RSP in background, and each call to the function might trigger a
-    // memmove of internal samples.
+    // Decode into one contiguous append (Opus frames are larger than the ring
+    // margin; samplebuffer_append relocates the live window if needed).
     int16_t *out = samplebuffer_append(sbuf, ext->frame_size*nframes);
 
     for (int i=0; i<nframes+preroll_frames; i++) {

--- a/src/audio/wav64_opus.c
+++ b/src/audio/wav64_opus.c
@@ -104,8 +104,8 @@ static void waveform_opus_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wl
     uint8_t alignas(16) buf[ext->max_cmp_frame_size + 1];
     int nframes = DIVIDE_CEIL(wlen + intra_skip, ext->frame_size);
 
-    // Decode into one contiguous append (Opus frames are larger than the ring
-    // margin; samplebuffer_append relocates the live window if needed).
+    // Decode into one contiguous append (Opus frames are larger than the
+    // samplebuffer margin; samplebuffer_append relocates the live window if needed).
     int16_t *out = samplebuffer_append(sbuf, ext->frame_size*nframes);
 
     for (int i=0; i<nframes+preroll_frames; i++) {
@@ -162,6 +162,7 @@ void wav64_opus_init(wav64_t *wav, int state_size) {
 
     wav->wave.read = waveform_opus_read;
     wav->wave.start = waveform_opus_start;
+    wav->wave.append_units = ext->frame_size;
 }
 
 void wav64_opus_close(wav64_t *wav) {

--- a/src/audio/wav64_ulc.c
+++ b/src/audio/wav64_ulc.c
@@ -109,7 +109,6 @@ static const uint16_t ulc_decimation_patterns[] = {
     0x3321 | 0x8000, // 1111: N/2,N/4,N/8,N/8*
 };
 
-static bool ulc_rsp_in_highpri = false;
 static uint32_t ulc_rsp_overlay_id = 0;
 
 /** @brief RSP overlay ID for the ULC decoder. */
@@ -301,18 +300,10 @@ static void ulc_decode_coeffs(int16_t *coeff_dst, int sb_size, const uint8_t **s
 }
 
 static inline void ulc_rsp_synthesize(int16_t *coeffs, int16_t *lap, int16_t *dst, int flags) {
-    if (!ulc_rsp_in_highpri) {
-        ulc_rsp_in_highpri = true;
-        rspq_highpri_begin();
-    }
     rspq_write(ulc_rsp_overlay_id, ULC_RSP_CMD_synthesize, PhysicalAddr(coeffs), PhysicalAddr(lap), PhysicalAddr(dst), flags);
 }
 
 static inline void ulc_rsp_stereo_interleave(int16_t *mid, int16_t *side, int16_t *dst) {
-    if (!ulc_rsp_in_highpri) {
-        ulc_rsp_in_highpri = true;
-        rspq_highpri_begin();
-    }
     rspq_write(ulc_rsp_overlay_id, ULC_RSP_CMD_stereo_interleave, PhysicalAddr(mid), PhysicalAddr(side), PhysicalAddr(dst));
 }
 
@@ -558,6 +549,10 @@ static void waveform_ulc_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wle
         blocks_len += ULC_PREROLL_BLOCKS;
     }
 
+    // Batch all the decode commands in a single highpri sequence. When the
+    // mixer calls us from within its own highpri burst, this simply nests.
+    rspq_highpri_begin();
+
     for (int i = 0; i < blocks_len; i++) {
         assertf(state->block_index < ext->blocks_len, "wav64: %s: ULC blocks exhausted: %lu/%lu", wav->wave.name, state->block_index, ext->blocks_len);
 
@@ -573,10 +568,7 @@ static void waveform_ulc_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wle
         }
     }
 
-    if (ulc_rsp_in_highpri) {
-        ulc_rsp_in_highpri = false;
-        rspq_highpri_end();
-    }
+    rspq_highpri_end();
 
     int valid = wav->wave.loop_len ? MIN(appended, wav->wave.len - wpos) : appended;
     if (appended > valid) {
@@ -600,6 +592,7 @@ void wav64_ulc_init(wav64_t *wav, int state_size) {
 
     wav->wave.start = waveform_ulc_start;
     wav->wave.read = waveform_ulc_read;
+    wav->wave.append_units = ULC_BLOCK_SIZE;
 }
 
 int wav64_ulc_get_bitrate(wav64_t *wav) {

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -13,136 +13,10 @@
 #include "utils.h"
 #include "n64types.h"
 #include <unistd.h>
-#include <limits.h>
 #include <string.h>
+#include <stdlib.h>
 #include <alloca.h>
 
-
-/** @brief Set to 1 to use the reference C decode for VADPCM */
-#define VADPCM_REFERENCE_DECODER     0
-
-#if VADPCM_REFERENCE_DECODER
-/** @brief VADPCM decoding errors */
-typedef enum {
-    // No error (success). Equal to 0.
-    kVADPCMErrNone,
-
-    // Invalid data.
-    kVADPCMErrInvalidData,
-
-    // Predictor order is too large.
-    kVADPCMErrLargeOrder,
-
-    // Predictor count is too large.
-    kVADPCMErrLargePredictorCount,
-
-    // Data uses an unsupported / unknown version of VADPCM.
-    kVADPCMErrUnknownVersion,
-
-    // Invalid encoding parameters.
-    kVADPCMErrInvalidParams,
-} vadpcm_error;
-
-// Extend the sign bit of a 4-bit integer.
-static int vadpcm_ext4(int x) {
-    return x > 7 ? x - 16 : x;
-}
-
-// Clamp an integer to a 16-bit range.
-static int vadpcm_clamp16(int x) {
-    if (x < -0x8000 || 0x7fff < x) {
-        return (x >> (sizeof(int) * CHAR_BIT - 1)) ^ 0x7fff;
-    }
-    return x;
-}
-
-__attribute__((unused))
-static vadpcm_error vadpcm_decode(int predictor_count, int order,
-                           const wav64_vadpcm_vector_t *restrict codebook,
-                           wav64_vadpcm_vector_t *restrict state,
-                           size_t frame_count, int16_t *restrict dest,
-                           const void *restrict src) {
-    const uint8_t *sptr = src;
-    for (size_t frame = 0; frame < frame_count; frame++) {
-        const uint8_t *fin = sptr + 9 * frame;
-
-        // Control byte: scaling & predictor index.
-        int control = fin[0];
-        int scaling = control >> 4;
-        int predictor_index = control & 15;
-        if (predictor_index >= predictor_count) {
-            return kVADPCMErrInvalidData;
-        }
-        const wav64_vadpcm_vector_t *predictor =
-            codebook + order * predictor_index;
-
-        // Decode each of the two vectors within the frame.
-        for (int vector = 0; vector < 2; vector++) {
-            int32_t accumulator[8];
-            for (int i = 0; i < 8; i++) {
-                accumulator[i] = 0;
-            }
-
-            // Accumulate the part of the predictor from the previous block.
-            for (int k = 0; k < order; k++) {
-                int sample = state->v[8 - order + k];
-                for (int i = 0; i < 8; i++) {
-                    accumulator[i] += sample * predictor[k].v[i];
-                }
-            }
-
-            // Decode the ADPCM residual.
-            int residuals[8];
-            for (int i = 0; i < 4; i++) {
-                int byte = fin[1 + 4 * vector + i];
-                residuals[2 * i] = vadpcm_ext4(byte >> 4);
-                residuals[2 * i + 1] = vadpcm_ext4(byte & 15);
-            }
-
-            // Accumulate the residual and predicted values.
-            const wav64_vadpcm_vector_t *v = &predictor[order - 1];
-            for (int k = 0; k < 8; k++) {
-                int residual = residuals[k] << scaling;
-                accumulator[k] += residual << 11;
-                for (int i = 0; i < 7 - k; i++) {
-                    accumulator[k + 1 + i] += residual * v->v[i];
-                }
-            }
-
-            // Discard fractional part and clamp to 16-bit range.
-            for (int i = 0; i < 8; i++) {
-                int sample = vadpcm_clamp16(accumulator[i] >> 11);
-                dest[16 * frame + 8 * vector + i] = sample;
-                state->v[i] = sample;
-            }
-        }
-    }
-    return 0;
-}
-#else
-
-static inline void rsp_vadpcm_decompress(void *input, int16_t *output, bool stereo, int nframes, 
-	wav64_vadpcm_vector_t *state, wav64_vadpcm_vector_t *codebook)
-{
-	assert(nframes > 0 && nframes <= 256);
-	rspq_write(__mixer_overlay_id, 0x1,
-		PhysicalAddr(input), 
-		PhysicalAddr(output) | (nframes-1) << 24,
-		PhysicalAddr(state)  | (stereo ? 1 : 0) << 31,
-		PhysicalAddr(codebook));
-}
-
-// Copy the VADPCM state. If src is NULL, the state is cleared.
-// This is basically a memcpy but performed by RSP, so it's in-order with the
-// other RSP operations.
-static inline void rsp_vadpcm_copystate(wav64_vadpcm_vector_t *dst, wav64_vadpcm_vector_t *src)
-{
-    rspq_write(__mixer_overlay_id, 0x2,
-        PhysicalAddr(dst),
-        PhysicalAddr(src));
-}
-
-#endif /* VADPCM_REFERENCE_DECODER */
 
 /**
  * @brief Find a VADPCM skip point index by sample offset.
@@ -187,7 +61,7 @@ static inline void rsp_vadpcm_copystate(wav64_vadpcm_vector_t *dst, wav64_vadpcm
      return (d_hi < d_lo) ? lo : (lo - 1);
 }
 
-static void huffv_decompress(int nframe, wav64_t *wav, wav64_state_vadpcm_t *vstate, uint8_t *dst, int len, uint8_t *scratch, int slen) {
+static void huffv_decompress(wav64_t *wav, wav64_state_vadpcm_t *vstate, uint8_t *dst, int len, uint8_t *scratch, int slen) {
 	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
 
     unsigned int bitpos = vstate->bitpos;
@@ -239,8 +113,6 @@ static void huffv_decompress(int nframe, wav64_t *wav, wav64_state_vadpcm_t *vst
             
             *dst++ = (val1 << 4) | val2;
         }
-
-        nframe++;
     }
 
     vstate->bitpos = bitpos;
@@ -249,197 +121,184 @@ static void huffv_decompress(int nframe, wav64_t *wav, wav64_state_vadpcm_t *vst
 }
 
 /**
- * @brief Compressed mono read: fill the samplebuffer with plain 9-byte VADPCM
- *        frames. Decode happens later in the mixer ucode (MIX_CHANNEL).
+ * File-frame index of channel `ch`'s frame `frame` in a block-planar VADPCM
+ * stream (`nframes` total frames per channel).
+ */
+static int vadpcm_file_index(int frame, int ch, int nframes, int channels) {
+	if (channels == 1) return frame;
+	int B = WAV64_VADPCM_BLOCK_FRAMES;
+	int block = frame / B;
+	int off = frame % B;
+	int nblocks = (nframes + B - 1) / B;
+	int bs = (block == nblocks - 1) ? (nframes - block * B) : B;
+	return block * B * channels + ch * bs + off;
+}
+
+/**
+ * @brief Fill samplebuffer(s) with plain 9-byte VADPCM frames.
  *
- * wpos/wlen are in frames. Huffman is expanded to plain frames on the CPU.
+ * wpos/wlen are in frames. Mono writes into `sbuf`. Stereo also writes the
+ * right plane into `sbuf+1` (mixer allocates adjacent channel buffers).
+ * Huffman is expanded to plain frames on the CPU.
+ *
+ * Stereo always fills through the end of the current file block so Huffman
+ * can consume L-then-R contiguously and leave bitpos at the next block.
  */
 static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	wav64_t *wav = (wav64_t*)sbuf->wave;
 	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
 	wav64_state_vadpcm_t *vstate = sbuf->state;
 	assert(sbuf->state_size >= sizeof(wav64_state_vadpcm_t));
-	assert(wav->wave.channels == 1);
+	int channels = wav->wave.channels;
+	int nframes_total = wav->wave.len / 16;
+	samplebuffer_t *sbuf_r = (channels == 2) ? sbuf + 1 : NULL;
+	(void)ctx;
 
 	if (seeking) {
 		int sample_pos = wpos * 16;
 		if (wpos == 0) {
-			// samplebuffer state is uncached: stores go straight to RDRAM.
-			memset(vstate->state, 0, sizeof(vstate->state[0]));
-			lseek(wav->st->current_fd, wav->st->base_offset, SEEK_SET);
+			memset(vstate->state, 0, sizeof(vstate->state));
 			vstate->bitpos = 0;
 		} else {
 			int idx = wav64_vadpcm_find_skippoint(vhead, sample_pos, false);
 			assertf(idx >= 0, "wav64: %s: invalid VADPCM seeking point: 0x%x", wav->wave.name, sample_pos);
 			vstate->bitpos = vhead->skip_points[idx].bitpos;
-			memcpy(vstate->state, vhead->skip_states + idx, sizeof(vstate->state[0]));
-			if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0)
-				lseek(wav->st->current_fd, wav->st->base_offset + wpos * 9, SEEK_SET);
+			memcpy(vstate->state, vhead->skip_states + idx * channels,
+				sizeof(vstate->state[0]) * channels);
 		}
-	} else if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0) {
-		lseek(wav->st->current_fd, wav->st->base_offset + wpos * 9, SEEK_SET);
+		if (sbuf_r) {
+			samplebuffer_flush(sbuf_r);
+			sbuf_r->wpos = wpos;
+			sbuf_r->head = 0;
+		}
 	}
 
 	if (wlen <= 0) return;
 
 	while (wlen > 0) {
-		int nframes = wlen;
-		uint8_t *dest = samplebuffer_append(sbuf, nframes);
-		int nbytes = nframes * 9;
+		int n;
+		if (channels == 1) {
+			n = MIN(wlen, SAMPLEBUFFER_MARGIN_UNITS);
+		} else {
+			// Fill through end of block (may exceed wlen; allowed by WaveformRead).
+			int B = WAV64_VADPCM_BLOCK_FRAMES;
+			int block_end = (wpos / B + 1) * B;
+			if (block_end > nframes_total) block_end = nframes_total;
+			n = block_end - wpos;
+			assert(n > 0 && n <= B);
+		}
+
+		uint8_t *dest_l = samplebuffer_append(sbuf, n);
+		uint8_t *dest_r = sbuf_r ? samplebuffer_append(sbuf_r, n) : NULL;
 
 		if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
-			int scratch_size = ROUND_UP(nbytes * 2, 16);
-			void *scratch = alloca(scratch_size);
-			// dest is uncached; huffv writes there directly (no cache ops).
-			huffv_decompress(wpos, wav, vstate, dest, nbytes, scratch, scratch_size);
+			if (channels == 1) {
+				int nbytes = n * 9;
+				int scratch_size = ROUND_UP(nbytes * 2, 16);
+				void *scratch = alloca(scratch_size);
+				huffv_decompress(wav, vstate, dest_l, nbytes, scratch, scratch_size);
+			} else {
+				// From bitpos at L_wpos: stream is L_wpos..L_end, R_0..R_end of block.
+				int B = WAV64_VADPCM_BLOCK_FRAMES;
+				int block = wpos / B;
+				int off = wpos % B;
+				int nblocks = (nframes_total + B - 1) / B;
+				int bs = (block == nblocks - 1) ? (nframes_total - block * B) : B;
+				int n_l = bs - off;           // L frames still in this block
+				int n_r = bs;                 // full R plane of this block
+				assert(n_l == n);
+				int span = n_l + n_r;
+				int nbytes = span * 9;
+				int scratch_size = ROUND_UP(nbytes * 2, 16);
+				void *scratch = alloca(scratch_size);
+				uint8_t *spanbuf = alloca(ROUND_UP(nbytes, 16));
+				huffv_decompress(wav, vstate, spanbuf, nbytes, scratch, scratch_size);
+				memcpy(dest_l, spanbuf, n * 9);
+				memcpy(dest_r, spanbuf + (n_l + off) * 9, n * 9);
+			}
 		} else {
-			int read_bytes = read(wav->st->current_fd, CachedAddr(dest), nbytes);
-			assertf(nbytes == read_bytes, "invalid read past end: %d vs %d", nbytes, read_bytes);
-			// dfs read() DMAs directly to RDRAM when the destination has the
-			// same 2-byte phase of the file position, but otherwise falls back
-			// to a CPU memcpy through the pointer we pass. Since we pass the
-			// cached alias, that leaves dirty cachelines that the RSP would
-			// not see: flush them (on the *cached* alias; cache-ops on the
-			// uncached pointer would be no-ops / warnings).
-			data_cache_hit_writeback_invalidate(CachedAddr(dest), nbytes);
-		}
-
-		wlen -= nframes;
-		wpos += nframes;
-	}
-}
-
-/** @brief Legacy stereo (and optional reference) path: decompress to PCM in the samplebuffer. */
-static void waveform_vadpcm_read_legacy(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
-	wav64_t *wav = (wav64_t*)sbuf->wave;
-	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
-
-    wav64_state_vadpcm_t *vstate = sbuf->state;
-    assert(sbuf->state_size >= sizeof(wav64_state_vadpcm_t));
-	bool highpri = false;
-
-	if (seeking) {
-        rspq_highpri_begin();
-		if (wpos == 0) {
-            rsp_vadpcm_copystate(vstate->state, NULL);
-			lseek(wav->st->current_fd, wav->st->base_offset, SEEK_SET);
-            vstate->bitpos = 0;
-		} else {
-			int idx = wav64_vadpcm_find_skippoint(vhead, wpos, false);
-            assertf(idx >= 0, "wav64: %s: invalid VADPCM seeking point: 0x%x", wav->wave.name, wpos);
-            vstate->bitpos = vhead->skip_points[idx].bitpos;
-            rsp_vadpcm_copystate(vstate->state, vhead->skip_states + idx*wav->wave.channels);
-            if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0)
-                lseek(wav->st->current_fd, wav->st->base_offset + (wpos / 16) * 9 * wav->wave.channels, SEEK_SET);
-		}
-        rspq_highpri_end();
-	} else {
-        assert((wpos % 16) == 0);
-        if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0)
-            lseek(wav->st->current_fd, wav->st->base_offset + (wpos / 16) * 9 * wav->wave.channels, SEEK_SET);
-    }
-
-	wlen = ROUND_UP(wlen, 32);
-	if (wlen == 0) return;
-
-	enum { MAX_VADPCM_FRAMES = 94 };
-
-	while (wlen > 0) {
-		int max_vadpcm_frames = (wav->wave.channels == 1) ? MAX_VADPCM_FRAMES : MAX_VADPCM_FRAMES / 2;
-		int nframes = MIN(wlen / 16, max_vadpcm_frames);
-
-		int16_t *dest = (int16_t*)samplebuffer_append(sbuf, nframes*16);
-		int src_bytes = 9 * nframes * wav->wave.channels;
-		void *src = (void*)dest + ((nframes*16) << SAMPLES_BPS_SHIFT(sbuf)) - src_bytes;
-
-        if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
-            void *scratch = dest;
-            int scratch_size = ROUND_UP(((void*)src - (void*)dest) / 2, 16);
-            if ((uint32_t)scratch & 15)
-                scratch += 16 - ((uint32_t)scratch & 15);
-            huffv_decompress(wpos/16, wav, vstate, src, src_bytes, scratch, scratch_size);
-        } else {
-            int read_bytes = read(wav->st->current_fd, CachedAddr(src), src_bytes);
-            assertf(src_bytes == read_bytes, "invalid read past end: %d vs %d", src_bytes, read_bytes);
-        }
-
-		#if VADPCM_REFERENCE_DECODER
-		if (wav->wave.channels == 1) {
-			vadpcm_error err = vadpcm_decode(
-				vhead->npredictors, vhead->order, vhead->codebook, vstate->state,
-				nframes, dest, src);
-			assertf(err == 0, "VADPCM decoding error: %d\n", err);
-		} else {
-			assert(wav->wave.channels == 2);
-			int16_t uncomp[2][16];
-			int16_t *dst = dest;
-
-			for (int i=0; i<nframes; i++) {
-				for (int j=0; j<2; j++) {
-					vadpcm_error err = vadpcm_decode(
-						vhead->npredictors, vhead->order, vhead->codebook + 8*j, &vstate->state[j],
-						1, uncomp[j], src);
-					assertf(err == 0, "VADPCM decoding error: %d\n", err);
-					src += 9;
-				}
-				for (int j=0; j<16; j++) {
-					*dst++ = uncomp[0][j];
-					*dst++ = uncomp[1][j];
-				}
+			for (int c = 0; c < channels; c++) {
+				uint8_t *dest = (c == 0) ? dest_l : dest_r;
+				int fidx = vadpcm_file_index(wpos, c, nframes_total, channels);
+				lseek(wav->st->current_fd, wav->st->base_offset + fidx * 9, SEEK_SET);
+				int nbytes = n * 9;
+				int read_bytes = read(wav->st->current_fd, CachedAddr(dest), nbytes);
+				assertf(nbytes == read_bytes, "invalid read past end: %d vs %d", nbytes, read_bytes);
+				data_cache_hit_writeback_invalidate(CachedAddr(dest), nbytes);
 			}
 		}
-		#else
-		if (!highpri) {
-			rspq_highpri_begin();
-			highpri = true;
-		}
-		rsp_vadpcm_decompress(src, dest, wav->wave.channels==2, nframes, vstate->state, vhead->codebook);
-		#endif
 
-		wlen -= 16*nframes;
-		wpos += 16*nframes;
+		if (sbuf_r)
+			sbuf_r->wnext = sbuf_r->wpos + sbuf_r->widx;
+
+		wlen -= n;
+		if (wlen < 0) wlen = 0;
+		wpos += n;
 	}
-
-	if (highpri)
-		rspq_highpri_end();
-
-    if (wav->wave.loop_len && wpos > wav->wave.len) {
-        samplebuffer_undo(sbuf, wpos - wav->wave.len);
-    }
 }
 
-/** @brief Preloaded compressed mono: memcpy frames from st->samples. */
-static void waveform_vadpcm_read_mem(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+/** @brief Seek VADPCM predictor state for a resident (preloaded) waveform. */
+static void waveform_vadpcm_seek_state(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+	(void)ctx; (void)wlen;
+	if (!seeking) return;
+
 	wav64_t *wav = (wav64_t*)sbuf->wave;
 	wav64_state_vadpcm_t *vstate = sbuf->state;
-
-	if (seeking) {
-		wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
-		int sample_pos = wpos * 16;
-		if (wpos == 0) {
-			memset(vstate->state, 0, sizeof(vstate->state[0]));
-		} else {
-			int idx = wav64_vadpcm_find_skippoint(vhead, sample_pos, false);
-			assertf(idx >= 0, "wav64: %s: invalid VADPCM seeking point: 0x%x", wav->wave.name, sample_pos);
-			memcpy(vstate->state, vhead->skip_states + idx, sizeof(vstate->state[0]));
-		}
+	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
+	int channels = wav->wave.channels;
+	int sample_pos = wpos * 16;
+	if (wpos == 0) {
+		memset(vstate->state, 0, sizeof(vstate->state[0]) * channels);
+	} else {
+		int idx = wav64_vadpcm_find_skippoint(vhead, sample_pos, false);
+		assertf(idx >= 0, "wav64: %s: invalid VADPCM seeking point: 0x%x", wav->wave.name, sample_pos);
+		memcpy(vstate->state, vhead->skip_states + idx * channels,
+			sizeof(vstate->state[0]) * channels);
 	}
-
-	if (wlen <= 0) return;
-	uint8_t *dst = samplebuffer_append(sbuf, wlen);
-	memcpy(dst, (uint8_t*)wav->st->samples + wpos * 9, wlen * 9);
 }
 
 static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	wav64_t *wav = (wav64_t*)sbuf->wave;
-	if (wav->wave.format == WAVEFORM_FORMAT_VADPCM) {
-		if (wav->st->samples)
-			waveform_vadpcm_read_mem(ctx, sbuf, wpos, wlen, seeking);
-		else
-			waveform_vadpcm_read_compressed(ctx, sbuf, wpos, wlen, seeking);
+	if (wav->wave.mem)
+		waveform_vadpcm_seek_state(ctx, sbuf, wpos, wlen, seeking);
+	else
+		waveform_vadpcm_read_compressed(ctx, sbuf, wpos, wlen, seeking);
+}
+
+/**
+ * @brief Load the whole VADPCM body into a fully-planar plain-frame buffer.
+ *
+ * File layout is block-planar (and possibly Huffman); `dst` receives
+ * [all L frames][all R frames] for direct MIX_CHANNEL addressing.
+ */
+void wav64_vadpcm_preload(wav64_t *wav, void *dst)
+{
+	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
+	int channels = wav->wave.channels;
+	int nframes = wav->wave.len / 16;
+	int file_bytes = nframes * 9 * channels;
+	uint8_t *scratch = malloc(ROUND_UP(file_bytes, 16));
+	assertf(scratch, "Out of memory");
+
+	lseek(wav->st->current_fd, wav->st->base_offset, SEEK_SET);
+	if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
+		wav64_state_vadpcm_t st = {0};
+		int scratch2_size = ROUND_UP(file_bytes * 2, 16);
+		void *scratch2 = malloc(scratch2_size);
+		assertf(scratch2, "Out of memory");
+		huffv_decompress(wav, &st, scratch, file_bytes, scratch2, scratch2_size);
+		free(scratch2);
 	} else {
-		waveform_vadpcm_read_legacy(ctx, sbuf, wpos, wlen, seeking);
+		int n = read(wav->st->current_fd, scratch, file_bytes);
+		assertf(n == file_bytes, "wav64: short VADPCM preload read");
 	}
+
+	uint8_t *out = dst;
+	for (int c = 0; c < channels; c++)
+		for (int f = 0; f < nframes; f++)
+			memcpy(out + (c * nframes + f) * 9,
+				scratch + vadpcm_file_index(f, c, nframes, channels) * 9, 9);
+	free(scratch);
 }
 
 static void wav64_vadpcm_init_huffman(wav64_t *wav) {
@@ -499,26 +358,17 @@ void wav64_vadpcm_init(wav64_t *wav, int state_size)
     }
 
     wav->wave.start = NULL;
-
-    // Mono VADPCM: decode in the mixer (samplebuffer holds compressed frames).
-    // Stereo keeps the legacy decompress-to-PCM path.
-    if (wav->wave.channels == 1) {
-        wav->wave.format = WAVEFORM_FORMAT_VADPCM;
-        wav->st->vadpcm.codebook = vhead->codebook;
-        wav->st->vadpcm.loop_state = NULL;
-        if (wav->wave.loop_len > 0 && vhead->num_skippoints > 0) {
-            int loop_start = wav->wave.len - wav->wave.loop_len;
-            int idx = wav64_vadpcm_find_skippoint(vhead, loop_start, false);
-            if (idx >= 0)
-                wav->st->vadpcm.loop_state = vhead->skip_states + idx;
-        }
-        wav->wave.codec = &wav->st->vadpcm;
-        wav->wave.read = waveform_vadpcm_read;
-    } else {
-        wav->wave.format = WAVEFORM_FORMAT_PCM;
-        wav->wave.codec = NULL;
-        wav->wave.read = waveform_vadpcm_read;
+    wav->wave.format = WAVEFORM_FORMAT_VADPCM;
+    wav->st->vadpcm.codebook = vhead->codebook;
+    wav->st->vadpcm.loop_state = NULL;
+    if (wav->wave.loop_len > 0 && vhead->num_skippoints > 0) {
+        int loop_start = wav->wave.len - wav->wave.loop_len;
+        int idx = wav64_vadpcm_find_skippoint(vhead, loop_start, false);
+        if (idx >= 0)
+            wav->st->vadpcm.loop_state = vhead->skip_states + idx * wav->wave.channels;
     }
+    wav->wave.codec = &wav->st->vadpcm;
+    wav->wave.read = waveform_vadpcm_read;
 }
 
 void wav64_vadpcm_close(wav64_t *wav)

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -13,6 +13,7 @@
 #include "dma.h"
 #include "utils.h"
 #include "n64types.h"
+#include "profile.h"
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
@@ -63,6 +64,7 @@
 }
 
 static void huffv_decompress(wav64_t *wav, wav64_state_vadpcm_t *vstate, uint8_t *dst, int len, uint8_t *scratch, int slen) {
+	PROFILE_SCOPE(PS_VADPCM_HUFF) {
 	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
 
     unsigned int bitpos = vstate->bitpos;
@@ -119,6 +121,7 @@ static void huffv_decompress(wav64_t *wav, wav64_state_vadpcm_t *vstate, uint8_t
     vstate->bitpos = bitpos;
     assertf((void*)src <= CachedAddr(scratch) + slen, "invalid read past end: %p vs %p", src, scratch + slen);
     data_cache_hit_invalidate(CachedAddr(scratch), slen);
+	}
 }
 
 /**
@@ -146,6 +149,7 @@ static int vadpcm_file_index(int frame, int ch, int nframes, int channels) {
  * can consume L-then-R contiguously and leave bitpos at the next block.
  */
 static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+	PROFILE_SCOPE(PS_VADPCM_READ) {
 	wav64_t *wav = (wav64_t*)sbuf->wave;
 	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
 	wav64_state_vadpcm_t *vstate = sbuf->state;
@@ -174,7 +178,7 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 		}
 	}
 
-	if (wlen <= 0) return;
+	if (wlen <= 0) goto done;
 
 	while (wlen > 0) {
 		int n;
@@ -218,6 +222,7 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 				memcpy(dest_r, spanbuf + (n_l + off) * 9, n * 9);
 			}
 		} else {
+			PROFILE_SCOPE(PS_VADPCM_IO) {
 			for (int c = 0; c < channels; c++) {
 				uint8_t *dest = (c == 0) ? dest_l : dest_r;
 				samplebuffer_t *dstbuf = (c == 0) ? sbuf : sbuf_r;
@@ -225,6 +230,9 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 				int nbytes = n * 9;
 				uint32_t pi_addr = wav->st->rom_base + wav->st->base_offset + fidx * 9;
 				if (wav->st->rom_base && !(((uint32_t)dest ^ pi_addr) & 1)) {
+					// A prior chunk of this same WaveformRead may still be in
+					// flight; wait before replacing the ticket.
+					samplebuffer_dma_wait(dstbuf);
 					dstbuf->dma_ticket = dma_read_async(dest, pi_addr, nbytes);
 				} else {
 					lseek(wav->st->current_fd, wav->st->base_offset + fidx * 9, SEEK_SET);
@@ -232,6 +240,7 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 					assertf(nbytes == read_bytes, "invalid read past end: %d vs %d", nbytes, read_bytes);
 					data_cache_hit_writeback_invalidate(CachedAddr(dest), nbytes);
 				}
+			}
 			}
 		}
 
@@ -241,6 +250,8 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 		wlen -= n;
 		if (wlen < 0) wlen = 0;
 		wpos += n;
+	}
+done: ;
 	}
 }
 
@@ -376,6 +387,10 @@ void wav64_vadpcm_init(wav64_t *wav, int state_size)
     }
     wav->wave.codec = &wav->st->vadpcm;
     wav->wave.read = waveform_vadpcm_read;
+    // Plain frames stream from ROM with async PI DMA. Huffman frames must be
+    // decompressed by the CPU, and any other medium is read synchronously.
+    wav->wave.async_read = wav->st->rom_base != 0 &&
+        !(vhead->flags & VADPCM_FLAG_HUFFMAN);
 }
 
 void wav64_vadpcm_close(wav64_t *wav)

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -363,19 +363,11 @@ static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int 
 		rspq_highpri_end();
 
     if (wav->wave.loop_len && wpos > wav->wave.len) {
+        // Truncate padding past the loop end. samplebuffer_undo tags the
+        // discarded region as a dirty tail so a subsequent append (e.g. the
+        // next loop iteration staging compressed frames into the same bytes)
+        // waits for the in-flight RSP decode if needed — no sync here.
         samplebuffer_undo(sbuf, wpos - wav->wave.len);
-
-        // We are forced to sync here. The reason is the following:
-        //  * We reached the end of a looping sample
-        //  * The code in waveform_read could now immediately decode another
-        //    chunk of samples at the beginning of the loop.
-        //  * This other read will call read() on the file to read the compressed
-        //    frames *into the output buffer*
-        //  * The bytes into which we load them could overlap with the bytes
-        //    that were just "undo'd". But on those bytes, the RSP is going to
-        //    write soon as part of the just-scheduled decoding.
-        //  This might cause a race condition.
-        rspq_highpri_sync();
     }
 }
 

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include <string.h>
+#include <alloca.h>
 
 
 /** @brief Set to 1 to use the reference C decode for VADPCM */
@@ -247,11 +248,72 @@ static void huffv_decompress(int nframe, wav64_t *wav, wav64_state_vadpcm_t *vst
     data_cache_hit_invalidate(CachedAddr(scratch), slen);
 }
 
-static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+/**
+ * @brief Compressed mono read: fill the samplebuffer with plain 9-byte VADPCM
+ *        frames. Decode happens later in the mixer ucode (MIX_CHANNEL).
+ *
+ * wpos/wlen are in frames. Huffman is expanded to plain frames on the CPU.
+ */
+static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+	wav64_t *wav = (wav64_t*)sbuf->wave;
+	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
+	wav64_state_vadpcm_t *vstate = sbuf->state;
+	assert(sbuf->state_size >= sizeof(wav64_state_vadpcm_t));
+	assert(wav->wave.channels == 1);
+
+	if (seeking) {
+		int sample_pos = wpos * 16;
+		if (wpos == 0) {
+			// samplebuffer state is uncached: stores go straight to RDRAM.
+			memset(vstate->state, 0, sizeof(vstate->state[0]));
+			lseek(wav->st->current_fd, wav->st->base_offset, SEEK_SET);
+			vstate->bitpos = 0;
+		} else {
+			int idx = wav64_vadpcm_find_skippoint(vhead, sample_pos, false);
+			assertf(idx >= 0, "wav64: %s: invalid VADPCM seeking point: 0x%x", wav->wave.name, sample_pos);
+			vstate->bitpos = vhead->skip_points[idx].bitpos;
+			memcpy(vstate->state, vhead->skip_states + idx, sizeof(vstate->state[0]));
+			if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0)
+				lseek(wav->st->current_fd, wav->st->base_offset + wpos * 9, SEEK_SET);
+		}
+	} else if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0) {
+		lseek(wav->st->current_fd, wav->st->base_offset + wpos * 9, SEEK_SET);
+	}
+
+	if (wlen <= 0) return;
+
+	while (wlen > 0) {
+		int nframes = wlen;
+		uint8_t *dest = samplebuffer_append(sbuf, nframes);
+		int nbytes = nframes * 9;
+
+		if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
+			int scratch_size = ROUND_UP(nbytes * 2, 16);
+			void *scratch = alloca(scratch_size);
+			// dest is uncached; huffv writes there directly (no cache ops).
+			huffv_decompress(wpos, wav, vstate, dest, nbytes, scratch, scratch_size);
+		} else {
+			int read_bytes = read(wav->st->current_fd, CachedAddr(dest), nbytes);
+			assertf(nbytes == read_bytes, "invalid read past end: %d vs %d", nbytes, read_bytes);
+			// dfs read() DMAs directly to RDRAM when the destination has the
+			// same 2-byte phase of the file position, but otherwise falls back
+			// to a CPU memcpy through the pointer we pass. Since we pass the
+			// cached alias, that leaves dirty cachelines that the RSP would
+			// not see: flush them (on the *cached* alias; cache-ops on the
+			// uncached pointer would be no-ops / warnings).
+			data_cache_hit_writeback_invalidate(CachedAddr(dest), nbytes);
+		}
+
+		wlen -= nframes;
+		wpos += nframes;
+	}
+}
+
+/** @brief Legacy stereo (and optional reference) path: decompress to PCM in the samplebuffer. */
+static void waveform_vadpcm_read_legacy(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
 	wav64_t *wav = (wav64_t*)sbuf->wave;
 	wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
 
-    // Access the per-channel state
     wav64_state_vadpcm_t *vstate = sbuf->state;
     assert(sbuf->state_size >= sizeof(wav64_state_vadpcm_t));
 	bool highpri = false;
@@ -273,50 +335,30 @@ static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int 
         rspq_highpri_end();
 	} else {
         assert((wpos % 16) == 0);
-
-        // If not huffman compressed, seek here, once. Otherwise, the huffman
-        // decompressor will seek as needed.
         if ((vhead->flags & VADPCM_FLAG_HUFFMAN) == 0)
             lseek(wav->st->current_fd, wav->st->base_offset + (wpos / 16) * 9 * wav->wave.channels, SEEK_SET);
     }
 
-	// Round up wlen to 32 because our RSP decompressor only supports multiples
-	// of 32 samples (2 frames) because of DMA alignment issues. audioconv64
-	// makes sure files are padded to that length, so this is valid also at the
-	// end of the file.
 	wlen = ROUND_UP(wlen, 32);
 	if (wlen == 0) return;
 
-	// Maximum number of VADPCM frames that can be decompressed in a single
-	// RSP call. Keep this in sync with rsp_mixer.S.
 	enum { MAX_VADPCM_FRAMES = 94 };
 
 	while (wlen > 0) {
-		// Calculate number of frames to decompress in this iteration
 		int max_vadpcm_frames = (wav->wave.channels == 1) ? MAX_VADPCM_FRAMES : MAX_VADPCM_FRAMES / 2;
 		int nframes = MIN(wlen / 16, max_vadpcm_frames);
 
-		// Acquire destination buffer from the sample buffer
 		int16_t *dest = (int16_t*)samplebuffer_append(sbuf, nframes*16);
-
-		// Calculate source pointer at the end of the destination buffer.
-		// VADPCM decoding can be safely made in-place, so no auxillary buffer
-		// is necessary.
 		int src_bytes = 9 * nframes * wav->wave.channels;
 		void *src = (void*)dest + ((nframes*16) << SAMPLES_BPS_SHIFT(sbuf)) - src_bytes;
 
-		// Fetch compressed data
         if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
             void *scratch = dest;
             int scratch_size = ROUND_UP(((void*)src - (void*)dest) / 2, 16);
             if ((uint32_t)scratch & 15)
                 scratch += 16 - ((uint32_t)scratch & 15);
-
-            // debugf("huffv_decompress: scratch:%p-%p src:%p-%p nframes:%d-%d\n", 
-            //     scratch, scratch + scratch_size, src, src + src_bytes, wpos/16, wpos/16 + nframes -1);
             huffv_decompress(wpos/16, wav, vstate, src, src_bytes, scratch, scratch_size);
         } else {
-            // FIXME: remove CachedAddr() when read() supports uncached addresses
             int read_bytes = read(wav->st->current_fd, CachedAddr(src), src_bytes);
             assertf(src_bytes == read_bytes, "invalid read past end: %d vs %d", src_bytes, read_bytes);
         }
@@ -347,7 +389,6 @@ static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int 
 			}
 		}
 		#else
-		// Switch to highpri as late as possible
 		if (!highpri) {
 			rspq_highpri_begin();
 			highpri = true;
@@ -363,12 +404,42 @@ static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int 
 		rspq_highpri_end();
 
     if (wav->wave.loop_len && wpos > wav->wave.len) {
-        // Truncate padding past the loop end. samplebuffer_undo tags the
-        // discarded region as a dirty tail so a subsequent append (e.g. the
-        // next loop iteration staging compressed frames into the same bytes)
-        // waits for the in-flight RSP decode if needed — no sync here.
         samplebuffer_undo(sbuf, wpos - wav->wave.len);
     }
+}
+
+/** @brief Preloaded compressed mono: memcpy frames from st->samples. */
+static void waveform_vadpcm_read_mem(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+	wav64_t *wav = (wav64_t*)sbuf->wave;
+	wav64_state_vadpcm_t *vstate = sbuf->state;
+
+	if (seeking) {
+		wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
+		int sample_pos = wpos * 16;
+		if (wpos == 0) {
+			memset(vstate->state, 0, sizeof(vstate->state[0]));
+		} else {
+			int idx = wav64_vadpcm_find_skippoint(vhead, sample_pos, false);
+			assertf(idx >= 0, "wav64: %s: invalid VADPCM seeking point: 0x%x", wav->wave.name, sample_pos);
+			memcpy(vstate->state, vhead->skip_states + idx, sizeof(vstate->state[0]));
+		}
+	}
+
+	if (wlen <= 0) return;
+	uint8_t *dst = samplebuffer_append(sbuf, wlen);
+	memcpy(dst, (uint8_t*)wav->st->samples + wpos * 9, wlen * 9);
+}
+
+static void waveform_vadpcm_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking) {
+	wav64_t *wav = (wav64_t*)sbuf->wave;
+	if (wav->wave.format == WAVEFORM_FORMAT_VADPCM) {
+		if (wav->st->samples)
+			waveform_vadpcm_read_mem(ctx, sbuf, wpos, wlen, seeking);
+		else
+			waveform_vadpcm_read_compressed(ctx, sbuf, wpos, wlen, seeking);
+	} else {
+		waveform_vadpcm_read_legacy(ctx, sbuf, wpos, wlen, seeking);
+	}
 }
 
 static void wav64_vadpcm_init_huffman(wav64_t *wav) {
@@ -408,16 +479,7 @@ void wav64_vadpcm_init(wav64_t *wav, int state_size)
     assertf(state_size == sizeof(wav64_state_vadpcm_t), 
         "wav64: invalid state size for VADPCM: %d/%d\n", state_size, sizeof(wav64_state_vadpcm_t));
 
-    // Set wave callback functions
-	wav->wave.start = NULL;
-    wav->wave.read = waveform_vadpcm_read;
-
-    // Init huffman
     wav64_header_vadpcm_t *vhead = (wav64_header_vadpcm_t*)wav->st->ext;
-    assertf(vhead->huff_tbl == NULL, "huff_tbl must be NULL before initialization");
-    if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
-        wav64_vadpcm_init_huffman(wav);
-    }
 
     // Decode the skip pointer table pointer. The table is stored after the codebook,
     // and the exact byte offset is stored in the pointer itself to simplify initialization.
@@ -428,6 +490,34 @@ void wav64_vadpcm_init(wav64_t *wav, int state_size)
         vhead->skip_states = (void*)vhead->codebook + state_off;
         data_cache_hit_writeback(vhead->skip_points, sizeof(wav64_vadpcm_skippoint_t) * vhead->num_skippoints);
         data_cache_hit_writeback(vhead->skip_states, sizeof(wav64_vadpcm_vector_t) * vhead->num_skippoints * wav->wave.channels);
+    }
+
+    // Init huffman
+    assertf(vhead->huff_tbl == NULL, "huff_tbl must be NULL before initialization");
+    if (vhead->flags & VADPCM_FLAG_HUFFMAN) {
+        wav64_vadpcm_init_huffman(wav);
+    }
+
+    wav->wave.start = NULL;
+
+    // Mono VADPCM: decode in the mixer (samplebuffer holds compressed frames).
+    // Stereo keeps the legacy decompress-to-PCM path.
+    if (wav->wave.channels == 1) {
+        wav->wave.format = WAVEFORM_FORMAT_VADPCM;
+        wav->st->vadpcm.codebook = vhead->codebook;
+        wav->st->vadpcm.loop_state = NULL;
+        if (wav->wave.loop_len > 0 && vhead->num_skippoints > 0) {
+            int loop_start = wav->wave.len - wav->wave.loop_len;
+            int idx = wav64_vadpcm_find_skippoint(vhead, loop_start, false);
+            if (idx >= 0)
+                wav->st->vadpcm.loop_state = vhead->skip_states + idx;
+        }
+        wav->wave.codec = &wav->st->vadpcm;
+        wav->wave.read = waveform_vadpcm_read;
+    } else {
+        wav->wave.format = WAVEFORM_FORMAT_PCM;
+        wav->wave.codec = NULL;
+        wav->wave.read = waveform_vadpcm_read;
     }
 }
 

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -200,7 +200,9 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 			if (channels == 1) {
 				int nbytes = n * 9;
 				int scratch_size = ROUND_UP(nbytes * 2, 16);
-				void *scratch = alloca(scratch_size);
+				// data_cache_hit_invalidate requires a 16-byte aligned address;
+				// alloca only guarantees the platform ABI alignment.
+				uint8_t *scratch = (uint8_t *)ROUND_UP((uintptr_t)alloca(scratch_size + 15), 16);
 				huffv_decompress(wav, vstate, dest_l, nbytes, scratch, scratch_size);
 			} else {
 				// From bitpos at L_wpos: stream is L_wpos..L_end, R_0..R_end of block.
@@ -215,8 +217,8 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 				int span = n_l + n_r;
 				int nbytes = span * 9;
 				int scratch_size = ROUND_UP(nbytes * 2, 16);
-				void *scratch = alloca(scratch_size);
-				uint8_t *spanbuf = alloca(ROUND_UP(nbytes, 16));
+				uint8_t *scratch = (uint8_t *)ROUND_UP((uintptr_t)alloca(scratch_size + 15), 16);
+				uint8_t *spanbuf = (uint8_t *)ROUND_UP((uintptr_t)alloca(nbytes + 15), 16);
 				huffv_decompress(wav, vstate, spanbuf, nbytes, scratch, scratch_size);
 				memcpy(dest_l, spanbuf, n * 9);
 				memcpy(dest_r, spanbuf + (n_l + off) * 9, n * 9);

--- a/src/audio/wav64_vadpcm.c
+++ b/src/audio/wav64_vadpcm.c
@@ -10,6 +10,7 @@
 #include "mixer.h"
 #include "mixer_internal.h"
 #include "samplebuffer.h"
+#include "dma.h"
 #include "utils.h"
 #include "n64types.h"
 #include <unistd.h>
@@ -219,12 +220,18 @@ static void waveform_vadpcm_read_compressed(void *ctx, samplebuffer_t *sbuf, int
 		} else {
 			for (int c = 0; c < channels; c++) {
 				uint8_t *dest = (c == 0) ? dest_l : dest_r;
+				samplebuffer_t *dstbuf = (c == 0) ? sbuf : sbuf_r;
 				int fidx = vadpcm_file_index(wpos, c, nframes_total, channels);
-				lseek(wav->st->current_fd, wav->st->base_offset + fidx * 9, SEEK_SET);
 				int nbytes = n * 9;
-				int read_bytes = read(wav->st->current_fd, CachedAddr(dest), nbytes);
-				assertf(nbytes == read_bytes, "invalid read past end: %d vs %d", nbytes, read_bytes);
-				data_cache_hit_writeback_invalidate(CachedAddr(dest), nbytes);
+				uint32_t pi_addr = wav->st->rom_base + wav->st->base_offset + fidx * 9;
+				if (wav->st->rom_base && !(((uint32_t)dest ^ pi_addr) & 1)) {
+					dstbuf->dma_ticket = dma_read_async(dest, pi_addr, nbytes);
+				} else {
+					lseek(wav->st->current_fd, wav->st->base_offset + fidx * 9, SEEK_SET);
+					int read_bytes = read(wav->st->current_fd, CachedAddr(dest), nbytes);
+					assertf(nbytes == read_bytes, "invalid read past end: %d vs %d", nbytes, read_bytes);
+					data_cache_hit_writeback_invalidate(CachedAddr(dest), nbytes);
+				}
 			}
 		}
 

--- a/src/audio/wav64_vadpcm_internal.h
+++ b/src/audio/wav64_vadpcm_internal.h
@@ -7,6 +7,13 @@
 
 #define VADPCM_FLAG_HUFFMAN      (1 << 0)	///< Huffman-encoded VADPCM
 
+/**
+ * Stereo VADPCM file layout: blocks of this many frames per channel, alternating
+ * L then R (mono is a single linear plane). Matches #SAMPLEBUFFER_MARGIN_UNITS
+ * so one ring fill is one file block.
+ */
+#define WAV64_VADPCM_BLOCK_FRAMES  128
+
 /** @brief A vector of audio samples */
 typedef struct __attribute__((aligned(8))) {
 	int16_t v[8];						///< Samples
@@ -72,5 +79,8 @@ int wav64_vadpcm_get_bitrate(wav64_t *wav);
 
 /** @brief Adjust a requested seek position (samples) to a valid VADPCM skip point (samples). */
 int wav64_vadpcm_adjust_seek(wav64_t *wav, int wpos);
+
+/** @brief Preload VADPCM body into a fully-planar plain-frame buffer at `dst`. */
+void wav64_vadpcm_preload(wav64_t *wav, void *dst);
 
 #endif

--- a/src/audio/wav64_vadpcm_internal.h
+++ b/src/audio/wav64_vadpcm_internal.h
@@ -10,7 +10,7 @@
 /**
  * Stereo VADPCM file layout: blocks of this many frames per channel, alternating
  * L then R (mono is a single linear plane). Matches #SAMPLEBUFFER_MARGIN_UNITS
- * so one ring fill is one file block.
+ * so one samplebuffer fill is one file block.
  */
 #define WAV64_VADPCM_BLOCK_FRAMES  128
 

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -8,6 +8,7 @@
 #include "xm64.h"
 #include "wav64.h"
 #include "mixer.h"
+#include "mixer_internal.h"
 #include "audio.h"
 #include <assert.h>
 #include "debug.h"
@@ -15,6 +16,7 @@
 #include "dragonfs.h"
 #include "wav64_internal.h"
 #include "asset_internal.h"
+#include "profile.h"
 #include "libxm/xm.h"
 #include "libxm/xm_internal.h"
 #include <stdbool.h>
@@ -31,29 +33,34 @@ static void stop(xm_context_t *ctx, xm64player_t *xmp) {
 }
 
 static int tick(void *arg) {
+	int delay;
+	PROFILE_SCOPE(PS_XM_TICK) {
 	xm64player_t *xmp = (xm64player_t*)arg;
 	xm_context_t *ctx = xmp->ctx;
 	int first_ch = xmp->first_ch;
 
-	for (int i=0;i<ctx->module.num_channels;i++) {
-		xm_channel_context_t *ch = &ctx->channels[i];
-		if (mixer_ch_playing(first_ch+i))
-			ch->sample_position = mixer_ch_get_pos(first_ch+i);
-		else
-			// The mixer auto-stopped the channel: a non-looping sample
-			// reached its end. Mark it as finished like libxm's own mixer
-			// would (see xm_next_of_sample), otherwise the playback loop
-			// below would keep restarting the waveform at the last synced
-			// (stale) position, which is also an invalid seek point for
-			// compressed streams. Any new note will reset this via
-			// xm_trigger_note; seeks reset it explicitly below.
-			ch->sample_position = -1;
+	PROFILE_SCOPE(PS_XM_GETPOS) {
+		for (int i=0;i<ctx->module.num_channels;i++) {
+			xm_channel_context_t *ch = &ctx->channels[i];
+			if (mixer_ch_playing(first_ch+i))
+				ch->sample_position = mixer_ch_get_pos(first_ch+i);
+			else
+				// The mixer auto-stopped the channel: a non-looping sample
+				// reached its end. Mark it as finished like libxm's own mixer
+				// would (see xm_next_of_sample), otherwise the playback loop
+				// below would keep restarting the waveform at the last synced
+				// (stale) position, which is also an invalid seek point for
+				// compressed streams. Any new note will reset this via
+				// xm_trigger_note; seeks reset it explicitly below.
+				ch->sample_position = -1;
+		}
 	}
 
 	// If we're requested to stop playback, do it.
 	if (xmp->stop_requested) {
 		stop(ctx, xmp);
-		return 0;
+		delay = 0;
+		goto done;
 	}
 
 	if (xmp->seek.patidx >= 0) {
@@ -71,48 +78,55 @@ static int tick(void *arg) {
 	}
 
 	assert(ctx->remaining_samples_in_tick <= 0);
-	xm_tick(ctx);
+	PROFILE_SCOPE(PS_XM_LIBXM) {
+		xm_tick(ctx);
+	}
 
 	if (!xmp->looping && ctx->loop_count > 0) {
 		stop(ctx, xmp);
-		return 0;
+		delay = 0;
+		goto done;
 	}
 
 	float gvol = ctx->global_volume * ctx->amplification;
 
-	for (int i=0;i<ctx->module.num_channels;i++) {
-		xm_channel_context_t *ch = &ctx->channels[i];
-		if (ch->sample && ch->sample_position >= 0) {
-			wav64_t *w = ch->sample->wave;
-			
-			// Check if this sample is muted. This is an user-level muting
-			// control exposed via the xm.h API that we respect in case the
-			// user wants to mute some channels (usually for debugging).
-			bool muted = ch->muted || ch->instrument->muted;
+	PROFILE_SCOPE(PS_XM_SYNC) {
+		for (int i=0;i<ctx->module.num_channels;i++) {
+			xm_channel_context_t *ch = &ctx->channels[i];
+			if (ch->sample && ch->sample_position >= 0) {
+				wav64_t *w = ch->sample->wave;
 
-			// Play the waveform, if it was not already playing. We don't handle
-			// explicit key-on events here since it's a bit complex in XM, so
-			// we just passively check whether we need to start playing or not.
-			if (mixer_ch_playing_waveform(first_ch+i) != &w->wave)
-				wav64_play(w, first_ch+i);
+				// Check if this sample is muted. This is an user-level muting
+				// control exposed via the xm.h API that we respect in case the
+				// user wants to mute some channels (usually for debugging).
+				bool muted = ch->muted || ch->instrument->muted;
 
-			// Set the position of the sample expected by the playback engine.
-			mixer_ch_set_pos(first_ch+i, ch->sample_position);
+				// Play the waveform, if it was not already playing. We don't handle
+				// explicit key-on events here since it's a bit complex in XM, so
+				// we just passively check whether we need to start playing or not.
+				if (mixer_ch_playing_waveform(first_ch+i) != &w->wave)
+					wav64_play(w, first_ch+i);
 
-			// Configure also frequency and volume that might have changed
-			// since last tick.
-			mixer_ch_set_freq(first_ch+i, ch->frequency);
-			mixer_ch_set_vol(first_ch+i,
-				muted ? 0 : gvol * ch->actual_volume[0],
-				muted ? 0 : gvol * ch->actual_volume[1]);
-		} else {
-			mixer_ch_stop(first_ch+i);
+				// Set the position of the sample expected by the playback engine.
+				mixer_ch_set_pos(first_ch+i, ch->sample_position);
+
+				// Configure also frequency and volume that might have changed
+				// since last tick.
+				mixer_ch_set_freq(first_ch+i, ch->frequency);
+				mixer_ch_set_vol(first_ch+i,
+					muted ? 0 : gvol * ch->actual_volume[0],
+					muted ? 0 : gvol * ch->actual_volume[1]);
+			} else {
+				mixer_ch_stop(first_ch+i);
+			}
 		}
 	}
 
 	// Schedule next tick according to the number of samples in this tick.
-	int delay = ceilf(ctx->remaining_samples_in_tick);
+	delay = ceilf(ctx->remaining_samples_in_tick);
 	ctx->remaining_samples_in_tick -= delay;
+done: ;
+	}
 	return delay;
 }
 

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -186,8 +186,9 @@ void xm64player_open(xm64player_t *player, const char *fn) {
 				lseek(player->fd, samp->data8_offset, SEEK_SET);
 				samp->wave = wav64_loadfd(player->fd, filename, NULL);
 			} else {
+				wav64_loadparms_t parms = { .streaming_mode = WAV64_STREAMING_NONE };
 				sprintf(extfn, "%s/%08lx.wav64", xm64_extsampledir, samp->data8_offset);
-				samp->wave = wav64_load(strdup(extfn), NULL);
+				samp->wave = wav64_load(strdup(extfn), &parms);
 			}
 		}
 	}

--- a/src/audio/xm64.c
+++ b/src/audio/xm64.c
@@ -39,6 +39,15 @@ static int tick(void *arg) {
 		xm_channel_context_t *ch = &ctx->channels[i];
 		if (mixer_ch_playing(first_ch+i))
 			ch->sample_position = mixer_ch_get_pos(first_ch+i);
+		else
+			// The mixer auto-stopped the channel: a non-looping sample
+			// reached its end. Mark it as finished like libxm's own mixer
+			// would (see xm_next_of_sample), otherwise the playback loop
+			// below would keep restarting the waveform at the last synced
+			// (stale) position, which is also an invalid seek point for
+			// compressed streams. Any new note will reset this via
+			// xm_trigger_note; seeks reset it explicitly below.
+			ch->sample_position = -1;
 	}
 
 	// If we're requested to stop playback, do it.
@@ -134,7 +143,8 @@ void xm64player_open(xm64player_t *player, const char *fn) {
 		}
 		assertf(0, "cannot load XM64 file: %s\nFile corrupted", fn);
 	}
-	assertf(header.version == 11, "cannot load XM64 file: %s\nVersion %d not supported", fn, header.version);
+	assertf(header.version == 11 || header.version == 12,
+		"cannot load XM64 file: %s\nVersion %d not supported", fn, header.version);
 
 	// Seek to the beginning of the metadata, that are asset-compressed. We need
 	// to read the metadata in small chunks, so we use asset_fopen() for this.

--- a/src/audio/ym64.c
+++ b/src/audio/ym64.c
@@ -66,7 +66,7 @@ static void ym_wave_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bo
 	// Now switch to integers. Number of audioframes to process, and number
 	// of (integer) samplers per audioframe.
 	int nframes = lastframe - player->curframe + 1;
-	int samples_per_frame = (int)f_samples_per_frame;
+	int samples_per_frame = player->wave.append_units;
 
 	// Get the pointer to the sample buffer.
 	int16_t *samples = samplebuffer_append(sbuf, nframes*samples_per_frame);
@@ -205,6 +205,8 @@ void ym64player_open(ym64player_t *player, const char *fn, ym64player_songinfo_t
 		.loop_len = len-loop_start,
 		.read = ym_wave_read,
 		.ctx = player,
+		// Every audioframe is reconstructed as a whole (see #ym_wave_read).
+		.append_units = (int)(freq / player->playfreq),
 	};
 
 	ay8910_reset(&player->ay);

--- a/src/rspq/rspq.c
+++ b/src/rspq/rspq.c
@@ -373,6 +373,7 @@ typedef struct rspq_queue_s {
 
 static rspq_ctx_t lowpri;               ///< Lowpri queue context
 static rspq_ctx_t highpri;              ///< Highpri queue context
+static int highpri_nesting;             ///< Nesting level of #rspq_highpri_begin
 
 rspq_ctx_t *rspq_ctx;                   ///< Current context
 volatile uint32_t *rspq_cur_pointer;    ///< Copy of the current write pointer (see #rspq_ctx_t)
@@ -794,6 +795,7 @@ void rspq_init(void)
     rspq_block = NULL;
     rspq_queue_recording = NULL;
     rspq_is_running = false;
+    highpri_nesting = 0;
 
     // Activate SP interrupt (used for syncpoints)
     register_SP_handler(rspq_sp_interrupt);
@@ -1198,9 +1200,13 @@ void rspq_flush(void)
 
 void rspq_highpri_begin(void)
 {
-    assertf(rspq_ctx != &highpri, "already in highpri mode");
     assertf(!rspq_block, "cannot switch to highpri mode while creating a block");
     assertf(!rspq_queue_recording, "cannot switch to highpri mode while recording a queue");
+
+    if (rspq_ctx == &highpri) {
+        highpri_nesting++;
+        return;
+    }
 
     rspq_switch_context(&highpri);
 
@@ -1259,6 +1265,11 @@ void rspq_highpri_end(void)
 {
     assertf(rspq_ctx == &highpri, "not in highpri mode");
 
+    if (highpri_nesting) {
+        highpri_nesting--;
+        return;
+    }
+
     // Write the highpri epilog. The epilog starts with a JUMP to the next
     // instruction because we want to force the RSP to reload the buffer
     // from RDRAM in case the epilog has been overwritten by a new highpri
@@ -1273,10 +1284,29 @@ void rspq_highpri_end(void)
 
 void rspq_highpri_sync(void)
 {
-    assertf(rspq_ctx != &highpri, "this function can only be called outside of highpri mode");
-
     // Make sure the RSP is running, otherwise we might be blocking forever.
+    // This also clears HALT, so that the check below cannot be fooled by a
+    // halted state that predates the commands we are waiting for.
     rspq_flush_internal();
+
+    if (rspq_ctx == &highpri) {
+        // We are in the middle of building a highpri sequence, so its epilog
+        // (the only thing that clears SIG_HIGHPRI_RUNNING) has not been written
+        // yet and the wait below would never be satisfied. Wait on a different
+        // condition: an unterminated highpri queue simply ends at our write
+        // pointer, where the RSP finds the queue terminator and halts itself
+        // (see RSPQCmd_WaitNewInput in rsp_queue.inc). So the halt means that
+        // everything written so far has been executed. DMA status must be
+        // checked too: "break" also runs while an asynchronous transfer
+        // started by the last command is still in flight.
+        ACCT_SCOPE(ACCT_CAT_RSPQ) RSP_WAIT_LOOP(200) {
+            uint32_t status = *SP_STATUS;
+            if ((status & SP_STATUS_HALTED) &&
+                !(status & (SP_STATUS_DMA_BUSY | SP_STATUS_DMA_FULL)))
+                break;
+        }
+        return;
+    }
 
     ACCT_SCOPE(ACCT_CAT_RSPQ) RSP_WAIT_LOOP(200) {
         __rspq_deferred_poll();

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ include $(N64_INST)/include/n64.mk
 
 N64_MKMATERIAL = $(N64_INST)/bin/mkmaterial
 
-all: testrom.z64 testrom_emu.z64 testrom_h264.z64 testrom_wav64.z64
+all: testrom.z64 testrom_emu.z64 testrom_h264.z64 testrom_wav64.z64 testrom_samplebuffer.z64
 
 MAIN_ELF_EXTERNS := $(BUILD_DIR)/testrom.externs
 DSO_MODULES = dl_test_syms.dso dl_test_relocs.dso dl_test_imports.dso dl_test_ctors.dso
@@ -64,6 +64,9 @@ testrom_emu.z64: N64_ROM_TITLE="Libdragon H264 Test"
 $(BUILD_DIR)/testrom_wav64.elf: $(BUILD_DIR)/test_wav64.o
 testrom_wav64.z64: N64_ROM_TITLE="Libdragon WAV64 Test"
 
+$(BUILD_DIR)/testrom_samplebuffer.elf: $(BUILD_DIR)/test_samplebuffer.o
+testrom_samplebuffer.z64: N64_ROM_TITLE="Samplebuffer Test"
+
 $(BUILD_DIR)/testrom_emu.o: $(SOURCE_DIR)/testrom.c
 	@mkdir -p $(dir $@)
 	@echo "    [CC] $<"
@@ -81,7 +84,7 @@ filesystem/dl_test_imports.dso: $(BUILD_DIR)/dl_test_imports.o
 filesystem/dl_test_ctors.dso: $(BUILD_DIR)/dl_test_ctors.o
 
 clean:
-	rm -rf $(BUILD_DIR) testrom.z64 testrom_emu.z64 testrom_h264.z64 testrom_wav64.z64
+	rm -rf $(BUILD_DIR) testrom.z64 testrom_emu.z64 testrom_h264.z64 testrom_wav64.z64 testrom_samplebuffer.z64
 	$(MAKE) -C h264decoder_host clean
 
 h264decoder_host:

--- a/tests/test_samplebuffer.c
+++ b/tests/test_samplebuffer.c
@@ -1,0 +1,173 @@
+/**
+ * @file test_samplebuffer.c
+ * @brief Standalone testrom for the samplebuffer circular logic
+ *
+ * A synthetic producer appends fixed-size chunks whose content is a known
+ * function of the absolute waveform position; every window handed out by
+ * #samplebuffer_get is verified against it. Covers declared /
+ * auto-detected / small-declared append granularities, seeks and undos that
+ * break the write phase (forcing an aligned relocate).
+ */
+#include <libdragon.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define SB_CHUNK       960     // append granularity of the fake codec
+
+static int sb_undo_units;      // units the producer drops from a read
+static bool sb_undo_always;    // drop on every read, not just the seeking ones
+static int sb_nwindows;
+static int sb_failed;
+
+static int16_t sb_expected(int pos) {
+	return (int16_t)(pos * 7919 + 12345);
+}
+
+static void sb_prod_read(void *ctx, samplebuffer_t *sbuf, int wpos, int wlen, bool seeking)
+{
+	int n = (wlen + SB_CHUNK - 1) / SB_CHUNK;
+	int16_t *out = samplebuffer_append(sbuf, n * SB_CHUNK);
+	for (int i = 0; i < n * SB_CHUNK; i++)
+		out[i] = sb_expected(wpos + i);
+	// Emulate the Opus intra-frame skip: part of the decoded frame is dropped,
+	// which leaves the write cursor out of phase with the chunk size.
+	if (sb_undo_units && (seeking || sb_undo_always))
+		samplebuffer_undo(sbuf, sb_undo_units);
+}
+
+static waveform_t sb_wave = {
+	.name = "fake", .bits = 16, .channels = 1, .frequency = 48000,
+	.len = 1 << 30, .read = sb_prod_read, .append_units = SB_CHUNK,
+};
+
+// Same producer, but without declaring the granularity: the samplebuffer has
+// to learn it from the appends themselves.
+static waveform_t sb_wave_undeclared = {
+	.name = "fake2", .bits = 16, .channels = 1, .frequency = 48000,
+	.len = 1 << 30, .read = sb_prod_read,
+};
+
+// Declares a divisor of the chunk it really appends, small enough to fit the
+// tail margin: useless as it is, so the samplebuffer must look past it.
+static waveform_t sb_wave_small = {
+	.name = "fake3", .bits = 16, .channels = 1, .frequency = 48000,
+	.len = 1 << 30, .read = sb_prod_read, .append_units = 96,
+};
+
+static waveform_t *sb_cur_wave = &sb_wave;
+
+static bool sb_check_window(const int16_t *p, int pos, int len)
+{
+	sb_nwindows++;
+	for (int i = 0; i < len; i++) {
+		if (p[i] != sb_expected(pos + i)) {
+			printf("  FAIL mismatch at pos=%d (+%d): got %04x, expected %04x\n",
+				pos, i, (uint16_t)p[i], (uint16_t)sb_expected(pos + i));
+			debugf("  FAIL mismatch at pos=%d (+%d): got %04x, expected %04x\n",
+				pos, i, (uint16_t)p[i], (uint16_t)sb_expected(pos + i));
+			return false;
+		}
+	}
+	return true;
+}
+
+// Drive a samplebuffer of `nbytes` for `niter` windows, seeking every
+// `seek_every` iterations, and verify all the data handed out.
+static bool sb_stress(const char *tag, int nbytes,
+	int niter, int seek_every, int undo, bool ualways)
+{
+	sb_undo_units = undo;
+	sb_undo_always = ualways;
+	sb_nwindows = 0;
+
+	void *mem = malloc_uncached(nbytes);
+	assertf(mem != NULL, "malloc_uncached(%d) failed", nbytes);
+
+	samplebuffer_t sb = {0};
+	samplebuffer_init(&sb, mem, nbytes, 0);
+	samplebuffer_set_bps(&sb, 16);
+	samplebuffer_set_waveform(&sb, sb_cur_wave, sb_prod_read);
+
+	uint32_t rng = 12345;
+	int pos = 0;
+	bool ok = true;
+	for (int i = 0; i < niter && ok; i++) {
+		rng = rng * 1103515245 + 12345;
+		if (seek_every && i && i % seek_every == 0) {
+			// Jump around: backwards (flush) or far forward (flush).
+			pos = (int)((rng >> 8) % 100000);
+			continue;
+		}
+		int want = 1 + (int)((rng >> 9) % 100);
+		int len = want;
+		int16_t *p = samplebuffer_get(&sb, pos, &len);
+		assertf(len > 0, "samplebuffer_get returned nothing");
+		ok = sb_check_window(p, pos, len);
+		// Consume part of the window, like the mixer does.
+		pos += 1 + (int)((rng >> 17) % len);
+	}
+
+	char line[96];
+	snprintf(line, sizeof(line), "  %-22s %s  size=%5d windows=%5d\n",
+		tag, ok ? "PASS" : "FAIL", sb.size, sb_nwindows);
+	printf("%s", line);
+	debugf("%s", line);
+
+	// Do not call samplebuffer_close: it would free `mem` a second time.
+	memset(&sb, 0, sizeof(sb));
+	free_uncached(mem);
+	return ok;
+}
+
+int main(void)
+{
+	debug_init_emulog();
+	debug_init_usblog();
+	emux_ioctl_fast();
+	console_init();
+
+	// Relocate may call #rspq_highpri_sync; keep the queue engine alive.
+	rspq_init();
+
+	printf("samplebuffer stress tests\n\n");
+	debugf("samplebuffer stress tests\n\n");
+
+	// A buffer whose usable size is a multiple of the chunk (the alignment
+	// engages) and one where it is not (falls back to relocating), stressed
+	// with seeks and with undos that break the write cursor phase.
+	int big = (SB_CHUNK * 4 + SAMPLEBUFFER_MARGIN_UNITS) * 2;
+	int odd = big + 2 * 133;
+	int small = (SB_CHUNK * 3 + SAMPLEBUFFER_MARGIN_UNITS) * 2;
+
+	static waveform_t *waves[] = { &sb_wave, &sb_wave_undeclared, &sb_wave_small };
+	static const char *names[] = { "declared", "learnt", "smalldecl" };
+
+	int total = 0;
+	for (int w = 0; w < 3; w++) {
+		sb_cur_wave = waves[w];
+		char tag[48];
+		#define T(name)  (sprintf(tag, "%s/%s", name, names[w]), tag)
+		#define RUN(...) do { total++; if (!sb_stress(__VA_ARGS__)) sb_failed++; } while (0)
+		RUN(T("plain"),       big,   3000, 0,   0,   false);
+		RUN(T("seek"),        big,   3000, 97,  0,   false);
+		RUN(T("seek+undo"),   big,   3000, 97,  333, false);
+		RUN(T("odd"),         odd,   3000, 0,   0,   false);
+		RUN(T("odd+undo"),    odd,   3000, 97,  333, false);
+		RUN(T("drift"),       small, 6000, 0,   333, true);
+		RUN(T("drift+seek"),  small, 6000, 397, 333, true);
+		RUN(T("drift-odd"),   odd,   6000, 0,   333, true);
+		#undef RUN
+		#undef T
+	}
+
+	if (sb_failed) {
+		printf("\n%d/%d TESTS FAILED\n", sb_failed, total);
+		debugf("\n%d/%d TESTS FAILED\n", sb_failed, total);
+		abort();
+	}
+	printf("\nALL TESTS PASSED (%d)\n", total);
+	debugf("\nALL TESTS PASSED (%d)\n", total);
+	return 0;
+}

--- a/tests/test_wav64.c
+++ b/tests/test_wav64.c
@@ -1,16 +1,9 @@
 /**
  * @file test_wav64.c
- * @brief Standalone testrom for the VADPCM RSP decompressor
+ * @brief Standalone testrom for in-mixer VADPCM (MIX_CHANNEL)
  *
- * This test exercises the VADPCM decompression microcode in rsp_mixer.S by
- * decompressing a sequence of frames (so that the inter-frame context update
- * is exercised too) and comparing the RSP output, bit by bit, against the
- * reference C decoder taken from src/audio/wav64_vadpcm.c.
- *
- * The frames and codebook are synthesized in this file using a deterministic
- * PRNG, using value ranges that match what a real VADPCM encoder produces
- * (small codebook coefficients, limited scaling), so that RSP and reference
- * agree bit-exactly without hitting unrealistic intermediate overflows.
+ * Exercises the VADPCM path inside MIX_CHANNEL and compares against the
+ * reference C decoder. The legacy VADPCM_Decompress command has been removed.
  */
 #include <libdragon.h>
 #include <malloc.h>
@@ -23,7 +16,7 @@
 #include "../src/audio/wav64_vadpcm_internal.h"
 
 //////////////////////////////////////////////////////////////////////////////
-// Reference VADPCM decoder (copied verbatim from src/audio/wav64_vadpcm.c)
+// Reference VADPCM decoder
 //////////////////////////////////////////////////////////////////////////////
 
 typedef enum {
@@ -105,138 +98,35 @@ static uint32_t my_rand(void) {
     return rand_state = x;
 }
 
-// Number of predictors in the synthesized codebook. Must be <= 4 so that the
-// per-channel codebook (8 vectors = 4 predictors of order 2) fits in the
-// 128-byte half used by the RSP for each stereo channel.
 #define NPREDICTORS   4
 #define ORDER         2
-
-// RSP decompression: replicates rsp_vadpcm_decompress() from wav64_vadpcm.c.
-static void rsp_vadpcm_decompress(void *input, int16_t *output, bool stereo,
-    int nframes, wav64_vadpcm_vector_t *state, wav64_vadpcm_vector_t *codebook)
-{
-    rspq_write(__mixer_overlay_id, 0x1,
-        PhysicalAddr(input),
-        PhysicalAddr(output) | (nframes-1) << 24,
-        PhysicalAddr(state)  | (stereo ? 1 : 0) << 31,
-        PhysicalAddr(codebook));
-    rspq_wait();
-}
-
-// Synthesize a realistic codebook (16 vectors = 256 bytes: 8 vectors per
-// channel). Coefficients are kept small to mimic a real VADPCM encoder.
-static void gen_codebook(wav64_vadpcm_vector_t *cb) {
-    for (int v = 0; v < 16; v++)
-        for (int i = 0; i < 8; i++)
-            cb[v].v[i] = (int16_t)((my_rand() % 4096) - 2048);
-}
-
-// Synthesize a sequence of VADPCM frames (9 bytes each).
-static void gen_frames(uint8_t *frames, int nframes_total) {
-    for (int f = 0; f < nframes_total; f++) {
-        uint8_t *fin = frames + 9 * f;
-        int scaling = my_rand() % 5;            // 0..4: keeps accumulator bounded
-        int predictor = my_rand() % NPREDICTORS;
-        fin[0] = (scaling << 4) | predictor;
-        for (int i = 1; i < 9; i++)
-            fin[i] = my_rand();                 // 8 residual bytes (random nibbles)
-    }
-}
-
-// out_misalign: byte offset (0/2/4/6) applied to the RDRAM output buffer to
-// exercise the misaligned-output path (rdram_output & 7 != 0), which triggers
-// the read-modify-write merge loop (VADPCM_OutputMergeLoop) in rsp_mixer.S.
-static bool test_vadpcm(int nframes, bool stereo, int seed, int out_misalign) {
-    int channels = stereo ? 2 : 1;
-    my_srand(seed);
-
-    wav64_vadpcm_vector_t *codebook = malloc_uncached(16 * sizeof(wav64_vadpcm_vector_t));
-    gen_codebook(codebook);
-
-    wav64_vadpcm_vector_t *state_rsp = malloc_uncached(2 * sizeof(wav64_vadpcm_vector_t));
-    memset(state_rsp, 0, 2 * sizeof(wav64_vadpcm_vector_t));
-    wav64_vadpcm_vector_t state_ref[2];
-    memset(state_ref, 0, sizeof(state_ref));
-
-    int nframes_total = nframes * channels;
-    int in_bytes = 9 * nframes_total;
-    uint8_t *frames = malloc(in_bytes);     // pristine copy (reference reads this)
-    gen_frames(frames, nframes_total);
-
-    // Output buffer. The RSP decoder works in-place: the compressed input is
-    // placed at the tail of the output buffer (exactly like waveform_vadpcm_read).
-    // To exercise the misaligned-output path we allocate a 16-byte aligned base
-    // (malloc_uncached) and offset the output pointer by out_misalign bytes; the
-    // decoded sample values are independent of where the buffer lands.
-    int out_samples = nframes * 16 * channels;
-    int out_bytes = out_samples * 2;
-    int buf_bytes = (out_bytes + 15) & ~15;
-    uint8_t *rsp_buf = malloc_uncached(buf_bytes + 32);
-    // Fill with a sentinel so a buggy merge that corrupts neighbouring bytes
-    // (before the output or in the trailing word) is more likely to be noticed.
-    memset(rsp_buf, 0xA5, buf_bytes + 32);
-    int16_t *rsp_out = (int16_t*)(rsp_buf + out_misalign);
-    uint8_t *rsp_in = (uint8_t*)rsp_out + out_bytes - in_bytes;
-    memcpy(rsp_in, frames, in_bytes);
-
-    rsp_vadpcm_decompress(rsp_in, rsp_out, stereo, nframes, state_rsp, codebook);
-
-    // Reference decode
-    int16_t *ref_out = malloc(out_bytes);
-    if (!stereo) {
-        vadpcm_error err = vadpcm_decode(NPREDICTORS, ORDER, codebook, state_ref,
-            nframes, ref_out, frames);
-        assertf(err == 0, "reference decode error: %d", err);
-    } else {
-        int16_t uncomp[2][16];
-        int16_t *dst = ref_out;
-        uint8_t *src = frames;
-        for (int i = 0; i < nframes; i++) {
-            for (int j = 0; j < 2; j++) {
-                vadpcm_error err = vadpcm_decode(NPREDICTORS, ORDER, codebook + 8*j,
-                    &state_ref[j], 1, uncomp[j], src);
-                assertf(err == 0, "reference decode error: %d", err);
-                src += 9;
-            }
-            for (int j = 0; j < 16; j++) {
-                *dst++ = uncomp[0][j];
-                *dst++ = uncomp[1][j];
-            }
-        }
-    }
-
-    // Compare
-    bool ok = true;
-    for (int i = 0; i < out_samples; i++) {
-        if (rsp_out[i] != ref_out[i]) {
-            printf("FAILED: %s nframes=%d seed=%d misalign=%d: sample %d: rsp=%d ref=%d\n",
-                stereo ? "stereo" : "mono", nframes, seed, out_misalign, i, rsp_out[i], ref_out[i]);
-            ok = false;
-            break;
-        }
-    }
-
-    free_uncached(codebook);
-    free_uncached(state_rsp);
-    free_uncached(rsp_buf);
-    free(frames);
-    free(ref_out);
-    return ok;
-}
-
-// ---------------------------------------------------------------------------
-// In-mixer VADPCM path (MIX_CHANNEL + CH_FLAGS_VADPCM)
-// ---------------------------------------------------------------------------
 
 #define CH_FLAGS_16BIT       (1<<2)
 #define CH_FLAGS_VADPCM      (1<<5)
 #define CH_FLAGS_CLEAR_ACCUM (1<<7)
 #define MIXER_FX64_FRAC      12
 
+static void gen_codebook(wav64_vadpcm_vector_t *cb) {
+    for (int v = 0; v < 8; v++)
+        for (int i = 0; i < 8; i++)
+            cb[v].v[i] = (int16_t)((my_rand() % 4096) - 2048);
+}
+
+static void gen_frames(uint8_t *frames, int nframes_total) {
+    for (int f = 0; f < nframes_total; f++) {
+        uint8_t *fin = frames + 9 * f;
+        int scaling = my_rand() % 5;
+        int predictor = my_rand() % NPREDICTORS;
+        fin[0] = (scaling << 4) | predictor;
+        for (int i = 1; i < 9; i++)
+            fin[i] = my_rand();
+    }
+}
+
 static bool test_vadpcm_inmixer(int nframes, int seed) {
     my_srand(seed);
 
-    wav64_vadpcm_vector_t *codebook = malloc_uncached(16 * sizeof(wav64_vadpcm_vector_t));
+    wav64_vadpcm_vector_t *codebook = malloc_uncached(8 * sizeof(wav64_vadpcm_vector_t));
     gen_codebook(codebook);
 
     wav64_vadpcm_vector_t *state_rsp = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
@@ -249,7 +139,7 @@ static bool test_vadpcm_inmixer(int nframes, int seed) {
     gen_frames(frames, nframes);
 
     int nsamples = nframes * 16;
-    int16_t *ref_out = malloc(nsamples * 2);
+    int16_t *ref_out = malloc((size_t)nsamples * sizeof(int16_t));
     vadpcm_error err = vadpcm_decode(NPREDICTORS, ORDER, codebook, &state_ref,
         nframes, ref_out, frames);
     assertf(err == 0, "reference decode error: %d", err);
@@ -261,10 +151,7 @@ static bool test_vadpcm_inmixer(int nframes, int seed) {
     int16_t vol = 0x7FFF;
     uint32_t flags = CH_FLAGS_VADPCM | CH_FLAGS_16BIT | CH_FLAGS_CLEAR_ACCUM;
 
-    // Warm up the per-channel volume filter: XVOL starts at 0 in the overlay
-    // saved state and converges to the channel volume via the one-tap filter
-    // (one step every 8 samples), so run a few full discarded rounds first.
-    // The warm-up loops over the same frames with a throwaway decoder state.
+    // Warm up the per-channel volume filter.
     wav64_vadpcm_vector_t *state_warm = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
     memset(state_warm, 0, sizeof(*state_warm));
     int32_t *warm_out = malloc_uncached(256 * 4);
@@ -310,9 +197,7 @@ static bool test_vadpcm_inmixer(int nframes, int seed) {
     rspq_highpri_end();
     rspq_wait();
 
-    // The in-mixer path multiplies by the filtered volume with vmulf, so it
-    // cannot be bit-exact: XVOL settles at 0x7FFE/0x7FFF, which can shift
-    // full-scale samples by up to 2 LSB.
+    // vmulf volume path: allow ±2 LSB vs full-scale reference.
     bool ok = true;
     int16_t *stereo = (int16_t*)out;
     for (int i = 0; i < nsamples; i++) {
@@ -346,56 +231,20 @@ int main(void)
 
     console_init();
 
-    printf("WAV64 VADPCM RSP decoder tests\n\n");
+    printf("WAV64 VADPCM in-mixer tests\n\n");
 
     audio_init(44100, 4);
     mixer_init(8);
 
     int total = 0, failed = 0;
-#if 0
-    // TRACE MODE: single run so the RSP trace (xtracestart/xtracestop around the
-    // decode loop) is short and readable; flip stereo to measure each path.
-    total++;
-    if (!test_vadpcm(32, true, 1, 0))
-        failed++;
-#else
-    int frame_counts[] = { 1, 2, 16, 32 };
-
-    // Aligned output buffer (out_misalign = 0).
-    for (int s = 0; s < 8; s++) {
-        for (int fc = 0; fc < 4; fc++) {
-            for (int stereo = 0; stereo < 2; stereo++) {
-                total++;
-                if (!test_vadpcm(frame_counts[fc], stereo, s + 1, 0))
-                    failed++;
-            }
-        }
-    }
-
-    // Misaligned output buffer (out_misalign = 2/4/6): exercises the
-    // rdram_output & 7 != 0 merge path (VADPCM_OutputMergeLoop).
-    for (int s = 0; s < 2; s++) {
-        for (int fc = 0; fc < 4; fc++) {
-            for (int stereo = 0; stereo < 2; stereo++) {
-                for (int m = 2; m <= 6; m += 2) {
-                    total++;
-                    if (!test_vadpcm(frame_counts[fc], stereo, s + 1, m))
-                        failed++;
-                }
-            }
-        }
-    }
-
-    // In-mixer mono VADPCM (MIX_CHANNEL path). Cap at 16 frames (256 samples).
     int inmix_frames[] = { 1, 2, 8, 16 };
-    for (int s = 0; s < 4; s++) {
+    for (int s = 0; s < 8; s++) {
         for (int fc = 0; fc < 4; fc++) {
             total++;
             if (!test_vadpcm_inmixer(inmix_frames[fc], s + 1))
                 failed++;
         }
     }
-#endif
 
     if (failed) {
         printf("\n%d/%d TESTS FAILED\n", failed, total);

--- a/tests/test_wav64.c
+++ b/tests/test_wav64.c
@@ -103,6 +103,8 @@ static uint32_t my_rand(void) {
 
 #define CH_FLAGS_BPS_SHIFT   (3<<0)
 #define CH_FLAGS_16BIT       (1<<2)
+#define CH_FLAGS_STEREO      (1<<3)
+#define CH_FLAGS_STEREO_SUB  (1<<4)
 #define CH_FLAGS_VADPCM      (1<<5)
 #define CH_FLAGS_CLEAR_ACCUM (1<<7)
 #define MIXER_FX64_FRAC      12
@@ -119,12 +121,13 @@ static void emit_setchannel(int ch, void *codebook, void *state) {
         PhysicalAddr(codebook), PhysicalAddr(state), 0);
 }
 
-static void emit_channel(int ch, uint32_t flags, int16_t vol, uint32_t pos,
-    uint32_t step, uint32_t len, uint32_t loop_len, void *ptr, int nsamples)
+static void emit_channel_lr(int ch, uint32_t flags, int16_t lvol, int16_t rvol,
+    uint32_t pos, uint32_t step, uint32_t len, uint32_t loop_len, void *ptr,
+    int nsamples)
 {
     rspq_write_t w = rspq_write_begin(__mixer_overlay_id, MIXER_CMD_CHANNEL, 8);
     rspq_write_arg(&w, ((uint32_t)ch << 16) | ((flags & 0xFF) << 8));
-    rspq_write_arg(&w, ((uint32_t)(uint16_t)vol << 16) | (uint16_t)vol);
+    rspq_write_arg(&w, ((uint32_t)(uint16_t)lvol << 16) | (uint16_t)rvol);
     rspq_write_arg(&w, pos);
     rspq_write_arg(&w, step);
     rspq_write_arg(&w, len);
@@ -132,6 +135,12 @@ static void emit_channel(int ch, uint32_t flags, int16_t vol, uint32_t pos,
     rspq_write_arg(&w, PhysicalAddr(ptr));
     rspq_write_arg(&w, (uint32_t)nsamples);   // acc_offset 0
     rspq_write_end(&w);
+}
+
+static void emit_channel(int ch, uint32_t flags, int16_t vol, uint32_t pos,
+    uint32_t step, uint32_t len, uint32_t loop_len, void *ptr, int nsamples)
+{
+    emit_channel_lr(ch, flags, vol, vol, pos, step, len, loop_len, ptr, nsamples);
 }
 
 static void emit_flush(int nsamples, void *out) {
@@ -373,6 +382,89 @@ static bool test_pcm_resample(bool is16, uint32_t step, int nsamples, int seed)
     return ok;
 }
 
+// Stereo PCM: interleaved L/R in the waveform, two MIX_CHANNELs (owner=L,
+// STEREO_SUB=R) that share the Hermite loop with mono.
+static bool test_pcm_resample_stereo(bool is16, uint32_t step, int nsamples, int seed)
+{
+    my_srand(seed);
+
+    int bps = (is16 ? 1 : 0) + 1; // stereo
+    int nframes = 512;
+    int wave_bytes = (nframes << bps) + 256;
+    uint8_t *wave = malloc_uncached(wave_bytes);
+    memset(wave, 0, wave_bytes);
+    for (int i = 0; i < nframes * 2; i++) {
+        if (is16) ((int16_t*)wave)[i] = (int16_t)my_rand();
+        else      ((int8_t*)wave)[i]  = (int8_t)my_rand();
+    }
+
+    int32_t *out = malloc_uncached(nsamples * 4);
+    memset(out, 0, nsamples * 4);
+
+    int16_t vol = 0x7FFF;
+    uint32_t flags_l = CH_FLAGS_CLEAR_ACCUM | CH_FLAGS_STEREO |
+        (is16 ? (CH_FLAGS_16BIT | 2) : 1);
+    uint32_t flags_r = CH_FLAGS_STEREO | CH_FLAGS_STEREO_SUB |
+        (is16 ? (CH_FLAGS_16BIT | 2) : 1);
+    uint32_t len = (uint32_t)(nframes << bps) << MIXER_FX64_FRAC;
+
+    int32_t *warm = malloc_uncached(WARMUP_SAMPLES * 4);
+    for (int i = 0; i < 4; i++) {
+        rspq_highpri_begin();
+        emit_channel_lr(0, flags_l, vol, 0, 0, 0, len, 0, wave, WARMUP_SAMPLES);
+        emit_channel_lr(1, flags_r, 0, vol, 0, 0, len, 0, wave, WARMUP_SAMPLES);
+        emit_flush(WARMUP_SAMPLES, warm);
+        rspq_highpri_end();
+    }
+    rspq_wait();
+    free_uncached(warm);
+
+    rspq_highpri_begin();
+    emit_channel_lr(0, flags_l, vol, 0, 0, step, len, 0, wave, nsamples);
+    emit_channel_lr(1, flags_r, 0, vol, 0, step, len, 0, wave, nsamples);
+    emit_flush(nsamples, out);
+    rspq_highpri_end();
+    rspq_wait();
+
+    bool ok = true;
+    int16_t *stereo = (int16_t*)out;
+    int16_t settled = volume_settle(vol);
+    for (int i = 0; i < nsamples; i++) {
+        uint32_t pos = step * (uint32_t)i;
+        int fi = pos >> (MIXER_FX64_FRAC + bps);
+        uint16_t x = (uint16_t)(pos << (4 - bps));
+
+        int16_t yl[4], yr[4];
+        for (int t = 0; t < 4; t++) {
+            if (is16) {
+                yl[t] = ((int16_t*)wave)[(fi + t) * 2];
+                yr[t] = ((int16_t*)wave)[(fi + t) * 2 + 1];
+            } else {
+                yl[t] = (int16_t)(((int8_t*)wave)[(fi + t) * 2] << 8);
+                yr[t] = (int16_t)(((int8_t*)wave)[(fi + t) * 2 + 1] << 8);
+            }
+        }
+        int16_t res_l = hermite_ref(yl[0], yl[1], yl[2], yl[3], x);
+        int16_t res_r = hermite_ref(yr[0], yr[1], yr[2], yr[3], x);
+        int32_t vl = (int32_t)(((int64_t)res_l * settled * 2) >> 16);
+        int32_t vr = (int32_t)(((int64_t)res_r * settled * 2) >> 16);
+
+        int16_t l = stereo[i*2], r = stereo[i*2+1];
+        int d0 = l - vl, d1 = r - vr;
+        if (d0 < -2 || d0 > 2 || d1 < -2 || d1 > 2) {
+            printf("FAILED resample stereo %dbit step=%#lx: sample %d: L=%d/%ld R=%d/%ld\n",
+                is16 ? 16 : 8, step, i, l, vl, r, vr);
+            printf("  fi=%d x=%#x\n", fi, x);
+            ok = false;
+            break;
+        }
+    }
+
+    free_uncached(wave);
+    free_uncached(out);
+    return ok;
+}
+
 int main(void)
 {
     debug_init_emulog();
@@ -407,6 +499,19 @@ int main(void)
             uint32_t step = (uint32_t)(ratios[r] * (1 << (MIXER_FX64_FRAC + (is16 ? 1 : 0))));
             total++;
             if (!test_pcm_resample(is16, step, 96, r + 1))
+                failed++;
+        }
+    }
+
+    printf("Stereo PCM resampling tests\n");
+    fflush(stdout);
+    for (int b = 0; b < 2; b++) {
+        bool is16 = b != 0;
+        int bps = (is16 ? 1 : 0) + 1;
+        for (int r = 0; r < 7; r++) {
+            uint32_t step = (uint32_t)(ratios[r] * (1 << (MIXER_FX64_FRAC + bps)));
+            total++;
+            if (!test_pcm_resample_stereo(is16, step, 96, r + 10))
                 failed++;
         }
     }

--- a/tests/test_wav64.c
+++ b/tests/test_wav64.c
@@ -1,9 +1,9 @@
 /**
  * @file test_wav64.c
- * @brief Standalone testrom for in-mixer VADPCM (MIX_CHANNEL)
+ * @brief Standalone testrom for in-mixer VADPCM + PCM Hermite resampling
  *
- * Exercises the VADPCM path inside MIX_CHANNEL and compares against the
- * reference C decoder. The legacy VADPCM_Decompress command has been removed.
+ * Exercises MIX_CHANNEL: VADPCM decode into the sample cache followed by the
+ * same 4-tap Hermite resampler used for PCM, compared against a C reference.
  */
 #include <libdragon.h>
 #include <malloc.h>
@@ -165,102 +165,13 @@ static void gen_frames(uint8_t *frames, int nframes_total) {
     }
 }
 
-static bool test_vadpcm_inmixer(int nframes, int seed) {
-    my_srand(seed);
-
-    wav64_vadpcm_vector_t *codebook = malloc_uncached(8 * sizeof(wav64_vadpcm_vector_t));
-    gen_codebook(codebook);
-
-    wav64_vadpcm_vector_t *state_rsp = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
-    memset(state_rsp, 0, sizeof(*state_rsp));
-    wav64_vadpcm_vector_t state_ref;
-    memset(&state_ref, 0, sizeof(state_ref));
-
-    int in_bytes = 9 * nframes;
-    uint8_t *frames = malloc_uncached(in_bytes + 16);
-    gen_frames(frames, nframes);
-
-    int nsamples = nframes * 16;
-    int16_t *ref_out = malloc((size_t)nsamples * sizeof(int16_t));
-    vadpcm_error err = vadpcm_decode(NPREDICTORS, ORDER, codebook, &state_ref,
-        nframes, ref_out, frames);
-    assertf(err == 0, "reference decode error: %d", err);
-
-    int32_t *out = malloc_uncached(nsamples * 4);
-    memset(out, 0, nsamples * 4);
-
-    uint32_t step = 1u << MIXER_FX64_FRAC;
-    int16_t vol = 0x7FFF;
-    uint32_t flags = CH_FLAGS_VADPCM | CH_FLAGS_16BIT | CH_FLAGS_CLEAR_ACCUM;
-
-    // Warm up the per-channel volume filter.
-    wav64_vadpcm_vector_t *state_warm = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
-    memset(state_warm, 0, sizeof(*state_warm));
-    int32_t *warm_out = malloc_uncached(256 * 4);
-    for (int i = 0; i < 4; i++) {
-        rspq_highpri_begin();
-        emit_setchannel(0, codebook, state_warm);
-        emit_channel(0, flags, vol, 0, step,
-            (uint32_t)nsamples << MIXER_FX64_FRAC,
-            (uint32_t)nsamples << MIXER_FX64_FRAC,
-            frames, 256);
-        emit_flush(256, warm_out);
-        rspq_highpri_end();
-    }
-    rspq_wait();
-    free_uncached(state_warm);
-    free_uncached(warm_out);
-
-    rspq_highpri_begin();
-    emit_setchannel(0, codebook, state_rsp);
-    emit_channel(0, flags, vol, 0, step, 0xFFFFFFFFu, 0, frames, nsamples);
-    emit_flush(nsamples, out);
-    rspq_highpri_end();
-    rspq_wait();
-
-    // vmulf volume path: allow ±2 LSB vs full-scale reference.
-    bool ok = true;
-    int16_t *stereo = (int16_t*)out;
-    for (int i = 0; i < nsamples; i++) {
-        int16_t l = stereo[i*2], r = stereo[i*2+1];
-        int d0 = l - ref_out[i], d1 = r - ref_out[i];
-        if (d0 < -2 || d0 > 2 || d1 < -2 || d1 > 2) {
-            printf("FAILED in-mixer: nframes=%d seed=%d sample %d: L=%d R=%d ref=%d\n",
-                nframes, seed, i, l, r, ref_out[i]);
-            ok = false;
-            break;
-        }
-    }
-    if (ok && memcmp(state_rsp, &state_ref, sizeof(state_ref)) != 0) {
-        printf("FAILED in-mixer: nframes=%d seed=%d: state mismatch\n", nframes, seed);
-        ok = false;
-    }
-
-    free_uncached(codebook);
-    free_uncached(state_rsp);
-    free_uncached(frames);
-    free_uncached(out);
-    free(ref_out);
-    return ok;
-}
-
 //////////////////////////////////////////////////////////////////////////////
-// Mono PCM resampling
+// Hermite reference (shared by PCM and VADPCM tests)
 //////////////////////////////////////////////////////////////////////////////
 
 // Reference implementation of the RSP mono resampler: 4-tap Catmull-Rom
 // evaluated between the second and third tap, in the exact fixed point the
 // ucode uses.
-//
-//   x    = fraction of the sample position, 0.16 unsigned
-//   y0..3= the four taps around it, int16 (8-bit data is scaled by 256)
-//   out  = y1
-//        + x  *(y2 - y0)/2
-//        + x^2*(y0 - 5*y1/2 + 2*y2 - y3/2)
-//        + x^3*(-y0/2 + 3*y1/2 - 3*y2/2 + y3/2)
-//
-// Powers of x are truncated back to 0.16 after each product (vmudl), and every
-// term is summed in the 48-bit accumulator; only the final read clamps.
 static int16_t hermite_ref(int16_t y0, int16_t y1, int16_t y2, int16_t y3, uint16_t x)
 {
     uint16_t x2   = (uint16_t)(((uint32_t)x  * x) >> 16);
@@ -300,9 +211,6 @@ static int16_t hermite_ref(int16_t y0, int16_t y1, int16_t y2, int16_t y3, uint1
 #define WARMUP_SAMPLES  256
 
 // Value the one-tap volume filter of the ucode settles on for a given target.
-// It is not the target itself: the accumulator is read back truncated, so the
-// recurrence has a whole range of fixed points and, coming from zero, it stops
-// a few LSB short. Mirrors the vmudm/vmadm pair in the ucode.
 static int16_t volume_settle(int16_t target)
 {
     int32_t x = 0;
@@ -310,6 +218,111 @@ static int16_t volume_settle(int16_t target)
         x = (int32_t)(((int64_t)x * 0xe076 + (int64_t)target * 0x1f8a) >> 16);
     return (int16_t)x;
 }
+
+static bool test_vadpcm_inmixer(int nframes, uint32_t step, int nout, int seed) {
+    my_srand(seed);
+
+    wav64_vadpcm_vector_t *codebook = malloc_uncached(8 * sizeof(wav64_vadpcm_vector_t));
+    gen_codebook(codebook);
+
+    wav64_vadpcm_vector_t *state_rsp = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
+    memset(state_rsp, 0, sizeof(*state_rsp));
+    wav64_vadpcm_vector_t state_ref;
+    memset(&state_ref, 0, sizeof(state_ref));
+
+    int in_bytes = 9 * nframes;
+    uint8_t *frames = malloc_uncached(in_bytes + 16);
+    memset(frames, 0, in_bytes + 16);
+    gen_frames(frames, nframes);
+
+    int nsamples = nframes * 16;
+    // Pad decoded PCM with zeros for Hermite taps past the last sample.
+    int16_t *ref_pcm = malloc((size_t)(nsamples + 4) * sizeof(int16_t));
+    memset(ref_pcm, 0, (size_t)(nsamples + 4) * sizeof(int16_t));
+    vadpcm_error err = vadpcm_decode(NPREDICTORS, ORDER, codebook, &state_ref,
+        nframes, ref_pcm, frames);
+    assertf(err == 0, "reference decode error: %d", err);
+
+    int32_t *out = malloc_uncached(nout * 4);
+    memset(out, 0, nout * 4);
+
+    int16_t vol = 0x7FFF;
+    uint32_t flags = CH_FLAGS_VADPCM | CH_FLAGS_16BIT | CH_FLAGS_CLEAR_ACCUM;
+    uint32_t len = (uint32_t)nsamples << MIXER_FX64_FRAC;
+
+    // Warm up the per-channel volume filter (step 0 keeps pos at 0).
+    wav64_vadpcm_vector_t *state_warm = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
+    memset(state_warm, 0, sizeof(*state_warm));
+    int32_t *warm_out = malloc_uncached(WARMUP_SAMPLES * 4);
+    for (int i = 0; i < 4; i++) {
+        rspq_highpri_begin();
+        emit_setchannel(0, codebook, state_warm);
+        emit_channel(0, flags, vol, 0, 0, len, 0, frames, WARMUP_SAMPLES);
+        emit_flush(WARMUP_SAMPLES, warm_out);
+        rspq_highpri_end();
+    }
+    rspq_wait();
+    free_uncached(state_warm);
+    free_uncached(warm_out);
+
+    // Fresh state for the measured run.
+    memset(state_rsp, 0, sizeof(*state_rsp));
+    rspq_highpri_begin();
+    emit_setchannel(0, codebook, state_rsp);
+    emit_channel(0, flags, vol, 0, step, len, 0, frames, nout);
+    emit_flush(nout, out);
+    rspq_highpri_end();
+    rspq_wait();
+
+    bool ok = true;
+    int16_t *stereo = (int16_t*)out;
+    int16_t settled = volume_settle(vol);
+    for (int i = 0; i < nout; i++) {
+        uint32_t pos = step * (uint32_t)i;
+        int si = pos >> MIXER_FX64_FRAC;
+        uint16_t x = (uint16_t)(pos << 4);
+        int16_t y0 = ref_pcm[si], y1 = ref_pcm[si+1], y2 = ref_pcm[si+2], y3 = ref_pcm[si+3];
+        int16_t res = hermite_ref(y0, y1, y2, y3, x);
+        int32_t v = (int32_t)(((int64_t)res * settled * 2) >> 16);
+        int16_t l = stereo[i*2], r = stereo[i*2+1];
+        int d0 = l - v, d1 = r - v;
+        if (d0 < -2 || d0 > 2 || d1 < -2 || d1 > 2) {
+            printf("FAILED vadpcm hermite: nf=%d step=%#lx seed=%d i=%d: L=%d R=%d ref=%ld\n",
+                nframes, (long)step, seed, i, l, r, (long)v);
+            printf("  si=%d x=%#x taps=%d %d %d %d\n", si, x, y0, y1, y2, y3);
+            ok = false;
+            break;
+        }
+    }
+
+    // State ready for floor(final_pos / 16).
+    uint32_t end_pos = step * (uint32_t)nout;
+    int end_frame = end_pos >> (MIXER_FX64_FRAC + 4);
+    if (end_frame > nframes) end_frame = nframes;
+    wav64_vadpcm_vector_t state_end;
+    memset(&state_end, 0, sizeof(state_end));
+    int16_t *discard = malloc((size_t)nframes * 16 * sizeof(int16_t));
+    err = vadpcm_decode(NPREDICTORS, ORDER, codebook, &state_end,
+        end_frame, discard, frames);
+    assertf(err == 0, "reference end-state decode error: %d", err);
+    free(discard);
+    if (ok && memcmp(state_rsp, &state_end, sizeof(state_end)) != 0) {
+        printf("FAILED vadpcm hermite: nf=%d step=%#lx seed=%d: state mismatch (end_frame=%d)\n",
+            nframes, (long)step, seed, end_frame);
+        ok = false;
+    }
+
+    free_uncached(codebook);
+    free_uncached(state_rsp);
+    free_uncached(frames);
+    free_uncached(out);
+    free(ref_pcm);
+    return ok;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Mono PCM resampling
+//////////////////////////////////////////////////////////////////////////////
 
 static bool test_pcm_resample(bool is16, uint32_t step, int nsamples, int seed)
 {
@@ -473,18 +486,27 @@ int main(void)
 
     console_init();
 
-    printf("WAV64 VADPCM in-mixer tests\n\n");
+    printf("WAV64 VADPCM Hermite tests\n\n");
 
     audio_init(44100, 4);
     mixer_init(8);
 
     int total = 0, failed = 0;
     int inmix_frames[] = { 1, 2, 8, 16 };
-    for (int s = 0; s < 8; s++) {
+    const double vad_ratios[] = { 0.5, 1.0, 1.2891, 1.5 };
+    for (int s = 0; s < 4; s++) {
         for (int fc = 0; fc < 4; fc++) {
-            total++;
-            if (!test_vadpcm_inmixer(inmix_frames[fc], s + 1))
-                failed++;
+            for (int r = 0; r < 4; r++) {
+                uint32_t step = (uint32_t)(vad_ratios[r] * (1 << MIXER_FX64_FRAC));
+                int nwave = inmix_frames[fc] * 16;
+                // Stay inside the waveform including Hermite overread.
+                int nout = nwave / 2;
+                if (nout > 96) nout = 96;
+                if (nout < 8) nout = nwave > 8 ? 8 : nwave;
+                total++;
+                if (!test_vadpcm_inmixer(inmix_frames[fc], step, nout, s + 1))
+                    failed++;
+            }
         }
     }
 

--- a/tests/test_wav64.c
+++ b/tests/test_wav64.c
@@ -101,10 +101,43 @@ static uint32_t my_rand(void) {
 #define NPREDICTORS   4
 #define ORDER         2
 
+#define CH_FLAGS_BPS_SHIFT   (3<<0)
 #define CH_FLAGS_16BIT       (1<<2)
 #define CH_FLAGS_VADPCM      (1<<5)
 #define CH_FLAGS_CLEAR_ACCUM (1<<7)
 #define MIXER_FX64_FRAC      12
+
+// Mirrors the private command ids/layouts in src/audio/mixer.c.
+#define MIXER_CMD_CHANNEL     0x0
+#define MIXER_CMD_SETCHANNEL  0x1
+#define MIXER_CMD_FLUSH       0x2
+
+// Register the VADPCM codebook and predictor state of a channel in the ucode
+// channel table (MIX_CHANNEL only carries the sample pointer).
+static void emit_setchannel(int ch, void *codebook, void *state) {
+    rspq_write(__mixer_overlay_id, MIXER_CMD_SETCHANNEL, (uint32_t)ch << 16,
+        PhysicalAddr(codebook), PhysicalAddr(state), 0);
+}
+
+static void emit_channel(int ch, uint32_t flags, int16_t vol, uint32_t pos,
+    uint32_t step, uint32_t len, uint32_t loop_len, void *ptr, int nsamples)
+{
+    rspq_write_t w = rspq_write_begin(__mixer_overlay_id, MIXER_CMD_CHANNEL, 8);
+    rspq_write_arg(&w, ((uint32_t)ch << 16) | ((flags & 0xFF) << 8));
+    rspq_write_arg(&w, ((uint32_t)(uint16_t)vol << 16) | (uint16_t)vol);
+    rspq_write_arg(&w, pos);
+    rspq_write_arg(&w, step);
+    rspq_write_arg(&w, len);
+    rspq_write_arg(&w, loop_len);
+    rspq_write_arg(&w, PhysicalAddr(ptr));
+    rspq_write_arg(&w, (uint32_t)nsamples);   // acc_offset 0
+    rspq_write_end(&w);
+}
+
+static void emit_flush(int nsamples, void *out) {
+    rspq_write(__mixer_overlay_id, MIXER_CMD_FLUSH, (uint32_t)nsamples,
+        PhysicalAddr(out));
+}
 
 static void gen_codebook(wav64_vadpcm_vector_t *cb) {
     for (int v = 0; v < 8; v++)
@@ -157,21 +190,12 @@ static bool test_vadpcm_inmixer(int nframes, int seed) {
     int32_t *warm_out = malloc_uncached(256 * 4);
     for (int i = 0; i < 4; i++) {
         rspq_highpri_begin();
-        rspq_write_t w = rspq_write_begin(__mixer_overlay_id, 0x0, 12);
-        rspq_write_arg(&w, (0u << 16) | ((flags & 0xFF) << 8));
-        rspq_write_arg(&w, ((uint32_t)(uint16_t)vol << 16) | (uint16_t)vol);
-        rspq_write_arg(&w, 0);
-        rspq_write_arg(&w, step);
-        rspq_write_arg(&w, (uint32_t)nsamples << MIXER_FX64_FRAC);
-        rspq_write_arg(&w, (uint32_t)nsamples << MIXER_FX64_FRAC);
-        rspq_write_arg(&w, PhysicalAddr(frames));
-        rspq_write_arg(&w, 256);
-        rspq_write_arg(&w, PhysicalAddr(codebook));
-        rspq_write_arg(&w, PhysicalAddr(state_warm));
-        rspq_write_arg(&w, 0);
-        rspq_write_arg(&w, 0);
-        rspq_write_end(&w);
-        rspq_write(__mixer_overlay_id, 0x4, 256, PhysicalAddr(warm_out), 1);
+        emit_setchannel(0, codebook, state_warm);
+        emit_channel(0, flags, vol, 0, step,
+            (uint32_t)nsamples << MIXER_FX64_FRAC,
+            (uint32_t)nsamples << MIXER_FX64_FRAC,
+            frames, 256);
+        emit_flush(256, warm_out);
         rspq_highpri_end();
     }
     rspq_wait();
@@ -179,21 +203,9 @@ static bool test_vadpcm_inmixer(int nframes, int seed) {
     free_uncached(warm_out);
 
     rspq_highpri_begin();
-    rspq_write_t w = rspq_write_begin(__mixer_overlay_id, 0x0, 12);
-    rspq_write_arg(&w, (0u << 16) | ((flags & 0xFF) << 8));
-    rspq_write_arg(&w, ((uint32_t)(uint16_t)vol << 16) | (uint16_t)vol);
-    rspq_write_arg(&w, 0);
-    rspq_write_arg(&w, step);
-    rspq_write_arg(&w, 0xFFFFFFFFu);
-    rspq_write_arg(&w, 0);
-    rspq_write_arg(&w, PhysicalAddr(frames));
-    rspq_write_arg(&w, (uint32_t)nsamples);
-    rspq_write_arg(&w, PhysicalAddr(codebook));
-    rspq_write_arg(&w, PhysicalAddr(state_rsp));
-    rspq_write_arg(&w, 0);
-    rspq_write_arg(&w, 0);
-    rspq_write_end(&w);
-    rspq_write(__mixer_overlay_id, 0x4, (uint32_t)nsamples, PhysicalAddr(out), 1);
+    emit_setchannel(0, codebook, state_rsp);
+    emit_channel(0, flags, vol, 0, step, 0xFFFFFFFFu, 0, frames, nsamples);
+    emit_flush(nsamples, out);
     rspq_highpri_end();
     rspq_wait();
 
@@ -223,6 +235,144 @@ static bool test_vadpcm_inmixer(int nframes, int seed) {
     return ok;
 }
 
+//////////////////////////////////////////////////////////////////////////////
+// Mono PCM resampling
+//////////////////////////////////////////////////////////////////////////////
+
+// Reference implementation of the RSP mono resampler: 4-tap Catmull-Rom
+// evaluated between the second and third tap, in the exact fixed point the
+// ucode uses.
+//
+//   x    = fraction of the sample position, 0.16 unsigned
+//   y0..3= the four taps around it, int16 (8-bit data is scaled by 256)
+//   out  = y1
+//        + x  *(y2 - y0)/2
+//        + x^2*(y0 - 5*y1/2 + 2*y2 - y3/2)
+//        + x^3*(-y0/2 + 3*y1/2 - 3*y2/2 + y3/2)
+//
+// Powers of x are truncated back to 0.16 after each product (vmudl), and every
+// term is summed in the 48-bit accumulator; only the final read clamps.
+static int16_t hermite_ref(int16_t y0, int16_t y1, int16_t y2, int16_t y3, uint16_t x)
+{
+    uint16_t x2   = (uint16_t)(((uint32_t)x  * x) >> 16);
+    uint16_t x05  = (uint16_t)(((uint32_t)x  * 0x8000) >> 16);
+    uint16_t x205 = (uint16_t)(((uint32_t)x2 * 0x8000) >> 16);
+    uint16_t x3   = (uint16_t)(((uint32_t)x2 * x) >> 16);
+    uint16_t x305 = (uint16_t)(((uint32_t)x3 * 0x8000) >> 16);
+
+    // vsub against zero saturates, so -32768 negates to 32767.
+    #define NEG(v) ((int16_t)((v) == INT16_MIN ? INT16_MAX : -(v)))
+    int16_t y0n = NEG(y0), y1n = NEG(y1), y2n = NEG(y2), y3n = NEG(y3);
+    #undef NEG
+
+    int64_t acc = (int64_t)y1 << 16;
+    acc += (int64_t)y2  * x05;
+    acc += (int64_t)y0n * x05;
+    acc += (int64_t)y0  * x2;
+    acc += (int64_t)y1n * x2;
+    acc += (int64_t)y1n * x2;
+    acc += (int64_t)y1n * x205;
+    acc += (int64_t)y2  * x2;
+    acc += (int64_t)y2  * x2;
+    acc += (int64_t)y3n * x205;
+    acc += (int64_t)y0n * x305;
+    acc += (int64_t)y1  * x3;
+    acc += (int64_t)y1  * x305;
+    acc += (int64_t)y2n * x3;
+    acc += (int64_t)y2n * x305;
+    acc += (int64_t)y3  * x305;
+
+    int64_t v = acc >> 16;
+    if (v > INT16_MAX) v = INT16_MAX;
+    if (v < INT16_MIN) v = INT16_MIN;
+    return (int16_t)v;
+}
+
+#define WARMUP_SAMPLES  256
+
+// Value the one-tap volume filter of the ucode settles on for a given target.
+// It is not the target itself: the accumulator is read back truncated, so the
+// recurrence has a whole range of fixed points and, coming from zero, it stops
+// a few LSB short. Mirrors the vmudm/vmadm pair in the ucode.
+static int16_t volume_settle(int16_t target)
+{
+    int32_t x = 0;
+    for (int i = 0; i < 1024; i++)
+        x = (int32_t)(((int64_t)x * 0xe076 + (int64_t)target * 0x1f8a) >> 16);
+    return (int16_t)x;
+}
+
+static bool test_pcm_resample(bool is16, uint32_t step, int nsamples, int seed)
+{
+    my_srand(seed);
+
+    // Waveform, padded so that the tap window and the RSP overread past the
+    // last played sample always land on readable (zero) memory.
+    int bps = is16 ? 1 : 0;
+    int nwave = 512;
+    int wave_bytes = (nwave << bps) + 256;
+    uint8_t *wave = malloc_uncached(wave_bytes);
+    memset(wave, 0, wave_bytes);
+    for (int i = 0; i < nwave; i++) {
+        if (is16) ((int16_t*)wave)[i] = (int16_t)my_rand();
+        else      ((int8_t*)wave)[i]  = (int8_t)my_rand();
+    }
+
+    int32_t *out = malloc_uncached(nsamples * 4);
+    memset(out, 0, nsamples * 4);
+
+    int16_t vol = 0x7FFF;
+    uint32_t flags = CH_FLAGS_CLEAR_ACCUM | (is16 ? (CH_FLAGS_16BIT | 1) : 0);
+    uint32_t len = (uint32_t)(nwave << bps) << MIXER_FX64_FRAC;
+
+    // The volume filter converges on the target geometrically, one step every
+    // 8 output samples. Run it on a zero step (which keeps replaying sample 0,
+    // so it cannot run off the waveform) until it has settled.
+    int32_t *warm = malloc_uncached(WARMUP_SAMPLES * 4);
+    for (int i = 0; i < 4; i++) {
+        rspq_highpri_begin();
+        emit_channel(0, flags, vol, 0, 0, len, 0, wave, WARMUP_SAMPLES);
+        emit_flush(WARMUP_SAMPLES, warm);
+        rspq_highpri_end();
+    }
+    rspq_wait();
+    free_uncached(warm);
+
+    rspq_highpri_begin();
+    emit_channel(0, flags, vol, 0, step, len, 0, wave, nsamples);
+    emit_flush(nsamples, out);
+    rspq_highpri_end();
+    rspq_wait();
+
+    bool ok = true;
+    int16_t *stereo = (int16_t*)out;
+    for (int i = 0; i < nsamples; i++) {
+        uint32_t pos = step * (uint32_t)i;
+        int si = pos >> (MIXER_FX64_FRAC + bps);
+        uint16_t x = (uint16_t)(pos << (is16 ? 3 : 4));
+
+        int16_t y[4];
+        for (int t = 0; t < 4; t++)
+            y[t] = is16 ? ((int16_t*)wave)[si+t] : (int16_t)(((int8_t*)wave)[si+t] << 8);
+        int16_t res = hermite_ref(y[0], y[1], y[2], y[3], x);
+
+        int32_t v = (int32_t)(((int64_t)res * volume_settle(vol) * 2) >> 16);
+        int16_t l = stereo[i*2], r = stereo[i*2+1];
+        int d0 = l - v, d1 = r - v;
+        if (d0 < -2 || d0 > 2 || d1 < -2 || d1 > 2) {
+            printf("FAILED resample %dbit step=%#lx: sample %d: L=%d R=%d ref=%ld\n",
+                is16 ? 16 : 8, step, i, l, r, v);
+            printf("  si=%d x=%#x taps=%d %d %d %d\n", si, x, y[0], y[1], y[2], y[3]);
+            ok = false;
+            break;
+        }
+    }
+
+    free_uncached(wave);
+    free_uncached(out);
+    return ok;
+}
+
 int main(void)
 {
     debug_init_emulog();
@@ -242,6 +392,21 @@ int main(void)
         for (int fc = 0; fc < 4; fc++) {
             total++;
             if (!test_vadpcm_inmixer(inmix_frames[fc], s + 1))
+                failed++;
+        }
+    }
+
+    printf("Mono PCM resampling tests\n");
+    fflush(stdout);
+    // Enough output samples to force several cache refills, but few enough
+    // that even the fastest ratio stays inside the 512-sample waveform.
+    const double ratios[] = { 0.5, 1.0, 1.2891, 1.5, 2.0, 3.0, 3.7 };
+    for (int b = 0; b < 2; b++) {
+        bool is16 = b != 0;
+        for (int r = 0; r < 7; r++) {
+            uint32_t step = (uint32_t)(ratios[r] * (1 << (MIXER_FX64_FRAC + (is16 ? 1 : 0))));
+            total++;
+            if (!test_pcm_resample(is16, step, 96, r + 1))
                 failed++;
         }
     }

--- a/tests/test_wav64.c
+++ b/tests/test_wav64.c
@@ -224,6 +224,120 @@ static bool test_vadpcm(int nframes, bool stereo, int seed, int out_misalign) {
     return ok;
 }
 
+// ---------------------------------------------------------------------------
+// In-mixer VADPCM path (MIX_CHANNEL + CH_FLAGS_VADPCM)
+// ---------------------------------------------------------------------------
+
+#define CH_FLAGS_16BIT       (1<<2)
+#define CH_FLAGS_VADPCM      (1<<5)
+#define CH_FLAGS_CLEAR_ACCUM (1<<7)
+#define MIXER_FX64_FRAC      12
+
+static bool test_vadpcm_inmixer(int nframes, int seed) {
+    my_srand(seed);
+
+    wav64_vadpcm_vector_t *codebook = malloc_uncached(16 * sizeof(wav64_vadpcm_vector_t));
+    gen_codebook(codebook);
+
+    wav64_vadpcm_vector_t *state_rsp = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
+    memset(state_rsp, 0, sizeof(*state_rsp));
+    wav64_vadpcm_vector_t state_ref;
+    memset(&state_ref, 0, sizeof(state_ref));
+
+    int in_bytes = 9 * nframes;
+    uint8_t *frames = malloc_uncached(in_bytes + 16);
+    gen_frames(frames, nframes);
+
+    int nsamples = nframes * 16;
+    int16_t *ref_out = malloc(nsamples * 2);
+    vadpcm_error err = vadpcm_decode(NPREDICTORS, ORDER, codebook, &state_ref,
+        nframes, ref_out, frames);
+    assertf(err == 0, "reference decode error: %d", err);
+
+    int32_t *out = malloc_uncached(nsamples * 4);
+    memset(out, 0, nsamples * 4);
+
+    uint32_t step = 1u << MIXER_FX64_FRAC;
+    int16_t vol = 0x7FFF;
+    uint32_t flags = CH_FLAGS_VADPCM | CH_FLAGS_16BIT | CH_FLAGS_CLEAR_ACCUM;
+
+    // Warm up the per-channel volume filter: XVOL starts at 0 in the overlay
+    // saved state and converges to the channel volume via the one-tap filter
+    // (one step every 8 samples), so run a few full discarded rounds first.
+    // The warm-up loops over the same frames with a throwaway decoder state.
+    wav64_vadpcm_vector_t *state_warm = malloc_uncached(sizeof(wav64_vadpcm_vector_t));
+    memset(state_warm, 0, sizeof(*state_warm));
+    int32_t *warm_out = malloc_uncached(256 * 4);
+    for (int i = 0; i < 4; i++) {
+        rspq_highpri_begin();
+        rspq_write_t w = rspq_write_begin(__mixer_overlay_id, 0x0, 12);
+        rspq_write_arg(&w, (0u << 16) | ((flags & 0xFF) << 8));
+        rspq_write_arg(&w, ((uint32_t)(uint16_t)vol << 16) | (uint16_t)vol);
+        rspq_write_arg(&w, 0);
+        rspq_write_arg(&w, step);
+        rspq_write_arg(&w, (uint32_t)nsamples << MIXER_FX64_FRAC);
+        rspq_write_arg(&w, (uint32_t)nsamples << MIXER_FX64_FRAC);
+        rspq_write_arg(&w, PhysicalAddr(frames));
+        rspq_write_arg(&w, 256);
+        rspq_write_arg(&w, PhysicalAddr(codebook));
+        rspq_write_arg(&w, PhysicalAddr(state_warm));
+        rspq_write_arg(&w, 0);
+        rspq_write_arg(&w, 0);
+        rspq_write_end(&w);
+        rspq_write(__mixer_overlay_id, 0x4, 256, PhysicalAddr(warm_out), 1);
+        rspq_highpri_end();
+    }
+    rspq_wait();
+    free_uncached(state_warm);
+    free_uncached(warm_out);
+
+    rspq_highpri_begin();
+    rspq_write_t w = rspq_write_begin(__mixer_overlay_id, 0x0, 12);
+    rspq_write_arg(&w, (0u << 16) | ((flags & 0xFF) << 8));
+    rspq_write_arg(&w, ((uint32_t)(uint16_t)vol << 16) | (uint16_t)vol);
+    rspq_write_arg(&w, 0);
+    rspq_write_arg(&w, step);
+    rspq_write_arg(&w, 0xFFFFFFFFu);
+    rspq_write_arg(&w, 0);
+    rspq_write_arg(&w, PhysicalAddr(frames));
+    rspq_write_arg(&w, (uint32_t)nsamples);
+    rspq_write_arg(&w, PhysicalAddr(codebook));
+    rspq_write_arg(&w, PhysicalAddr(state_rsp));
+    rspq_write_arg(&w, 0);
+    rspq_write_arg(&w, 0);
+    rspq_write_end(&w);
+    rspq_write(__mixer_overlay_id, 0x4, (uint32_t)nsamples, PhysicalAddr(out), 1);
+    rspq_highpri_end();
+    rspq_wait();
+
+    // The in-mixer path multiplies by the filtered volume with vmulf, so it
+    // cannot be bit-exact: XVOL settles at 0x7FFE/0x7FFF, which can shift
+    // full-scale samples by up to 2 LSB.
+    bool ok = true;
+    int16_t *stereo = (int16_t*)out;
+    for (int i = 0; i < nsamples; i++) {
+        int16_t l = stereo[i*2], r = stereo[i*2+1];
+        int d0 = l - ref_out[i], d1 = r - ref_out[i];
+        if (d0 < -2 || d0 > 2 || d1 < -2 || d1 > 2) {
+            printf("FAILED in-mixer: nframes=%d seed=%d sample %d: L=%d R=%d ref=%d\n",
+                nframes, seed, i, l, r, ref_out[i]);
+            ok = false;
+            break;
+        }
+    }
+    if (ok && memcmp(state_rsp, &state_ref, sizeof(state_ref)) != 0) {
+        printf("FAILED in-mixer: nframes=%d seed=%d: state mismatch\n", nframes, seed);
+        ok = false;
+    }
+
+    free_uncached(codebook);
+    free_uncached(state_rsp);
+    free_uncached(frames);
+    free_uncached(out);
+    free(ref_out);
+    return ok;
+}
+
 int main(void)
 {
     debug_init_emulog();
@@ -269,6 +383,16 @@ int main(void)
                         failed++;
                 }
             }
+        }
+    }
+
+    // In-mixer mono VADPCM (MIX_CHANNEL path). Cap at 16 frames (256 samples).
+    int inmix_frames[] = { 1, 2, 8, 16 };
+    for (int s = 0; s < 4; s++) {
+        for (int fc = 0; fc < 4; fc++) {
+            total++;
+            if (!test_vadpcm_inmixer(inmix_frames[fc], s + 1))
+                failed++;
         }
     }
 #endif

--- a/tools/audioconv64/conv_wav64.cpp
+++ b/tools/audioconv64/conv_wav64.cpp
@@ -278,7 +278,7 @@ bool wav64_write(const char *infn, const char *outfn, FILE *out, wav_data_t* wav
 	}
 
 	fwrite("WV64", 1, 4, out);
-	w8(out, 6); 				 			// version
+	w8(out, 7); 				 			// version
 	w8(out, format);  						// format
 	w8(out, wav->channels);					// channels
 	w8(out, wav->bitsPerSample);			// bits
@@ -395,9 +395,22 @@ bool wav64_write(const char *infn, const char *outfn, FILE *out, wav_data_t* wav
 				}
 			}
 
-			// Copy encoded samples to output buffer
-			for (int j=0; j<nframes; j++)
-				memcpy(dest + (i + wav->channels * j) * kVADPCMFrameByteSize, destchan + j * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
+			// Block-planar layout: for each block of B frames, all L then all R
+			// (mono unchanged). One ring fill maps to one file block.
+			const int B = 128;
+			for (int j=0; j<nframes; j++) {
+				int dstj;
+				if (wav->channels == 1) {
+					dstj = j;
+				} else {
+					int block = j / B;
+					int off = j % B;
+					int nblocks = (nframes + B - 1) / B;
+					int bs = (block == nblocks - 1) ? (nframes - block * B) : B;
+					dstj = block * B * wav->channels + i * bs + off;
+				}
+				memcpy(dest + dstj * kVADPCMFrameByteSize, destchan + j * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
+			}
 			free(destchan);
 		}
 		free(schan);
@@ -435,12 +448,23 @@ bool wav64_write(const char *infn, const char *outfn, FILE *out, wav_data_t* wav
 			assert((bitpos+7)/8 == compbuflen);
 			assert(memcmp(&scratch[0], dest, dest_size) == 0);
 
-			// Compute bit offset for each skip point (O(1) lookup from full decode stats)
-			for (int i=0; i<skip_points.size(); i++) {
-				int blocks = (skip_points[i] / kVADPCMFrameSampleCount) * wav->channels;
-				assert(blocks >= 0);
-				assert(blocks < (int)bitpos_stats.size());
-				skip_bitpos[i] = bitpos_stats[blocks];
+			// Compute bit offset for each skip point (O(1) lookup from full decode stats).
+			// Bitpos is the start of channel-0's frame F in the block-planar stream,
+			// so seeking can resume Huffman decoding from that point.
+			const int B = 128;
+			for (int i=0; i<(int)skip_points.size(); i++) {
+				int F = skip_points[i] / kVADPCMFrameSampleCount;
+				int idx;
+				if (wav->channels == 1) {
+					idx = F;
+				} else {
+					int block = F / B;
+					int off = F % B;
+					idx = block * B * wav->channels + off; // channel 0 within block
+				}
+				assert(idx >= 0);
+				assert(idx < (int)bitpos_stats.size());
+				skip_bitpos[i] = bitpos_stats[idx];
 			}
 		}
 
@@ -488,10 +512,22 @@ bool wav64_write(const char *infn, const char *outfn, FILE *out, wav_data_t* wav
 			
 			int16_t *out_samples = (int16_t *)malloc(wav->cnt * wav->channels * sizeof(int16_t));
 			int16_t *out_channel = (int16_t *)malloc(wav->cnt * sizeof(int16_t));
+			const int B = 128;
 			for (int i=0;i<wav->channels;i++) {		
 				uint8_t *in_channel = (uint8_t*)malloc(nframes * kVADPCMFrameByteSize);
-				for (int j=0;j<nframes;j++)
-					memcpy(in_channel + j * kVADPCMFrameByteSize, dest + (i + wav->channels * j) * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
+				for (int j=0;j<nframes;j++) {
+					int srcj;
+					if (wav->channels == 1) {
+						srcj = j;
+					} else {
+						int block = j / B;
+						int off = j % B;
+						int nblocks = (nframes + B - 1) / B;
+						int bs = (block == nblocks - 1) ? (nframes - block * B) : B;
+						srcj = block * B * wav->channels + i * bs + off;
+					}
+					memcpy(in_channel + j * kVADPCMFrameByteSize, dest + srcj * kVADPCMFrameByteSize, kVADPCMFrameByteSize);
+				}
 
 				memset(&state, 0, sizeof(state));
 				vadpcm_decode(kPREDICTORS, kVADPCMEncodeOrder,

--- a/tools/audioconv64/conv_xm64.cpp
+++ b/tools/audioconv64/conv_xm64.cpp
@@ -582,28 +582,22 @@ int xm_convert(const char *infn, const char *outfn) {
 						n = ch->sample->length;
 					}
 
-					// Convert samples to bytes (compressed samples are always 16-bit)
-					if (ch->sample->bits == 16 || flag_xm_compress_samples > 0)
-						n *= 2;
-
-					// Take overread buffer into account
-					n += MIXER_LOOP_OVERREAD;
-
 					if (flag_xm_compress_samples > 0) {
-						// Runtime VADPCM decoding rounds up each decode request to
-						// 32 *samples* (wav64_vadpcm_read), not 32 bytes.
-						// For mono decoded as 16-bit this means 64-byte granularity.
-						// Keep one full decode quantum of extra room to absorb
-						// round-up when part of the requested region is already
-						// cached in the samplebuffer.
-						const int vadpcm_decode_quantum = 64;
-						n = (n + vadpcm_decode_quantum - 1) / vadpcm_decode_quantum * vadpcm_decode_quantum;
-						n += vadpcm_decode_quantum;
-
-						// During loop wrapping, a single tick read may be split into
-						// two decode calls, each with its own round-up behavior.
+						// In-mixer VADPCM: the samplebuffer stores compressed
+						// 9-byte frames (16 samples each), not decoded PCM.
+						// Size the buffer in the compressed domain (~3.5x smaller).
+						int nframes = (n + 15) / 16;
+						// Overread a few frames so resampling can run past the
+						// requested window without forcing an immediate refill.
+						nframes += (MIXER_LOOP_OVERREAD + 8) / 9;
+						nframes += 2;
 						if (ch->sample->loop_type)
-							n += vadpcm_decode_quantum;
+							nframes += 2;
+						n = nframes * 9;
+					} else {
+						if (ch->sample->bits == 16)
+							n *= 2;
+						n += MIXER_LOOP_OVERREAD;
 					}
 
 					// Keep the maximum

--- a/tools/audioconv64/conv_xm64.cpp
+++ b/tools/audioconv64/conv_xm64.cpp
@@ -205,7 +205,8 @@ static void xm_context_save(xm_context_t* ctx, FILE* xm64, const char *outfn) {
 	//  9: metadata compressed with asset library
 	// 10: added sample position memory to xm_channel_context_t
 	// 11: change sample_position to double
-	const uint8_t version = 11;
+	// 12: extra sample-buffer headroom for syncless mixer in-flight rounds
+	const uint8_t version = 12;
 	wa(xm64, "XM64", 4);
 	w8(xm64, version);
 	w32_placeholderf(xm64, "metadata_offset");
@@ -645,6 +646,11 @@ int xm_convert(const char *infn, const char *outfn) {
 		// Add a 5% of margin, just in case there is a bug somewhere. We're still
 		// pretty tight on RAM so let's not exaggerate.
 		ch_buf[i] = ch_buf[i] * 1.05;
+
+		// Syncless mixer: samplebuffer compaction is deferred to frame start, so
+		// during multi-buffer catch-up an append may need one extra window of
+		// samples while a previous round is still in flight. Size for that.
+		ch_buf[i] *= 2;
 
 		// Round up to 8 bytes, which is the required alignment for a sample buffer.
 		ch_buf[i] = ((ch_buf[i] + 7) / 8) * 8;


### PR DESCRIPTION
Optimize the mixer in various ways:

- **Syncless pipeline.** On the preview branch, `mixer_poll` blocks until the RSP has finished the round, which costs 1.0-2.7 ms per frame of pure waiting. The RSP now runs concurrently with the CPU and that wait is gone.
- **Asynchronous PI prefetch.** Cartridge wait drops by an order of magnitude (512 → 39 µs on BUTTERFL) because sample data is fetched ahead of the round that needs it instead of on demand.
- **Various optimizations in the mixer** Various pure optimizations in the mixer code (avoid useless work, optimize silent channels, add some caching, increase round size, etc.) 
- **Native mixer VADPCM support**. Now VADPCM is no more a wav64 feature but is rather part of the mixer itself. This has no direct effect on these benchmarks (in facts, it is a net negative when measured by itself) but it should help in the grand picture as it reduces memory bandwidth. The optional Huffman layer is left in wav64 instead.
- **4th order Hermite resampling**. The RSP resampling is now fully vectorized and uses a 4th order interpolation with a much softer output. The previous code used point resampling and was not optimized.

The effects on XM64 playback are very noticeable:

| song | wall CPU µS | wall RSP µS | speedup | wait RSP µS | wait PI DMA µS | net CPU µS |
|---|---|---|---|---|---|---|
| BUTTERFL | 3678 → 1119 | 2309 → 1634 | 3.29x | 1794 → 0 | 512 → 64 | 1373 → 1055 |
| christmas_day | 5236 → 1593 | 3090 → 2567 | 3.29x | 2708 → 2 | 581 → 43 | 1947 → 1548 |
| TheMorningAfter | 3797 → 1121 | 2307 → 1578 | 3.39x | 2001 → 1 | 424 → 56 | 1372 → 1064 |
| Caverns16bit | 2284 → 860 | — → 1050 | 2.66x | 1255 → 0 | 293 → 72 | 737 → 788 |
| db_key | 1495 → 326 | 1032 → 560 | 4.59x | 975 → 0 | 55 → 16 | 465 → 310 |

Also the effects on streamed music positives, as there are no more syncs:

| waveform | bitrate | wall CPU | wall RSP | speedup | wait RSP | wait PI DMA | net CPU |
|---|---|---|---|---|---|---|---|
| raw stereo | 1411k | 1202 → 923 | 672 → 524 | 1.30x | 499 → 0 | 555 → 517 | 148 → 406 |
| vadpcm stereo | 397k | 841 → 120 | 760 → 370 | 7.01x | 511 → 0 | 148 → 0 | 182 → 120 |
| ulc mono | 25k | 1274 → 425 | 1093 → 671 | 3.00* | 903 → 0 | 16 → 23 | 355 → 402 |
| ulc stereo | 56k | 1824 → 626 | 1583 → 1435 | 2.91x | 1227 → 0 | 37 → 42 | 560 → 584 |
| opus mono | 47k | 5352 → 4056 | 1693 → 1241 | 1.32x | 1348 → 0 | 19 → 30 | 3985 → 4026 |
| opus stereo | 91k | 9634 → 7457 | 2720 → 2524 | 1.29x | 1888 → 0 | 42 → 47 | 7704 → 7410 |

Notice how even RSP time decreases, even though the new mixer does a much more complex interpolation.

There are no API breakages, but API additions to `waveform_t` to enable specific optimizations. `samplebuffer` API was a bit affected, but that one wasn't never meant to be fully public anyway.