### PR TITLE
magma.h: add missing explicit float casts

### DIFF
--- a/include/magma.h
+++ b/include/magma.h
@@ -674,8 +674,8 @@ inline void mg_set_viewport_fullscreen(resolution_t res)
     mg_viewport_t viewport = {
         .x = 0,
         .y = 0,
-        .width = res.width,
-        .height = res.height,
+        .width = (float) res.width,
+        .height = (float) res.height,
         .minDepth = 0.0f,
         .maxDepth = 1.0f,
     };


### PR DESCRIPTION
The C++ compiler does not seem to like the lack of explicit float cast here when the header is included as C++, causing the cpptest example, and probably C++ code in general, to fail building with latest preview.

```
    [CXX] cpptest.cpp
In file included from /nix/store/xrn9slj3w72hv80ib8qjp71z07mfawrf-libdragon-dc8ce34/mips64-elf/include/libdragon.h:112,
                 from cpptest.cpp:3:
/nix/store/xrn9slj3w72hv80ib8qjp71z07mfawrf-libdragon-dc8ce34/mips64-elf/include/magma.h: In function 'void mg_set_viewport_fullscreen(resolution_t)':
/nix/store/xrn9slj3w72hv80ib8qjp71z07mfawrf-libdragon-dc8ce34/mips64-elf/include/magma.h:677:22: error: narrowing conversion of 'res.resolution_t::width' from 'int32_t' {aka 'long int'} to 'float' [-Werror=narrowing]
  677 |         .width = res.width,
      |                  ~~~~^~~~~
/nix/store/xrn9slj3w72hv80ib8qjp71z07mfawrf-libdragon-dc8ce34/mips64-elf/include/magma.h:678:23: error: narrowing conversion of 'res.resolution_t::height' from 'int32_t' {aka 'long int'} to 'float' [-Werror=narrowing]
  678 |         .height = res.height,
      |                   ~~~~^~~~~~
cc1plus: all warnings being treated as errors
```