### PR TITLE
feat: add public FAT sector mapping APIs for flashcart support

### DIFF
--- a/include/fat.h
+++ b/include/fat.h
@@ -141,6 +141,45 @@ typedef struct {
 #define IOFAT_GET_CLUSTER_SIZE  _IO('F', 3)
 
 /**
+ * @brief Physical SD sector range for a file chunk
+ * 
+ * Represents a contiguous range of physical SD card sectors that contain
+ * a portion of a file's data. Used by #fat_file_get_sector_ranges.
+ */
+typedef struct {
+    uint32_t start_sector;      ///< Physical SD sector LBA
+    uint32_t sector_count;      ///< Number of consecutive sectors in this range
+} fatfs_sector_range_t;
+
+/**
+ * @brief Get FAT filesystem information
+ * 
+ * Returns filesystem-wide parameters needed for sector address calculations.
+ * 
+ * The argument must be a pointer to a structure:
+ * \code{.c}
+ *   typedef struct {
+ *       uint32_t cluster_size_sectors;   // Output: sectors per cluster
+ *       uint32_t data_area_lba;          // Output: LBA of data area start
+ *   } fatfs_filesystem_info_t;
+ * 
+ *   FILE *f = fopen("sd:/myfile.bin", "rb");
+ *   fatfs_filesystem_info_t info = {0};
+ *   ioctl(fileno(f), IOFAT_GET_FILESYSTEM_INFO, &info);
+ *   // Use info.cluster_size_sectors and info.data_area_lba
+ * \endcode
+ */
+#define IOFAT_GET_FILESYSTEM_INFO  _IO('F', 4)
+
+/**
+ * @brief Input/output structure for #IOFAT_GET_FILESYSTEM_INFO
+ */
+typedef struct {
+    uint32_t cluster_size_sectors;   ///< Output: sectors per cluster
+    uint32_t data_area_lba;          ///< Output: LBA of FAT data area start
+} fatfs_filesystem_info_t;
+
+/**
  * @brief FAT file attribute bits (matching FatFS AM_* constants)
  *
  * When stat() or fstat() is called on a file from a FAT-mounted volume
@@ -253,6 +292,64 @@ int fat_mount(const char *prefix, const fat_disk_t* disk, int flags);
  * @return -1 on failure (errno will be set)
  */
 int fat_unmount(int vol_id);
+
+/**
+ * @brief Get physical sector ranges for a file using a FILE pointer
+ * 
+ * User-space convenience wrapper that traverses all clusters of an open file
+ * and maps them to physical SD card sector addresses. Useful for DMA transfers
+ * or flashcart hardware configuration.
+ * 
+ * Retrieves all physical SD card sectors used by an open file.
+ * 
+ * @param f                 Open file handle (from fopen)
+ * @param ranges            Pointer to array of fatfs_sector_range_t (caller allocated)
+ * @param max_ranges        Maximum number of ranges that fit in the array
+ * @param num_ranges        Output: pointer to store actual number of ranges populated
+ * 
+ * @return 0 on success
+ * @return -1 on failure (errno will be set; ENOBUFS if file has too many ranges)
+ * 
+ * Example:
+ * \code{.c}
+ *   FILE *f = fopen("sd:/game.rom", "rb");
+ *   fatfs_sector_range_t ranges[32];
+ *   uint32_t num_ranges;
+ *   
+ *   if (fat_file_get_sector_ranges(f, ranges, 32, &num_ranges) == 0) {
+ *       for (uint32_t i = 0; i < num_ranges; i++) {
+ *           printf("Range %d: sector %lu, count %lu\n",
+ *               i, ranges[i].start_sector, ranges[i].sector_count);
+ *       }
+ *   }
+ * \endcode
+ */
+int fat_file_get_sector_ranges(FILE *f, fatfs_sector_range_t *ranges,
+    uint32_t max_ranges, uint32_t *num_ranges);
+
+/**
+ * @brief Get FAT filesystem information using a FILE pointer
+ * 
+ * Convenience wrapper around #IOFAT_GET_FILESYSTEM_INFO ioctl.
+ * 
+ * @param f                 Open file handle (from fopen)
+ * @param info              Pointer to output structure (caller allocated)
+ * 
+ * @return 0 on success
+ * @return -1 on failure (errno will be set)
+ * 
+ * Example:
+ * \code{.c}
+ *   FILE *f = fopen("sd:/game.rom", "rb");
+ *   fatfs_filesystem_info_t info;
+ *   
+ *   if (fat_get_filesystem_info(f, &info) == 0) {
+ *       printf("Cluster size: %lu sectors\n", info.cluster_size_sectors);
+ *       printf("Data area LBA: 0x%lx\n", info.data_area_lba);
+ *   }
+ * \endcode
+ */
+int fat_get_filesystem_info(FILE *f, fatfs_filesystem_info_t *info);
 
 #ifdef __cplusplus
 }

