### PR TITLE
Fatfs r0.16 patch2

### DIFF
--- a/src/fatfs/00history.txt
+++ b/src/fatfs/00history.txt
@@ -375,3 +375,15 @@ R0.15a (November 22, 2024)
   Made f_setlabel() accept a volume label in Unix style volume ID when FF_STR_VOLUME_ID == 2.
   Made FatFs update PercInUse field in exFAT VBR. (A preceding f_getfree() is needed for the accuracy)
 
+
+
+R0.15b (June 21, 2025)
+  Added support for timestamp of created time. (FF_FS_CRTIME)
+  Fixed FatFs fails to load the FsInfo in FAT32 volumes and the f_getfree always be forced a full FAT scan which takes a long time. (appeared at R0.15a)
+
+
+
+R0.16 (July 22, 2025)
+  Removed a long-pending limitation that f_getcwd and double-dot .. in the path name did not work on the exFAT volume.
+  Fixed f_readdir cannot detect end of directory and it leads the application process into infinite loop. (appeared at R0.15b)
+  Fixed dot names with terminating separator or duplicated separator are rejected when LFN is not enabled.

--- a/src/fatfs/00readme.txt
+++ b/src/fatfs/00readme.txt
@@ -1,4 +1,4 @@
-FatFs Module Source Files R0.15a
+FatFs Module Source Files R0.16 w/patch 2
 
 
 FILES

--- a/src/fatfs/ff.c
+++ b/src/fatfs/ff.c
@@ -1,8 +1,8 @@
 /*----------------------------------------------------------------------------/
-/  FatFs - Generic FAT Filesystem Module  R0.15a                              /
+/  FatFs - Generic FAT Filesystem Module  R0.16 w/patch 2                     /
 /-----------------------------------------------------------------------------/
 /
-/ Copyright (C) 2024, ChaN, all right reserved.
+/ Copyright (C) 2025, ChaN, all right reserved.
 /
 / FatFs module is an open source software. Redistribution and use of FatFs in
 / source and binary forms, with or without modification, are permitted provided
@@ -20,9 +20,8 @@
 
 
 #include <string.h>
-#include "ff.h"			/* Declarations of FatFs API */
-#include "diskio.h"		/* Declarations of device I/O functions */
-
+#include "ff.h"			/* Basic definitions and declarations of API */
+#include "diskio.h"		/* Declarations of MAI */
 
 /*--------------------------------------------------------------------------
 
@@ -30,7 +29,7 @@
 
 ---------------------------------------------------------------------------*/
 
-#if FF_DEFINED != 5380	/* Revision ID */
+#if FF_DEFINED != 80386	/* Revision ID */
 #error Wrong include file (ff.h).
 #endif
 
@@ -42,6 +41,9 @@
 #define MAX_FAT16	0xFFF5			/* Max FAT16 clusters (differs from specs, but right for real DOS/Windows behavior) */
 #define MAX_FAT32	0x0FFFFFF5		/* Max FAT32 clusters (not defined in specs, practical limit) */
 #define MAX_EXFAT	0x7FFFFFFD		/* Max exFAT clusters (differs from specs, implementation limit) */
+#define MIN_EXFAT	0x00000100		/* Min exFAT clusters (Not defined in specs, implementation limit) */
+#define MIN_FAT12	32					/* Min FAT12 clusters (Not defined in specs, implementation limit) */
+#define MIN_VOLUME	64					/* Min volume sectors (Not defined in specs, implementation limit) */
 
 
 /* Character code support macros */
@@ -194,7 +196,7 @@
 #define FSI_StrucSig		484		/* FAT32 FSI: Structure signature (DWORD) */
 #define FSI_Free_Count		488		/* FAT32 FSI: Number of free clusters (DWORD) */
 #define FSI_Nxt_Free		492		/* FAT32 FSI: Last allocated cluster (DWORD) */
-#define FSI_TrailSig		498		/* FAT32 FSI: Trailing signature (DWORD) */
+#define FSI_TrailSig		508		/* FAT32 FSI: Trailing signature (DWORD) */
 
 #define MBR_Table			446		/* MBR: Offset of partition table in the MBR */
 #define SZ_PTE				16		/* MBR: Size of a partition table entry */
@@ -222,7 +224,7 @@
 #define GPTH_PtNum			80		/* GPT HDR: Number of table entries (DWORD) */
 #define GPTH_PteSize		84		/* GPT HDR: Size of table entry (DWORD) */
 #define GPTH_PtBcc			88		/* GPT HDR: Partition table BCC (DWORD) */
-#define SZ_GPTE				128		/* GPT PTE: Size of partition table entry */
+#define SZ_GPTE				128		/* GPT PTE: Size of a GPT partition table entry */
 #define GPTE_PtGuid			0		/* GPT PTE: Partition type GUID (16-byte) */
 #define GPTE_UpGuid			16		/* GPT PTE: Partition unique GUID (16-byte) */
 #define GPTE_FstLba			32		/* GPT PTE: First LBA of partition (QWORD) */
