### PR TITLE
rspq: make lowpri buffer handoff atomic

### DIFF
--- a/include/rsp_queue.inc
+++ b/include/rsp_queue.inc
@@ -644,9 +644,10 @@ rspq_switch_highpri:
     #############################################################
     # RSPQCmd_SwapBuffers
     #
-    # Switch between lowpri and highpri or viceversa. This is
-    # called by RSP itself to go into highpri mode, and scheduled
-    # as normal command by CPU when going back into lowpri.
+    # Switch between buffers (eg: lowpri to highpri or viceversa). 
+    # This is called by RSP itself to go into highpri mode, and scheduled
+    # as normal command by CPU when going back into lowpri, or when switching
+    # between lowpri buffers.
     #
     # ARGS:
     #   a0: Byte offset of the pointer-stack slot that contains the address
@@ -655,7 +656,8 @@ rspq_switch_highpri:
     #       block-call slot whose target was staged by RSPQCmd_WriteWord.
     #   a1: Byte offset of the pointer-stack slot where the current address is
     #       saved. This may match a0 when the saved address is discarded.
-    #   a2: New mask to check for HIGHPRI signal (0 in highpri mode).
+    #   a2: Write mask for SP_STATUS register. Useful to change signals
+    #       atomically while swapping buffers.
     #############################################################
     .func RSPQCmd_SwapBuffers
 RSPQCmd_SwapBuffers:

--- a/include/rsp_queue.inc
+++ b/include/rsp_queue.inc
@@ -649,10 +649,12 @@ rspq_switch_highpri:
     # as normal command by CPU when going back into lowpri.
     #
     # ARGS:
-    #   a0: Pointer stack slot that contains the address to switch to.
-    #       (either RSPQ_LOWPRI_CALL_SLOT<<2 or RSPQ_HIGHPRI_CALL_SLOT<<2)
-    #   a1: Pointer stack slot where to save the current address to.
-    #       (either RSPQ_LOWPRI_CALL_SLOT<<2 or RSPQ_HIGHPRI_CALL_SLOT<<2)
+    #   a0: Byte offset of the pointer-stack slot that contains the address
+    #       to switch to. Highpri switching uses RSPQ_LOWPRI_CALL_SLOT or
+    #       RSPQ_HIGHPRI_CALL_SLOT; lowpri buffer handoff uses an inactive
+    #       block-call slot whose target was staged by RSPQCmd_WriteWord.
+    #   a1: Byte offset of the pointer-stack slot where the current address is
+    #       saved. This may match a0 when the saved address is discarded.
     #   a2: New mask to check for HIGHPRI signal (0 in highpri mode).
     #############################################################
     .func RSPQCmd_SwapBuffers

--- a/src/rspq/rspq.c
+++ b/src/rspq/rspq.c
@@ -111,12 +111,8 @@
  * each of the buffers is RSPQ_DRAM_LOWPRI_BUFFER_SIZE. When a buffer is full,
  * the low-priority queue engine stages the address of the other buffer with a
  * #RSPQ_CMD_WRITE_WORD, then executes #RSPQ_CMD_SWAP_BUFFERS. The latter sets
- * the buffer-done signal and jumps to the replacement buffer without passing
- * through the command dispatcher between the two operations. The signal tells
- * the CPU when a buffer becomes free for reuse, while the atomic jump prevents
- * high-priority preemption from retaining a pointer into a buffer that the CPU
- * is then allowed to clear. The high-priority queue cannot itself be
- * preempted, so it retains the smaller status-plus-jump handoff.
+ * the buffer-done signal and jumps to the other buffer. The signal tells
+ * the CPU when a buffer becomes free for reuse.
  * 
  * This logic is implemented in #rspq_next_buffer.
  *
