### PR TITLE
GL/mgfx: Invert fog formula

### DIFF
--- a/src/GL/rendermode.c
+++ b/src/GL/rendermode.c
@@ -92,10 +92,10 @@ void gl_rendermode_init()
 
 void gl_update_fog()
 {
-    float fog_diff = state->fog_end - state->fog_start;
+    float fog_diff = state->fog_start - state->fog_end;
     // start == end is undefined, so disable fog by setting the factor to 0
     state->fog_factor = fabsf(fog_diff) < FLT_MIN ? 0.0f : 1.0f / fog_diff;
-    state->fog_offset = state->fog_start;
+    state->fog_offset = state->fog_end;
 
     // Convert to s15.16 and premultiply with 1.15 conversion factor
     int32_t factor_fx = state->fog_factor * (1<<(16 + 7 + (8 - VTX_SHIFT)));

--- a/src/GL/rsp_gl.S
+++ b/src/GL/rsp_gl.S
@@ -827,7 +827,7 @@ gl_matrix_palette_loop:
     andi t0, state_flags, FLAG_FOG
     beqz t0, 1f
     sltu t2, zero, t0
-    li t0, RDPQ_BLENDER((FOG_RGB, SHADE_ALPHA, IN_RGB, INV_MUX_ALPHA)) | SOM_BLENDING
+    li t0, RDPQ_FOG_STANDARD | SOM_BLENDING
 1:
     sw t0, %lo(RDPQ_MODE_BLENDER_STEPS) + 0x0
     or modes0, t2

--- a/src/GL/rsp_gl_pipeline.S
+++ b/src/GL/rsp_gl_pipeline.S
@@ -470,37 +470,18 @@ GL_TnL:
     llv vfog_i, 0,s1
     llv vfog_f, 4,s1
 
-    # Note that the GL spec says the correct formula is
-    #   f = (fog_end - abs(veyepos.z)) / (fog_end - fog_start)
-    # And the final fogged color is calculated as
-    #   C = f * Ci + (1 - f) * Cf
-    # Where Ci is the incoming fragment color and Cf is the fog color.
-    
-    # However, there is a problem with translating this formula directly to a blender configuration:
-    #   RDPQ_BLENDER((IN_RGB, SHADE_ALPHA, FOG_RGB, INV_MUX_ALPHA))
-    # This would mean that a shade alpha of 1 represents "no fog" and a value of 0 is "full fog".
-    # Because shade alpha is internally an 8 bit fixed point value (0-255), it's not possible to represent
-    # a value of 1.0 exactly, only just below it. This leads to triangles that are completely outside of
-    # the fog area to still be tinted slightly with the fog color.
-
-    # To avoid this, we turn the formula around, so that shade alpha 0 (which is exactly representable)
-    # corresponds to "no fog".
-    # This means we have to compute 1-f instead of f. If we rearrange the formula, we get
-    #   (abs(veyepos.z) - fog_start) / (fog_end - fog_start)
-    # instead.
-
     # Compute abs(veyepos.z).
     # abs(veyepos.z) is an approximation for the distance between the
     # vertex and the origin in eye space, as recommended by the GL spec.
     vsubc vtmp, vzero, veyepos.e2
     vge vtmp, veyepos.e2
 
-    # vtmp.e0 = abs(veyepos.z) - fog_start
-    # Note that fog_start might be negative. In practice this would
+    # vtmp.e0 = abs(veyepos.z) - fog_end
+    # Note that fog_end might be negative. In practice this would
     # rarely be the case, but it is not forbidden by the GL spec.
     vsubc vtmp, vfog_i.e1
 
-    # vtmp.e0 = (abs(veyepos.z) - fog_start) / (fog_end - fog_start)
+    # vtmp.e0 = (abs(veyepos.z) - fog_end) / (fog_start - fog_end)
     # The factor is premultiplied so that combined with VTX_SHIFT
     # the product will be in 1.15 precision and saturated to 0x7FFF.
     vmudm v___, vtmp, vfog_f.e0

--- a/src/magma/mgfx.c
+++ b/src/magma/mgfx.c
@@ -98,11 +98,11 @@ void mgfx_get_lighting(mgfx_lighting_t *dst, const mgfx_lighting_parms_t *parms)
 
 void mgfx_get_fog(mgfx_fog_t *dst, const mgfx_fog_parms_t *parms)
 {
-    float diff = parms->end - parms->start;
+    float diff = parms->start - parms->end;
     // start == end is undefined, so disable fog by setting the factor to 0
     bool is_disabled = fabsf(diff) < FLT_MIN;
     float factor = is_disabled ? 0.0f : 1.0f / diff;
-    float offset = -parms->start;
+    float offset = -parms->end;
 
     int32_t offset_fx = offset * (1<<16);
     // Premultiply with 1.15 conversion factor


### PR DESCRIPTION
Previously, GL and mgfx used an "inverted" fog blender formula to avoid geometry getting slightly tinted by the fog color even if it was not fogged (for an explanation, see the deleted comment in rsp_gl_pipeline.S). However, this had the following unfortunate side effects:
- mgfx and GL's `GL_RDPQ_MATERIAL_N64` mode were not compatible with the `RDPQ_FOG_STANDARD` macro, which is not friendly to users.
- The opposite of the original problem was now happening: Geometry that was supposed to be fully fogged was not quite fully colored by the fog color, for the same reason. This is expecially undesirable when fog is being used to cull distant objects, because they would remain slightly visible even beyond the "fog-border".

This PR switches both GL and mgfx to using the "standard" fog formula, because it results in a better user experience overall.

Note that it is still possible for users to manually switch to the inverted formula if so desired. To do this, the fog start and end parameters simply need to be swapped, and the appropriate fog blender formula needs to be used. In GL, this is only possible by enabling `GL_RDPQ_MATERIAL_N64`.