@@ -465,7 +467,7 @@ typedef struct {	/* Open object identifier with status */
 static FATFS *FatFs[FF_VOLUMES];	/* Pointer to the filesystem objects (logical drives) */
 static WORD Fsid;					/* Filesystem mount ID */
 
-#if FF_FS_RPATH != 0
+#if FF_FS_RPATH
 static BYTE CurrVol;				/* Current drive number set by f_chdrive() */
 #endif
 
@@ -500,9 +502,9 @@ static const BYTE GUID_MS_Basic[16] = {0xA2,0xA0,0xD0,0xEB,0xE5,0xB9,0x33,0x44,0
 #if FF_FS_EXFAT
 #error LFN must be enabled when enable exFAT
 #endif
-#define DEF_NAMBUF
-#define INIT_NAMBUF(fs)
-#define FREE_NAMBUF()
+#define DEF_NAMEBUFF
+#define INIT_NAMEBUFF(fs)
+#define FREE_NAMEBUFF()
 #define LEAVE_MKFS(res)	return res
 
 #else					/* LFN configurations */
@@ -523,32 +525,32 @@ static const BYTE LfnOfs[] = {1,3,5,7,9,14,16,18,20,22,24,28,30};	/* FAT: Offset
 static BYTE	DirBuf[MAXDIRB(FF_MAX_LFN)];	/* Directory entry block scratchpad buffer */
 #endif
 static WCHAR LfnBuf[FF_MAX_LFN + 1];		/* LFN working buffer */
-#define DEF_NAMBUF
-#define INIT_NAMBUF(fs)
-#define FREE_NAMBUF()
+#define DEF_NAMEBUFF
+#define INIT_NAMEBUFF(fs)
+#define FREE_NAMEBUFF()
 #define LEAVE_MKFS(res)	return res
 
 #elif FF_USE_LFN == 2 	/* LFN enabled with dynamic working buffer on the stack */
 #if FF_FS_EXFAT
-#define DEF_NAMBUF		WCHAR lbuf[FF_MAX_LFN+1]; BYTE dbuf[MAXDIRB(FF_MAX_LFN)];	/* LFN working buffer and directory entry block scratchpad buffer */
-#define INIT_NAMBUF(fs)	{ (fs)->lfnbuf = lbuf; (fs)->dirbuf = dbuf; }
-#define FREE_NAMBUF()
+#define DEF_NAMEBUFF		WCHAR lbuf[FF_MAX_LFN+1]; BYTE dbuf[MAXDIRB(FF_MAX_LFN)];	/* LFN working buffer and directory entry block scratchpad buffer */
+#define INIT_NAMEBUFF(fs)	{ (fs)->lfnbuf = lbuf; (fs)->dirbuf = dbuf; }
+#define FREE_NAMEBUFF()
 #else
-#define DEF_NAMBUF		WCHAR lbuf[FF_MAX_LFN+1];	/* LFN working buffer */
-#define INIT_NAMBUF(fs)	{ (fs)->lfnbuf = lbuf; }
-#define FREE_NAMBUF()
+#define DEF_NAMEBUFF		WCHAR lbuf[FF_MAX_LFN+1];	/* LFN working buffer */
+#define INIT_NAMEBUFF(fs)	{ (fs)->lfnbuf = lbuf; }
+#define FREE_NAMEBUFF()
 #endif
 #define LEAVE_MKFS(res)	return res
 
 #elif FF_USE_LFN == 3 	/* LFN enabled with dynamic working buffer on the heap */
 #if FF_FS_EXFAT
-#define DEF_NAMBUF		WCHAR *lfn;	/* Pointer to LFN working buffer and directory entry block scratchpad buffer */
-#define INIT_NAMBUF(fs)	{ lfn = ff_memalloc((FF_MAX_LFN+1)*2 + MAXDIRB(FF_MAX_LFN)); if (!lfn) LEAVE_FF(fs, FR_NOT_ENOUGH_CORE); (fs)->lfnbuf = lfn; (fs)->dirbuf = (BYTE*)(lfn+FF_MAX_LFN+1); }
-#define FREE_NAMBUF()	ff_memfree(lfn)
+#define DEF_NAMEBUFF		WCHAR *lfn;	/* Pointer to LFN working buffer and directory entry block scratchpad buffer */
+#define INIT_NAMEBUFF(fs)	{ lfn = ff_memalloc((FF_MAX_LFN+1)*2 + MAXDIRB(FF_MAX_LFN)); if (!lfn) LEAVE_FF(fs, FR_NOT_ENOUGH_CORE); (fs)->lfnbuf = lfn; (fs)->dirbuf = (BYTE*)(lfn+FF_MAX_LFN+1); }
+#define FREE_NAMEBUFF()	ff_memfree(lfn)
 #else
-#define DEF_NAMBUF		WCHAR *lfn;	/* Pointer to LFN working buffer */
-#define INIT_NAMBUF(fs)	{ lfn = ff_memalloc((FF_MAX_LFN+1)*2); if (!lfn) LEAVE_FF(fs, FR_NOT_ENOUGH_CORE); (fs)->lfnbuf = lfn; }
-#define FREE_NAMBUF()	ff_memfree(lfn)
+#define DEF_NAMEBUFF		WCHAR *lfn;	/* Pointer to LFN working buffer */
+#define INIT_NAMEBUFF(fs)	{ lfn = ff_memalloc((FF_MAX_LFN+1)*2); if (!lfn) LEAVE_FF(fs, FR_NOT_ENOUGH_CORE); (fs)->lfnbuf = lfn; }
+#define FREE_NAMEBUFF()	ff_memfree(lfn)
 #endif
 #define LEAVE_MKFS(res)	{ if (!work) ff_memfree(buf); return res; }
 #define MAX_MALLOC	0x8000	/* Must be >=FF_MAX_SS */
@@ -617,7 +619,7 @@ static const BYTE DbcTbl[] = MKCVTBL(TBL_DC, FF_CODE_PAGE);
 /* Load/Store multi-byte word in the FAT structure                       */
 /*-----------------------------------------------------------------------*/
 
-static WORD ld_word (const BYTE* ptr)	/*	 Load a 2-byte little-endian word */
+static WORD ld_16 (const BYTE* ptr)	/*	 Load a 2-byte little-endian word */
 {
 	WORD rv;
 
@@ -626,7 +628,7 @@ static WORD ld_word (const BYTE* ptr)	/*	 Load a 2-byte little-endian word */
 	return rv;
 }
 
-static DWORD ld_dword (const BYTE* ptr)	/* Load a 4-byte little-endian word */
+static DWORD ld_32 (const BYTE* ptr)	/* Load a 4-byte little-endian word */
 {
 	DWORD rv;
 
@@ -638,7 +640,7 @@ static DWORD ld_dword (const BYTE* ptr)	/* Load a 4-byte little-endian word */
 }
 
 #if FF_FS_EXFAT
-static QWORD ld_qword (const BYTE* ptr)	/* Load an 8-byte little-endian word */
+static QWORD ld_64 (const BYTE* ptr)	/* Load an 8-byte little-endian word */
 {
 	QWORD rv;
 
@@ -655,13 +657,13 @@ static QWORD ld_qword (const BYTE* ptr)	/* Load an 8-byte little-endian word */
 #endif
 
 #if !FF_FS_READONLY
-static void st_word (BYTE* ptr, WORD val)	/* Store a 2-byte word in little-endian */
+static void st_16 (BYTE* ptr, WORD val)	/* Store a 2-byte word in little-endian */
 {
 	*ptr++ = (BYTE)val; val >>= 8;
 	*ptr++ = (BYTE)val;
 }
 
-static void st_dword (BYTE* ptr, DWORD val)	/* Store a 4-byte word in little-endian */
+static void st_32 (BYTE* ptr, DWORD val)	/* Store a 4-byte word in little-endian */
 {
 	*ptr++ = (BYTE)val; val >>= 8;
 	*ptr++ = (BYTE)val; val >>= 8;
@@ -670,7 +672,7 @@ static void st_dword (BYTE* ptr, DWORD val)	/* Store a 4-byte word in little-end
 }
 
 #if FF_FS_EXFAT
-static void st_qword (BYTE* ptr, QWORD val)	/* Store an 8-byte word in little-endian */
+static void st_64 (BYTE* ptr, QWORD val)	/* Store an 8-byte word in little-endian */
 {
 	*ptr++ = (BYTE)val; val >>= 8;
 	*ptr++ = (BYTE)val; val >>= 8;
@@ -1122,11 +1124,11 @@ static FRESULT sync_fs (	/* Returns FR_OK or FR_DISK_ERR */
 			if (fs->fs_type == FS_FAT32) {	/* FAT32: Update FSInfo sector */
 				/* Create FSInfo structure */
 				memset(fs->win, 0, sizeof fs->win);
-				st_dword(fs->win + FSI_LeadSig, 0x41615252);		/* Leading signature */
-				st_dword(fs->win + FSI_StrucSig, 0x61417272);		/* Structure signature */
-				st_dword(fs->win + FSI_Free_Count, fs->free_clst);	/* Number of free clusters */
-				st_dword(fs->win + FSI_Nxt_Free, fs->last_clst);	/* Last allocated culuster */
-				st_dword(fs->win + FSI_TrailSig, 0xAA550000);		/* Trailing signature */
+				st_32(fs->win + FSI_LeadSig, 0x41615252);		/* Leading signature */
+				st_32(fs->win + FSI_StrucSig, 0x61417272);		/* Structure signature */
+				st_32(fs->win + FSI_Free_Count, fs->free_clst);	/* Number of free clusters */
+				st_32(fs->win + FSI_Nxt_Free, fs->last_clst);	/* Last allocated culuster */
+				st_32(fs->win + FSI_TrailSig, 0xAA550000);		/* Trailing signature */
 				disk_write(fs->pdrv, fs->win, fs->winsect = fs->volbase + 1, 1);	/* Write it into the FSInfo sector (Next to VBR) */
 			}
 #if FF_FS_EXFAT
@@ -1202,12 +1204,12 @@ static DWORD get_fat (		/* 0xFFFFFFFF:Disk error, 1:Internal error, 2..0x7FFFFFF
 
 		case FS_FAT16 :
 			if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 2))) != FR_OK) break;
-			val = ld_word(fs->win + clst * 2 % SS(fs));		/* Simple WORD array */
+			val = ld_16(fs->win + clst * 2 % SS(fs));		/* Simple WORD array */
 			break;
 
 		case FS_FAT32 :
 			if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 4))) != FR_OK) break;
-			val = ld_dword(fs->win + clst * 4 % SS(fs)) & 0x0FFFFFFF;	/* Simple DWORD array but mask out upper 4 bits */
+			val = ld_32(fs->win + clst * 4 % SS(fs)) & 0x0FFFFFFF;	/* Simple DWORD array but mask out upper 4 bits */
 			break;
 #if FF_FS_EXFAT
 		case FS_EXFAT :
@@ -1228,7 +1230,7 @@ static DWORD get_fat (		/* 0xFFFFFFFF:Disk error, 1:Internal error, 2..0x7FFFFFF
 						val = 0x7FFFFFFF;	/* Generate EOC */
 					} else {
 						if (move_window(fs, fs->fatbase + (clst / (SS(fs) / 4))) != FR_OK) break;
-						val = ld_dword(fs->win + clst * 4 % SS(fs)) & 0x7FFFFFFF;
+						val = ld_32(fs->win + clst * 4 % SS(fs)) & 0x7FFFFFFF;
 					}
 					break;
 				}
@@ -1282,7 +1284,7 @@ static FRESULT put_fat (	/* FR_OK(0):succeeded, !=0:error */
 		case FS_FAT16:
 			res = move_window(fs, fs->fatbase + (clst / (SS(fs) / 2)));
 			if (res != FR_OK) break;
-			st_word(fs->win + clst * 2 % SS(fs), (WORD)val);	/* Simple WORD array */
+			st_16(fs->win + clst * 2 % SS(fs), (WORD)val);	/* Simple WORD array */
 			fs->wflag = 1;
 			break;
 
@@ -1293,9 +1295,9 @@ static FRESULT put_fat (	/* FR_OK(0):succeeded, !=0:error */
 			res = move_window(fs, fs->fatbase + (clst / (SS(fs) / 4)));
 			if (res != FR_OK) break;
 			if (!FF_FS_EXFAT || fs->fs_type != FS_EXFAT) {
-				val = (val & 0x0FFFFFFF) | (ld_dword(fs->win + clst * 4 % SS(fs)) & 0xF0000000);
+				val = (val & 0x0FFFFFFF) | (ld_32(fs->win + clst * 4 % SS(fs)) & 0xF0000000);
 			}
-			st_dword(fs->win + clst * 4 % SS(fs), val);
+			st_32(fs->win + clst * 4 % SS(fs), val);
 			fs->wflag = 1;
 			break;
 		}
@@ -1870,9 +1872,9 @@ static DWORD ld_clust (	/* Returns the top cluster value of the SFN entry */
 {
 	DWORD cl;
 
-	cl = ld_word(dir + DIR_FstClusLO);
+	cl = ld_16(dir + DIR_FstClusLO);
 	if (fs->fs_type == FS_FAT32) {
-		cl |= (DWORD)ld_word(dir + DIR_FstClusHI) << 16;
+		cl |= (DWORD)ld_16(dir + DIR_FstClusHI) << 16;
 	}
 
 	return cl;
@@ -1886,9 +1888,9 @@ static void st_clust (
 	DWORD cl	/* Value to be set */
 )
 {
-	st_word(dir + DIR_FstClusLO, (WORD)cl);
+	st_16(dir + DIR_FstClusLO, (WORD)cl);
 	if (fs->fs_type == FS_FAT32) {
-		st_word(dir + DIR_FstClusHI, (WORD)(cl >> 16));
+		st_16(dir + DIR_FstClusHI, (WORD)(cl >> 16));
 	}
 }
 #endif
@@ -1909,12 +1911,12 @@ static int cmp_lfn (		/* 1:matched, 0:not matched */
 	WCHAR pchr, chr;
 
 
-	if (ld_word(dir + LDIR_FstClusLO) != 0) return 0;	/* Check if LDIR_FstClusLO is 0 */
+	if (ld_16(dir + LDIR_FstClusLO) != 0) return 0;	/* Check if LDIR_FstClusLO is 0 */
 
 	ni = (UINT)((dir[LDIR_Ord] & 0x3F) - 1) * 13;	/* Offset in the name to be compared */
 
 	for (pchr = 1, di = 0; di < 13; di++) {	/* Process all characters in the entry */
-		chr = ld_word(dir + LfnOfs[di]);	/* Pick a character from the entry */
+		chr = ld_16(dir + LfnOfs[di]);		/* Pick a character from the entry */
 		if (pchr != 0) {
 			if (ni >= FF_MAX_LFN + 1 || ff_wtoupper(chr) != ff_wtoupper(lfnbuf[ni++])) {	/* Compare it with name */
 				return 0;					/* Not matched */
@@ -1945,12 +1947,12 @@ static int pick_lfn (	/* 1:succeeded, 0:buffer overflow or invalid LFN entry */
 	WCHAR pchr, chr;
 
 
-	if (ld_word(dir + LDIR_FstClusLO) != 0) return 0;	/* Check if LDIR_FstClusLO is 0 */
+	if (ld_16(dir + LDIR_FstClusLO) != 0) return 0;	/* Check if LDIR_FstClusLO is 0 */
 
 	ni = (UINT)((dir[LDIR_Ord] & ~LLEF) - 1) * 13;	/* Offset in the name buffer */
 
 	for (pchr = 1, di = 0; di < 13; di++) {		/* Process all characters in the entry */
-		chr = ld_word(dir + LfnOfs[di]);		/* Pick a character from the entry */
+		chr = ld_16(dir + LfnOfs[di]);			/* Pick a character from the entry */
 		if (pchr != 0) {
 			if (ni >= FF_MAX_LFN + 1) return 0;	/* Buffer overflow? */
 			lfnbuf[ni++] = pchr = chr;			/* Store it */
@@ -1988,13 +1990,13 @@ static void put_lfn (
 	dir[LDIR_Chksum] = sum;			/* Set checksum */
 	dir[LDIR_Attr] = AM_LFN;		/* Set attribute */
 	dir[LDIR_Type] = 0;
-	st_word(dir + LDIR_FstClusLO, 0);
+	st_16(dir + LDIR_FstClusLO, 0);
 
 	ni = (UINT)(ord - 1) * 13;		/* Offset in the name */
 	di = chr = 0;
 	do {	/* Fill the directory entry */
 		if (chr != 0xFFFF) chr = lfn[ni++];	/* Get an effective character */
-		st_word(dir + LfnOfs[di], chr);	/* Set it */
+		st_16(dir + LfnOfs[di], chr);	/* Set it */
 		if (chr == 0) chr = 0xFFFF;		/* Padding characters after the terminator */
 	} while (++di < 13);
 	if (chr == 0xFFFF || !lfn[ni]) ord |= LLEF;	/* Last LFN part is the start of an enrty set */
@@ -2015,19 +2017,19 @@ static void gen_numname (
 	BYTE* dst,			/* Pointer to the buffer to store numbered SFN */
 	const BYTE* src,	/* Pointer to SFN in directory form */
 	const WCHAR* lfn,	/* Pointer to LFN */
-	UINT seq			/* Sequence number */
+	WORD seq			/* Sequence number */
 )
 {
 	BYTE ns[8], c;
 	UINT i, j;
-	WCHAR wc;
-	DWORD crc_sreg;
 
 
 	memcpy(dst, src, 11);	/* Prepare the SFN to be modified */
 
 	if (seq > 5) {	/* In case of many collisions, generate a hash number instead of sequential number */
-		crc_sreg = seq;
+		WCHAR wc;
+		DWORD crc_sreg = seq;
+
 		while (*lfn) {	/* Create a CRC value as a hash of LFN */
 			wc = *lfn++;
 			for (i = 0; i < 16; i++) {
@@ -2036,10 +2038,10 @@ static void gen_numname (
 				if (crc_sreg & 0x10000) crc_sreg ^= 0x11021;
 			}
 		}
-		seq = (UINT)crc_sreg;
+		seq = (WORD)crc_sreg;
 	}
 
-	/* Make suffix (~ + hexdecimal) */
+	/* Make suffix (~ + 4-digit hexadecimal) */
 	i = 7;
 	do {
 		c = (BYTE)((seq % 16) + '0'); seq /= 16;
@@ -2186,7 +2188,7 @@ static FRESULT load_xdir (	/* FR_INT_ERR: invalid entry block */
 
 	/* Sanity check (do it for only accessible object) */
 	if (i <= MAXDIRB(FF_MAX_LFN)) {
-		if (xdir_sum(dirb) != ld_word(dirb + XDIR_SetSum)) return FR_INT_ERR;
+		if (xdir_sum(dirb) != ld_16(dirb + XDIR_SetSum)) return FR_INT_ERR;
 	}
 
 	return FR_OK;
@@ -2198,19 +2200,27 @@ static FRESULT load_xdir (	/* FR_INT_ERR: invalid entry block */
 /*------------------------------------------------------------------*/
 
 static void init_alloc_info (
-	FATFS* fs,		/* Filesystem object */
-	FFOBJID* obj	/* Object allocation information to be initialized */
+	FFOBJID* dobj,	/* Object allocation information to be initialized */
+	DIR* sdir		/* Additional source about containing direcotry */
 )
 {
-	obj->sclust = ld_dword(fs->dirbuf + XDIR_FstClus);		/* Start cluster */
-	obj->objsize = ld_qword(fs->dirbuf + XDIR_FileSize);	/* Size */
-	obj->stat = fs->dirbuf[XDIR_GenFlags] & 2;				/* Allocation status */
-	obj->n_frag = 0;										/* No last fragment info */
+	FATFS *fs = dobj->fs;
+
+
+	if (sdir) {	/* Initialize the containing directory. This block needs to precede the followings. */
+		dobj->c_scl = sdir->obj.sclust;
+		dobj->c_size = ((DWORD)sdir->obj.objsize & 0xFFFFFF00) | sdir->obj.stat;
+		dobj->c_ofs = sdir->blk_ofs;
+	}
+	dobj->sclust = ld_32(fs->dirbuf + XDIR_FstClus);	/* Start cluster */
+	dobj->objsize = ld_64(fs->dirbuf + XDIR_FileSize);	/* Size */
+	dobj->stat = fs->dirbuf[XDIR_GenFlags] & 2;			/* Allocation status */
+	dobj->n_frag = 0;									/* No last fragment info */
 }
 
 
 
-#if !FF_FS_READONLY || FF_FS_RPATH != 0
+#if !FF_FS_READONLY || FF_FS_RPATH
 /*------------------------------------------------*/
 /* exFAT: Load the object's directory entry block */
 /*------------------------------------------------*/
@@ -2253,7 +2263,7 @@ static FRESULT store_xdir (
 	BYTE *dirb = dp->obj.fs->dirbuf;	/* Pointer to the entry set 85+C0+C1s */
 
 
-	st_word(dirb + XDIR_SetSum, xdir_sum(dirb));	/* Create check sum */
+	st_16(dirb + XDIR_SetSum, xdir_sum(dirb));	/* Create check sum */
 
 	/* Store the entry set to the directory */
 	nent = dirb[XDIR_NumSec] + 1;	/* Number of entries */
@@ -2300,7 +2310,7 @@ static void create_xdir (
 		dirb[i++] = ET_FILENAME; dirb[i++] = 0;
 		do {	/* Fill name field */
 			if (chr != 0 && (chr = lfn[nlen]) != 0) nlen++;	/* Get a character if exist */
-			st_word(dirb + i, chr); 	/* Store it */
+			st_16(dirb + i, chr); 	/* Store it */
 			i += 2;
 		} while (i % SZDIRE != 0);
 		n_c1++;
@@ -2308,7 +2318,7 @@ static void create_xdir (
 
 	dirb[XDIR_NumName] = nlen;		/* Set name length */
 	dirb[XDIR_NumSec] = 1 + n_c1;	/* Set secondary count (C0 + C1s) */
-	st_word(dirb + XDIR_NameHash, xname_sum(lfn));	/* Set name hash */
+	st_16(dirb + XDIR_NameHash, xname_sum(lfn));	/* Set name hash */
 }
 
 #endif	/* !FF_FS_READONLY */
@@ -2331,7 +2341,7 @@ static FRESULT dir_read (
 {
 	FRESULT res = FR_NO_FILE;
 	FATFS *fs = dp->obj.fs;
-	BYTE attr, b;
+	BYTE attr, et;
 #if FF_USE_LFN
 	BYTE ord = 0xFF, sum = 0xFF;
 #endif
@@ -2339,16 +2349,16 @@ static FRESULT dir_read (
 	while (dp->sect) {
 		res = move_window(fs, dp->sect);
 		if (res != FR_OK) break;
-		b = dp->dir[DIR_Name];	/* Test for the entry type */
-		if (b == 0) {
+		et = dp->dir[DIR_Name];	/* Test for the entry type */
+		if (et == 0) {
 			res = FR_NO_FILE; break; /* Reached to end of the directory */
 		}
 #if FF_FS_EXFAT
 		if (fs->fs_type == FS_EXFAT) {	/* On the exFAT volume */
 			if (FF_USE_LABEL && vol) {
-				if (b == ET_VLABEL) break;	/* Volume label entry? */
+				if (et == ET_VLABEL) break;	/* Volume label entry? */
 			} else {
-				if (b == ET_FILEDIR) {		/* Start of the file entry block? */
+				if (et == ET_FILEDIR) {		/* Start of the file entry block? */
 					dp->blk_ofs = dp->dptr;	/* Get location of the block */
 					res = load_xdir(dp);	/* Load the entry block */
 					if (res == FR_OK) {
@@ -2362,17 +2372,17 @@ static FRESULT dir_read (
 		{	/* On the FAT/FAT32 volume */
 			dp->obj.attr = attr = dp->dir[DIR_Attr] & AM_MASK;	/* Get attribute */
 #if FF_USE_LFN		/* LFN configuration */
-			if (b == DDEM || b == '.' || (int)((attr & ~AM_ARC) == AM_VOL) != vol) {	/* An entry without valid data */
+			if (et == DDEM || et == '.' || (int)((attr & ~AM_ARC) == AM_VOL) != vol) {	/* An entry without valid data */
 				ord = 0xFF;
 			} else {
 				if (attr == AM_LFN) {	/* An LFN entry is found */
-					if (b & LLEF) {		/* Is it start of an LFN sequence? */
+					if (et & LLEF) {		/* Is it start of an LFN sequence? */
 						sum = dp->dir[LDIR_Chksum];
-						b &= (BYTE)~LLEF; ord = b;
+						et &= (BYTE)~LLEF; ord = et;
 						dp->blk_ofs = dp->dptr;
 					}
 					/* Check LFN validity and capture it */
-					ord = (b == ord && sum == dp->dir[LDIR_Chksum] && pick_lfn(fs->lfnbuf, dp->dir)) ? ord - 1 : 0xFF;
+					ord = (et == ord && sum == dp->dir[LDIR_Chksum] && pick_lfn(fs->lfnbuf, dp->dir)) ? ord - 1 : 0xFF;
 				} else {				/* An SFN entry is found */
 					if (ord != 0 || sum != sum_sfn(dp->dir)) {	/* Is there a valid LFN? */
 						dp->blk_ofs = 0xFFFFFFFF;	/* It has no LFN. */
@@ -2381,7 +2391,7 @@ static FRESULT dir_read (
 				}
 			}
 #else		/* Non LFN configuration */
-			if (b != DDEM && b != '.' && attr != AM_LFN && (int)((attr & ~AM_ARC) == AM_VOL) == vol) {	/* Is it a valid entry? */
+			if (et != DDEM && et != '.' && attr != AM_LFN && (int)((attr & ~AM_ARC) == AM_VOL) == vol) {	/* Is it a valid entry? */
 				break;
 			}
 #endif
@@ -2408,9 +2418,9 @@ static FRESULT dir_find (	/* FR_OK(0):succeeded, !=0:error */
 {
 	FRESULT res;
 	FATFS *fs = dp->obj.fs;
-	BYTE c;
+	BYTE et;
 #if FF_USE_LFN
-	BYTE a, ord, sum;
+	BYTE attr, ord, sum;
 #endif
 
 	res = dir_sdi(dp, 0);			/* Rewind directory object */
@@ -2425,10 +2435,10 @@ static FRESULT dir_find (	/* FR_OK(0):succeeded, !=0:error */
 #if FF_MAX_LFN < 255
 			if (fs->dirbuf[XDIR_NumName] > FF_MAX_LFN) continue;		/* Skip comparison if inaccessible object name */
 #endif
-			if (ld_word(fs->dirbuf + XDIR_NameHash) != hash) continue;	/* Skip comparison if hash mismatched */
+			if (ld_16(fs->dirbuf + XDIR_NameHash) != hash) continue;	/* Skip comparison if hash mismatched */
 			for (nc = fs->dirbuf[XDIR_NumName], di = SZDIRE * 2, ni = 0; nc; nc--, di += 2, ni++) {	/* Compare the name */
 				if ((di % SZDIRE) == 0) di += 2;
-				if (ff_wtoupper(ld_word(fs->dirbuf + di)) != ff_wtoupper(fs->lfnbuf[ni])) break;
+				if (ff_wtoupper(ld_16(fs->dirbuf + di)) != ff_wtoupper(fs->lfnbuf[ni])) break;
 			}
 			if (nc == 0 && !fs->lfnbuf[ni]) break;	/* Name matched? */
 		}
@@ -2442,23 +2452,23 @@ static FRESULT dir_find (	/* FR_OK(0):succeeded, !=0:error */
 	do {
 		res = move_window(fs, dp->sect);
 		if (res != FR_OK) break;
-		c = dp->dir[DIR_Name];
-		if (c == 0) { res = FR_NO_FILE; break; }	/* Reached end of directory table */
+		et = dp->dir[DIR_Name];		/* Entry type */
+		if (et == 0) { res = FR_NO_FILE; break; }	/* Reached end of directory table */
 #if FF_USE_LFN		/* LFN configuration */
-		dp->obj.attr = a = dp->dir[DIR_Attr] & AM_MASK;
-		if (c == DDEM || ((a & AM_VOL) && a != AM_LFN)) {	/* An entry without valid data */
+		dp->obj.attr = attr = dp->dir[DIR_Attr] & AM_MASK;
+		if (et == DDEM || ((attr & AM_VOL) && attr != AM_LFN)) {	/* An entry without valid data */
 			ord = 0xFF; dp->blk_ofs = 0xFFFFFFFF;	/* Reset LFN sequence */
 		} else {
-			if (a == AM_LFN) {			/* Is it an LFN entry? */
+			if (attr == AM_LFN) {			/* Is it an LFN entry? */
 				if (!(dp->fn[NSFLAG] & NS_NOLFN)) {
-					if (c & LLEF) {		/* Is it start of an entry set? */
-						c &= (BYTE)~LLEF;
-						ord = c;					/* Number of LFN entries */
+					if (et & LLEF) {		/* Is it start of an entry set? */
+						et &= (BYTE)~LLEF;
+						ord = et;					/* Number of LFN entries */
 						dp->blk_ofs = dp->dptr;		/* Start offset of LFN */
 						sum = dp->dir[LDIR_Chksum];	/* Sum of the SFN */
 					}
 					/* Check validity of the LFN entry and compare it with given name */
-					ord = (c == ord && sum == dp->dir[LDIR_Chksum] && cmp_lfn(fs->lfnbuf, dp->dir)) ? ord - 1 : 0xFF;
+					ord = (et == ord && sum == dp->dir[LDIR_Chksum] && cmp_lfn(fs->lfnbuf, dp->dir)) ? ord - 1 : 0xFF;
 				}
 			} else {					/* SFN entry */
 				if (ord == 0 && sum == sum_sfn(dp->dir)) break;	/* LFN matched? */
@@ -2492,7 +2502,7 @@ static FRESULT dir_register (	/* FR_OK:succeeded, FR_DENIED:no free entry or too
 	FATFS *fs = dp->obj.fs;
 #if FF_USE_LFN		/* LFN configuration */
 	UINT n, len, n_ent;
-	BYTE sn[12], sum;
+	BYTE sn[12];
 
 
 	if (dp->fn[NSFLAG] & (NS_DOT | NS_NONAME)) return FR_INVALID_NAME;	/* Check name validity */
@@ -2517,11 +2527,17 @@ static FRESULT dir_register (	/* FR_OK:succeeded, FR_DENIED:no free entry or too
 				res = load_obj_xdir(&dj, &dp->obj);	/* Load the object status */
 				if (res != FR_OK) return res;
 				dp->obj.objsize += (DWORD)fs->csize * SS(fs);		/* Increase the directory size by cluster size */
-				st_qword(fs->dirbuf + XDIR_FileSize, dp->obj.objsize);
-				st_qword(fs->dirbuf + XDIR_ValidFileSize, dp->obj.objsize);
-				fs->dirbuf[XDIR_GenFlags] = dp->obj.stat | 1;		/* Update the allocation status */
+				st_64(fs->dirbuf + XDIR_FileSize, dp->obj.objsize);
+				st_64(fs->dirbuf + XDIR_ValidFileSize, dp->obj.objsize);
+				fs->dirbuf[XDIR_GenFlags] = dp->obj.stat | 1;	/* Update the allocation status */
 				res = store_xdir(&dj);				/* Store the object status */
 				if (res != FR_OK) return res;
+#if FF_FS_RPATH	/* Refrect changes to the current dir chain if the stretched dir is in it */
+				for (n = 1; n <= fs->xcwds.depth && dp->obj.sclust != fs->xcwds.tbl[n].d_scl; n++) ;	/* Check if the dir is in the current dir path */
+				if (n <= fs->xcwds.depth) {		/* If exist, update it */
+					fs->xcwds.tbl[n].d_size = (DWORD)dp->obj.objsize | dp->obj.stat;
+				}
+#endif
 			}
 		}
 
@@ -2534,7 +2550,7 @@ static FRESULT dir_register (	/* FR_OK:succeeded, FR_DENIED:no free entry or too
 	if (sn[NSFLAG] & NS_LOSS) {			/* When LFN is out of 8.3 format, generate a numbered name */
 		dp->fn[NSFLAG] = NS_NOLFN;		/* Find only SFN */
 		for (n = 1; n < 100; n++) {
-			gen_numname(dp->fn, sn, fs->lfnbuf, n);	/* Generate a numbered name */
+			gen_numname(dp->fn, sn, fs->lfnbuf, (WORD)n);	/* Generate a numbered name */
 			res = dir_find(dp);				/* Check if the name collides with existing SFN */
 			if (res != FR_OK) break;
 		}
@@ -2549,7 +2565,8 @@ static FRESULT dir_register (	/* FR_OK:succeeded, FR_DENIED:no free entry or too
 	if (res == FR_OK && --n_ent) {	/* Set LFN entry if needed */
 		res = dir_sdi(dp, dp->dptr - n_ent * SZDIRE);
 		if (res == FR_OK) {
-			sum = sum_sfn(dp->fn);	/* Checksum value of the SFN tied to the LFN */
+			BYTE sum = sum_sfn(dp->fn);	/* Checksum value of the SFN tied to the LFN */
+
 			do {					/* Store LFN entries in bottom first */
 				res = move_window(fs, dp->sect);
 				if (res != FR_OK) break;
@@ -2572,7 +2589,7 @@ static FRESULT dir_register (	/* FR_OK:succeeded, FR_DENIED:no free entry or too
 			memset(dp->dir, 0, SZDIRE);	/* Clean the entry */
 			memcpy(dp->dir + DIR_Name, dp->fn, 11);	/* Put SFN */
 #if FF_USE_LFN
-			dp->dir[DIR_NTres] = dp->fn[NSFLAG] & (NS_BODY | NS_EXT);	/* Put NT flag */
+			dp->dir[DIR_NTres] = dp->fn[NSFLAG] & (NS_BODY | NS_EXT);	/* Put low-case flags */
 #endif
 			fs->wflag = 1;
 		}
@@ -2643,7 +2660,6 @@ static void get_fileinfo (
 {
 	UINT si, di;
 #if FF_USE_LFN
-	BYTE lcf;
 	WCHAR wc, hs;
 	FATFS *fs = dp->obj.fs;
 	UINT nw;
@@ -2652,7 +2668,7 @@ static void get_fileinfo (
 #endif
 
 
-	fno->fname[0] = 0;			/* Invaidate file info */
+	fno->fname[0] = 0;
 	if (dp->sect == 0) return;	/* Exit if read pointer has reached end of directory */
 
 #if FF_USE_LFN		/* LFN configuration */
@@ -2667,7 +2683,7 @@ static void get_fileinfo (
 				di = 0; break;
 			}
 			if ((si % SZDIRE) == 0) si += 2;	/* Skip entry type field */
-			wc = ld_word(fs->dirbuf + si); si += 2; nc++;	/* Get a character */
+			wc = ld_16(fs->dirbuf + si); si += 2; nc++;	/* Get a character */
 			if (hs == 0 && IsSurrogate(wc)) {	/* Is it a surrogate? */
 				hs = wc; continue;				/* Get low surrogate */
 			}
@@ -2683,10 +2699,14 @@ static void get_fileinfo (
 		fno->fname[di] = 0;						/* Terminate the name */
 		fno->altname[0] = 0;					/* exFAT does not support SFN */
 
-		fno->fattrib = fs->dirbuf[XDIR_Attr] & AM_MASKX;		/* Attribute */
-		fno->fsize = (fno->fattrib & AM_DIR) ? 0 : ld_qword(fs->dirbuf + XDIR_FileSize);	/* Size */
-		fno->ftime = ld_word(fs->dirbuf + XDIR_ModTime + 0);	/* Time */
-		fno->fdate = ld_word(fs->dirbuf + XDIR_ModTime + 2);	/* Date */
+		fno->fattrib = fs->dirbuf[XDIR_Attr] & AM_MASKX;	/* Attribute */
+		fno->fsize = (fno->fattrib & AM_DIR) ? 0 : ld_64(fs->dirbuf + XDIR_FileSize);	/* Size */
+		fno->ftime = ld_16(fs->dirbuf + XDIR_ModTime + 0);	/* Last modified time */
+		fno->fdate = ld_16(fs->dirbuf + XDIR_ModTime + 2);	/* Last modified date */
+#if FF_FS_CRTIME
+		fno->crtime = ld_16(fs->dirbuf + XDIR_CrtTime + 0);	/* Created time */
+		fno->crdate = ld_16(fs->dirbuf + XDIR_CrtTime + 2);	/* Created date */
+#endif
 		return;
 	} else
 #endif
@@ -2736,14 +2756,16 @@ static void get_fileinfo (
 	}
 	fno->altname[di] = 0;	/* Terminate the SFN  (null string means SFN is invalid) */
 
-	if (fno->fname[0] == 0) {	/* If LFN is invalid, altname[] needs to be copied to fname[] */
-		if (di == 0) {	/* If LFN and SFN both are invalid, this object is inaccessible */
-			fno->fname[di++] = '\?';
+	if (!fno->fname[0]) {	/* If LFN is invalid, altname[] needs to be copied to fname[] */
+		if (di == 0) {		/* If LFN and SFN both are invalid, */
+			fno->fname[di++] = '\?';	/* This object is inaccessible due to wrong buffer or locale settings */
 		} else {
-			for (si = di = 0, lcf = NS_BODY; fno->altname[si]; si++, di++) {	/* Copy altname[] to fname[] with case information */
+			BYTE lcflg = NS_BODY;
+
+			for (si = di = 0; fno->altname[si]; si++, di++) {	/* Copy altname[] to fname[] with case information */
 				wc = (WCHAR)fno->altname[si];
-				if (wc == '.') lcf = NS_EXT;
-				if (IsUpper(wc) && (dp->dir[DIR_NTres] & lcf)) wc += 0x20;
+				if (wc == '.') lcflg = NS_EXT;
+				if (IsUpper(wc) && (dp->dir[DIR_NTres] & lcflg)) wc += 0x20;
 				fno->fname[di] = (TCHAR)wc;
 			}
 		}
@@ -2763,10 +2785,14 @@ static void get_fileinfo (
 	fno->fname[di] = 0;		/* Terminate the SFN */
 #endif
 
-	fno->fattrib = dp->dir[DIR_Attr] & AM_MASK;			/* Attribute */
-	fno->fsize = ld_dword(dp->dir + DIR_FileSize);		/* Size */
-	fno->ftime = ld_word(dp->dir + DIR_ModTime + 0);	/* Time */
-	fno->fdate = ld_word(dp->dir + DIR_ModTime + 2);	/* Date */
+	fno->fattrib = dp->dir[DIR_Attr] & AM_MASK;		/* Attribute */
+	fno->fsize = ld_32(dp->dir + DIR_FileSize);		/* Size */
+	fno->ftime = ld_16(dp->dir + DIR_ModTime + 0);	/* Last modified time */
+	fno->fdate = ld_16(dp->dir + DIR_ModTime + 2);	/* Last Modified date */
+#if FF_FS_CRTIME
+	fno->crtime = ld_16(dp->dir + DIR_CrtTime + 0);	/* Created time */
+	fno->crdate = ld_16(dp->dir + DIR_CrtTime + 2);	/* Created date */
+#endif
 }
 
 #endif /* FF_FS_MINIMIZE <= 1 || FF_FS_RPATH >= 2 */
@@ -2880,7 +2906,7 @@ static FRESULT create_name (	/* FR_OK: successful, FR_INVALID_NAME: could not cr
 	UINT i, ni, si, di;
 
 
-	/* Create LFN into LFN working buffer */
+	/* Create an LFN into LFN working buffer */
 	p = *path; lfn = dp->obj.fs->lfnbuf; di = 0;
 	for (;;) {
 		uc = tchar2uni(&p);			/* Get a character */
@@ -2901,7 +2927,7 @@ static FRESULT create_name (	/* FR_OK: successful, FR_INVALID_NAME: could not cr
 	}
 	*path = p;					/* Return pointer to the next segment */
 
-#if FF_FS_RPATH != 0
+#if FF_FS_RPATH
 	if ((di == 1 && lfn[di - 1] == '.') ||
 		(di == 2 && lfn[di - 1] == '.' && lfn[di - 2] == '.')) {	/* Is this segment a dot name? */
 		lfn[di] = 0;
@@ -3008,14 +3034,19 @@ static FRESULT create_name (	/* FR_OK: successful, FR_INVALID_NAME: could not cr
 	p = *path; sfn = dp->fn;
 	memset(sfn, ' ', 11);
 	si = i = 0; ni = 8;
-#if FF_FS_RPATH != 0
+#if FF_FS_RPATH
 	if (p[si] == '.') { /* Is this a dot entry? */
-		for (;;) {
+		for (;;) {	/* Copy one or two dots */
 			c = (BYTE)p[si++];
 			if (c != '.' || si >= 3) break;
 			sfn[i++] = c;
 		}
-		if (!IsSeparator(c) && c > ' ') return FR_INVALID_NAME;
+		if (IsSeparator(c)) {
+			while (IsSeparator(p[si])) si++;	/* Skip duplicated separators */
+			if ((BYTE)p[si] <= ' ') c = 0;		/* Terminate if no segment follows */
+		} else if (c > ' ') {			/* Not in dot name */
+			return FR_INVALID_NAME;
+		}
 		*path = p + si;					/* Return pointer to the next segment */
 		sfn[NSFLAG] = (c <= ' ') ? NS_LAST | NS_DOT : NS_DOT;	/* Set last segment flag if end of the path */
 		return FR_OK;
@@ -3025,7 +3056,7 @@ static FRESULT create_name (	/* FR_OK: successful, FR_INVALID_NAME: could not cr
 		c = (BYTE)p[si++];				/* Get a byte */
 		if (c <= ' ') break; 			/* Break if end of the path name */
 		if (IsSeparator(c)) {			/* Break if a separator is found */
-			while (IsSeparator(p[si])) si++;	/* Skip duplicated separator if exist */
+			while (IsSeparator(p[si])) si++;	/* Skip duplicated separators */
 			break;
 		}
 		if (c == '.' || i >= ni) {		/* End of body or field overflow? */
@@ -3080,28 +3111,33 @@ static FRESULT follow_path (	/* FR_OK(0): successful, !=0: error code */
 	FATFS *fs = dp->obj.fs;
 
 
-#if FF_FS_RPATH != 0
+	/* Determins the start directory (current directory or forced root directory) */
+#if FF_FS_RPATH
 	if (!IsSeparator(*path) && (FF_STR_VOLUME_ID != 2 || !IsTerminator(*path))) {	/* Without heading separator */
 		dp->obj.sclust = fs->cdir;			/* Start at the current directory */
 	} else
 #endif
 	{										/* With heading separator */
-		while (IsSeparator(*path)) path++;	/* Strip separators */
-		dp->obj.sclust = 0;					/* Start from the root directory */
+		while (IsSeparator(*path)) path++;	/* Strip heading separators */
+		dp->obj.sclust = 0;					/* Start at the root directory */
 	}
+
 #if FF_FS_EXFAT
 	dp->obj.n_frag = 0;	/* Invalidate last fragment counter of the object */
-#if FF_FS_RPATH != 0
-	if (fs->fs_type == FS_EXFAT && dp->obj.sclust) {	/* exFAT: Retrieve the sub-directory's status */
-		DIR dj;
-
-		dp->obj.c_scl = fs->cdc_scl;
-		dp->obj.c_size = fs->cdc_size;
-		dp->obj.c_ofs = fs->cdc_ofs;
-		res = load_obj_xdir(&dj, &dp->obj);
-		if (res != FR_OK) return res;
-		dp->obj.objsize = ld_dword(fs->dirbuf + XDIR_FileSize);
-		dp->obj.stat = fs->dirbuf[XDIR_GenFlags] & 2;
+#if FF_FS_RPATH
+	if (fs->fs_type == FS_EXFAT) {	/* exFAT: Retrieve the start-directory's status */
+		if (dp->obj.sclust) {	/* Start directory is a sub-directory */
+			/* Load the current directory chain into working buffer and initialize directory object as current dir */
+			memcpy(&fs->xcwds2, &fs->xcwds, sizeof fs->xcwds2);
+			dp->obj.stat = (BYTE)fs->xcwds2.tbl[fs->xcwds2.depth].d_size;
+			dp->obj.objsize = fs->xcwds2.tbl[fs->xcwds2.depth].d_size & 0xFFFFFF00;
+			dp->obj.c_scl = fs->xcwds2.tbl[fs->xcwds2.depth - 1].d_scl;
+			dp->obj.c_size = fs->xcwds2.tbl[fs->xcwds2.depth - 1].d_size & 0xFFFFFF00;
+			dp->obj.c_ofs = fs->xcwds2.tbl[fs->xcwds2.depth - 1].nxt_ofs;
+		} else {				/* Start directory is the root directory */
+			/* Clear the directory path working buffer as root directory */
+			memset(&fs->xcwds2, 0, sizeof fs->xcwds2);
+		}
 	}
 #endif
 #endif
@@ -3114,11 +3150,31 @@ static FRESULT follow_path (	/* FR_OK(0): successful, !=0: error code */
 		for (;;) {
 			res = create_name(dp, &path);	/* Get a segment name of the path */
 			if (res != FR_OK) break;
-			res = dir_find(dp);				/* Find an object with the segment name */
 			ns = dp->fn[NSFLAG];
+#if FF_FS_EXFAT && FF_FS_RPATH
+			if (fs->fs_type == FS_EXFAT && (ns & NS_DOT)) {	/* Is it a dot name? */
+				/* There is no dot entry in exFAT volume, so it needs to follow the parent directory with recorded path */
+				if (fs->lfnbuf[1] == '.' && fs->xcwds2.depth) {	/* ".." in the sub-dir? */
+					fs->xcwds2.depth--;	/* Get into the parent directory and load the directory info */
+					dp->obj.sclust = fs->xcwds2.tbl[fs->xcwds2.depth].d_scl;
+					dp->obj.stat = (BYTE)fs->xcwds2.tbl[fs->xcwds2.depth].d_size;
+					dp->obj.objsize = fs->xcwds2.tbl[fs->xcwds2.depth].d_size & 0xFFFFFF00;
+					if (fs->xcwds2.depth) {		/* Load containing dir info if needed */
+						dp->obj.c_scl = fs->xcwds2.tbl[fs->xcwds2.depth - 1].d_scl;
+						dp->obj.c_size = fs->xcwds2.tbl[fs->xcwds2.depth - 1].d_size;
+						dp->obj.c_ofs = fs->xcwds2.tbl[fs->xcwds2.depth - 1].nxt_ofs;
+					}
+				}
+				dp->obj.attr |= AM_DIR;			/* This is a directory */
+				dp->fn[NSFLAG] |= NS_NONAME;	/* but dot names in exFAT volume are not directory entry */
+				if (ns & NS_LAST) break;		/* Last segment? */
+				continue;		/* Follow next segment */
+			}
+#endif
+			res = dir_find(dp);				/* Find an object with the segment name */
 			if (res != FR_OK) {				/* Failed to find the object */
 				if (res == FR_NO_FILE) {	/* Object is not found */
-					if (FF_FS_RPATH && (ns & NS_DOT)) {	/* If dot entry is not exist, stay there */
+					if (FF_FS_RPATH && (ns & NS_DOT)) {	/* If dot entry is not exist, stay there (may be root dir in FAT volume) */
 						if (!(ns & NS_LAST)) continue;	/* Continue to follow if not last segment */
 						dp->fn[NSFLAG] = NS_NONAME;
 						res = FR_OK;
@@ -3128,17 +3184,24 @@ static FRESULT follow_path (	/* FR_OK(0): successful, !=0: error code */
 				}
 				break;
 			}
-			if (ns & NS_LAST) break;		/* Last segment matched. Function completed. */
+#if FF_FS_EXFAT && FF_FS_RPATH
+			if (fs->fs_type == FS_EXFAT && (dp->obj.attr & AM_DIR)) {	/* Record the path if it is a sub-directory */
+				fs->xcwds2.tbl[fs->xcwds2.depth].nxt_ofs = dp->blk_ofs;
+				if (++fs->xcwds2.depth >= sizeof fs->xcwds2.tbl / sizeof fs->xcwds2.tbl[0]) {	/* Is it too deep path? */
+					res = FR_NOT_ENOUGH_CORE; break;
+				}
+				fs->xcwds2.tbl[fs->xcwds2.depth].d_scl = ld_32(fs->dirbuf + XDIR_FstClus);
+				fs->xcwds2.tbl[fs->xcwds2.depth].d_size = ld_32(fs->dirbuf + XDIR_FileSize) | (fs->dirbuf[XDIR_GenFlags] & 2);
+			}
+#endif
+			if (ns & NS_LAST) break;		/* If last segment matched, the function completed */
 			/* Get into the sub-directory */
-			if (!(dp->obj.attr & AM_DIR)) {	/* It is not a sub-directory and cannot follow */
-				res = FR_NO_PATH; break;
+			if (!(dp->obj.attr & AM_DIR)) {
+				res = FR_NO_PATH; break;	/* It is not a sub-directory and cannot follow the path */
 			}
 #if FF_FS_EXFAT
-			if (fs->fs_type == FS_EXFAT) {	/* Save containing directory information for next dir */
-				dp->obj.c_scl = dp->obj.sclust;
-				dp->obj.c_size = ((DWORD)dp->obj.objsize & 0xFFFFFF00) | dp->obj.stat;
-				dp->obj.c_ofs = dp->blk_ofs;
-				init_alloc_info(fs, &dp->obj);	/* Open next directory */
+			if (fs->fs_type == FS_EXFAT) {
+				init_alloc_info(&dp->obj, dp);	/* Open next directory */
 			} else
 #endif
 			{
@@ -3216,7 +3279,7 @@ static int get_ldnumber (	/* Returns logical drive number (-1:invalid drive numb
 	}
 #endif
 	/* No drive prefix */
-#if FF_FS_RPATH != 0
+#if FF_FS_RPATH
 	return (int)CurrVol;	/* Default drive is current drive */
 #else
 	return 0;				/* Default drive is 0 */
@@ -3261,14 +3324,14 @@ static int test_gpt_header (	/* 0:Invalid, 1:Valid */
 
 
 	if (memcmp(gpth + GPTH_Sign, "EFI PART" "\0\0\1", 12)) return 0;	/* Check signature and version (1.0) */
-	hlen = ld_dword(gpth + GPTH_Size);						/* Check header size */
+	hlen = ld_32(gpth + GPTH_Size);							/* Check header size */
 	if (hlen < 92 || hlen > FF_MIN_SS) return 0;
 	for (i = 0, bcc = 0xFFFFFFFF; i < hlen; i++) {			/* Check header BCC */
 		bcc = crc32(bcc, i - GPTH_Bcc < 4 ? 0 : gpth[i]);
 	}
-	if (~bcc != ld_dword(gpth + GPTH_Bcc)) return 0;
-	if (ld_dword(gpth + GPTH_PteSize) != SZ_GPTE) return 0;	/* Table entry size (must be SZ_GPTE bytes) */
-	if (ld_dword(gpth + GPTH_PtNum) > 128) return 0;		/* Table size (must be 128 entries or less) */
+	if (~bcc != ld_32(gpth + GPTH_Bcc)) return 0;
+	if (ld_32(gpth + GPTH_PteSize) != SZ_GPTE) return 0;	/* Table entry size (must be SZ_GPTE bytes) */
+	if (ld_32(gpth + GPTH_PtNum) > 128) return 0;			/* Table size (must be 128 entries or less) */
 
 	return 1;
 }
@@ -3315,7 +3378,7 @@ static UINT check_fs (	/* 0:FAT/FAT32 VBR, 1:exFAT VBR, 2:Not FAT and valid BS, 
 
 	fs->wflag = 0; fs->winsect = (LBA_t)0 - 1;		/* Invaidate window */
 	if (move_window(fs, sect) != FR_OK) return 4;	/* Load the boot sector */
-	sign = ld_word(fs->win + BS_55AA);
+	sign = ld_16(fs->win + BS_55AA);
 #if FF_FS_EXFAT
 	if (sign == 0xAA55 && !memcmp(fs->win + BS_JmpBoot, "\xEB\x76\x90" "EXFAT   ", 11)) return 1;	/* It is an exFAT VBR */
 #endif
@@ -3325,15 +3388,15 @@ static UINT check_fs (	/* 0:FAT/FAT32 VBR, 1:exFAT VBR, 2:Not FAT and valid BS, 
 			return 0;	/* It is an FAT32 VBR */
 		}
 		/* FAT volumes created in the early MS-DOS era lack BS_55AA and BS_FilSysType, so FAT VBR needs to be identified without them. */
-		w = ld_word(fs->win + BPB_BytsPerSec);
+		w = ld_16(fs->win + BPB_BytsPerSec);
 		b = fs->win[BPB_SecPerClus];
 		if ((w & (w - 1)) == 0 && w >= FF_MIN_SS && w <= FF_MAX_SS	/* Properness of sector size (512-4096 and 2^n) */
 			&& b != 0 && (b & (b - 1)) == 0				/* Properness of cluster size (2^n) */
-			&& ld_word(fs->win + BPB_RsvdSecCnt) != 0	/* Properness of number of reserved sectors (MNBZ) */
+			&& ld_16(fs->win + BPB_RsvdSecCnt) != 0		/* Properness of number of reserved sectors (MNBZ) */
 			&& (UINT)fs->win[BPB_NumFATs] - 1 <= 1		/* Properness of number of FATs (1 or 2) */
-			&& ld_word(fs->win + BPB_RootEntCnt) != 0	/* Properness of root dir size (MNBZ) */
-			&& (ld_word(fs->win + BPB_TotSec16) >= 128 || ld_dword(fs->win + BPB_TotSec32) >= 0x10000)	/* Properness of volume size (>=128) */
-			&& ld_word(fs->win + BPB_FATSz16) != 0) {	/* Properness of FAT size (MNBZ) */
+			&& ld_16(fs->win + BPB_RootEntCnt) != 0		/* Properness of root dir size (MNBZ) */
+			&& (ld_16(fs->win + BPB_TotSec16) >= MIN_VOLUME || ld_32(fs->win + BPB_TotSec32) >= 0x10000)	/* Properness of volume size */
+			&& ld_16(fs->win + BPB_FATSz16) != 0) {		/* Properness of FAT size (MNBZ) */
 				return 0;	/* It can be presumed an FAT VBR */
 		}
 	}
@@ -3356,7 +3419,7 @@ static UINT find_volume (	/* Returns BS status found in the hosting drive */
 	fmt = check_fs(fs, 0);				/* Load sector 0 and check if it is an FAT VBR as SFD format */
 	if (fmt != 2 && (fmt >= 3 || part == 0)) return fmt;	/* Returns if it is an FAT VBR as auto scan, not a BS or disk error */
 
-	/* Sector 0 is not an FAT VBR or forced partition number wants a partition */
+	/* Sector 0 is not an FAT VBR or forced partition number wants a partitioned drive */
 
 #if FF_LBA64
 	if (fs->win[MBR_Table + PTE_System] == 0xEE) {	/* GPT protective MBR? */
@@ -3365,14 +3428,14 @@ static UINT find_volume (	/* Returns BS status found in the hosting drive */
 
 		if (move_window(fs, 1) != FR_OK) return 4;	/* Load GPT header sector (next to MBR) */
 		if (!test_gpt_header(fs->win)) return 3;	/* Check if GPT header is valid */
-		n_ent = ld_dword(fs->win + GPTH_PtNum);		/* Number of entries */
-		pt_lba = ld_qword(fs->win + GPTH_PtOfs);	/* Table location */
+		n_ent = ld_32(fs->win + GPTH_PtNum);		/* Number of entries */
+		pt_lba = ld_64(fs->win + GPTH_PtOfs);		/* Table location */
 		for (v_ent = i = 0; i < n_ent; i++) {		/* Find FAT partition */
 			if (move_window(fs, pt_lba + i * SZ_GPTE / SS(fs)) != FR_OK) return 4;	/* PT sector */
 			ofs = i * SZ_GPTE % SS(fs);												/* Offset in the sector */
 			if (!memcmp(fs->win + ofs + GPTE_PtGuid, GUID_MS_Basic, 16)) {	/* MS basic data partition? */
-				v_ent++;
-				fmt = check_fs(fs, ld_qword(fs->win + ofs + GPTE_FstLba));	/* Load VBR and check status */
+				v_ent++;	/* Order of MS BDP */
+				fmt = check_fs(fs, ld_64(fs->win + ofs + GPTE_FstLba));	/* Load VBR and check status */
 				if (part == 0 && fmt <= 1) return fmt;			/* Auto search (valid FAT volume found first) */
 				if (part != 0 && v_ent == part) return fmt;		/* Forced partition order (regardless of it is valid or not) */
 			}
@@ -3380,9 +3443,9 @@ static UINT find_volume (	/* Returns BS status found in the hosting drive */
 		return 3;	/* Not found */
 	}
 #endif
-	if (FF_MULTI_PARTITION && part > 4) return 3;	/* MBR has 4 partitions max */
+	if (FF_MULTI_PARTITION && part > 4) return 3;	/* MBR has four primary partitions max (FatFs does not support logical partition) */
 	for (i = 0; i < 4; i++) {		/* Load partition offset in the MBR */
-		mbr_pt[i] = ld_dword(fs->win + MBR_Table + i * SZ_PTE + PTE_StLba);
+		mbr_pt[i] = ld_32(fs->win + MBR_Table + i * SZ_PTE + PTE_StLba);
 	}
 	i = part ? part - 1 : 0;		/* Table index to find first */
 	do {							/* Find an FAT volume */
@@ -3408,8 +3471,6 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 	FATFS *fs;
 	DSTATUS stat;
 	LBA_t bsect;
-	DWORD tsect, sysect, fasize, nclst, szbfat;
-	WORD nrsv;
 	UINT fmt;
 
 
@@ -3464,21 +3525,21 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 #if FF_FS_EXFAT
 	if (fmt == 1) {
 		QWORD maxlba;
-		DWORD so, cv, bcl, i;
+		DWORD so, cv, bcl, ncl, i;
 
 		for (i = BPB_ZeroedEx; i < BPB_ZeroedEx + 53 && fs->win[i] == 0; i++) ;	/* Check zero filler */
 		if (i < BPB_ZeroedEx + 53) return FR_NO_FILESYSTEM;
 
-		if (ld_word(fs->win + BPB_FSVerEx) != 0x100) return FR_NO_FILESYSTEM;	/* Check exFAT version (must be version 1.0) */
+		if (ld_16(fs->win + BPB_FSVerEx) != 0x100) return FR_NO_FILESYSTEM;	/* Check exFAT version (must be version 1.0) */
 
 		if (1 << fs->win[BPB_BytsPerSecEx] != SS(fs)) {	/* (BPB_BytsPerSecEx must be equal to the physical sector size) */
 			return FR_NO_FILESYSTEM;
 		}
 
-		maxlba = ld_qword(fs->win + BPB_TotSecEx) + bsect;	/* Last LBA of the volume + 1 */
+		maxlba = ld_64(fs->win + BPB_TotSecEx) + bsect;	/* Last LBA of the volume + 1 */
 		if (!FF_LBA64 && maxlba >= 0x100000000) return FR_NO_FILESYSTEM;	/* (It cannot be accessed in 32-bit LBA) */
 
-		fs->fsize = ld_dword(fs->win + BPB_FatSzEx);	/* Number of sectors per FAT */
+		fs->fsize = ld_32(fs->win + BPB_FatSzEx);		/* Number of sectors per FAT */
 
 		fs->n_fats = fs->win[BPB_NumFATsEx];			/* Number of FATs */
 		if (fs->n_fats != 1) return FR_NO_FILESYSTEM;	/* (Supports only 1 FAT) */
@@ -3486,16 +3547,16 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 		fs->csize = 1 << fs->win[BPB_SecPerClusEx];		/* Cluster size */
 		if (fs->csize == 0)	return FR_NO_FILESYSTEM;	/* (Must be 1..32768 sectors) */
 
-		nclst = ld_dword(fs->win + BPB_NumClusEx);		/* Number of clusters */
-		if (nclst > MAX_EXFAT) return FR_NO_FILESYSTEM;	/* (Too many clusters) */
-		fs->n_fatent = nclst + 2;
+		ncl = ld_32(fs->win + BPB_NumClusEx);			/* Number of clusters */
+		if (ncl < MIN_EXFAT || ncl > MAX_EXFAT) return FR_NO_FILESYSTEM;	/* (Wrong cluster count) */
+		fs->n_fatent = ncl + 2;
 
 		/* Boundaries and Limits */
 		fs->volbase = bsect;
-		fs->database = bsect + ld_dword(fs->win + BPB_DataOfsEx);
-		fs->fatbase = bsect + ld_dword(fs->win + BPB_FatOfsEx);
-		if (maxlba < (QWORD)fs->database + nclst * fs->csize) return FR_NO_FILESYSTEM;	/* (Volume size must not be smaller than the size required) */
-		fs->dirbase = ld_dword(fs->win + BPB_RootClusEx);
+		fs->database = bsect + ld_32(fs->win + BPB_DataOfsEx);
+		fs->fatbase = bsect + ld_32(fs->win + BPB_FatOfsEx);
+		if (maxlba < (QWORD)fs->database + ncl * fs->csize) return FR_NO_FILESYSTEM;	/* (Volume size must not be smaller than the size required) */
+		fs->dirbase = ld_32(fs->win + BPB_RootClusEx);
 
 		/* Get bitmap location and check if it is contiguous (implementation assumption) */
 		so = i = 0;
@@ -3505,19 +3566,18 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 				if (move_window(fs, clst2sect(fs, (DWORD)fs->dirbase) + so) != FR_OK) return FR_DISK_ERR;
 				so++;
 			}
-			if (fs->win[i] == ET_BITMAP) break;			/* Is it a bitmap entry? */
+			if (fs->win[i] == ET_BITMAP) break;		/* Is it a bitmap entry? */
 			i = (i + SZDIRE) % SS(fs);	/* Next entry */
 		}
-		bcl = ld_dword(fs->win + i + 20);				/* Bitmap cluster */
+		bcl = ld_32(fs->win + i + 20);				/* Bitmap cluster */
 		if (bcl < 2 || bcl >= fs->n_fatent) return FR_NO_FILESYSTEM;	/* (Wrong cluster#) */
 		fs->bitbase = fs->database + fs->csize * (bcl - 2);	/* Bitmap sector */
 		for (;;) {	/* Check if bitmap is contiguous */
 			if (move_window(fs, fs->fatbase + bcl / (SS(fs) / 4)) != FR_OK) return FR_DISK_ERR;
-			cv = ld_dword(fs->win + bcl % (SS(fs) / 4) * 4);
+			cv = ld_32(fs->win + bcl % (SS(fs) / 4) * 4);
 			if (cv == 0xFFFFFFFF) break;				/* Last link? */
 			if (cv != ++bcl) return FR_NO_FILESYSTEM;	/* Fragmented bitmap? */
 		}
-
 #if !FF_FS_READONLY
 		fs->last_clst = fs->free_clst = 0xFFFFFFFF;		/* Invalidate cluster allocation information */
 		fs->fsi_flag = 0;	/* Enable to sync PercInUse value in VBR */
@@ -3526,10 +3586,14 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 	} else
 #endif	/* FF_FS_EXFAT */
 	{
-		if (ld_word(fs->win + BPB_BytsPerSec) != SS(fs)) return FR_NO_FILESYSTEM;	/* (BPB_BytsPerSec must be equal to the physical sector size) */
+		DWORD tsect, sysect, fasize, nclst, szbfat;
+		WORD nrsv;
 
-		fasize = ld_word(fs->win + BPB_FATSz16);		/* Number of sectors per FAT */
-		if (fasize == 0) fasize = ld_dword(fs->win + BPB_FATSz32);
+		if (ld_16(fs->win + BPB_BytsPerSec) != SS(fs)) return FR_NO_FILESYSTEM;	/* (BPB_BytsPerSec must be equal to the physical sector size) */
+
+		fasize = ld_16(fs->win + BPB_FATSz16);		/* Number of sectors per FAT */
+		if (fasize == 0) fasize = ld_32(fs->win + BPB_FATSz32);
+		if (fasize >= 0x200000) return FR_NO_FILESYSTEM;	/* (Must be smaller than max FAT size) */
 		fs->fsize = fasize;
 
 		fs->n_fats = fs->win[BPB_NumFATs];				/* Number of FATs */
@@ -3539,13 +3603,13 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 		fs->csize = fs->win[BPB_SecPerClus];			/* Cluster size */
 		if (fs->csize == 0 || (fs->csize & (fs->csize - 1))) return FR_NO_FILESYSTEM;	/* (Must be power of 2) */
 
-		fs->n_rootdir = ld_word(fs->win + BPB_RootEntCnt);	/* Number of root directory entries */
+		fs->n_rootdir = ld_16(fs->win + BPB_RootEntCnt);	/* Number of root directory entries */
 		if (fs->n_rootdir % (SS(fs) / SZDIRE)) return FR_NO_FILESYSTEM;	/* (Must be sector aligned) */
 
-		tsect = ld_word(fs->win + BPB_TotSec16);		/* Number of sectors on the volume */
-		if (tsect == 0) tsect = ld_dword(fs->win + BPB_TotSec32);
+		tsect = ld_16(fs->win + BPB_TotSec16);			/* Number of sectors on the volume */
+		if (tsect == 0) tsect = ld_32(fs->win + BPB_TotSec32);
 
-		nrsv = ld_word(fs->win + BPB_RsvdSecCnt);		/* Number of reserved sectors */
+		nrsv = ld_16(fs->win + BPB_RsvdSecCnt);			/* Number of reserved sectors */
 		if (nrsv == 0) return FR_NO_FILESYSTEM;			/* (Must not be 0) */
 
 		/* Determine the FAT sub type */
@@ -3557,6 +3621,7 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 		if (nclst <= MAX_FAT32) fmt = FS_FAT32;
 		if (nclst <= MAX_FAT16) fmt = FS_FAT16;
 		if (nclst <= MAX_FAT12) fmt = FS_FAT12;
+		if (nclst <= MIN_FAT12) fmt = 0;
 		if (fmt == 0) return FR_NO_FILESYSTEM;
 
 		/* Boundaries and Limits */
@@ -3565,9 +3630,9 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 		fs->fatbase = bsect + nrsv; 					/* FAT start sector */
 		fs->database = bsect + sysect;					/* Data start sector */
 		if (fmt == FS_FAT32) {
-			if (ld_word(fs->win + BPB_FSVer32) != 0) return FR_NO_FILESYSTEM;	/* (Must be FAT32 revision 0.0) */
+			if (ld_16(fs->win + BPB_FSVer32) != 0) return FR_NO_FILESYSTEM;	/* (Must be FAT32 revision 0.0) */
 			if (fs->n_rootdir != 0) return FR_NO_FILESYSTEM;	/* (BPB_RootEntCnt must be 0) */
-			fs->dirbase = ld_dword(fs->win + BPB_RootClus32);	/* Root directory start cluster */
+			fs->dirbase = ld_32(fs->win + BPB_RootClus32);	/* Root directory start cluster */
 			szbfat = fs->n_fatent * 4;					/* (Needed FAT size) */
 		} else {
 			if (fs->n_rootdir == 0)	return FR_NO_FILESYSTEM;	/* (BPB_RootEntCnt must not be 0) */
@@ -3582,19 +3647,19 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 		fs->last_clst = fs->free_clst = 0xFFFFFFFF;		/* Invalidate cluster allocation information */
 		fs->fsi_flag = 0x80;	/* Disable FSInfo by default */
 		if (fmt == FS_FAT32
-			&& ld_word(fs->win + BPB_FSInfo32) == 1	/* FAT32: Enable FSInfo feature only if FSInfo sector is next to VBR */
+			&& ld_16(fs->win + BPB_FSInfo32) == 1	/* FAT32: Enable FSInfo feature only if FSInfo sector is next to VBR */
 			&& move_window(fs, bsect + 1) == FR_OK)
 		{
 			fs->fsi_flag = 0;
-			if (   ld_dword(fs->win + FSI_LeadSig) == 0x41615252	/* Load FSInfo data if available */
-				&& ld_dword(fs->win + FSI_StrucSig) == 0x61417272
-				&& ld_dword(fs->win + FSI_TrailSig) == 0xAA550000)
+			if (   ld_32(fs->win + FSI_LeadSig) == 0x41615252	/* Load FSInfo data if available */
+				&& ld_32(fs->win + FSI_StrucSig) == 0x61417272
+				&& ld_32(fs->win + FSI_TrailSig) == 0xAA550000)
 			{
 #if (FF_FS_NOFSINFO & 1) == 0	/* Get free cluster count if trust it */
-				fs->free_clst = ld_dword(fs->win + FSI_Free_Count);
+				fs->free_clst = ld_32(fs->win + FSI_Free_Count);
 #endif
 #if (FF_FS_NOFSINFO & 2) == 0	/* Get next free cluster if rtust it */
-				fs->last_clst = ld_dword(fs->win + FSI_Nxt_Free);
+				fs->last_clst = ld_32(fs->win + FSI_Nxt_Free);
 #endif
 			}
 		}
@@ -3603,18 +3668,25 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 
 	fs->fs_type = (BYTE)fmt;/* FAT sub-type (the filesystem object gets valid) */
 	fs->id = ++Fsid;		/* Volume mount ID */
-#if FF_USE_LFN == 1
-	fs->lfnbuf = LfnBuf;	/* Static LFN working buffer */
+
+#if FF_USE_LFN == 1			/* Initilize pointers to the static working buffers */
+	fs->lfnbuf = LfnBuf;	/* LFN working buffer */
 #if FF_FS_EXFAT
-	fs->dirbuf = DirBuf;	/* Static directory block scratchpad buuffer */
+	fs->dirbuf = DirBuf;	/* Directory block scratchpad buuffer */
 #endif
 #endif
-#if FF_FS_RPATH != 0
-	fs->cdir = 0;			/* Initialize current directory */
+
+#if FF_FS_RPATH				/* Set the current directory top layer (root) */
+	fs->cdir = 0;
+#if FF_FS_EXFAT
+	memset(&fs->xcwds, 0, sizeof fs->xcwds);
 #endif
+#endif
+
 #if FF_FS_LOCK				/* Clear file lock semaphores */
 	clear_share(fs);
 #endif
+
 	return FR_OK;
 }
 
@@ -3666,7 +3738,7 @@ static FRESULT validate (	/* Returns FR_OK or FR_INVALID_OBJECT */
 
 
 /*-----------------------------------------------------------------------*/
-/* Mount/Unmount a Logical Drive                                         */
+/* API: Mount/Unmount a Logical Drive                                    */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_mount (
@@ -3684,11 +3756,11 @@ FRESULT f_mount (
 	/* Get volume ID (logical drive number) */
 	vol = get_ldnumber(&rp);
 	if (vol < 0) return FR_INVALID_DRIVE;
-	cfs = FatFs[vol];			/* Pointer to the filesystem object of the volume */
 
-	if (cfs) {					/* Unregister current filesystem object if registered */
+	cfs = FatFs[vol];			/* Pointer to the filesystem object of the volume */
+	if (cfs) {					/* Unregister current filesystem object */
 		FatFs[vol] = 0;
-#if FF_FS_LOCK
+#if FF_FS_LOCK					/* Clear file lock semaphores correspond to this volume */
 		clear_share(cfs);
 #endif
 #if FF_FS_REENTRANT				/* Discard mutex of the current volume */
@@ -3713,12 +3785,12 @@ FRESULT f_mount (
 #endif
 #endif
 		fs->fs_type = 0;		/* Invalidate the new filesystem object */
-		FatFs[vol] = fs;		/* Register new fs object */
+		FatFs[vol] = fs;		/* Register it */
 	}
 
 	if (opt == 0) return FR_OK;	/* Do not mount now, it will be mounted in subsequent file functions */
 
-	res = mount_volume(&path, &fs, 0);	/* Force mounted the volume */
+	res = mount_volume(&path, &fs, 0);	/* Force mounted the volume in this function */
 	LEAVE_FF(fs, res);
 }
 
@@ -3726,7 +3798,7 @@ FRESULT f_mount (
 
 
 /*-----------------------------------------------------------------------*/
-/* Open or Create a File                                                 */
+/* API: Open or Create a File                                            */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_open (
@@ -3738,22 +3810,19 @@ FRESULT f_open (
 	FRESULT res;
 	DIR dj;
 	FATFS *fs;
-#if !FF_FS_READONLY
-	DWORD cl, bcs, clst, tm;
-	LBA_t sc;
-	FSIZE_t ofs;
-#endif
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	if (!fp) return FR_INVALID_OBJECT;
+	if (!fp) return FR_INVALID_OBJECT;	/* Reject null pointer */
 
-	/* Get logical drive number */
+	/* Get logical drive number and mount the volume if needed */
 	mode &= FF_FS_READONLY ? FA_READ : FA_READ | FA_WRITE | FA_CREATE_ALWAYS | FA_CREATE_NEW | FA_OPEN_ALWAYS | FA_OPEN_APPEND;
 	res = mount_volume(&path, &fs, mode);
+
 	if (res == FR_OK) {
+		fp->obj.fs = fs;
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
 		res = follow_path(&dj, path);	/* Follow the file path */
 #if !FF_FS_READONLY	/* Read/Write configuration */
 		if (res == FR_OK) {
@@ -3778,24 +3847,25 @@ FRESULT f_open (
 				}
 				mode |= FA_CREATE_ALWAYS;		/* File is created */
 			}
-			else {								/* Any object with the same name is already existing */
-				if (dj.obj.attr & (AM_RDO | AM_DIR)) {	/* Cannot overwrite it (R/O or DIR) */
-					res = FR_DENIED;
+			else {								/* An object with the same name is already existing */
+				if (mode & FA_CREATE_NEW) {
+					res = FR_EXIST;				/* Cannot create as new file */
 				} else {
-					if (mode & FA_CREATE_NEW) res = FR_EXIST;	/* Cannot create as new file */
+					if (dj.obj.attr & (AM_RDO | AM_DIR)) res = FR_DENIED;	/* Cannot overwrite it (R/O or DIR) */
 				}
 			}
 			if (res == FR_OK && (mode & FA_CREATE_ALWAYS)) {	/* Truncate the file if overwrite mode */
+				DWORD tm = GET_FATTIME();
 #if FF_FS_EXFAT
 				if (fs->fs_type == FS_EXFAT) {
 					/* Get current allocation info */
-					fp->obj.fs = fs;
-					init_alloc_info(fs, &fp->obj);
-					/* Set directory entry block initial state */
+					init_alloc_info(&fp->obj, 0);
+					/* Set exFAT directory entry block initial state */
 					memset(fs->dirbuf + 2, 0, 30);	/* Clear 85 entry except for NumSec */
 					memset(fs->dirbuf + 38, 0, 26);	/* Clear C0 entry except for NumName and NameHash */
 					fs->dirbuf[XDIR_Attr] = AM_ARC;
-					st_dword(fs->dirbuf + XDIR_CrtTime, GET_FATTIME());
+					st_32(fs->dirbuf + XDIR_CrtTime, tm);	/* Set created time */
+					st_32(fs->dirbuf + XDIR_ModTime, tm);	/* Set modified time (tmp setting) */
 					fs->dirbuf[XDIR_GenFlags] = 1;
 					res = store_xdir(&dj);
 					if (res == FR_OK && fp->obj.sclust != 0) {	/* Remove the cluster chain if exist */
@@ -3805,17 +3875,18 @@ FRESULT f_open (
 				} else
 #endif
 				{
-					/* Set directory entry initial state */
-					tm = GET_FATTIME();					/* Set created time */
-					st_dword(dj.dir + DIR_CrtTime, tm);
-					st_dword(dj.dir + DIR_ModTime, tm);
+					DWORD cl;
+					/* Set FAT directory entry initial state */
+					st_32(dj.dir + DIR_CrtTime, tm);	/* Set created time */
+					st_32(dj.dir + DIR_ModTime, tm);	/* Set modified time (tmp setting) */
 					cl = ld_clust(fs, dj.dir);			/* Get current cluster chain */
 					dj.dir[DIR_Attr] = AM_ARC;			/* Reset attribute */
 					st_clust(fs, dj.dir, 0);			/* Reset file allocation info */
-					st_dword(dj.dir + DIR_FileSize, 0);
+					st_32(dj.dir + DIR_FileSize, 0);
 					fs->wflag = 1;
 					if (cl != 0) {						/* Remove the cluster chain if exist */
-						sc = fs->winsect;
+						LBA_t sc = fs->winsect;
+
 						res = remove_chain(&dj.obj, cl, 0);
 						if (res == FR_OK) {
 							res = move_window(fs, sc);
@@ -3845,7 +3916,8 @@ FRESULT f_open (
 			if (fp->obj.lockid == 0) res = FR_INT_ERR;
 #endif
 		}
-#else		/* R/O configuration */
+
+#else	/* R/O configuration */
 		if (res == FR_OK) {
 			if (dj.fn[NSFLAG] & NS_NONAME) {	/* Is it origin directory itself? */
 				res = FR_INVALID_NAME;
@@ -3860,21 +3932,17 @@ FRESULT f_open (
 		if (res == FR_OK) {
 #if FF_FS_EXFAT
 			if (fs->fs_type == FS_EXFAT) {
-				fp->obj.c_scl = dj.obj.sclust;							/* Get containing directory info */
-				fp->obj.c_size = ((DWORD)dj.obj.objsize & 0xFFFFFF00) | dj.obj.stat;
-				fp->obj.c_ofs = dj.blk_ofs;
-				init_alloc_info(fs, &fp->obj);
+				init_alloc_info(&fp->obj, &dj);
 			} else
 #endif
 			{
 				fp->obj.sclust = ld_clust(fs, dj.dir);					/* Get object allocation info */
-				fp->obj.objsize = ld_dword(dj.dir + DIR_FileSize);
+				fp->obj.objsize = ld_32(dj.dir + DIR_FileSize);
 			}
 #if FF_USE_FASTSEEK
 			fp->cltbl = 0;		/* Disable fast seek mode */
 #endif
-			fp->obj.fs = fs;	/* Validate the file object */
-			fp->obj.id = fs->id;
+			fp->obj.id = fs->id;	/* Set current volume mount ID */
 			fp->flag = mode;	/* Set file access mode */
 			fp->err = 0;		/* Clear error flag */
 			fp->sect = 0;		/* Invalidate current data sector */
@@ -3884,6 +3952,9 @@ FRESULT f_open (
 			memset(fp->buf, 0, sizeof fp->buf);	/* Clear sector buffer */
 #endif
 			if ((mode & FA_SEEKEND) && fp->obj.objsize > 0) {	/* Seek to end of file if FA_OPEN_APPEND is specified */
+				DWORD bcs, clst;
+				FSIZE_t ofs;
+
 				fp->fptr = fp->obj.objsize;			/* Offset to seek */
 				bcs = (DWORD)fs->csize * SS(fs);	/* Cluster size in byte */
 				clst = fp->obj.sclust;				/* Follow the cluster chain */
@@ -3894,11 +3965,12 @@ FRESULT f_open (
 				}
 				fp->clust = clst;
 				if (res == FR_OK && ofs % SS(fs)) {	/* Fill sector buffer if not on the sector boundary */
-					sc = clst2sect(fs, clst);
-					if (sc == 0) {
+					LBA_t sec = clst2sect(fs, clst);
+
+					if (sec == 0) {
 						res = FR_INT_ERR;
 					} else {
-						fp->sect = sc + (DWORD)(ofs / SS(fs));
+						fp->sect = sec + (DWORD)(ofs / SS(fs));
 #if !FF_FS_TINY
 						if (disk_read(fs->pdrv, fp->buf, fp->sect, 1) != RES_OK) res = FR_DISK_ERR;
 #endif
@@ -3911,7 +3983,7 @@ FRESULT f_open (
 #endif
 		}
 
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
 	if (res != FR_OK) fp->obj.fs = 0;	/* Invalidate file object on error */
@@ -3923,7 +3995,7 @@ FRESULT f_open (
 
 
 /*-----------------------------------------------------------------------*/
-/* Read File                                                             */
+/* API: Read File                                                        */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_read (
@@ -3935,7 +4007,6 @@ FRESULT f_read (
 {
 	FRESULT res;
 	FATFS *fs;
-	DWORD clst;
 	LBA_t sect;
 	FSIZE_t remain;
 	UINT rcnt, cc, csect;
@@ -3953,6 +4024,8 @@ FRESULT f_read (
 		if (fp->fptr % SS(fs) == 0) {			/* On the sector boundary? */
 			csect = (UINT)(fp->fptr / SS(fs) & (fs->csize - 1));	/* Sector offset in the cluster */
 			if (csect == 0) {					/* On the cluster boundary? */
+				DWORD clst;
+
 				if (fp->fptr == 0) {			/* On the top of the file? */
 					clst = fp->obj.sclust;		/* Follow cluster chain from the origin */
 				} else {						/* Middle or end of the file */
@@ -4023,7 +4096,7 @@ FRESULT f_read (
 
 #if !FF_FS_READONLY
 /*-----------------------------------------------------------------------*/
-/* Write File                                                            */
+/* API: Write File                                                       */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_write (
@@ -4144,7 +4217,7 @@ FRESULT f_write (
 
 
 /*-----------------------------------------------------------------------*/
-/* Synchronize the File                                                  */
+/* API: Synchronize the File                                             */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_sync (
@@ -4153,8 +4226,6 @@ FRESULT f_sync (
 {
 	FRESULT res;
 	FATFS *fs;
-	DWORD tm;
-	BYTE *dir;
 
 
 	res = validate(&fp->obj, &fs);	/* Check validity of the file object */
@@ -4167,7 +4238,6 @@ FRESULT f_sync (
 			}
 #endif
 			/* Update the directory entry */
-			tm = GET_FATTIME();				/* Modified time */
 #if FF_FS_EXFAT
 			if (fs->fs_type == FS_EXFAT) {
 				res = fill_first_frag(&fp->obj);	/* Fill first fragment on the FAT if needed */
@@ -4176,40 +4246,43 @@ FRESULT f_sync (
 				}
 				if (res == FR_OK) {
 					DIR dj;
-					DEF_NAMBUF
+					DEF_NAMEBUFF
 
-					INIT_NAMBUF(fs);
+					INIT_NAMEBUFF(fs);
 					res = load_obj_xdir(&dj, &fp->obj);	/* Load directory entry block */
 					if (res == FR_OK) {
-						fs->dirbuf[XDIR_Attr] |= AM_ARC;				/* Set archive attribute to indicate that the file has been changed */
-						fs->dirbuf[XDIR_GenFlags] = fp->obj.stat | 1;	/* Update file allocation information */
-						st_dword(fs->dirbuf + XDIR_FstClus, fp->obj.sclust);		/* Update start cluster */
-						st_qword(fs->dirbuf + XDIR_FileSize, fp->obj.objsize);		/* Update file size */
-						st_qword(fs->dirbuf + XDIR_ValidFileSize, fp->obj.objsize);	/* (FatFs does not support Valid File Size feature) */
-						st_dword(fs->dirbuf + XDIR_ModTime, tm);		/* Update modified time */
+						fs->dirbuf[XDIR_Attr] |= AM_ARC;					/* Set archive attribute to indicate that the file has been changed */
+						fs->dirbuf[XDIR_GenFlags] = fp->obj.stat | 1;		/* Update file allocation information */
+						st_32(fs->dirbuf + XDIR_FstClus, fp->obj.sclust);	/* Update start cluster */
+						st_64(fs->dirbuf + XDIR_FileSize, fp->obj.objsize);	/* Update file size */
+						st_64(fs->dirbuf + XDIR_ValidFileSize, fp->obj.objsize);	/* (FatFs does not support Valid File Size feature) */
+						st_32(fs->dirbuf + XDIR_ModTime, GET_FATTIME());	/* Update modified time */
 						fs->dirbuf[XDIR_ModTime10] = 0;
-						st_dword(fs->dirbuf + XDIR_AccTime, 0);
-						res = store_xdir(&dj);	/* Restore it to the directory */
+						fs->dirbuf[XDIR_ModTZ] = 0;
+						st_32(fs->dirbuf + XDIR_AccTime, 0);				/* Invalidate last access time */
+						fs->dirbuf[XDIR_AccTZ] = 0;
+						res = store_xdir(&dj);								/* Restore it to the directory */
 						if (res == FR_OK) {
 							res = sync_fs(fs);
 							fp->flag &= (BYTE)~FA_MODIFIED;
 						}
 					}
-					FREE_NAMBUF();
+					FREE_NAMEBUFF();
 				}
 			} else
 #endif
 			{
 				res = move_window(fs, fp->dir_sect);
 				if (res == FR_OK) {
-					dir = fp->dir_ptr;
-					dir[DIR_Attr] |= AM_ARC;						/* Set archive attribute to indicate that the file has been changed */
-					st_clust(fp->obj.fs, dir, fp->obj.sclust);		/* Update file allocation information  */
-					st_dword(dir + DIR_FileSize, (DWORD)fp->obj.objsize);	/* Update file size */
-					st_dword(dir + DIR_ModTime, tm);				/* Update modified time */
-					st_word(dir + DIR_LstAccDate, 0);
+					BYTE *dir = fp->dir_ptr;
+
+					dir[DIR_Attr] |= AM_ARC;					/* Set archive attribute to indicate that the file has been changed */
+					st_clust(fp->obj.fs, dir, fp->obj.sclust);	/* Update file allocation information  */
+					st_32(dir + DIR_FileSize, (DWORD)fp->obj.objsize);	/* Update file size */
+					st_32(dir + DIR_ModTime, GET_FATTIME());	/* Update modified time */
+					st_16(dir + DIR_LstAccDate, 0);				/* Invalidate last access date */
 					fs->wflag = 1;
-					res = sync_fs(fs);					/* Restore it to the directory */
+					res = sync_fs(fs);							/* Restore it to the directory */
 					fp->flag &= (BYTE)~FA_MODIFIED;
 				}
 			}
@@ -4225,7 +4298,7 @@ FRESULT f_sync (
 
 
 /*-----------------------------------------------------------------------*/
-/* Close File                                                            */
+/* API: Close File                                                       */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_close (
@@ -4261,7 +4334,7 @@ FRESULT f_close (
 
 #if FF_FS_RPATH >= 1
 /*-----------------------------------------------------------------------*/
-/* Change Current Directory or Current Drive, Get Current Directory      */
+/* API: Change Current Drive                                             */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_chdrive (
@@ -4281,57 +4354,56 @@ FRESULT f_chdrive (
 
 
 
+
+/*-----------------------------------------------------------------------*/
+/* API: Change Current Directory                                         */
+/*-----------------------------------------------------------------------*/
+
 FRESULT f_chdir (
 	const TCHAR* path	/* Pointer to the directory path */
 )
 {
-#if FF_STR_VOLUME_ID == 2
-	UINT i;
-#endif
 	FRESULT res;
 	DIR dj;
 	FATFS *fs;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	/* Get logical drive */
-	res = mount_volume(&path, &fs, 0);
+	res = mount_volume(&path, &fs, 0);	/* Get logical drive and mount the volume if needed */
 	if (res == FR_OK) {
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
 		res = follow_path(&dj, path);		/* Follow the path */
 		if (res == FR_OK) {					/* Follow completed */
 			if (dj.fn[NSFLAG] & NS_NONAME) {	/* Is it the start directory itself? */
-				fs->cdir = dj.obj.sclust;
 #if FF_FS_EXFAT
 				if (fs->fs_type == FS_EXFAT) {
-					fs->cdc_scl = dj.obj.c_scl;
-					fs->cdc_size = dj.obj.c_size;
-					fs->cdc_ofs = dj.obj.c_ofs;
+					memcpy(&fs->xcwds, &fs->xcwds2, sizeof fs->xcwds);
 				}
 #endif
+				fs->cdir = dj.obj.sclust;
 			} else {
 				if (dj.obj.attr & AM_DIR) {	/* It is a sub-directory */
 #if FF_FS_EXFAT
 					if (fs->fs_type == FS_EXFAT) {
-						fs->cdir = ld_dword(fs->dirbuf + XDIR_FstClus);		/* Sub-directory cluster */
-						fs->cdc_scl = dj.obj.sclust;						/* Save containing directory information */
-						fs->cdc_size = ((DWORD)dj.obj.objsize & 0xFFFFFF00) | dj.obj.stat;
-						fs->cdc_ofs = dj.blk_ofs;
+						memcpy(&fs->xcwds, &fs->xcwds2, sizeof fs->xcwds);
+						fs->cdir = fs->xcwds.tbl[fs->xcwds.depth].d_scl;	/* Sub-directory cluster */
 					} else
 #endif
 					{
-						fs->cdir = ld_clust(fs, dj.dir);					/* Sub-directory cluster */
+						fs->cdir = ld_clust(fs, dj.dir);	/* Sub-directory cluster */
 					}
 				} else {
 					res = FR_NO_PATH;		/* Reached but a file */
 				}
 			}
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 		if (res == FR_NO_FILE) res = FR_NO_PATH;
 #if FF_STR_VOLUME_ID == 2	/* Also current drive is changed if in Unix style volume ID */
 		if (res == FR_OK) {
+			UINT i;
+
 			for (i = FF_VOLUMES - 1; i && fs != FatFs[i]; i--) ;	/* Set current drive */
 			CurrVol = (BYTE)i;
 		}
@@ -4342,96 +4414,136 @@ FRESULT f_chdir (
 }
 
 
+
+
 #if FF_FS_RPATH >= 2
+/*-----------------------------------------------------------------------*/
+/* API: Get Curent Directory                                             */
+/*-----------------------------------------------------------------------*/
+
 FRESULT f_getcwd (
-	TCHAR* buff,	/* Pointer to the directory path */
+	TCHAR* buff,	/* Pointer to the buffer to store the current direcotry path */
 	UINT len		/* Size of buff in unit of TCHAR */
 )
 {
 	FRESULT res;
 	DIR dj;
 	FATFS *fs;
-	UINT i, n;
-	DWORD ccl;
-	TCHAR *tp = buff;
 #if FF_VOLUMES >= 2
 	UINT vl;
 #if FF_STR_VOLUME_ID
-	const char *vp;
+	const char *vid;
 #endif
 #endif
 	FILINFO fno;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	/* Get logical drive */
-	buff[0] = 0;	/* Set null string to get current volume */
-	res = mount_volume((const TCHAR**)&buff, &fs, 0);	/* Get current volume */
+	buff[0] = 0;	/* A null str to get current drive */
+	res = mount_volume((const TCHAR**)&buff, &fs, 0);
 	if (res == FR_OK) {
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
+#if FF_FS_EXFAT
+		if (fs->fs_type == FS_EXFAT) {	/* On the exFAT volume */
+			UINT wi = 0;
+			UINT di, ni;
 
-		/* Follow parent directories and create the path */
-		i = len;			/* Bottom of buffer (directory stack base) */
-		if (!FF_FS_EXFAT || fs->fs_type != FS_EXFAT) {	/* (Cannot do getcwd on exFAT and returns root path) */
+#if FF_VOLUMES >= 2			/* Add drive prefix if needed */
+#if FF_STR_VOLUME_ID == 0	/* Numeric volume ID */
+			if (wi < len) buff[wi++] = '0' + CurrVol;
+#else						/* String volume ID */
+			if (FF_STR_VOLUME_ID == 2 && wi < len) buff[wi++] = '/';
+			for (vid = (const char*)VolumeStr[CurrVol]; *vid && wi < len; buff[wi++] = *vid++) ;
+#endif
+			if (FF_STR_VOLUME_ID <= 1 && wi < len) buff[wi++] = ':';
+#endif
+			if (wi < len) buff[wi++] = '/';
+			for (di = 0; wi < len && di < fs->xcwds.depth; di++) {	/* Follow current directory path with cwd structure */
+				dj.obj.sclust = fs->xcwds.tbl[di].d_scl;		/* Open this directory */
+				dj.obj.stat = (BYTE)fs->xcwds.tbl[di].d_size;
+				dj.obj.objsize = fs->xcwds.tbl[di].d_size & 0xFFFFFF00;
+				res = dir_sdi(&dj, fs->xcwds.tbl[di].nxt_ofs);	/* Find next directory */
+				if (res != FR_OK) break;
+				res = DIR_READ_FILE(&dj);						/* Get the directory name */
+				if (res != FR_OK) break;
+				get_fileinfo(&dj, &fno);
+				if (di > 0 && wi < len) buff[wi++] = '/';		/* Add the directory name with a directory separator */
+				for (ni = 0; fno.fname[ni] && wi < len; buff[wi++] = fno.fname[ni++]) ;
+			}
+			if (wi == len) {	/* Buffer overflow? */
+				res = FR_NOT_ENOUGH_CORE;
+			} else {
+				buff[wi] = 0;	/* Terminate the string */
+			}
+		}
+		else
+#endif
+		{	/* On the FAT/FAT32 volume */
+			TCHAR *tp = buff;
+			UINT i, nl;
+			DWORD ccl;
+
+			/* Follow parent directories toward the root directory and create the cwd path */
+			i = len;			/* Bottom of buffer (directory stack base) */
 			dj.obj.sclust = fs->cdir;				/* Start to follow upper directory from current directory */
 			while ((ccl = dj.obj.sclust) != 0) {	/* Repeat while current directory is a sub-directory */
-				res = dir_sdi(&dj, 1 * SZDIRE);	/* Get parent directory */
+				res = dir_sdi(&dj, 1 * SZDIRE);		/* Get parent directory */
 				if (res != FR_OK) break;
 				res = move_window(fs, dj.sect);
 				if (res != FR_OK) break;
-				dj.obj.sclust = ld_clust(fs, dj.dir);	/* Goto parent directory */
+				dj.obj.sclust = ld_clust(fs, dj.dir);	/* Go to parent directory */
 				res = dir_sdi(&dj, 0);
 				if (res != FR_OK) break;
-				do {							/* Find the entry links to the child directory */
+				do {								/* Find the entry links to this sub-directory */
 					res = DIR_READ_FILE(&dj);
 					if (res != FR_OK) break;
 					if (ccl == ld_clust(fs, dj.dir)) break;	/* Found the entry */
 					res = dir_next(&dj, 0);
 				} while (res == FR_OK);
-				if (res == FR_NO_FILE) res = FR_INT_ERR;/* It cannot be 'not found'. */
+				if (res == FR_NO_FILE) res = FR_INT_ERR;	/* It cannot be 'not found'. */
 				if (res != FR_OK) break;
-				get_fileinfo(&dj, &fno);		/* Get the directory name and push it to the buffer */
-				for (n = 0; fno.fname[n]; n++) ;	/* Name length */
-				if (i < n + 1) {	/* Insufficient space to store the path name? */
+				get_fileinfo(&dj, &fno);			/* Get the directory name and push it to the buffer */
+				for (nl = 0; fno.fname[nl]; nl++) ;	/* Name length */
+				if (i < nl + 1) {	/* Insufficient space to store the path name? */
 					res = FR_NOT_ENOUGH_CORE; break;
 				}
-				while (n) buff[--i] = fno.fname[--n];	/* Stack the name */
+				while (nl) buff[--i] = fno.fname[--nl];	/* Stack the name */
 				buff[--i] = '/';
 			}
-		}
-		if (res == FR_OK) {
-			if (i == len) buff[--i] = '/';	/* Is it the root-directory? */
-#if FF_VOLUMES >= 2			/* Put drive prefix */
-			vl = 0;
-#if FF_STR_VOLUME_ID >= 1	/* String volume ID */
-			for (n = 0, vp = (const char*)VolumeStr[CurrVol]; vp[n]; n++) ;
-			if (i >= n + 2) {
-				if (FF_STR_VOLUME_ID == 2) *tp++ = (TCHAR)'/';
-				for (vl = 0; vl < n; *tp++ = (TCHAR)vp[vl], vl++) ;
-				if (FF_STR_VOLUME_ID == 1) *tp++ = (TCHAR)':';
-				vl++;
-			}
-#else						/* Numeric volume ID */
-			if (i >= 3) {
-				*tp++ = (TCHAR)'0' + CurrVol;
-				*tp++ = (TCHAR)':';
-				vl = 2;
-			}
-#endif
-			if (vl == 0) res = FR_NOT_ENOUGH_CORE;
-#endif
-			/* Add current directory path */
 			if (res == FR_OK) {
-				do {	/* Copy stacked path string */
-					*tp++ = buff[i++];
-				} while (i < len);
+				if (i == len) buff[--i] = '/';	/* Is it the root-directory? */
+#if FF_VOLUMES >= 2			/* Put drive prefix */
+				vl = 0;
+#if FF_STR_VOLUME_ID >= 1	/* String volume ID */
+				for (nl = 0, vid = (const char*)VolumeStr[CurrVol]; vid[nl]; nl++) ;	/* Volume ID length */
+				if (i >= nl + 2) {
+					if (FF_STR_VOLUME_ID == 2) *tp++ = '/';	/* Unix style */
+					for (vl = 0; vl < nl; *tp++ = vid[vl], vl++) ;
+					if (FF_STR_VOLUME_ID == 1) *tp++ = ':';	/* DOS/Windows style */
+					vl++;
+				}
+#else						/* Numeric volume ID */
+				if (i >= 3) {
+					*tp++ = '0' + CurrVol;
+					*tp++ = ':';
+					vl = 2;
+				}
+#endif
+				if (vl == 0) res = FR_NOT_ENOUGH_CORE;
+#endif
+				/* Add current directory path */
+				if (res == FR_OK) {
+					do {	/* Copy stacked path string */
+						*tp++ = buff[i++];
+					} while (i < len);
+				}
 			}
+			*tp = 0;
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
-	*tp = 0;
 	LEAVE_FF(fs, res);
 }
 
@@ -4442,7 +4554,7 @@ FRESULT f_getcwd (
 
 #if FF_FS_MINIMIZE <= 2
 /*-----------------------------------------------------------------------*/
-/* Seek File Read/Write Pointer                                          */
+/* API: Seek File Read/Write Pointer                                     */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_lseek (
@@ -4455,11 +4567,7 @@ FRESULT f_lseek (
 	DWORD clst, bcs;
 	LBA_t nsect;
 	FSIZE_t ifptr;
-#if FF_USE_FASTSEEK
-	DWORD cl, pcl, ncl, tcl, tlen, ulen;
-	DWORD *tbl;
-	LBA_t dsc;
-#endif
+
 
 	res = validate(&fp->obj, &fs);		/* Check validity of the file object */
 	if (res == FR_OK) res = (FRESULT)fp->err;
@@ -4472,6 +4580,10 @@ FRESULT f_lseek (
 
 #if FF_USE_FASTSEEK
 	if (fp->cltbl) {	/* Fast seek */
+		DWORD cl, pcl, ncl, tcl, tlen, ulen;
+		DWORD *tbl;
+		LBA_t dsc;
+
 		if (ofs == CREATE_LINKMAP) {	/* Create CLMT */
 			tbl = fp->cltbl;
 			tlen = *tbl++; ulen = 2;	/* Given table size and required table size */
@@ -4606,7 +4718,7 @@ FRESULT f_lseek (
 
 #if FF_FS_MINIMIZE <= 1
 /*-----------------------------------------------------------------------*/
-/* Create a Directory Object                                             */
+/* API: Create a Directory Object                                        */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_opendir (
@@ -4616,26 +4728,22 @@ FRESULT f_opendir (
 {
 	FRESULT res;
 	FATFS *fs;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	if (!dp) return FR_INVALID_OBJECT;
+	if (!dp) return FR_INVALID_OBJECT;	/* Reject null pointer */
 
-	/* Get logical drive */
-	res = mount_volume(&path, &fs, 0);
+	res = mount_volume(&path, &fs, 0);	/* Get logical drive and mount the volume if needed */
 	if (res == FR_OK) {
 		dp->obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
 		res = follow_path(dp, path);			/* Follow the path to the directory */
 		if (res == FR_OK) {						/* Follow completed */
-			if (!(dp->fn[NSFLAG] & NS_NONAME)) {	/* It is not the origin directory itself */
+			if (!(dp->fn[NSFLAG] & NS_NONAME)) {	/* It is neither the origin directory itself nor dot name in exFAT */
 				if (dp->obj.attr & AM_DIR) {		/* This object is a sub-directory */
 #if FF_FS_EXFAT
 					if (fs->fs_type == FS_EXFAT) {
-						dp->obj.c_scl = dp->obj.sclust;	/* Get containing directory information */
-						dp->obj.c_size = ((DWORD)dp->obj.objsize & 0xFFFFFF00) | dp->obj.stat;
-						dp->obj.c_ofs = dp->blk_ofs;
-						init_alloc_info(fs, &dp->obj);	/* Get object allocation info */
+						init_alloc_info(&dp->obj, dp);	/* Get object allocation info */
 					} else
 #endif
 					{
@@ -4646,21 +4754,21 @@ FRESULT f_opendir (
 				}
 			}
 			if (res == FR_OK) {
-				dp->obj.id = fs->id;
-				res = dir_sdi(dp, 0);			/* Rewind directory */
+				dp->obj.id = fs->id;		/* Set current volume mount ID */
+				res = dir_sdi(dp, 0);		/* Rewind directory */
 #if FF_FS_LOCK
 				if (res == FR_OK) {
-					if (dp->obj.sclust != 0) {
-						dp->obj.lockid = inc_share(dp, 0);	/* Lock the sub directory */
+					if (dp->obj.sclust) {	/* Is this a sub-directory? */
+						dp->obj.lockid = inc_share(dp, 0);	/* Lock the sub-directory */
 						if (!dp->obj.lockid) res = FR_TOO_MANY_OPEN_FILES;
 					} else {
-						dp->obj.lockid = 0;	/* Root directory need not to be locked */
+						dp->obj.lockid = 0;	/* Root directory does not need to be locked */
 					}
 				}
 #endif
 			}
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 		if (res == FR_NO_FILE) res = FR_NO_PATH;
 	}
 	if (res != FR_OK) dp->obj.fs = 0;		/* Invalidate the directory object if function failed */
@@ -4672,7 +4780,7 @@ FRESULT f_opendir (
 
 
 /*-----------------------------------------------------------------------*/
-/* Close Directory                                                       */
+/* API: Close Directory                                                  */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_closedir (
@@ -4702,7 +4810,7 @@ FRESULT f_closedir (
 
 
 /*-----------------------------------------------------------------------*/
-/* Read Directory Entries in Sequence                                    */
+/* API: Read Directory Entries in Sequence                               */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_readdir (
@@ -4712,7 +4820,7 @@ FRESULT f_readdir (
 {
 	FRESULT res;
 	FATFS *fs;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
 	res = validate(&dp->obj, &fs);	/* Check validity of the directory object */
@@ -4720,7 +4828,8 @@ FRESULT f_readdir (
 		if (!fno) {
 			res = dir_sdi(dp, 0);		/* Rewind the directory object */
 		} else {
-			INIT_NAMBUF(fs);
+			INIT_NAMEBUFF(fs);
+			fno->fname[0] = 0;				/* Clear file information */
 			res = DIR_READ_FILE(dp);		/* Read an item */
 			if (res == FR_NO_FILE) res = FR_OK;	/* Ignore end of directory */
 			if (res == FR_OK) {				/* A valid entry is found */
@@ -4728,9 +4837,11 @@ FRESULT f_readdir (
 				res = dir_next(dp, 0);		/* Increment index for next */
 				if (res == FR_NO_FILE) res = FR_OK;	/* Ignore end of directory now */
 			}
-			FREE_NAMBUF();
+			FREE_NAMEBUFF();
 		}
 	}
+
+	if (fno && res != FR_OK) fno->fname[0] = 0;	/* Clear the file information if any error occured */
 	LEAVE_FF(fs, res);
 }
 
@@ -4738,7 +4849,7 @@ FRESULT f_readdir (
 
 #if FF_USE_FIND
 /*-----------------------------------------------------------------------*/
-/* Find Next File                                                        */
+/* API: Find Next File                                                   */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_findnext (
@@ -4763,7 +4874,7 @@ FRESULT f_findnext (
 
 
 /*-----------------------------------------------------------------------*/
-/* Find First File                                                       */
+/* API: Find First File                                                  */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_findfirst (
@@ -4790,7 +4901,7 @@ FRESULT f_findfirst (
 
 #if FF_FS_MINIMIZE == 0
 /*-----------------------------------------------------------------------*/
-/* Get File Status                                                       */
+/* API: Get File Status                                                  */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_stat (
@@ -4800,13 +4911,14 @@ FRESULT f_stat (
 {
 	FRESULT res;
 	DIR dj;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	/* Get logical drive */
+	/* Get logical drive and mount the volume if needed */
 	res = mount_volume(&path, &dj.obj.fs, 0);
+
 	if (res == FR_OK) {
-		INIT_NAMBUF(dj.obj.fs);
+		INIT_NAMEBUFF(dj.obj.fs);
 		res = follow_path(&dj, path);	/* Follow the file path */
 		if (res == FR_OK) {				/* Follow completed */
 			if (dj.fn[NSFLAG] & NS_NONAME) {	/* It is origin directory */
@@ -4815,9 +4927,10 @@ FRESULT f_stat (
 				if (fno) get_fileinfo(&dj, fno);
 			}
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
+	if (fno && res != FR_OK) fno->fname[0] = 0;	/* Invalidate the file information if an error occured */
 	LEAVE_FF(dj.obj.fs, res);
 }
 
@@ -4825,7 +4938,7 @@ FRESULT f_stat (
 
 #if !FF_FS_READONLY
 /*-----------------------------------------------------------------------*/
-/* Get Number of Free Clusters                                           */
+/* API: Get Number of Free Clusters                                      */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_getfree (
@@ -4842,8 +4955,9 @@ FRESULT f_getfree (
 	FFOBJID obj;
 
 
-	/* Get logical drive */
+	/* Get logical drive and mount the volume if needed */
 	res = mount_volume(&path, &fs, 0);
+
 	if (res == FR_OK) {
 		*fatfs = fs;				/* Return ptr to the fs object */
 		/* If free_clst is valid, return it without full FAT scan */
@@ -4896,10 +5010,10 @@ FRESULT f_getfree (
 							if (res != FR_OK) break;
 						}
 						if (fs->fs_type == FS_FAT16) {
-							if (ld_word(fs->win + i) == 0) nfree++;	/* FAT16: Is this cluster free? */
+							if (ld_16(fs->win + i) == 0) nfree++;	/* FAT16: Is this cluster free? */
 							i += 2;	/* Next entry */
 						} else {
-							if ((ld_dword(fs->win + i) & 0x0FFFFFFF) == 0) nfree++;	/* FAT32: Is this cluster free? */
+							if ((ld_32(fs->win + i) & 0x0FFFFFFF) == 0) nfree++;	/* FAT32: Is this cluster free? */
 							i += 4;	/* Next entry */
 						}
 						i %= SS(fs);
@@ -4921,7 +5035,7 @@ FRESULT f_getfree (
 
 
 /*-----------------------------------------------------------------------*/
-/* Truncate File                                                         */
+/* API: Truncate File                                                    */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_truncate (
@@ -4933,7 +5047,8 @@ FRESULT f_truncate (
 	DWORD ncl;
 
 
-	res = validate(&fp->obj, &fs);	/* Check validity of the file object */
+	/* Check validity of the file object */
+	res = validate(&fp->obj, &fs);
 	if (res != FR_OK || (res = (FRESULT)fp->err) != FR_OK) LEAVE_FF(fs, res);
 	if (!(fp->flag & FA_WRITE)) LEAVE_FF(fs, FR_DENIED);	/* Check access mode */
 
@@ -4971,7 +5086,7 @@ FRESULT f_truncate (
 
 
 /*-----------------------------------------------------------------------*/
-/* Delete a File/Directory                                               */
+/* API: Delete a File/Directory                                          */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_unlink (
@@ -4985,77 +5100,72 @@ FRESULT f_unlink (
 #if FF_FS_EXFAT
 	FFOBJID obj;
 #endif
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
-
-	/* Get logical drive */
+	/* Get logical drive and mount the volume if needed */
 	res = mount_volume(&path, &fs, FA_WRITE);
 	if (res == FR_OK) {
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
-		res = follow_path(&dj, path);		/* Follow the file path */
-		if (FF_FS_RPATH && res == FR_OK && (dj.fn[NSFLAG] & NS_DOT)) {
-			res = FR_INVALID_NAME;			/* Cannot remove dot entry */
-		}
+		INIT_NAMEBUFF(fs);
+		res = follow_path(&dj, path);	/* Follow the path to the object */
+		if (res == FR_OK) {
+			if (dj.fn[NSFLAG] & (NS_DOT | NS_NONAME)) {
+				res = FR_INVALID_NAME;	/* It must be a real object */
+			} else if (dj.obj.attr & AM_RDO) {
+				res = FR_DENIED;		/* The object must not be read-only */
 #if FF_FS_LOCK
-		if (res == FR_OK) res = chk_share(&dj, 2);	/* Check if it is an open object */
-#endif
-		if (res == FR_OK) {					/* The object is accessible */
-			if (dj.fn[NSFLAG] & NS_NONAME) {
-				res = FR_INVALID_NAME;		/* Cannot remove the origin directory */
 			} else {
-				if (dj.obj.attr & AM_RDO) {
-					res = FR_DENIED;		/* Cannot remove R/O object */
-				}
+				res = chk_share(&dj, 2);	/* Check if the object is in use */
+#endif
 			}
-			if (res == FR_OK) {
+		}
+		if (res == FR_OK) {		/* The object is accessible */
 #if FF_FS_EXFAT
-				obj.fs = fs;
-				if (fs->fs_type == FS_EXFAT) {
-					init_alloc_info(fs, &obj);
-					dclst = obj.sclust;
+			obj.fs = fs;
+			if (fs->fs_type == FS_EXFAT) {
+				init_alloc_info(&obj, 0);
+				dclst = obj.sclust;
+			} else
+#endif
+			{
+				dclst = ld_clust(fs, dj.dir);
+			}
+			if (dj.obj.attr & AM_DIR) {		/* Is the object a sub-directory? */
+#if FF_FS_RPATH
+				if (dclst == fs->cdir) {
+					res = FR_DENIED;		/* Current directory cannot be removed */
 				} else
 #endif
 				{
-					dclst = ld_clust(fs, dj.dir);
-				}
-				if (dj.obj.attr & AM_DIR) {			/* Is it a sub-directory? */
-#if FF_FS_RPATH != 0
-					if (dclst == fs->cdir) {	 	/* Is it the current directory? */
-						res = FR_DENIED;
-					} else
-#endif
-					{
-						sdj.obj.fs = fs;			/* Open the sub-directory */
-						sdj.obj.sclust = dclst;
+					sdj.obj.fs = fs;		/* Open the sub-directory */
+					sdj.obj.sclust = dclst;
 #if FF_FS_EXFAT
-						if (fs->fs_type == FS_EXFAT) {
-							sdj.obj.objsize = obj.objsize;
-							sdj.obj.stat = obj.stat;
-						}
+					if (fs->fs_type == FS_EXFAT) {
+						sdj.obj.objsize = obj.objsize;
+						sdj.obj.stat = obj.stat;
+					}
 #endif
-						res = dir_sdi(&sdj, 0);
-						if (res == FR_OK) {
-							res = DIR_READ_FILE(&sdj);			/* Test if the directory is empty */
-							if (res == FR_OK) res = FR_DENIED;	/* Not empty? */
-							if (res == FR_NO_FILE) res = FR_OK;	/* Empty? */
-						}
+					res = dir_sdi(&sdj, 0);
+					if (res == FR_OK) {
+						res = DIR_READ_FILE(&sdj);			/* Check if the sub-directory is empty */
+						if (res == FR_OK) res = FR_DENIED;	/* Not empty? */
+						if (res == FR_NO_FILE) res = FR_OK;	/* Empty? */
 					}
 				}
 			}
-			if (res == FR_OK) {
-				res = dir_remove(&dj);			/* Remove the directory entry */
-				if (res == FR_OK && dclst != 0) {	/* Remove the cluster chain if exist */
-#if FF_FS_EXFAT
-					res = remove_chain(&obj, dclst, 0);
-#else
-					res = remove_chain(&dj.obj, dclst, 0);
-#endif
-				}
-				if (res == FR_OK) res = sync_fs(fs);
-			}
 		}
-		FREE_NAMBUF();
+		if (res == FR_OK) {		/* It is ready to remove the object */
+			res = dir_remove(&dj);				/* Remove the directory entry */
+			if (res == FR_OK && dclst != 0) {	/* Remove the cluster chain if exist */
+#if FF_FS_EXFAT
+				res = remove_chain(&obj, dclst, 0);
+#else
+				res = remove_chain(&dj.obj, dclst, 0);
+#endif
+			}
+			if (res == FR_OK) res = sync_fs(fs);
+		}
+		FREE_NAMEBUFF();
 	}
 
 	LEAVE_FF(fs, res);
@@ -5065,7 +5175,7 @@ FRESULT f_unlink (
 
 
 /*-----------------------------------------------------------------------*/
-/* Create a Directory                                                    */
+/* API: Create a Directory                                               */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_mkdir (
@@ -5077,20 +5187,19 @@ FRESULT f_mkdir (
 	DIR dj;
 	FFOBJID sobj;
 	DWORD dcl, pcl, tm;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	res = mount_volume(&path, &fs, FA_WRITE);	/* Get logical drive */
+	res = mount_volume(&path, &fs, FA_WRITE);	/* Get logical drive and mount the volume if needed */
 	if (res == FR_OK) {
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
 		res = follow_path(&dj, path);			/* Follow the file path */
-		if (res == FR_OK) res = FR_EXIST;		/* Name collision? */
-		if (FF_FS_RPATH && res == FR_NO_FILE && (dj.fn[NSFLAG] & NS_DOT)) {	/* Invalid name? */
-			res = FR_INVALID_NAME;
+		if (res == FR_OK) {						/* Invalid name or name collision */
+			res = (dj.fn[NSFLAG] & (NS_DOT | NS_NONAME)) ? FR_INVALID_NAME : FR_EXIST;
 		}
 		if (res == FR_NO_FILE) {				/* It is clear to create a new directory */
-			sobj.fs = fs;						/* New object id to create a new chain */
+			sobj.fs = fs;						/* New object ID to create a new chain */
 			dcl = create_chain(&sobj, 0);		/* Allocate a cluster for the new directory */
 			res = FR_OK;
 			if (dcl == 0) res = FR_DENIED;		/* No space to allocate a new cluster? */
@@ -5098,13 +5207,13 @@ FRESULT f_mkdir (
 			if (dcl == 0xFFFFFFFF) res = FR_DISK_ERR;	/* Disk error? */
 			tm = GET_FATTIME();
 			if (res == FR_OK) {
-				res = dir_clear(fs, dcl);		/* Clean up the new table */
+				res = dir_clear(fs, dcl);		/* Clear the allocated cluster as new direcotry table */
 				if (res == FR_OK) {
 					if (!FF_FS_EXFAT || fs->fs_type != FS_EXFAT) {	/* Create dot entries (FAT only) */
 						memset(fs->win + DIR_Name, ' ', 11);	/* Create "." entry */
 						fs->win[DIR_Name] = '.';
 						fs->win[DIR_Attr] = AM_DIR;
-						st_dword(fs->win + DIR_ModTime, tm);
+						st_32(fs->win + DIR_ModTime, tm);
 						st_clust(fs, fs->win, dcl);
 						memcpy(fs->win + SZDIRE, fs->win, SZDIRE);	/* Create ".." entry */
 						fs->win[SZDIRE + 1] = '.'; pcl = dj.obj.sclust;
@@ -5117,17 +5226,19 @@ FRESULT f_mkdir (
 			if (res == FR_OK) {
 #if FF_FS_EXFAT
 				if (fs->fs_type == FS_EXFAT) {	/* Initialize directory entry block */
-					st_dword(fs->dirbuf + XDIR_ModTime, tm);	/* Created time */
-					st_dword(fs->dirbuf + XDIR_FstClus, dcl);	/* Table start cluster */
-					st_dword(fs->dirbuf + XDIR_FileSize, (DWORD)fs->csize * SS(fs));	/* Directory size needs to be valid */
-					st_dword(fs->dirbuf + XDIR_ValidFileSize, (DWORD)fs->csize * SS(fs));
-					fs->dirbuf[XDIR_GenFlags] = 3;				/* Initialize the object flag */
-					fs->dirbuf[XDIR_Attr] = AM_DIR;				/* Attribute */
+					st_32(fs->dirbuf + XDIR_CrtTime, tm);	/* Created time */
+					st_32(fs->dirbuf + XDIR_ModTime, tm);
+					st_32(fs->dirbuf + XDIR_FstClus, dcl);	/* Table start cluster */
+					st_32(fs->dirbuf + XDIR_FileSize, (DWORD)fs->csize * SS(fs));	/* Directory size needs to be valid */
+					st_32(fs->dirbuf + XDIR_ValidFileSize, (DWORD)fs->csize * SS(fs));
+					fs->dirbuf[XDIR_GenFlags] = 3;			/* Initialize the object flag */
+					fs->dirbuf[XDIR_Attr] = AM_DIR;			/* Attribute */
 					res = store_xdir(&dj);
 				} else
 #endif
 				{
-					st_dword(dj.dir + DIR_ModTime, tm);	/* Created time */
+					st_32(dj.dir + DIR_CrtTime, tm);	/* Created time */
+					st_32(dj.dir + DIR_ModTime, tm);
 					st_clust(fs, dj.dir, dcl);			/* Table start cluster */
 					dj.dir[DIR_Attr] = AM_DIR;			/* Attribute */
 					fs->wflag = 1;
@@ -5139,7 +5250,7 @@ FRESULT f_mkdir (
 				remove_chain(&sobj, dcl, 0);		/* Could not register, remove the allocated cluster */
 			}
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
 	LEAVE_FF(fs, res);
@@ -5149,7 +5260,7 @@ FRESULT f_mkdir (
 
 
 /*-----------------------------------------------------------------------*/
-/* Rename a File/Directory                                               */
+/* API: Rename a File/Directory                                          */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_rename (
@@ -5161,42 +5272,55 @@ FRESULT f_rename (
 	FATFS *fs;
 	DIR djo, djn;
 	BYTE buf[FF_FS_EXFAT ? SZDIRE * 2 : SZDIRE], *dir;
-	LBA_t sect;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	get_ldnumber(&path_new);						/* Snip the drive number of new name off */
+	get_ldnumber(&path_new);	/* Snip the drive number of new name off */
 	res = mount_volume(&path_old, &fs, FA_WRITE);	/* Get logical drive of the old object */
 	if (res == FR_OK) {
 		djo.obj.fs = fs;
-		INIT_NAMBUF(fs);
-		res = follow_path(&djo, path_old);			/* Check old object */
-		if (res == FR_OK && (djo.fn[NSFLAG] & (NS_DOT | NS_NONAME))) res = FR_INVALID_NAME;	/* Check validity of name */
-#if FF_FS_LOCK
+		INIT_NAMEBUFF(fs);
+		res = follow_path(&djo, path_old);	/* Check old object */
 		if (res == FR_OK) {
-			res = chk_share(&djo, 2);
-		}
+			if (djo.fn[NSFLAG] & (NS_DOT | NS_NONAME)) {
+				res = FR_INVALID_NAME;		/* Object must not be a dot name or blank name */
+#if FF_FS_LOCK
+			} else {
+				res = chk_share(&djo, 2);	/* Check if the object is in use */
 #endif
-		if (res == FR_OK) {					/* Object to be renamed is found */
+			}
+		}
+		if (res == FR_OK) {					/* It is ready to rename the object */
 #if FF_FS_EXFAT
 			if (fs->fs_type == FS_EXFAT) {	/* At exFAT volume */
-				BYTE nf, nn;
-				WORD nh;
+#if FF_FS_RPATH
+				UINT i;
+				DWORD dscl = ld_32(fs->dirbuf + XDIR_FstClus);
 
-				memcpy(buf, fs->dirbuf, SZDIRE * 2);	/* Save 85+C0 entry of old object */
-				memcpy(&djn, &djo, sizeof djo);
-				res = follow_path(&djn, path_new);		/* Make sure if new object name is not in use */
-				if (res == FR_OK) {						/* Is new name already in use by any other object? */
+				for (i = 1; i <= fs->xcwds.depth && dscl != fs->xcwds.tbl[i].d_scl; i++) ;	/* Check if the object is a sub-dir in the current dir path */
+				if (i <= fs->xcwds.depth) {
+					res = FR_DENIED;	/* Reject to rename a sub-dir in the current dir path */
+				} else
+#endif
+				{
+					memcpy(buf, fs->dirbuf, SZDIRE * 2);	/* Save 85+C0 entry of old object */
+					memcpy(&djn, &djo, sizeof djn);
+					res = follow_path(&djn, path_new);		/* Check if new object name collides with an existing one */
+				}
+				if (res == FR_OK) {					/* Is new name already in use by another object? */
 					res = (djn.obj.sclust == djo.obj.sclust && djn.dptr == djo.dptr) ? FR_NO_FILE : FR_EXIST;
 				}
-				if (res == FR_NO_FILE) { 				/* It is a valid path and no name collision */
-					res = dir_register(&djn);			/* Register the new entry */
+				if (res == FR_NO_FILE) { 			/* It is a valid path and no name collision */
+					res = dir_register(&djn);		/* Register the new entry */
 					if (res == FR_OK) {
-						nf = fs->dirbuf[XDIR_NumSec]; nn = fs->dirbuf[XDIR_NumName];
-						nh = ld_word(fs->dirbuf + XDIR_NameHash);
+						BYTE nf, nn;
+						WORD nh;
+
+						nf = fs->dirbuf[XDIR_NumSec]; nn = fs->dirbuf[XDIR_NumName];	/* Save name length and hash */
+						nh = ld_16(fs->dirbuf + XDIR_NameHash);
 						memcpy(fs->dirbuf, buf, SZDIRE * 2);	/* Restore 85+C0 entry */
-						fs->dirbuf[XDIR_NumSec] = nf; fs->dirbuf[XDIR_NumName] = nn;
-						st_word(fs->dirbuf + XDIR_NameHash, nh);
+						fs->dirbuf[XDIR_NumSec] = nf; fs->dirbuf[XDIR_NumName] = nn;	/* Restore name length and hash */
+						st_16(fs->dirbuf + XDIR_NameHash, nh);
 						if (!(fs->dirbuf[XDIR_Attr] & AM_DIR)) fs->dirbuf[XDIR_Attr] |= AM_ARC;	/* Set archive attribute if it is a file */
 /* Start of critical section where an interruption can cause a cross-link */
 						res = store_xdir(&djn);
@@ -5206,9 +5330,9 @@ FRESULT f_rename (
 #endif
 			{	/* At FAT/FAT32 volume */
 				memcpy(buf, djo.dir, SZDIRE);			/* Save directory entry of the object */
-				memcpy(&djn, &djo, sizeof (DIR));		/* Duplicate the directory object */
+				memcpy(&djn, &djo, sizeof djn);			/* Duplicate the directory object */
 				res = follow_path(&djn, path_new);		/* Make sure if new object name is not in use */
-				if (res == FR_OK) {						/* Is new name already in use by any other object? */
+				if (res == FR_OK) {						/* Is new name already in use by another object? */
 					res = (djn.obj.sclust == djo.obj.sclust && djn.dptr == djo.dptr) ? FR_NO_FILE : FR_EXIST;
 				}
 				if (res == FR_NO_FILE) { 				/* It is a valid path and no name collision */
@@ -5219,8 +5343,9 @@ FRESULT f_rename (
 						dir[DIR_Attr] = buf[DIR_Attr];
 						if (!(dir[DIR_Attr] & AM_DIR)) dir[DIR_Attr] |= AM_ARC;	/* Set archive attribute if it is a file */
 						fs->wflag = 1;
-						if ((dir[DIR_Attr] & AM_DIR) && djo.obj.sclust != djn.obj.sclust) {	/* Update .. entry in the sub-directory if needed */
-							sect = clst2sect(fs, ld_clust(fs, dir));
+						if ((dir[DIR_Attr] & AM_DIR) && djo.obj.sclust != djn.obj.sclust) {	/* Update .. entry in the sub-directory being moved if needed */
+							LBA_t sect = clst2sect(fs, ld_clust(fs, dir));
+
 							if (sect == 0) {
 								res = FR_INT_ERR;
 							} else {
@@ -5236,15 +5361,15 @@ FRESULT f_rename (
 					}
 				}
 			}
-			if (res == FR_OK) {
-				res = dir_remove(&djo);		/* Remove old entry */
+			if (res == FR_OK) {		/* New entry has been created */
+				res = dir_remove(&djo);	/* Remove old entry */
 				if (res == FR_OK) {
 					res = sync_fs(fs);
 				}
 			}
 /* End of the critical section */
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
 	LEAVE_FF(fs, res);
@@ -5259,25 +5384,27 @@ FRESULT f_rename (
 
 #if FF_USE_CHMOD && !FF_FS_READONLY
 /*-----------------------------------------------------------------------*/
-/* Change Attribute                                                      */
+/* API: Change Attribute                                                 */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_chmod (
 	const TCHAR* path,	/* Pointer to the file path */
-	BYTE attr,			/* Attribute bits */
+	BYTE attr,			/* Attribute bits to set/clear */
 	BYTE mask			/* Attribute mask to change */
 )
 {
 	FRESULT res;
 	FATFS *fs;
 	DIR dj;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	res = mount_volume(&path, &fs, FA_WRITE);	/* Get logical drive */
+	/* Get logical drive and mount the volume if needed */
+	res = mount_volume(&path, &fs, FA_WRITE);
+
 	if (res == FR_OK) {
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
 		res = follow_path(&dj, path);	/* Follow the file path */
 		if (res == FR_OK && (dj.fn[NSFLAG] & (NS_DOT | NS_NONAME))) res = FR_INVALID_NAME;	/* Check object validity */
 		if (res == FR_OK) {
@@ -5296,7 +5423,7 @@ FRESULT f_chmod (
 				res = sync_fs(fs);
 			}
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
 	LEAVE_FF(fs, res);
@@ -5306,42 +5433,63 @@ FRESULT f_chmod (
 
 
 /*-----------------------------------------------------------------------*/
-/* Change Timestamp                                                      */
+/* API: Change Timestamp                                                 */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_utime (
 	const TCHAR* path,	/* Pointer to the file/directory name */
-	const FILINFO* fno	/* Pointer to the timestamp to be set */
+	const FILINFO* fno	/* Timestamp to be set */
 )
 {
 	FRESULT res;
 	FATFS *fs;
 	DIR dj;
-	DEF_NAMBUF
+	DEF_NAMEBUFF
 
 
-	res = mount_volume(&path, &fs, FA_WRITE);	/* Get logical drive */
+	/* Get logical drive and mount the volume if needed */
+	res = mount_volume(&path, &fs, FA_WRITE);
+
 	if (res == FR_OK) {
 		dj.obj.fs = fs;
-		INIT_NAMBUF(fs);
+		INIT_NAMEBUFF(fs);
 		res = follow_path(&dj, path);	/* Follow the file path */
 		if (res == FR_OK && (dj.fn[NSFLAG] & (NS_DOT | NS_NONAME))) res = FR_INVALID_NAME;	/* Check object validity */
 		if (res == FR_OK) {
 #if FF_FS_EXFAT
-			if (fs->fs_type == FS_EXFAT) {
-				st_dword(fs->dirbuf + XDIR_ModTime, (DWORD)fno->fdate << 16 | fno->ftime);
+			if (fs->fs_type == FS_EXFAT) {	/* On the exFAT volume */
+				if (fno->fdate) {	/* Change last modified time if needed */
+					st_32(fs->dirbuf + XDIR_ModTime, (DWORD)fno->fdate << 16 | fno->ftime);
+					fs->dirbuf[XDIR_ModTime10] = 0;
+					fs->dirbuf[XDIR_ModTZ] = 0;
+				}
+#if FF_FS_CRTIME
+				if (fno->crdate) {	/* Change created time if needed */
+					st_32(fs->dirbuf + XDIR_CrtTime, (DWORD)fno->crdate << 16 | fno->crtime);
+					fs->dirbuf[XDIR_CrtTime10] = 0;
+					fs->dirbuf[XDIR_CrtTZ] = 0;
+				}
+#endif
 				res = store_xdir(&dj);
 			} else
 #endif
-			{
-				st_dword(dj.dir + DIR_ModTime, (DWORD)fno->fdate << 16 | fno->ftime);
+			{	/* On the FAT volume */
+				if (fno->fdate) {	/* Change last modified time if needed */
+					st_32(dj.dir + DIR_ModTime, (DWORD)fno->fdate << 16 | fno->ftime);
+				}
+#if FF_FS_CRTIME
+				if (fno->crdate) {	/* Change created time if needed */
+					st_32(dj.dir + DIR_CrtTime, (DWORD)fno->crdate << 16 | fno->crtime);
+					dj.dir[DIR_CrtTime10] = 0;
+				}
+#endif
 				fs->wflag = 1;
 			}
 			if (res == FR_OK) {
 				res = sync_fs(fs);
 			}
 		}
-		FREE_NAMBUF();
+		FREE_NAMEBUFF();
 	}
 
 	LEAVE_FF(fs, res);
@@ -5353,7 +5501,7 @@ FRESULT f_utime (
 
 #if FF_USE_LABEL
 /*-----------------------------------------------------------------------*/
-/* Get Volume Label                                                      */
+/* API: Get Volume Label                                                 */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_getlabel (
@@ -5368,8 +5516,8 @@ FRESULT f_getlabel (
 	UINT si, di;
 	WCHAR wc;
 
-	/* Get logical drive */
-	res = mount_volume(&path, &fs, 0);
+
+	res = mount_volume(&path, &fs, 0);	/* Get logical drive and mount the volume if needed */
 
 	/* Get volume label */
 	if (res == FR_OK && label) {
@@ -5383,8 +5531,8 @@ FRESULT f_getlabel (
 					WCHAR hs;
 					UINT nw;
 
-					for (si = di = hs = 0; si < dj.dir[XDIR_NumLabel]; si++) {	/* Extract volume label from 83 entry */
-						wc = ld_word(dj.dir + XDIR_Label + si * 2);
+					for (si = di = hs = 0; si < dj.dir[XDIR_NumLabel] && si < 11; si++) {	/* Extract volume label from 83 entry */
+						wc = ld_16(dj.dir + XDIR_Label + si * 2);
 						if (hs == 0 && IsSurrogate(wc)) {	/* Is the code a surrogate? */
 							hs = wc; continue;
 						}
@@ -5443,7 +5591,7 @@ FRESULT f_getlabel (
 			default:	/* FAT12/16 */
 				di = fs->win[BS_BootSig] == 0x29 ? BS_VolID : 0;
 			}
-			*vsn = di ? ld_dword(fs->win + di) : 0;	/* Get VSN in the VBR */
+			*vsn = di ? ld_32(fs->win + di) : 0;	/* Get VSN in the VBR */
 		}
 	}
 
@@ -5454,7 +5602,7 @@ FRESULT f_getlabel (
 
 #if !FF_FS_READONLY
 /*-----------------------------------------------------------------------*/
-/* Set Volume Label                                                      */
+/* API: Set Volume Label                                                 */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_setlabel (
@@ -5472,7 +5620,7 @@ FRESULT f_setlabel (
 	DWORD dc;
 #endif
 
-	/* Get logical drive */
+	/* Get logical drive and mount the volume if needed */
 	res = mount_volume(&label, &fs, FA_WRITE);
 	if (res != FR_OK) LEAVE_FF(fs, res);
 #if FF_STR_VOLUME_ID == 2
@@ -5489,13 +5637,13 @@ FRESULT f_setlabel (
 				if (dc == 0xFFFFFFFF || di >= 10) {	/* Wrong surrogate or buffer overflow */
 					dc = 0;
 				} else {
-					st_word(dirvn + di * 2, (WCHAR)(dc >> 16)); di++;
+					st_16(dirvn + di * 2, (WCHAR)(dc >> 16)); di++;
 				}
 			}
 			if (dc == 0 || strchr(&badchr[7], (int)dc) || di >= 11) {	/* Check validity of the volume label */
 				LEAVE_FF(fs, FR_INVALID_NAME);
 			}
-			st_word(dirvn + di * 2, (WCHAR)dc); di++;
+			st_16(dirvn + di * 2, (WCHAR)dc); di++;
 		}
 	} else
 #endif
@@ -5577,7 +5725,7 @@ FRESULT f_setlabel (
 
 #if FF_USE_EXPAND && !FF_FS_READONLY
 /*-----------------------------------------------------------------------*/
-/* Allocate a Contiguous Blocks to the File                              */
+/* API: Allocate a Contiguous Blocks to the File                         */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_expand (
@@ -5673,7 +5821,7 @@ FRESULT f_expand (
 
 #if FF_USE_FORWARD
 /*-----------------------------------------------------------------------*/
-/* Forward Data to the Stream Directly                                   */
+/* API: Forward Data to the Stream Directly                              */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_forward (
@@ -5744,12 +5892,12 @@ FRESULT f_forward (
 
 #if !FF_FS_READONLY && FF_USE_MKFS
 /*-----------------------------------------------------------------------*/
-/* Create FAT/exFAT volume (with sub-functions)                          */
+/* API: Create FAT/exFAT volume (with a sub-function)                    */
 /*-----------------------------------------------------------------------*/
 
 #define N_SEC_TRACK 63			/* Sectors per track for determination of drive CHS */
 #define	GPT_ALIGN	0x100000	/* Alignment of partitions in GPT [byte] (>=128KB) */
-#define GPT_ITEMS	128			/* Number of GPT table size (>=128, sector aligned) */
+#define GPT_ITEMS	128			/* Number of GPT table items (>=128, sector aligned) */
 
 
 /* Create partitions on the physical drive in format of MBR or GPT */
@@ -5809,8 +5957,8 @@ static FRESULT create_partition (
 				ofs = pi * SZ_GPTE % ss;
 				memcpy(buf + ofs + GPTE_PtGuid, GUID_MS_Basic, 16);	/* Set partition GUID (Microsoft Basic Data) */
 				rnd = make_rand(rnd, buf + ofs + GPTE_UpGuid, 16);	/* Set unique partition GUID */
-				st_qword(buf + ofs + GPTE_FstLba, nxt_alloc);		/* Set partition start LBA */
-				st_qword(buf + ofs + GPTE_LstLba, nxt_alloc + sz_part - 1);	/* Set partition end LBA */
+				st_64(buf + ofs + GPTE_FstLba, nxt_alloc);			/* Set partition start LBA */
+				st_64(buf + ofs + GPTE_LstLba, nxt_alloc + sz_part - 1);	/* Set partition end LBA */
 				nxt_alloc += sz_part;								/* Next allocatable LBA */
 			}
 			if ((pi + 1) * SZ_GPTE % ss == 0) {		/* Write the sector buffer if it is filled up */
@@ -5823,32 +5971,32 @@ static FRESULT create_partition (
 		/* Create primary GPT header */
 		memset(buf, 0, ss);
 		memcpy(buf + GPTH_Sign, "EFI PART" "\0\0\1\0" "\x5C\0\0", 16);	/* Signature, version (1.0) and size (92) */
-		st_dword(buf + GPTH_PtBcc, ~bcc);			/* Table check sum */
-		st_qword(buf + GPTH_CurLba, 1);				/* LBA of this header */
-		st_qword(buf + GPTH_BakLba, sz_drv - 1);	/* LBA of secondary header */
-		st_qword(buf + GPTH_FstLba, 2 + sz_ptbl);	/* LBA of first allocatable sector */
-		st_qword(buf + GPTH_LstLba, top_bpt - 1);	/* LBA of last allocatable sector */
-		st_dword(buf + GPTH_PteSize, SZ_GPTE);		/* Size of a table entry */
-		st_dword(buf + GPTH_PtNum, GPT_ITEMS);		/* Number of table entries */
-		st_dword(buf + GPTH_PtOfs, 2);				/* LBA of this table */
+		st_32(buf + GPTH_PtBcc, ~bcc);			/* Table check sum */
+		st_64(buf + GPTH_CurLba, 1);			/* LBA of this header */
+		st_64(buf + GPTH_BakLba, sz_drv - 1);	/* LBA of secondary header */
+		st_64(buf + GPTH_FstLba, 2 + sz_ptbl);	/* LBA of first allocatable sector */
+		st_64(buf + GPTH_LstLba, top_bpt - 1);	/* LBA of last allocatable sector */
+		st_32(buf + GPTH_PteSize, SZ_GPTE);		/* Size of a table entry */
+		st_32(buf + GPTH_PtNum, GPT_ITEMS);		/* Number of table entries */
+		st_32(buf + GPTH_PtOfs, 2);				/* LBA of this table */
 		rnd = make_rand(rnd, buf + GPTH_DskGuid, 16);	/* Disk GUID */
 		for (i = 0, bcc= 0xFFFFFFFF; i < 92; bcc = crc32(bcc, buf[i++])) ;	/* Calculate header check sum */
-		st_dword(buf + GPTH_Bcc, ~bcc);				/* Header check sum */
+		st_32(buf + GPTH_Bcc, ~bcc);			/* Header check sum */
 		if (disk_write(drv, buf, 1, 1) != RES_OK) return FR_DISK_ERR;
 
 		/* Create secondary GPT header */
-		st_qword(buf + GPTH_CurLba, sz_drv - 1);	/* LBA of this header */
-		st_qword(buf + GPTH_BakLba, 1);				/* LBA of primary header */
-		st_qword(buf + GPTH_PtOfs, top_bpt);		/* LBA of this table */
-		st_dword(buf + GPTH_Bcc, 0);
+		st_64(buf + GPTH_CurLba, sz_drv - 1);	/* LBA of this header */
+		st_64(buf + GPTH_BakLba, 1);		 	/* LBA of primary header */
+		st_64(buf + GPTH_PtOfs, top_bpt);		/* LBA of this table */
+		st_32(buf + GPTH_Bcc, 0);
 		for (i = 0, bcc= 0xFFFFFFFF; i < 92; bcc = crc32(bcc, buf[i++])) ;	/* Calculate header check sum */
-		st_dword(buf + GPTH_Bcc, ~bcc);				/* Header check sum */
+		st_32(buf + GPTH_Bcc, ~bcc);			/* Header check sum */
 		if (disk_write(drv, buf, sz_drv - 1, 1) != RES_OK) return FR_DISK_ERR;
 
 		/* Create protective MBR */
 		memset(buf, 0, ss);
-		memcpy(buf + MBR_Table, gpt_mbr, 16);		/* Create a GPT partition */
-		st_word(buf + BS_55AA, 0xAA55);
+		memcpy(buf + MBR_Table, gpt_mbr, 16);	/* Create a GPT partition */
+		st_16(buf + BS_55AA, 0xAA55);
 		if (disk_write(drv, buf, 0, 1) != RES_OK) return FR_DISK_ERR;
 
 	} else
@@ -5867,8 +6015,8 @@ static FRESULT create_partition (
 			if (nxt_alloc32 + sz_part32 > sz_drv32 || nxt_alloc32 + sz_part32 < nxt_alloc32) sz_part32 = sz_drv32 - nxt_alloc32;	/* Clip at drive size */
 			if (sz_part32 == 0) break;	/* End of table or no sector to allocate? */
 
-			st_dword(pte + PTE_StLba, nxt_alloc32);	/* Partition start LBA sector */
-			st_dword(pte + PTE_SizLba, sz_part32);	/* Size of partition [sector] */
+			st_32(pte + PTE_StLba, nxt_alloc32);	/* Partition start LBA sector */
+			st_32(pte + PTE_SizLba, sz_part32);		/* Size of partition [sector] */
 			pte[PTE_System] = sys;					/* System type */
 
 			cy = (UINT)(nxt_alloc32 / n_sc / n_hd);	/* Partitio start CHS cylinder */
@@ -5888,7 +6036,7 @@ static FRESULT create_partition (
 			pte += SZ_PTE;		/* Next entry */
 		}
 
-		st_word(buf + BS_55AA, 0xAA55);		/* MBR signature */
+		st_16(buf + BS_55AA, 0xAA55);		/* MBR signature */
 		if (disk_write(drv, buf, 0, 1) != RES_OK) return FR_DISK_ERR;	/* Write it to the MBR */
 	}
 
@@ -5922,7 +6070,7 @@ FRESULT f_mkfs (
 
 
 	/* Check mounted drive and clear work area */
-	vol = get_ldnumber(&path);					/* Get target logical drive */
+	vol = get_ldnumber(&path);					/* Get logical drive number to be formatted */
 	if (vol < 0) return FR_INVALID_DRIVE;
 	if (FatFs[vol]) FatFs[vol]->fs_type = 0;	/* Clear the fs object if mounted */
 	pdrv = LD2PD(vol);		/* Hosting physical drive */
@@ -5966,7 +6114,7 @@ FRESULT f_mkfs (
 	if (FF_MULTI_PARTITION && ipart != 0) {	/* Is the volume associated with any specific partition? */
 		/* Get partition location from the existing partition table */
 		if (disk_read(pdrv, buf, 0, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);	/* Load MBR */
-		if (ld_word(buf + BS_55AA) != 0xAA55) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Check if MBR is valid */
+		if (ld_16(buf + BS_55AA) != 0xAA55) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Check if MBR is valid */
 #if FF_LBA64
 		if (buf[MBR_Table + PTE_System] == 0xEE) {	/* GPT protective MBR? */
 			DWORD n_ent, ofs;
@@ -5975,14 +6123,14 @@ FRESULT f_mkfs (
 			/* Get the partition location from GPT */
 			if (disk_read(pdrv, buf, 1, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);	/* Load GPT header sector (next to MBR) */
 			if (!test_gpt_header(buf)) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Check if GPT header is valid */
-			n_ent = ld_dword(buf + GPTH_PtNum);		/* Number of entries */
-			pt_lba = ld_qword(buf + GPTH_PtOfs);	/* Table start sector */
+			n_ent = ld_32(buf + GPTH_PtNum);	/* Number of entries */
+			pt_lba = ld_64(buf + GPTH_PtOfs);	/* Table start sector */
 			ofs = i = 0;
 			while (n_ent) {		/* Find MS Basic partition with order of ipart */
 				if (ofs == 0 && disk_read(pdrv, buf, pt_lba++, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);	/* Get PT sector */
 				if (!memcmp(buf + ofs + GPTE_PtGuid, GUID_MS_Basic, 16) && ++i == ipart) {	/* MS basic data partition? */
-					b_vol = ld_qword(buf + ofs + GPTE_FstLba);
-					sz_vol = ld_qword(buf + ofs + GPTE_LstLba) - b_vol + 1;
+					b_vol = ld_64(buf + ofs + GPTE_FstLba);
+					sz_vol = ld_64(buf + ofs + GPTE_LstLba) - b_vol + 1;
 					break;
 				}
 				n_ent--; ofs = (ofs + SZ_GPTE) % ss;	/* Next entry */
@@ -5994,8 +6142,8 @@ FRESULT f_mkfs (
 		{	/* Get the partition location from MBR partition table */
 			pte = buf + (MBR_Table + (ipart - 1) * SZ_PTE);
 			if (ipart > 4 || pte[PTE_System] == 0) LEAVE_MKFS(FR_MKFS_ABORTED);	/* No partition? */
-			b_vol = ld_dword(pte + PTE_StLba);		/* Get volume start sector */
-			sz_vol = ld_dword(pte + PTE_SizLba);	/* Get volume size */
+			b_vol = ld_32(pte + PTE_StLba);		/* Get volume start sector */
+			sz_vol = ld_32(pte + PTE_SizLba);	/* Get volume size */
 		}
 	} else {	/* The volume is associated with a physical drive */
 		if (disk_ioctl(pdrv, GET_SECTOR_COUNT, &sz_vol) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);
@@ -6014,13 +6162,13 @@ FRESULT f_mkfs (
 			}
 		}
 	}
-	if (sz_vol < 128) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Check if volume size is >=128 sectors */
+	if (sz_vol < MIN_VOLUME) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Check if volume size is not too small */
 
 	/* Now start to create an FAT volume at b_vol and sz_vol */
 
 	do {	/* Pre-determine the FAT type */
 		if (FF_FS_EXFAT && (fsopt & FM_EXFAT)) {	/* exFAT possible? */
-			if ((fsopt & FM_ANY) == FM_EXFAT || sz_vol >= 0x4000000 || sz_au > 128) {	/* exFAT only, vol >= 64M sectors or sz_au > 128 sectors ? */
+			if ((fsopt & FM_ANY) == FM_EXFAT || sz_vol >= 0x4000000 || sz_au > 128) {	/* exFAT only, vol >= 64M sectors or sz_au > 128 sectors? */
 				fsty = FS_EXFAT; break;
 			}
 		}
@@ -6122,13 +6270,13 @@ FRESULT f_mkfs (
 		do {
 			memset(buf, 0, sz_buf * ss); i = 0;	/* Clear work area and reset write offset */
 			if (clu == 0) {	/* Initialize FAT [0] and FAT[1] */
-				st_dword(buf + i, 0xFFFFFFF8); i += 4; clu++;
-				st_dword(buf + i, 0xFFFFFFFF); i += 4; clu++;
+				st_32(buf + i, 0xFFFFFFF8); i += 4; clu++;
+				st_32(buf + i, 0xFFFFFFFF); i += 4; clu++;
 			}
 
 			do {			/* Create chains of bitmap, up-case and root directory */
 				while (nbit != 0 && i < sz_buf * ss) {	/* Create a chain */
-					st_dword(buf + i, (nbit > 1) ? clu + 1 : 0xFFFFFFFF);
+					st_32(buf + i, (nbit > 1) ? clu + 1 : 0xFFFFFFFF);
 					i += 4; clu++; nbit--;
 				}
 				if (nbit == 0 && j < 3) nbit = clen[j++];	/* Get next chain length */
@@ -6140,14 +6288,14 @@ FRESULT f_mkfs (
 
 		/* Initialize the root directory */
 		memset(buf, 0, sz_buf * ss);
-		buf[SZDIRE * 0 + 0] = ET_VLABEL;				/* Volume label entry (no label) */
-		buf[SZDIRE * 1 + 0] = ET_BITMAP;				/* Bitmap entry */
-		st_dword(buf + SZDIRE * 1 + 20, 2);				/*  cluster */
-		st_dword(buf + SZDIRE * 1 + 24, szb_bit);		/*  size */
-		buf[SZDIRE * 2 + 0] = ET_UPCASE;				/* Up-case table entry */
-		st_dword(buf + SZDIRE * 2 + 4, sum);			/*  sum */
-		st_dword(buf + SZDIRE * 2 + 20, 2 + clen[0]);	/*  cluster */
-		st_dword(buf + SZDIRE * 2 + 24, szb_case);		/*  size */
+		buf[SZDIRE * 0 + 0] = ET_VLABEL;			/* Volume label entry (no label) */
+		buf[SZDIRE * 1 + 0] = ET_BITMAP;			/* Bitmap entry */
+		st_32(buf + SZDIRE * 1 + 20, 2);			/*  cluster */
+		st_32(buf + SZDIRE * 1 + 24, szb_bit);		/*  size */
+		buf[SZDIRE * 2 + 0] = ET_UPCASE;			/* Up-case table entry */
+		st_32(buf + SZDIRE * 2 + 4, sum);			/*  sum */
+		st_32(buf + SZDIRE * 2 + 20, 2 + clen[0]);	/*  cluster */
+		st_32(buf + SZDIRE * 2 + 24, szb_case);		/*  size */
 		sect = b_data + sz_au * (clen[0] + clen[1]); nsect = sz_au;	/* Start of the root directory and number of sectors */
 		do {	/* Fill root directory sectors */
 			n = (nsect > sz_buf) ? sz_buf : nsect;
@@ -6162,28 +6310,28 @@ FRESULT f_mkfs (
 			/* Main record (+0) */
 			memset(buf, 0, ss);
 			memcpy(buf + BS_JmpBoot, "\xEB\x76\x90" "EXFAT   ", 11);	/* Boot jump code (x86), OEM name */
-			st_qword(buf + BPB_VolOfsEx, b_vol);					/* Volume offset in the physical drive [sector] */
-			st_qword(buf + BPB_TotSecEx, sz_vol);					/* Volume size [sector] */
-			st_dword(buf + BPB_FatOfsEx, (DWORD)(b_fat - b_vol));	/* FAT offset [sector] */
-			st_dword(buf + BPB_FatSzEx, sz_fat);					/* FAT size [sector] */
-			st_dword(buf + BPB_DataOfsEx, (DWORD)(b_data - b_vol));	/* Data offset [sector] */
-			st_dword(buf + BPB_NumClusEx, n_clst);					/* Number of clusters */
-			st_dword(buf + BPB_RootClusEx, 2 + clen[0] + clen[1]);	/* Root directory cluster number */
-			st_dword(buf + BPB_VolIDEx, vsn);						/* VSN */
-			st_word(buf + BPB_FSVerEx, 0x100);						/* Filesystem version (1.00) */
+			st_64(buf + BPB_VolOfsEx, b_vol);						/* Volume offset in the physical drive [sector] */
+			st_64(buf + BPB_TotSecEx, sz_vol);						/* Volume size [sector] */
+			st_32(buf + BPB_FatOfsEx, (DWORD)(b_fat - b_vol));		/* FAT offset [sector] */
+			st_32(buf + BPB_FatSzEx, sz_fat);						/* FAT size [sector] */
+			st_32(buf + BPB_DataOfsEx, (DWORD)(b_data - b_vol));	/* Data offset [sector] */
+			st_32(buf + BPB_NumClusEx, n_clst);						/* Number of clusters */
+			st_32(buf + BPB_RootClusEx, 2 + clen[0] + clen[1]);		/* Root directory cluster number */
+			st_32(buf + BPB_VolIDEx, vsn);							/* VSN */
+			st_16(buf + BPB_FSVerEx, 0x100);						/* Filesystem version (1.00) */
 			for (buf[BPB_BytsPerSecEx] = 0, i = ss; i >>= 1; buf[BPB_BytsPerSecEx]++) ;		/* Log2 of sector size [byte] */
 			for (buf[BPB_SecPerClusEx] = 0, i = sz_au; i >>= 1; buf[BPB_SecPerClusEx]++) ;	/* Log2 of cluster size [sector] */
 			buf[BPB_NumFATsEx] = 1;					/* Number of FATs */
 			buf[BPB_DrvNumEx] = 0x80;				/* Drive number (for int13) */
-			st_word(buf + BS_BootCodeEx, 0xFEEB);	/* Boot code (x86) */
-			st_word(buf + BS_55AA, 0xAA55);			/* Signature (placed here regardless of sector size) */
+			st_16(buf + BS_BootCodeEx, 0xFEEB);	/* Boot code (x86) */
+			st_16(buf + BS_55AA, 0xAA55);			/* Signature (placed here regardless of sector size) */
 			for (i = sum = 0; i < ss; i++) {		/* VBR checksum */
 				if (i != BPB_VolFlagEx && i != BPB_VolFlagEx + 1 && i != BPB_PercInUseEx) sum = xsum32(buf[i], sum);
 			}
 			if (disk_write(pdrv, buf, sect++, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);
 			/* Extended bootstrap record (+1..+8) */
 			memset(buf, 0, ss);
-			st_word(buf + ss - 2, 0xAA55);	/* Signature (placed at end of sector) */
+			st_16(buf + ss - 2, 0xAA55);	/* Signature (placed at end of sector) */
 			for (j = 1; j < 9; j++) {
 				for (i = 0; i < ss; sum = xsum32(buf[i++], sum)) ;	/* VBR checksum */
 				if (disk_write(pdrv, buf, sect++, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);
@@ -6195,7 +6343,7 @@ FRESULT f_mkfs (
 				if (disk_write(pdrv, buf, sect++, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);
 			}
 			/* Sum record (+11) */
-			for (i = 0; i < ss; i += 4) st_dword(buf + i, sum);		/* Fill with checksum value */
+			for (i = 0; i < ss; i += 4) st_32(buf + i, sum);	/* Fill with checksum value */
 			if (disk_write(pdrv, buf, sect++, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);
 		}
 
@@ -6246,7 +6394,7 @@ FRESULT f_mkfs (
 			}
 
 			/* Determine number of clusters and final check of validity of the FAT sub-type */
-			if (sz_vol < b_data + pau * 16 - b_vol) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Too small volume? */
+			if (sz_vol < b_data + pau * MIN_FAT12 - b_vol) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Too small volume for this configuration? */
 			n_clst = ((DWORD)sz_vol - sz_rsv - sz_fat * n_fat - sz_dir) / pau;
 			if (fsty == FS_FAT32) {
 				if (n_clst <= MAX_FAT16) {	/* Too few clusters for FAT32? */
@@ -6283,48 +6431,48 @@ FRESULT f_mkfs (
 		/* Create FAT VBR */
 		memset(buf, 0, ss);
 		memcpy(buf + BS_JmpBoot, "\xEB\xFE\x90" "MSDOS5.0", 11);	/* Boot jump code (x86), OEM name */
-		st_word(buf + BPB_BytsPerSec, ss);				/* Sector size [byte] */
+		st_16(buf + BPB_BytsPerSec, ss);				/* Sector size [byte] */
 		buf[BPB_SecPerClus] = (BYTE)pau;				/* Cluster size [sector] */
-		st_word(buf + BPB_RsvdSecCnt, (WORD)sz_rsv);	/* Size of reserved area */
+		st_16(buf + BPB_RsvdSecCnt, (WORD)sz_rsv);		/* Size of reserved area */
 		buf[BPB_NumFATs] = (BYTE)n_fat;					/* Number of FATs */
-		st_word(buf + BPB_RootEntCnt, (WORD)((fsty == FS_FAT32) ? 0 : n_root));	/* Number of root directory entries */
+		st_16(buf + BPB_RootEntCnt, (WORD)((fsty == FS_FAT32) ? 0 : n_root));	/* Number of root directory entries */
 		if (sz_vol < 0x10000) {
-			st_word(buf + BPB_TotSec16, (WORD)sz_vol);	/* Volume size in 16-bit LBA */
+			st_16(buf + BPB_TotSec16, (WORD)sz_vol);	/* Volume size in 16-bit LBA */
 		} else {
-			st_dword(buf + BPB_TotSec32, (DWORD)sz_vol);	/* Volume size in 32-bit LBA */
+			st_32(buf + BPB_TotSec32, (DWORD)sz_vol);	/* Volume size in 32-bit LBA */
 		}
 		buf[BPB_Media] = 0xF8;							/* Media descriptor byte */
-		st_word(buf + BPB_SecPerTrk, 63);				/* Number of sectors per track (for int13) */
-		st_word(buf + BPB_NumHeads, 255);				/* Number of heads (for int13) */
-		st_dword(buf + BPB_HiddSec, (DWORD)b_vol);		/* Volume offset in the physical drive [sector] */
+		st_16(buf + BPB_SecPerTrk, 63);					/* Number of sectors per track (for int13) */
+		st_16(buf + BPB_NumHeads, 255);					/* Number of heads (for int13) */
+		st_32(buf + BPB_HiddSec, (DWORD)b_vol);			/* Volume offset in the physical drive [sector] */
 		if (fsty == FS_FAT32) {
-			st_dword(buf + BS_VolID32, vsn);			/* VSN */
-			st_dword(buf + BPB_FATSz32, sz_fat);		/* FAT size [sector] */
-			st_dword(buf + BPB_RootClus32, 2);			/* Root directory cluster # (2) */
-			st_word(buf + BPB_FSInfo32, 1);				/* Offset of FSINFO sector (VBR + 1) */
-			st_word(buf + BPB_BkBootSec32, 6);			/* Offset of backup VBR (VBR + 6) */
+			st_32(buf + BS_VolID32, vsn);				/* VSN */
+			st_32(buf + BPB_FATSz32, sz_fat);			/* FAT size [sector] */
+			st_32(buf + BPB_RootClus32, 2);				/* Root directory cluster # (2) */
+			st_16(buf + BPB_FSInfo32, 1);				/* Offset of FSINFO sector (VBR + 1) */
+			st_16(buf + BPB_BkBootSec32, 6);			/* Offset of backup VBR (VBR + 6) */
 			buf[BS_DrvNum32] = 0x80;					/* Drive number (for int13) */
 			buf[BS_BootSig32] = 0x29;					/* Extended boot signature */
 			memcpy(buf + BS_VolLab32, "NO NAME    " "FAT32   ", 19);	/* Volume label, FAT signature */
 		} else {
-			st_dword(buf + BS_VolID, vsn);				/* VSN */
-			st_word(buf + BPB_FATSz16, (WORD)sz_fat);	/* FAT size [sector] */
+			st_32(buf + BS_VolID, vsn);					/* VSN */
+			st_16(buf + BPB_FATSz16, (WORD)sz_fat);		/* FAT size [sector] */
 			buf[BS_DrvNum] = 0x80;						/* Drive number (for int13) */
 			buf[BS_BootSig] = 0x29;						/* Extended boot signature */
 			memcpy(buf + BS_VolLab, "NO NAME    " "FAT     ", 19);	/* Volume label, FAT signature */
 		}
-		st_word(buf + BS_55AA, 0xAA55);					/* Signature (offset is fixed here regardless of sector size) */
+		st_16(buf + BS_55AA, 0xAA55);					/* Signature (offset is fixed here regardless of sector size) */
 		if (disk_write(pdrv, buf, b_vol, 1) != RES_OK) LEAVE_MKFS(FR_DISK_ERR);	/* Write it to the VBR sector */
 
 		/* Create FSINFO record if needed */
 		if (fsty == FS_FAT32) {
 			disk_write(pdrv, buf, b_vol + 6, 1);		/* Write backup VBR (VBR + 6) */
 			memset(buf, 0, ss);
-			st_dword(buf + FSI_LeadSig, 0x41615252);
-			st_dword(buf + FSI_StrucSig, 0x61417272);
-			st_dword(buf + FSI_Free_Count, n_clst - 1);	/* Number of free clusters */
-			st_dword(buf + FSI_Nxt_Free, 2);			/* Last allocated cluster# */
-			st_word(buf + BS_55AA, 0xAA55);
+			st_32(buf + FSI_LeadSig, 0x41615252);
+			st_32(buf + FSI_StrucSig, 0x61417272);
+			st_32(buf + FSI_Free_Count, n_clst - 1);	/* Number of free clusters */
+			st_32(buf + FSI_Nxt_Free, 2);				/* Last allocated cluster# */
+			st_16(buf + BS_55AA, 0xAA55);
 			disk_write(pdrv, buf, b_vol + 7, 1);		/* Write backup FSINFO (VBR + 7) */
 			disk_write(pdrv, buf, b_vol + 1, 1);		/* Write original FSINFO (VBR + 1) */
 		}
@@ -6334,11 +6482,11 @@ FRESULT f_mkfs (
 		sect = b_fat;		/* FAT start sector */
 		for (i = 0; i < n_fat; i++) {			/* Initialize FATs each */
 			if (fsty == FS_FAT32) {
-				st_dword(buf + 0, 0xFFFFFFF8);	/* FAT[0] */
-				st_dword(buf + 4, 0xFFFFFFFF);	/* FAT[1] */
-				st_dword(buf + 8, 0x0FFFFFFF);	/* FAT[2] (root directory at cluster# 2) */
+				st_32(buf + 0, 0xFFFFFFF8);	/* FAT[0] */
+				st_32(buf + 4, 0xFFFFFFFF);	/* FAT[1] */
+				st_32(buf + 8, 0x0FFFFFFF);	/* FAT[2] (root directory at cluster# 2) */
 			} else {
-				st_dword(buf + 0, (fsty == FS_FAT12) ? 0xFFFFF8 : 0xFFFFFFF8);	/* FAT[0] and FAT[1] */
+				st_32(buf + 0, (fsty == FS_FAT12) ? 0xFFFFF8 : 0xFFFFFFF8);	/* FAT[0] and FAT[1] */
 			}
 			nsect = sz_fat;		/* Number of FAT sectors */
 			do {	/* Fill FAT sectors */
@@ -6399,7 +6547,7 @@ FRESULT f_mkfs (
 
 #if FF_MULTI_PARTITION
 /*-----------------------------------------------------------------------*/
-/* Create Partition Table on the Physical Drive                          */
+/* API: Create Partition Table on the Physical Drive                     */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_fdisk (
@@ -6439,7 +6587,7 @@ FRESULT f_fdisk (
 #error Wrong FF_STRF_ENCODE setting
 #endif
 /*-----------------------------------------------------------------------*/
-/* Get a String from the File                                            */
+/* API: Get a String from the File                                       */
 /*-----------------------------------------------------------------------*/
 
 TCHAR* f_gets (
@@ -6480,12 +6628,12 @@ TCHAR* f_gets (
 #elif FF_STRF_ENCODE == 1 || FF_STRF_ENCODE == 2 	/* Read a character in UTF-16LE/BE */
 		f_read(fp, s, 2, &rc);		/* Get a code unit */
 		if (rc != 2) break;			/* EOF? */
-		dc = (FF_STRF_ENCODE == 1) ? ld_word(s) : s[0] << 8 | s[1];
+		dc = (FF_STRF_ENCODE == 1) ? ld_16(s) : s[0] << 8 | s[1];
 		if (IsSurrogateL(dc)) continue;	/* Broken surrogate pair? */
 		if (IsSurrogateH(dc)) {		/* High surrogate? */
 			f_read(fp, s, 2, &rc);	/* Get low surrogate */
 			if (rc != 2) break;		/* EOF? */
-			wc = (FF_STRF_ENCODE == 1) ? ld_word(s) : s[0] << 8 | s[1];
+			wc = (FF_STRF_ENCODE == 1) ? ld_16(s) : s[0] << 8 | s[1];
 			if (!IsSurrogateL(wc)) continue;	/* Broken surrogate pair? */
 			dc = ((dc & 0x3FF) + 0x40) << 10 | (wc & 0x3FF);	/* Merge surrogate pair */
 		}
@@ -6574,7 +6722,7 @@ TCHAR* f_gets (
 #define SZ_NUM_BUF	32
 
 /*-----------------------------------------------------------------------*/
-/* Put a Character to the File (with sub-functions)                      */
+/* API: Put a Character to the File (with sub-functions)                 */
 /*-----------------------------------------------------------------------*/
 
 /* Output buffer and work area */
@@ -6663,11 +6811,11 @@ static void putc_bfd (putbuff* pb, TCHAR c)
 
 #if FF_STRF_ENCODE == 1		/* Write a code point in UTF-16LE */
 	if (hs != 0) {	/* Surrogate pair? */
-		st_word(&pb->buf[i], hs);
+		st_16(&pb->buf[i], hs);
 		i += 2;
 		nc++;
 	}
-	st_word(&pb->buf[i], wc);
+	st_16(&pb->buf[i], wc);
 	i += 2;
 #elif FF_STRF_ENCODE == 2	/* Write a code point in UTF-16BE */
 	if (hs != 0) {	/* Surrogate pair? */
@@ -6765,7 +6913,7 @@ int f_putc (
 
 
 /*-----------------------------------------------------------------------*/
-/* Put a String to the File                                              */
+/* API: Put a String to the File                                         */
 /*-----------------------------------------------------------------------*/
 
 int f_puts (
@@ -6785,7 +6933,7 @@ int f_puts (
 
 
 /*-----------------------------------------------------------------------*/
-/* Put a Formatted String to the File (with sub-functions)               */
+/* API: Put a Formatted String to the File (with sub-functions)          */
 /*-----------------------------------------------------------------------*/
 #if FF_PRINT_FLOAT && FF_INTDEF == 2
 #include <math.h>
@@ -7077,7 +7225,7 @@ int f_printf (
 
 #if FF_CODE_PAGE == 0
 /*-----------------------------------------------------------------------*/
-/* Set Active Codepage for the Path Name                                 */
+/* API: Set Active Codepage for the Path Name                            */
 /*-----------------------------------------------------------------------*/
 
 FRESULT f_setcp (

--- a/src/fatfs/ff.h
+++ b/src/fatfs/ff.h
@@ -1,8 +1,8 @@
 /*----------------------------------------------------------------------------/
-/  FatFs - Generic FAT Filesystem module  R0.15a                              /
+/  FatFs - Generic FAT Filesystem module  R0.16                               /
 /-----------------------------------------------------------------------------/
 /
-/ Copyright (C) 2024, ChaN, all right reserved.
+/ Copyright (C) 2025, ChaN, all right reserved.
 /
 / FatFs module is an open source software. Redistribution and use of FatFs in
 / source and binary forms, with or without modification, are permitted provided
@@ -20,7 +20,7 @@
 
 
 #ifndef FF_DEFINED
-#define FF_DEFINED	5380	/* Revision ID */
+#define FF_DEFINED	80386	/* Revision ID */
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,51 +127,65 @@ extern const char* VolumeStr[FF_VOLUMES];	/* User defined volume ID table */
 #endif
 
 
+/* Current working directory structure (FFXCWDS) */
+
+#if FF_FS_EXFAT && FF_FS_RPATH
+#if FF_PATH_DEPTH < 1
+#error FF_PATH_DEPTH must not be zero
+#endif
+typedef struct {
+	DWORD	d_scl;		/* Directory start cluster (0:root dir) */
+	DWORD	d_size;		/* Size of directory (b7-b0: cluster chain status) (invalid if d_scl == 0) */
+	DWORD	nxt_ofs;	/* Offset of entry of next dir in this directory (invalid if last link) */
+} FFXCWDL;
+typedef struct {
+	UINT	depth;		/* Current directory depth (0:root dir) */
+	FFXCWDL	tbl[FF_PATH_DEPTH + 1];	/* Directory chain of current working directory path */
+} FFXCWDS;
+#endif
+
 
 /* Filesystem object structure (FATFS) */
 
 typedef struct {
-	BYTE	fs_type;		/* Filesystem type (0:blank filesystem object) */
-	BYTE	pdrv;			/* Volume hosting physical drive */
-	BYTE	ldrv;			/* Logical drive number (used only when FF_FS_REENTRANT) */
-	BYTE	n_fats;			/* Number of FATs (1 or 2) */
-	BYTE	wflag;			/* win[] status (1:dirty) */
-	BYTE	fsi_flag;		/* Allocation information control (b7:disabled, b0:dirty) */
-	WORD	id;				/* Volume mount ID */
-	WORD	n_rootdir;		/* Number of root directory entries (FAT12/16) */
-	WORD	csize;			/* Cluster size [sectors] */
+	BYTE	fs_type;	/* Filesystem type (0:not mounted) */
+	BYTE	pdrv;		/* Physical drive that holds this volume */
+	BYTE	ldrv;		/* Logical drive number (used only when FF_FS_REENTRANT) */
+	BYTE	n_fats;		/* Number of FATs (1 or 2) */
+	BYTE	wflag;		/* win[] status (b0:dirty) */
+	BYTE	fsi_flag;	/* Allocation information control (b7:disabled, b0:dirty) */
+	WORD	id;			/* Volume mount ID */
+	WORD	n_rootdir;	/* Number of root directory entries (FAT12/16) */
+	WORD	csize;		/* Cluster size [sectors] */
 #if FF_MAX_SS != FF_MIN_SS
-	WORD	ssize;			/* Sector size (512, 1024, 2048 or 4096) */
+	WORD	ssize;		/* Sector size (512, 1024, 2048 or 4096) */
 #endif
 #if FF_USE_LFN
-	WCHAR*	lfnbuf;			/* LFN working buffer */
-#endif
-#if FF_FS_EXFAT
-	BYTE*	dirbuf;			/* Directory entry block scratch pad buffer for exFAT */
+	WCHAR*	lfnbuf;		/* Pointer to LFN working buffer */
 #endif
 #if !FF_FS_READONLY
-	DWORD	last_clst;		/* Last allocated cluster (Unknown if >= n_fatent) */
-	DWORD	free_clst;		/* Number of free clusters (Unknown if >= n_fatent-2) */
+	DWORD	last_clst;	/* Last allocated cluster (invalid if >=n_fatent) */
+	DWORD	free_clst;	/* Number of free clusters (invalid if >=fs->n_fatent-2) */
 #endif
 #if FF_FS_RPATH
-	DWORD	cdir;			/* Current directory start cluster (0:root) */
+	DWORD	cdir;		/* Current directory start cluster (0:root) */
+#endif
+	DWORD	n_fatent;	/* Number of FAT entries (number of clusters + 2) */
+	DWORD	fsize;		/* Number of sectors per FAT */
+	LBA_t	winsect;	/* Current sector appearing in the win[] */
+	LBA_t	volbase;	/* Volume base sector */
+	LBA_t	fatbase;	/* FAT base sector */
+	LBA_t	dirbase;	/* Root directory base sector (FAT12/16) or cluster (FAT32/exFAT) */
+	LBA_t	database;	/* Data base sector */
 #if FF_FS_EXFAT
-	DWORD	cdc_scl;		/* Containing directory start cluster (invalid when cdir is 0) */
-	DWORD	cdc_size;		/* b31-b8:Size of containing directory, b7-b0: Chain status */
-	DWORD	cdc_ofs;		/* Offset in the containing directory (invalid when cdir is 0) */
+	LBA_t	bitbase;	/* Allocation bitmap base sector */
+	BYTE*	dirbuf;		/* Pointer to directory entry block buffer */
+#if FF_FS_RPATH
+	FFXCWDS	xcwds;		/* Crrent working directory structure */
+	FFXCWDS	xcwds2;		/* Working buffer to follow the path */
 #endif
 #endif
-	DWORD	n_fatent;		/* Number of FAT entries (number of clusters + 2) */
-	DWORD	fsize;			/* Number of sectors per FAT */
-	LBA_t	volbase;		/* Volume base sector */
-	LBA_t	fatbase;		/* FAT base sector */
-	LBA_t	dirbase;		/* Root directory base sector (FAT12/16) or cluster (FAT32/exFAT) */
-	LBA_t	database;		/* Data base sector */
-#if FF_FS_EXFAT
-	LBA_t	bitbase;		/* Allocation bitmap base sector */
-#endif
-	LBA_t	winsect;		/* Current sector appearing in the win[] */
-	BYTE	win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
+	BYTE	win[FF_MAX_SS];	/* Disk access window for directory, FAT (and file data in tiny cfg) */
 } FATFS;
 
 
@@ -179,21 +193,21 @@ typedef struct {
 /* Object ID and allocation information (FFOBJID) */
 
 typedef struct {
-	FATFS*	fs;				/* Pointer to the hosting volume of this object */
-	WORD	id;				/* Hosting volume's mount ID */
-	BYTE	attr;			/* Object attribute */
-	BYTE	stat;			/* Object chain status (b1-0: =0:not contiguous, =2:contiguous, =3:fragmented in this session, b2:sub-directory stretched) */
-	DWORD	sclust;			/* Object data start cluster (0:no cluster or root directory) */
-	FSIZE_t	objsize;		/* Object size (valid when sclust != 0) */
+	FATFS*	fs;			/* Pointer to the volume holding this object */
+	WORD	id;			/* Volume mount ID when this object was opened */
+	BYTE	attr;		/* Object attribute */
+	BYTE	stat;		/* Object chain status (exFAT: b1-0: =0:not contiguous, =2:contiguous, =3:fragmented in this session, b2:sub-directory stretched) */
+	DWORD	sclust;		/* Object data cluster (0:no data or root directory) */
+	FSIZE_t	objsize;	/* Object size (valid when sclust != 0) */
 #if FF_FS_EXFAT
-	DWORD	n_cont;			/* Size of first fragment - 1 (valid when stat == 3) */
-	DWORD	n_frag;			/* Size of last fragment needs to be written to FAT (valid when not zero) */
-	DWORD	c_scl;			/* Containing directory start cluster (valid when sclust != 0) */
-	DWORD	c_size;			/* b31-b8:Size of containing directory, b7-b0: Chain status (valid when c_scl != 0) */
-	DWORD	c_ofs;			/* Offset in the containing directory (valid when file object and sclust != 0) */
+	DWORD	n_cont;		/* Size of first fragment - 1 (valid when stat == 3) */
+	DWORD	n_frag;		/* Size of last fragment needs to be written to FAT (valid when not zero) */
+	DWORD	c_scl;		/* Cluster of directory holding this object (valid when sclust != 0) */
+	DWORD	c_size;		/* Size of directory holding this object (b7-b0: allocation status, valid when c_scl != 0) */
+	DWORD	c_ofs;		/* Offset of entry in the holding directory */
 #endif
 #if FF_FS_LOCK
-	UINT	lockid;			/* File lock ID origin from 1 (index of file semaphore table Files[]) */
+	UINT	lockid;		/* File lock ID origin from 1 (index of file semaphore table Files[]) */
 #endif
 } FFOBJID;
 
@@ -202,18 +216,18 @@ typedef struct {
 /* File object structure (FIL) */
 
 typedef struct {
-	FFOBJID	obj;			/* Object identifier (must be the 1st member to detect invalid object pointer) */
-	BYTE	flag;			/* File status flags */
-	BYTE	err;			/* Abort flag (error code) */
-	FSIZE_t	fptr;			/* File read/write pointer (Zeroed on file open) */
-	DWORD	clust;			/* Current cluster of fpter (invalid when fptr is 0) */
-	LBA_t	sect;			/* Sector number appearing in buf[] (0:invalid) */
+	FFOBJID	obj;		/* Object identifier (must be the 1st member to detect invalid object pointer) */
+	BYTE	flag;		/* File status flags */
+	BYTE	err;		/* Abort flag (error code) */
+	FSIZE_t	fptr;		/* File read/write pointer (0 on open) */
+	DWORD	clust;		/* Current cluster of fptr (invalid when fptr is 0) */
+	LBA_t	sect;		/* Sector number appearing in buf[] (0:invalid) */
 #if !FF_FS_READONLY
-	LBA_t	dir_sect;		/* Sector number containing the directory entry (not used at exFAT) */
-	BYTE*	dir_ptr;		/* Pointer to the directory entry in the win[] (not used at exFAT) */
+	LBA_t	dir_sect;	/* Sector number containing the directory entry (not used in exFAT) */
+	BYTE*	dir_ptr;	/* Pointer to the directory entry in the win[] (not used in exFAT) */
 #endif
 #if FF_USE_FASTSEEK
-	DWORD*	cltbl;			/* Pointer to the cluster link map table (nulled on open, set by application) */
+	DWORD*	cltbl;		/* Pointer to the cluster link map table (nulled on open; set by application) */
 #endif
 #if !FF_FS_TINY
 	BYTE	buf[FF_MAX_SS];	/* File private data read/write window */
@@ -225,40 +239,44 @@ typedef struct {
 /* Directory object structure (DIR) */
 
 typedef struct {
-	FFOBJID	obj;			/* Object identifier */
-	DWORD	dptr;			/* Current read/write offset */
-	DWORD	clust;			/* Current cluster */
-	LBA_t	sect;			/* Current sector (0:Read operation has terminated) */
-	BYTE*	dir;			/* Pointer to the directory item in the win[] */
-	BYTE	fn[12];			/* SFN (in/out) {body[8],ext[3],status[1]} */
+	FFOBJID	obj;		/* Object identifier (must be the 1st member to detect invalid object pointer) */
+	DWORD	dptr;		/* Current read/write offset */
+	DWORD	clust;		/* Current cluster */
+	LBA_t	sect;		/* Current sector (0:no more item to read) */
+	BYTE*	dir;		/* Pointer to the directory item in the win[] in filesystem object */
+	BYTE	fn[12];		/* SFN (in/out) {body[0-7],ext[8-10],status[11]} */
 #if FF_USE_LFN
-	DWORD	blk_ofs;		/* Offset of current entry block being processed (0xFFFFFFFF:Invalid) */
+	DWORD	blk_ofs;	/* Offset of current entry block being processed (0xFFFFFFFF:invalid) */
 #endif
 #if FF_USE_FIND
-	const TCHAR* pat;		/* Pointer to the name matching pattern */
+	const TCHAR *pat;	/* Pointer to the name matching pattern */
 #endif
 } DIR;
 
 
 
-/* File information structure (FILINFO) */
+/* File/directory information structure (FILINFO) */
 
 typedef struct {
-	FSIZE_t	fsize;			/* File size */
-	WORD	fdate;			/* Modified date */
-	WORD	ftime;			/* Modified time */
-	BYTE	fattrib;		/* File attribute */
+	FSIZE_t	fsize;			/* File size (invalid for directory) */
+	WORD	fdate;			/* Date of file modification or directory creation */
+	WORD	ftime;			/* Time of file modification or directory creation */
+#if FF_FS_CRTIME
+	WORD	crdate;			/* Date of object createion */
+	WORD	crtime;			/* Time of object createion */
+#endif
+	BYTE	fattrib;		/* Object attribute */
 #if FF_USE_LFN
-	TCHAR	altname[FF_SFN_BUF + 1];/* Alternative file name */
-	TCHAR	fname[FF_LFN_BUF + 1];	/* Primary file name */
+	TCHAR	altname[FF_SFN_BUF + 1];/* Alternative object name */
+	TCHAR	fname[FF_LFN_BUF + 1];	/* Primary object name */
 #else
-	TCHAR	fname[12 + 1];	/* File name */
+	TCHAR	fname[12 + 1];	/* Object name */
 #endif
 } FILINFO;
 
 
 
-/* Format parameter structure (MKFS_PARM) */
+/* Format parameter structure (MKFS_PARM) used for f_mkfs() */
 
 typedef struct {
 	BYTE fmt;			/* Format option (FM_FAT, FM_FAT32, FM_EXFAT and FM_SFD) */
@@ -290,7 +308,7 @@ typedef enum {
 	FR_MKFS_ABORTED,		/* (14) The f_mkfs function aborted due to some problem */
 	FR_TIMEOUT,				/* (15) Could not take control of the volume within defined period */
 	FR_LOCKED,				/* (16) The operation is rejected according to the file sharing policy */
-	FR_NOT_ENOUGH_CORE,		/* (17) LFN working buffer could not be allocated or given buffer is insufficient in size */
+	FR_NOT_ENOUGH_CORE,		/* (17) LFN working buffer could not be allocated, given buffer size is insufficient or too deep path */
 	FR_TOO_MANY_OPEN_FILES,	/* (18) Number of open files > FF_FS_LOCK */
 	FR_INVALID_PARAMETER	/* (19) Given parameter is invalid */
 } FRESULT;

--- a/src/fatfs/ffconf.h
+++ b/src/fatfs/ffconf.h
@@ -254,7 +254,7 @@
 /  These options have no effect in read-only configuration (FF_FS_READONLY = 1). */
 
 
-#define FF_FS_CRTIME	0
+#define FF_FS_CRTIME	1
 /* This option switches support for creation time of files and directories.
 /  (0:Disable or 1:Enable)
 /  When enabled, crdate and crtime members are added to the FILINFO structure

--- a/src/fatfs/ffconf.h
+++ b/src/fatfs/ffconf.h
@@ -5,7 +5,7 @@
 /  Configurations of FatFs Module
 /---------------------------------------------------------------------------*/
 
-#define FFCONF_DEF	5380	/* Revision ID */
+#define FFCONF_DEF	80386	/* Revision ID */
 
 /*---------------------------------------------------------------------------/
 / Function Configurations
@@ -252,6 +252,13 @@
 /  to the project to read current time form real-time clock. FF_NORTC_MON,
 /  FF_NORTC_MDAY and FF_NORTC_YEAR have no effect.
 /  These options have no effect in read-only configuration (FF_FS_READONLY = 1). */
+
+
+#define FF_FS_CRTIME	0
+/* This option switches support for creation time of files and directories.
+/  (0:Disable or 1:Enable)
+/  When enabled, crdate and crtime members are added to the FILINFO structure
+/  and creation timestamps are managed in addition to modification timestamps. */
 
 
 #define FF_FS_NOFSINFO	0


### PR DESCRIPTION
## Update FatFs to R0.16 w/patch 2

### Summary

Updates the bundled [FatFs](https://elm-chan.org/fsw/ff/) library from **R0.15a** to **R0.16 w/patch 2**, incorporating two intermediate upstream releases and both official post-release patches.

### Upstream changelog (R0.15a → R0.16)

#### R0.15b (June 21, 2025)
- Added support for file/directory creation timestamps (`FF_FS_CRTIME`)
- Fixed FatFs failing to load FsInfo in FAT32 volumes, causing `f_getfree()` to always force a full FAT scan (regression introduced in R0.15a)

#### R0.16 (July 22, 2025)
- Removed the long-standing limitation that `f_getcwd()` and `..` path components did not work on exFAT volumes
- Fixed `f_readdir()` being unable to detect end-of-directory, leading to an infinite loop in the application (regression introduced in R0.15b)
- Fixed dot names with a trailing separator or duplicated separators being incorrectly rejected when LFN is disabled

### Patch 1 (September 13, 2025)
Adjusts minimum volume size requirements and adds a lower bound on FAT12 cluster counts:
- Minimum volume size lowered from 128 → 64 sectors (`MIN_VOLUME`)
- Added `MIN_FAT12` (32 clusters) guard to reject degenerate FAT12 volumes
- Affects `f_mkfs()` behaviour on very small drives

### Patch 2 (July 10, 2026) — security fixes
Addresses three CVEs affecting exFAT volumes, two of which are potential ACE vectors if the SD card socket and program code are both attacker-accessible:

| CVE | Severity | Description | Fix |
|-----|----------|-------------|-----|
| CVE-2026-6682 | ★ | Broken FAT size field in BPB can collapse files or crash the system | Added upper bound check on `fasize` |
| CVE-2026-6687 | ★ | Manipulated `NumLabel` field in exFAT volume label entry can overflow a buffer | Added `si < 11` bounds on label loop |
| CVE-2026-6683 | ★ | Manipulated cluster count in exFAT BPB can trigger a divide-by-zero crash | Added `ncl < MIN_EXFAT` lower bound check |

### `ffconf.h` configuration changes

| Option | Old | New | Reason |
|--------|-----|-----|--------|
| `FFCONF_DEF` | `5380` | `80386` | **Required** — must match `FF_DEFINED` in `ff.h` or compilation fails |
| `FF_FS_CRTIME` | *(absent)* | `1` | New in R0.15b; enabled because `get_fattime()` already provides accurate timestamps from the RTC when available, with a fixed-date fallback otherwise |

All other libdragon-specific settings (`FF_FS_TINY`, `FF_FS_EXFAT`, `FF_LFN_UNICODE`, `FF_VOLUMES`, etc.) are unchanged.

### What was deliberately *not* changed
- `diskio.h` — upstream R0.16 adds `(Not used by FatFs)` annotations to the MMC/SDC and ATA/CF ioctl sections; reverted to preserve existing wording
- `License.md` — upstream ships a plain-text `LICENSE.txt`; reverted to keep the existing markdown-formatted version
- `FF_PATH_DEPTH` — new R0.16 option enabling `f_getcwd`/`..` on exFAT; only active when `FF_FS_EXFAT && FF_FS_RPATH`. Libdragon uses `FF_FS_RPATH 0` so it has no effect and needs no declaration

### No application-level changes required
`fat.c` and `debug.c` use only the public FatFs API. None of the internal `FATFS` struct layout changes in `ff.h` affect them.