@@ -1161,10 +1157,11 @@ void rspq_next_buffer(void) {
     volatile uint32_t *prev = rspq_switch_buffer(new, rspq_ctx->buf_size, true);
 
     if (rspq_ctx == &lowpri) {
-        // Stage the target in call slot 0. All previously scheduled block
-        // calls have returned before this top-level handoff can execute, so
-        // the slot is inactive. A highpri request may safely preempt after
-        // this setup command because SIG_BUFDONE has not been set yet.
+        // Stage the target in call slot 0 (RSPQ_LOWPRI_HANDOFF_SLOT).
+        // All previously scheduled block calls have returned before this
+        // top-level handoff can execute, so the slot is inactive. A highpri
+        // request may safely preempt after this setup command because SIG_BUFDONE
+        // has not been set yet.
         const uint32_t handoff_slot_offset = RSPQ_LOWPRI_HANDOFF_SLOT << 2;
         rspq_append2(prev, RSPQ_CMD_WRITE_WORD,
             offsetof(rsp_queue_t, rspq_pointer_stack) + handoff_slot_offset,
@@ -1177,8 +1174,8 @@ void rspq_next_buffer(void) {
             handoff_slot_offset, handoff_slot_offset,
             rspq_ctx->sp_wstatus_set_bufdone);
     } else {
-        // Highpri execution cannot itself be preempted, so its original compact
-        // handoff does not expose the lowpri race described above.
+        // Highpri execution cannot itself be preempted, so we can use a smaller
+        // sequence instead, which would be vulnerable to be preempted in the middle.
         rspq_append1(prev, RSPQ_CMD_WRITE_STATUS,
             rspq_ctx->sp_wstatus_set_bufdone);
         rspq_append1(prev, RSPQ_CMD_JUMP, PhysicalAddr(new));
@@ -1458,6 +1455,9 @@ void rspq_block_run(rspq_block_t *block)
     // in highpri mode (to avoid stepping on the call stack of lowpri). This
     // would basically mean that a block can either work in highpri or in lowpri
     // mode, but it might be an acceptable limitation.
+    // NOTE: during highpri mode, the slot 0 (RSPQ_LOWPRI_HANDOFF_SLOT) might be
+    // in-use if highpri preempted lowpri exactly during a buffer swap, so make
+    // sure to avoid using it.
     assertf(rspq_ctx != &highpri, "block run is not supported in highpri mode");
 
     if((uint32_t)block < RSPQ_BLOCK_PLACEHOLDER_COUNT)

--- a/src/rspq/rspq.c
+++ b/src/rspq/rspq.c
@@ -109,13 +109,14 @@
  * 
  * Internally, double buffering is used to implement the queue. The size of
  * each of the buffers is RSPQ_DRAM_LOWPRI_BUFFER_SIZE. When a buffer is full,
- * the queue engine writes a #RSPQ_CMD_JUMP command with the address of the
- * other buffer, to tell the RSP to jump there when it is done. 
- * 
- * Moreover, just before the jump, the engine also enqueue a #RSPQ_CMD_WRITE_STATUS
- * command that sets the SP_STATUS_SIG_BUFDONE_LOW signal. This is used to
- * keep track when the RSP has finished processing a buffer, so that we know
- * it becomes free again for more commands.
+ * the low-priority queue engine stages the address of the other buffer with a
+ * #RSPQ_CMD_WRITE_WORD, then executes #RSPQ_CMD_SWAP_BUFFERS. The latter sets
+ * the buffer-done signal and jumps to the replacement buffer without passing
+ * through the command dispatcher between the two operations. The signal tells
+ * the CPU when a buffer becomes free for reuse, while the atomic jump prevents
+ * high-priority preemption from retaining a pointer into a buffer that the CPU
+ * is then allowed to clear. The high-priority queue cannot itself be
+ * preempted, so it retains the smaller status-plus-jump handoff.
  * 
  * This logic is implemented in #rspq_next_buffer.
  *
@@ -260,6 +261,12 @@ _Static_assert(RSPQ_MAX_COMMAND_SIZE * 4 <= RSPQ_DESCRIPTOR_MAX_SIZE);
     ((volatile uint32_t*)(ptr))[0] = ((cmd)<<24) | (arg1); \
     ptr += 3; \
 })
+
+/** @brief Number of words reserved for the lowpri buffer handoff sequence. */
+#define RSPQ_LOWPRI_HANDOFF_WORDS 5
+
+/** @brief Block-call slot temporarily reused by the lowpri buffer handoff. */
+#define RSPQ_LOWPRI_HANDOFF_SLOT 0
 
 static void rspq_crash_handler(rsp_snapshot_t *state);
 static void rspq_assert_handler(rsp_snapshot_t *state, uint16_t assert_code);
@@ -657,15 +664,18 @@ static volatile uint32_t* rspq_switch_buffer(uint32_t *new, int size, bool clear
     // Notice that the buffer must have been cleared before, as the
     // command queue are expected to always contain 0 on unwritten data.
     // We don't do this for performance reasons.
-    assert(size >= RSPQ_MAX_COMMAND_SIZE+2);
+    int terminator_words = clear && rspq_ctx == &lowpri ?
+        RSPQ_LOWPRI_HANDOFF_WORDS : 2;
+    assert(size >= RSPQ_MAX_COMMAND_SIZE + terminator_words);
     if (clear) memset(new, 0, size * sizeof(uint32_t));
 
     // Switch to the new buffer, and calculate the new sentinel. The sentinel
     // must allow for a maximum size command (RSPQ_MAX_SHORT_COMMAND_SIZE) to
-    // be written, plus the special block terminator written by rspq_next_buffer
-    // which is 2 words.
+    // be written, plus either the lowpri handoff sequence or the two-word
+    // reservation used by highpri, blocks, and recorded queues.
     rspq_cur_pointer = new;
-    rspq_cur_sentinel = new + size - (RSPQ_MAX_SHORT_COMMAND_SIZE + 2);
+    rspq_cur_sentinel = new + size -
+        (RSPQ_MAX_SHORT_COMMAND_SIZE + terminator_words);
 
     // Return a pointer to the previous buffer
     return prev;
@@ -1150,11 +1160,29 @@ void rspq_next_buffer(void) {
     uint32_t *new = rspq_ctx->buffers[rspq_ctx->buf_idx];
     volatile uint32_t *prev = rspq_switch_buffer(new, rspq_ctx->buf_size, true);
 
-    // Terminate the previous buffer with an op to set SIG_BUFDONE
-    // (to notify when the RSP finishes the buffer), plus a jump to
-    // the new buffer.
-    rspq_append1(prev, RSPQ_CMD_WRITE_STATUS, rspq_ctx->sp_wstatus_set_bufdone);
-    rspq_append1(prev, RSPQ_CMD_JUMP, PhysicalAddr(new));
+    if (rspq_ctx == &lowpri) {
+        // Stage the target in call slot 0. All previously scheduled block
+        // calls have returned before this top-level handoff can execute, so
+        // the slot is inactive. A highpri request may safely preempt after
+        // this setup command because SIG_BUFDONE has not been set yet.
+        const uint32_t handoff_slot_offset = RSPQ_LOWPRI_HANDOFF_SLOT << 2;
+        rspq_append2(prev, RSPQ_CMD_WRITE_WORD,
+            offsetof(rsp_queue_t, rspq_pointer_stack) + handoff_slot_offset,
+            PhysicalAddr(new));
+
+        // SWAP_BUFFERS sets SIG_BUFDONE, loads the staged target, and jumps to
+        // it without returning to RSPQ_Loop. Reusing the same slot for its
+        // discarded return address is safe because the target is loaded first.
+        rspq_append3(prev, RSPQ_CMD_SWAP_BUFFERS,
+            handoff_slot_offset, handoff_slot_offset,
+            rspq_ctx->sp_wstatus_set_bufdone);
+    } else {
+        // Highpri execution cannot itself be preempted, so its original compact
+        // handoff does not expose the lowpri race described above.
+        rspq_append1(prev, RSPQ_CMD_WRITE_STATUS,
+            rspq_ctx->sp_wstatus_set_bufdone);
+        rspq_append1(prev, RSPQ_CMD_JUMP, PhysicalAddr(new));
+    }
     assert(prev <= (uint32_t*)(rspq_ctx->buffers[1-rspq_ctx->buf_idx]) + rspq_ctx->buf_size);
     rspq_flush_internal();
 }
@@ -1836,4 +1864,3 @@ extern inline rspq_write_t rspq_write_begin(uint32_t ovl_id, uint32_t cmd_id, in
 extern inline void rspq_write_arg(rspq_write_t *w, uint32_t value);
 extern inline void rspq_write_end(rspq_write_t *w);
 extern inline void rspq_call_deferred(void (*func)(void *), void *arg);
-

--- a/tests/test_rspq.c
+++ b/tests/test_rspq.c
@@ -1,10 +1,12 @@
 #include <malloc.h>
+#include <stddef.h>
 #include <string.h>
 
 #include <rspq.h>
 #include <rspq_constants.h>
 #include <rdp.h>
 #include <rdpq_constants.h>
+#include "../src/rspq/rspq_internal.h"
 #include "test_rspq_constants.h"
 
 #define ASSERT_GP_BACKWARD           0xF001   // Also defined in rsp_test.S
@@ -203,6 +205,93 @@ void test_rspq_wrap(TestContext *ctx)
     for (uint32_t i = 0; i < block_count; i++)
         rspq_noop();
     
+    TEST_RSPQ_EPILOG(0, rspq_timeout);
+}
+
+void test_rspq_buffer_handoff_atomic(TestContext *ctx)
+{
+    TEST_RSPQ_PROLOG();
+
+    volatile uint32_t *first_buffer = rspq_cur_pointer;
+    uint32_t command_count = 0;
+
+    // Fill the initial low-priority buffer until rspq_next_buffer switches to
+    // its replacement. Each no-op occupies exactly one word, so the handoff
+    // command starts immediately after the commands counted here.
+    do {
+        rspq_noop();
+        command_count++;
+    } while ((uintptr_t)rspq_cur_pointer >= (uintptr_t)first_buffer &&
+             (uintptr_t)rspq_cur_pointer <
+                 (uintptr_t)(first_buffer + RSPQ_DRAM_LOWPRI_BUFFER_SIZE));
+
+    volatile uint32_t *handoff = first_buffer + command_count;
+    ASSERT_EQUAL_HEX(handoff[0] >> 24, RSPQ_CMD_WRITE_WORD,
+        "buffer handoff must stage its target before signaling completion");
+    ASSERT_EQUAL_HEX(handoff[0] & 0x00FFFFFF,
+        offsetof(rsp_queue_t, rspq_pointer_stack),
+        "buffer handoff stages its target in the wrong pointer slot");
+    ASSERT_EQUAL_HEX(handoff[1],
+        PhysicalAddr((void *)rspq_cur_pointer),
+        "buffer handoff has the wrong jump target");
+    ASSERT_EQUAL_HEX(handoff[2] >> 24, RSPQ_CMD_SWAP_BUFFERS,
+        "buffer completion and jump must use one atomic RSPQ command");
+    ASSERT_EQUAL_HEX(handoff[2] & 0x00FFFFFF, 0,
+        "buffer handoff loads its target from the wrong pointer slot");
+    ASSERT_EQUAL_HEX(handoff[3], 0,
+        "buffer handoff saves its discarded return to the wrong pointer slot");
+    ASSERT_EQUAL_HEX(handoff[4], SP_WSTATUS_SET_SIG_BUFDONE_LOW,
+        "buffer handoff has the wrong completion signal");
+    ASSERT_EQUAL_HEX(handoff[5], 0,
+        "buffer handoff must not leave a separate jump command");
+
+    ASSERT(rspq_cur_sentinel == rspq_cur_pointer +
+            RSPQ_DRAM_LOWPRI_BUFFER_SIZE -
+            (RSPQ_MAX_SHORT_COMMAND_SIZE + 5),
+        "lowpri sentinel must reserve the full atomic handoff");
+
+    // Exercise repeated highpri requests immediately after lowpri wraps. The
+    // layout assertions above make the old implementation fail deterministically;
+    // this loop also runs the handoff under the preemption pattern that exposed
+    // the original race.
+    for (int i = 0; i < 32; i++) {
+        volatile uint32_t *buffer = rspq_cur_pointer;
+        uint32_t buffer_command_count = 0;
+        do {
+            rspq_noop();
+            buffer_command_count++;
+        } while (rspq_cur_pointer == buffer + buffer_command_count);
+
+        rspq_highpri_begin();
+        rspq_noop();
+        rspq_highpri_end();
+    }
+    rspq_highpri_sync();
+
+    // Highpri cannot itself be preempted, so it should retain the compact
+    // status-plus-jump handoff and its original usable buffer capacity.
+    rspq_highpri_begin();
+    volatile uint32_t *first_highpri_buffer = rspq_cur_pointer;
+    uint32_t highpri_command_count = 0;
+    do {
+        rspq_noop();
+        highpri_command_count++;
+    } while (rspq_cur_pointer ==
+        first_highpri_buffer + highpri_command_count);
+
+    volatile uint32_t *highpri_handoff =
+        first_highpri_buffer + highpri_command_count;
+    ASSERT_EQUAL_HEX(highpri_handoff[0] >> 24, RSPQ_CMD_WRITE_STATUS,
+        "highpri handoff should retain its compact completion signal");
+    ASSERT_EQUAL_HEX(highpri_handoff[1] >> 24, RSPQ_CMD_JUMP,
+        "highpri handoff should retain its compact jump");
+    ASSERT(rspq_cur_sentinel == rspq_cur_pointer +
+            RSPQ_DRAM_HIGHPRI_BUFFER_SIZE -
+            (RSPQ_MAX_SHORT_COMMAND_SIZE + 2),
+        "highpri sentinel should reserve only its two-word handoff");
+    rspq_highpri_end();
+    rspq_highpri_sync();
+
     TEST_RSPQ_EPILOG(0, rspq_timeout);
 }
 

--- a/tests/testrom.c
+++ b/tests/testrom.c
@@ -299,6 +299,7 @@ static const struct Testsuite
 	TEST_FUNC(test_rspq_cmd_multiple,        0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_cmd_rapid,           0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_wrap,                  0, TEST_FLAGS_NO_BENCHMARK),
+	TEST_FUNC(test_rspq_buffer_handoff_atomic, 0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_high_load,             0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_load_overlay,          0, TEST_FLAGS_NO_BENCHMARK),
 	TEST_FUNC(test_rspq_switch_overlay,        0, TEST_FLAGS_NO_BENCHMARK),


### PR DESCRIPTION
Fix a race where highpri preemption can split the lowpri buffer-done signal from its jump, allowing the CPU to clear a buffer the RSP will resume into.

Stage the next buffer in an inactive call slot and use SWAP_BUFFERS for the atomic completion-and-transfer operation. Adds regression coverage.