### PR TITLE
Save 2 instructions in rsp common code

### DIFF
--- a/include/rsp_queue.inc
+++ b/include/rsp_queue.inc
@@ -511,7 +511,7 @@ rspq_overlay_check:
 
     # Map overlay index through the ID map. This allows to resolve ID for
     # overlays that spans multiple IDs.
-    lbu ovl_index, RSPQ_OVERLAY_IDMAP(ovl_id)
+    lbu ovl_index, %lo(RSPQ_OVERLAY_IDMAP)(ovl_id)
 
     # Load the command base (index of the first command of the overlay).
     lhu t0, %lo(_ovl_data_start) + RSPQ_OH_CMDBASE


### PR DESCRIPTION
turns:
```
a4001068:       3c0ca400        lui     t4,0xa400
a400106c:       018f6021        addu    t4,t4,t7
a4001070:       918c0048        lbu     t4,72(t4)
```
into
```
a4001068:       91ec0048        lbu     t4,72(t7)
```