### PR TITLE
built-{toolchain,gdb}.sh: retry downloads

### DIFF
--- a/tools/build-gdb.sh
+++ b/tools/build-gdb.sh
@@ -55,11 +55,15 @@ command_exists () {
 
 # Download the file URL using wget or curl (depending on which is installed)
 download () {
+    local n_retries=5
+    local retry_delay=30
     local url="$1"
     local file="$DOWNLOAD_PATH/$(basename "$url")"
     local tmpfile="$file.part"
-    if   command_exists wget ; then wget --continue --output-document "$tmpfile" "$url"
-    elif command_exists curl ; then curl --location --output "$tmpfile" "$url"
+    if command_exists wget ; then
+        wget --tries=$n_retries --wait=$retry_delay --continue --output-document "$tmpfile" "$url"
+    elif command_exists curl ; then
+        curl --retry $n_retries --retry-all-errors --retry-delay $retry_delay --location --output "$tmpfile" "$url"
     else
         echo "Install wget or curl to download toolchain sources" 1>&2
         return 1

--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -66,11 +66,15 @@ command_exists () {
 
 # Download the file URL using wget or curl (depending on which is installed)
 download () {
+    local n_retries=5
+    local retry_delay=30
     local url="$1"
     local file="$DOWNLOAD_PATH/$(basename "$url")"
     local tmpfile="$file.part"
-    if   command_exists wget ; then wget --continue --output-document "$tmpfile" "$url"
-    elif command_exists curl ; then curl --location --output "$tmpfile" "$url"
+    if command_exists wget ; then
+        wget --tries=$n_retries --wait=$retry_delay --continue --output-document "$tmpfile" "$url"
+    elif command_exists curl ; then
+        curl --retry $n_retries --retry-all-errors --retry-delay $retry_delay --location --output "$tmpfile" "$url"
     else
         echo "Install wget or curl to download toolchain sources" 1>&2
         return 1


### PR DESCRIPTION
Since mirrors.kernel.org is not fully stable either https://github.com/DragonMinded/libdragon/actions/runs/33212430077/job/98992008743
```
108.5 + wget --continue --output-document /tmp/download/mpc-1.3.1.tar.gz.part https://mirrors.kernel.org/gnu/mpc/mpc-1.3.1.tar.gz
108.5 --2026-08-28 21:42:28--  https://mirrors.kernel.org/gnu/mpc/mpc-1.3.1.tar.gz
108.5 Resolving mirrors.kernel.org (mirrors.kernel.org)... 142.0.200.124, 2605:f480:58:1:0:1994:3:14
108.5 Connecting to mirrors.kernel.org (mirrors.kernel.org)|142.0.200.124|:443... connected.
224.2 Unable to establish SSL connection.
```

Notes:
- wget also implements linear backoff (--waitretry)
- curl also implements exponential backoff (default without --retry-delay)