### PR TITLE
polyfill: Fix MSYS2's C++ memchr const overload from 01/08/2026

### DIFF
--- a/tools/common/polyfill.h
+++ b/tools/common/polyfill.h
@@ -272,7 +272,7 @@ static void *memmem(const void *l, size_t l_len, const void *s, size_t s_len)
 
 	/* special case where s_len == 1 */
 	if (s_len == 1)
-		return memchr(l, (int)*cs, l_len);
+		return (void*) memchr(l, (int)*cs, l_len);
 
 	/* the last position where its possible to find "s" in "l" */
 	last = (char *)cl + l_len - s_len;


### PR DESCRIPTION
On 01/08/2026, MSYS2 commited this change https://github.com/mingw-w64/mingw-w64/commit/f371ccacc028165542c6d7bd09fa43b714268c64 which overloaded `memchr` to return `const void*` if compiled as C++. This broke our polyfill of `memmem` when `polyfill.h` was included in a C++ file (such as `audioconv64.cpp`) because it was trying to return `const void*` from a function declared to return `void*`, causing `error: invalid conversion from 'const void*' to 'void*' [-fpermissive]`.