### PR TITLE
mixer: fix samplebuffer alignment when reused with different sample width

### DIFF
--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -137,8 +137,13 @@ static void samplebuffer_recalc_size(samplebuffer_t *buf) {
 	// RSP may still be reading. A full highpri sync is the safe barrier; the
 	// samplebuffer itself does not track rounds. The first configuration of a
 	// buffer has handed out no window yet, so it never syncs.
-	if (buf->size > 0 && n != buf->size)
+	if (buf->size > 0 && n != buf->size) {
 		rspq_highpri_sync();
+		// No old window is live after the sync, so restart at the aligned base.
+		// Keeping head here would also reinterpret an index from the old ring
+		// modulus as an index in the new one.
+		buf->head = 0;
+	}
 
 	buf->size = n;
 	// The buffer is empty, but head is where the next stream restarts, and the
@@ -151,6 +156,15 @@ void samplebuffer_set_unit_bytes(samplebuffer_t *buf, int unit_bytes) {
 	assertf(buf->widx == 0 && buf->ridx == 0 && buf->wpos == 0,
 		"samplebuffer_set_unit_bytes can only be called on an empty samplebuffer");
 
+	// head is an index in units. It cannot be carried across a unit-size
+	// change: the same numeric index denotes a different byte address, and an
+	// address aligned for stereo PCM can be unaligned for mono PCM. Drain old
+	// windows and restart the newly configured ring at its aligned base.
+	if (buf->unit_bytes && buf->unit_bytes != unit_bytes) {
+		rspq_highpri_sync();
+		buf->head = 0;
+		buf->size = 0;
+	}
 	buf->unit_bytes = (uint8_t)unit_bytes;
 	samplebuffer_recalc_size(buf);
 }

--- a/tests/test_samplebuffer.c
+++ b/tests/test_samplebuffer.c
@@ -41,6 +41,44 @@ static waveform_t sb_wave = {
 	.len = 1 << 30, .read = sb_prod_read, .append_units = SB_CHUNK,
 };
 
+static waveform_t sb_rsp_wave = {
+	.name = "fake-rsp", .bits = 16, .channels = 1, .frequency = 48000,
+	.len = 1 << 30, .append_units = 1024, .rsp_written = true,
+};
+
+// ULC produces an aligned full block and undoes the invalid tail. Verify that
+// reusing its stereo ring for mono keeps the next RSP destination aligned.
+static bool sb_rsp_undo_alignment(void)
+{
+	void *mem = malloc_uncached(16384);
+	assertf(mem != NULL, "malloc_uncached failed");
+
+	samplebuffer_t sb = {0};
+	samplebuffer_init(&sb, mem, 16384, 0);
+	samplebuffer_set_bps(&sb, 32);
+	samplebuffer_set_waveform(&sb, &sb_rsp_wave, NULL);
+
+	// 42 stereo frames occupy 168 bytes (aligned), but carrying the numeric
+	// head 42 into a mono configuration would address byte 84.
+	samplebuffer_append(&sb, 1024);
+	samplebuffer_undo(&sb, 1024 - 42);
+	samplebuffer_flush(&sb);
+	samplebuffer_set_bps(&sb, 16);
+	samplebuffer_set_waveform(&sb, &sb_rsp_wave, NULL);
+	void *mono = samplebuffer_append(&sb, 1024);
+	bool ok = ((uintptr_t)mono & 7) == 0;
+
+	char line[96];
+	snprintf(line, sizeof(line), "  %-22s %s\n",
+		"rsp undo/reconfigure", ok ? "PASS" : "FAIL");
+	printf("%s", line);
+	debugf("%s", line);
+
+	memset(&sb, 0, sizeof(sb));
+	free_uncached(mem);
+	return ok;
+}
+
 // 8-bit PCM: unit_bytes is 1, so an odd-length append leaves widx odd and the
 // next discard can make wpos odd. The ring slot and the waveform position must
 // keep the same byte parity for dma_read; both becoming odd is fine.
@@ -209,6 +247,10 @@ int main(void)
 	RUN("drift+seek",  small, 6000, 397, 333, true);
 	RUN("drift-odd",   odd,   6000, 0,   333, true);
 	#undef RUN
+	
+	total++;
+	if (!sb_rsp_undo_alignment())
+		sb_failed++;
 
 	// 8-bit PCM with odd appends: wraps the ring with an odd wpos.
 	{


### PR DESCRIPTION
Previously, `samplebuffer_set_unit_bytes()` retained `head` when changing the unit size, causing the same numerical index to refer to a different byte address. For example, a head aligned for 16-bit stereo could become unaligned when reused for 16-bit mono, triggering the RSP-written waveform alignment assertion.

This PR
  - Synchronizes pending RSP work and resets the ring position when `unit_bytes` changes.
  - Resets head when recalculating a different ring size, since indices from the previous modulus are no longer meaningful.
  - Adds a regression test covering a trimmed stereo ULC stream followed by mono RSP output.