### PR TITLE
[CI] Set LIBDRAGON_PREVIEW=0 by default

### DIFF
--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -123,17 +123,17 @@ jobs:
 
       - name: Build libdragon
         run: |
-          docker container exec libdragon ./build.sh --no-examples
+          docker container exec --env=LIBDRAGON_PREVIEW=0 libdragon ./build.sh --no-examples
 
       # This also builds the test ROMs, and checks that the preview APIs are
       # locked for a stable project and unlocked for a preview one.
       - name: Run tests
         run: |
-          docker container exec libdragon make test
+          docker container exec --env=LIBDRAGON_PREVIEW=0 libdragon make test
 
       - name: Build examples
         run: |
-          docker container exec libdragon make examples --keep-going
+          docker container exec --env=LIBDRAGON_PREVIEW=0 libdragon make examples --keep-going
 
       - name: "Upload built ROMs to artifacts"
         uses: actions/upload-artifact@v7

--- a/examples/savedoodle/Makefile
+++ b/examples/savedoodle/Makefile
@@ -3,6 +3,8 @@ all: savedoodle_eeprom4k.z64 savedoodle_eeprom16k.z64 savedoodle_sram256k.z64 \
 .PHONY: all
 
 BUILD_DIR = build
+# This example uses the eeprom, flashram and sram APIs, which are preview APIs
+LIBDRAGON_PREVIEW = 2
 include $(N64_INST)/include/n64.mk
 
 OBJS = $(BUILD_DIR)/savedoodle.o


### PR DESCRIPTION
This only affects CI, the n64.mk keeps LIBDRAGON_PREVIEW ?= 2 (where `?=` means we can override for CI by setting `LIBDRAGON_PREVIEW` as an env var)