--- a/src/fat.c
+++ b/src/fat.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <sys/errno.h>
 #include <time.h>
 #include "fat.h"
@@ -301,6 +302,12 @@ static int __fat_ioctl(void *file, unsigned long request, void *arg)
 			*cluster_size = f->obj.fs->csize;
 			return 0;
 		}
+		case IOFAT_GET_FILESYSTEM_INFO: {
+			fatfs_filesystem_info_t *info = arg;
+			info->cluster_size_sectors = f->obj.fs->csize;
+			info->data_area_lba = f->obj.fs->database;
+			return 0;
+		}
 		default: {
 			errno = ENOTTY;
 			return -1;
@@ -506,6 +513,127 @@ int fat_mount(const char *prefix, const fat_disk_t* disk, int flags)
     }
 
     return vol_id;
+}
+
+int fat_file_get_sector_ranges(FILE *f, fatfs_sector_range_t *ranges,
+    uint32_t max_ranges, uint32_t *num_ranges)
+{
+	if (!f || !ranges || !num_ranges || max_ranges == 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	// Get filesystem info
+	fatfs_filesystem_info_t fs_info;
+	if (ioctl(fileno(f), IOFAT_GET_FILESYSTEM_INFO, &fs_info) != 0) {
+		return -1;
+	}
+
+	uint32_t cluster_size_sectors = fs_info.cluster_size_sectors;
+	uint32_t data_area_lba = fs_info.data_area_lba;
+	uint32_t cluster_size_bytes = cluster_size_sectors * 512;
+	
+	// Get file size
+	long current_pos = ftell(f);
+	if (current_pos < 0) {
+		errno = EIO;
+		return -1;
+	}
+	
+	// Seek to end to get size
+	if (fseek(f, 0, SEEK_END) != 0) {
+		errno = EIO;
+		return -1;
+	}
+	
+	long file_size = ftell(f);
+	if (file_size < 0) {
+		errno = EIO;
+		return -1;
+	}
+
+	// Traverse file by seeking at cluster-size intervals
+	uint32_t range_count = 0;
+	uint32_t last_sector = 0;
+	uint32_t last_count = 0;
+	bool in_range = false;
+
+	if (file_size == 0) {
+		*num_ranges = 0;
+		fseek(f, current_pos, SEEK_SET);
+		return 0;
+	}
+
+	for (long file_offset = 0; file_offset < file_size; file_offset += cluster_size_bytes) {
+		// Seek to this position in the file
+		if (fseek(f, file_offset, SEEK_SET) != 0) {
+			errno = EIO;
+			return -1;
+		}
+
+		// Get current cluster
+		int32_t cluster = 0;
+		if (ioctl(fileno(f), IOFAT_GET_CLUSTER, &cluster) != 0) {
+			return -1;
+		}
+
+		// Check cluster validity (should be >= 2 for FAT)
+		if (cluster < 2) {
+			errno = EIO;
+			return -1;
+		}
+
+		// Calculate physical sector for this cluster
+		uint32_t cluster_sector = data_area_lba + (uint32_t)(cluster - 2) * cluster_size_sectors;
+
+		// Check if contiguous with previous cluster
+		if (in_range && cluster_sector == last_sector + last_count) {
+			// Extend current range
+			last_count += cluster_size_sectors;
+		} else {
+			// Save previous range if any
+			if (in_range) {
+				if (range_count >= max_ranges) {
+					errno = ENOBUFS;
+					fseek(f, current_pos, SEEK_SET);
+					return -1;
+				}
+				ranges[range_count].start_sector = last_sector;
+				ranges[range_count].sector_count = last_count;
+				range_count++;
+			}
+			// Start new range
+			last_sector = cluster_sector;
+			last_count = cluster_size_sectors;
+			in_range = true;
+		}
+	}
+
+	// Save last range
+	if (in_range) {
+		if (range_count >= max_ranges) {
+			errno = ENOBUFS;
+			fseek(f, current_pos, SEEK_SET);
+			return -1;
+		}
+		ranges[range_count].start_sector = last_sector;
+		ranges[range_count].sector_count = last_count;
+		range_count++;
+	}
+
+	*num_ranges = range_count;
+	fseek(f, current_pos, SEEK_SET);
+	return 0;
+}
+
+int fat_get_filesystem_info(FILE *f, fatfs_filesystem_info_t *info)
+{
+	if (!f || !info) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return ioctl(fileno(f), IOFAT_GET_FILESYSTEM_INFO, info);
 }
 
 int fat_unmount(int vol_id)


### PR DESCRIPTION
The SummerCart64 still requires direct use of FATFS to perform certain needs. This is a draft PR that attempts to solve it.
It should also solve the ability to consume, load and use DFS files like in https://github.com/Polprzewodnikowy/N64FlashcartMenu/pull/250.

I am sure it can be improved, but this was steered AI:

Provides public APIs to map file clusters to physical SD card sectors, eliminating the need for flashcart projects to access internal FatFS structures directly. This enables N64FlashcartMenu, SummerCart64, and other projects to work with FAT filesystems using libdragon's public abstraction layer.

Design
------
The implementation uses a minimal kernel API surface with user-space convenience wrappers for maximum flexibility and maintainability:

* Single new ioctl command: IOFAT_GET_FILESYSTEM_INFO
  - Returns cluster_size_sectors and data_area_lba
  - Provides filesystem-wide parameters for sector calculations
  - Minimal and stable kernel API

* User-space wrapper function: fat_file_get_sector_ranges()
  - Traverses file clusters using lseek(2) + ioctl(IOFAT_GET_CLUSTER)
  - Coalesces contiguous clusters into sector ranges for efficiency
  - Preserves file position throughout operation
  - Returns array of fatfs_sector_range_t structs

* User-space wrapper: fat_get_filesystem_info()
  - Simple convenience wrapper around the ioctl
  - Provides cluster_size_sectors and data_area_lba

Benefits
--------
- Minimal kernel code (only metadata ioctl)
- Complex cluster logic stays in maintainable user-space C
- Reuses existing IOFAT_GET_CLUSTER ioctl (no new kernel calls needed)
- Works through standard FILE* abstraction (fopen/fread/etc)
- Enables DFS files with sector mapping (Polprzewodnikowy PR #250)
- Unblocks N64FlashcartMenu elimination of direct FatFS access
- Enables any N64 flashcart project to use public APIs

API Changes
-----------
New ioctl commands in include/fat.h:
- IOFAT_GET_FILESYSTEM_INFO (_IO('F', 4))

New structures:
- fatfs_sector_range_t: Represents a contiguous sector range
- fatfs_filesystem_info_t: Filesystem metadata (cluster size, data area LBA)

New functions:
- fat_file_get_sector_ranges(FILE *f, ranges, max, *num_ranges)
- fat_get_filesystem_info(FILE *f, *info)

Both functions use the standard FILE pointer interface and can be called on any FAT-mounted volume accessed via fopen().

Files Modified
--------------
- include/fat.h: New API documentation and type definitions
- src/fat.c: Ioctl handler and wrapper implementations

Testing
-------
- Verified with N64FlashcartMenu build
- All ROM outputs generated successfully
- No compilation errors or warnings