### PR TITLE
Update GH actions to latest versions

### DIFF
--- a/.github/actions/path-diff/action.yml
+++ b/.github/actions/path-diff/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 
@@ -24,7 +24,7 @@ jobs:
           echo "default_ref=${{ format('refs/heads/{0}', github.event.repository.default_branch) }}" >> $GITHUB_OUTPUT
 
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@v1.9
+        uses: mattnotmitt/doxygen-action@v1.12
         with:
           doxyfile-path: 'doxygen-public.conf'
 

--- a/.github/workflows/build-tool-windows.yml
+++ b/.github/workflows/build-tool-windows.yml
@@ -22,7 +22,7 @@ jobs:
             unzip
           update: true
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1 # Using a shallow checkout. Change to `0` if a full fetch is required.
 

--- a/.github/workflows/build-toolchain-library-and-roms.yml
+++ b/.github/workflows/build-toolchain-library-and-roms.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Using a full fetch so that the diff action can run.
 

--- a/.github/workflows/build-toolchain-matrix.yml
+++ b/.github/workflows/build-toolchain-matrix.yml
@@ -74,13 +74,13 @@ jobs:
           fpm --version
 
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # we only require the last check-in, unless we want to create a changelog.
 
       # Cache and restore dependencies instead of downloading them to increase build speed.
       # Expires after 7 days.
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         id: cache
         with:
           path: |
@@ -207,7 +207,7 @@ jobs:
     needs: Build-Toolchain
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       
       - name: Download Windows-x86_64 artifact
         id: download-windows-x86_64-artifact


### PR DESCRIPTION
* Use checkout@v7
* Use actions/cache@v6 (Build toolchain was outdated compared to others that used it already).