### PR TITLE
mixer: fix assertion when reusing sample buffers across codecs

### DIFF
--- a/include/samplebuffer.h
+++ b/include/samplebuffer.h
@@ -254,6 +254,18 @@ static inline void samplebuffer_set_bps(samplebuffer_t *buf, int bps) {
 void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRead read);
 
 /**
+ * @brief Configure waveform and unit size together on empty samplebuffer.
+ * @preview
+ *
+ * Use when switching codecs: incoming append margin must match incoming
+ * unit size during capacity checks. Separate setters can combine stale
+ * margin with new unit size, or new margin with stale unit size.
+ */
+LIBDRAGON_PREVIEW_API
+void samplebuffer_configure(samplebuffer_t *buf, waveform_t *wave,
+    WaveformRead read, int unit_bytes);
+
+/**
  * @brief Get a pointer to specific set of samples in the buffer (zero-copy).
  *
  * "wpos" is the absolute waveform position of the first sample that the

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -1151,14 +1151,12 @@ void mixer_ch_play(int ch, waveform_t *wave)
 				memset(c->codec_state, 0, wave->state_size);
 			}
 		} else {
-			if (wave->format == WAVEFORM_FORMAT_VADPCM) {
-				samplebuffer_set_unit_bytes(sbuf, mixer_vadpcm_frame_bytes(wave));
-				if (stereo_vadpcm)
-					samplebuffer_set_unit_bytes(&Mixer.ch_buf[ch+1], mixer_vadpcm_frame_bytes(wave));
-			} else {
-				samplebuffer_set_bps(sbuf, wave->bits*wave->channels);
-			}
-			samplebuffer_set_waveform(sbuf, wave, wave->read ? waveform_read : NULL);
+			int unit_bytes = vadpcm ? mixer_vadpcm_frame_bytes(wave)
+				: wave->bits * wave->channels / 8;
+			samplebuffer_configure(sbuf, wave,
+				wave->read ? waveform_read : NULL, unit_bytes);
+			if (stereo_vadpcm)
+				samplebuffer_set_unit_bytes(&Mixer.ch_buf[ch+1], unit_bytes);
 			c->codec_state = sbuf->state;
 		}
 

--- a/src/audio/samplebuffer.c
+++ b/src/audio/samplebuffer.c
@@ -184,6 +184,16 @@ void samplebuffer_set_waveform(samplebuffer_t *buf, waveform_t *wave, WaveformRe
 		samplebuffer_recalc_size(buf);
 }
 
+void samplebuffer_configure(samplebuffer_t *buf, waveform_t *wave,
+	WaveformRead read, int unit_bytes) {
+	assert(wave->state_size <= buf->state_size);
+	// Install incoming margin/producer before resizing ring.
+	buf->wave = wave;
+	buf->wv_read = read;
+	buf->append_units = wave->append_units;
+	samplebuffer_set_unit_bytes(buf, unit_bytes);
+}
+
 bool samplebuffer_is_inited(samplebuffer_t *buf)
 {
 	return SAMPLES_PTR(buf) != NULL;

--- a/tests/test_wav64.c
+++ b/tests/test_wav64.c
@@ -904,6 +904,42 @@ static void ru_reset(waveform_t *w)
 	ru_sbuf = NULL;
 }
 
+// Block PCM -> mono VADPCM -> block PCM must reuse ring without stale margin.
+static bool test_mixer_block_vadpcm_reuse(void)
+{
+	const int ch = 6;
+	waveform_t block = {
+		.name = "block-reuse", .bits = 16, .channels = 1,
+		.frequency = 11025, .len = 4096, .append_units = 1024,
+		.state_size = sizeof(wav64_state_vadpcm_t), .start = ru_start,
+	};
+	waveform_t mono = block;
+	mono.name = "vadpcm-reuse";
+	mono.append_units = 0;
+	mono.format = WAVEFORM_FORMAT_VADPCM;
+	mono.codec = &sv_codec;
+	mixer_ch_stop(ch);
+	mixer_ch_set_limits(ch, 16, 11025, 0);
+	ru_sbuf = NULL;
+	mixer_ch_play(ch, &block);
+	bool ok = ru_sbuf && ru_sbuf->capacity_bytes < 1024 * 9;
+	void *ring = ru_sbuf ? SAMPLES_PTR(ru_sbuf) : NULL;
+	for (int i = 0; ok && i < 32; i++) {
+		mixer_ch_play(ch, &mono);
+		ok = ru_sbuf->wave == &mono && ru_sbuf->unit_bytes == 9
+			&& ru_sbuf->append_units == 0 && ru_sbuf->margin_units == 128
+			&& SAMPLES_PTR(ru_sbuf) == ring;
+		mixer_ch_play(ch, &block);
+		ok = ok && ru_sbuf->wave == &block && ru_sbuf->unit_bytes == 2
+			&& ru_sbuf->append_units == 1024 && ru_sbuf->margin_units == 1024
+			&& SAMPLES_PTR(ru_sbuf) == ring;
+	}
+	mixer_ch_stop(ch);
+	mixer_ch_set_limits(ch, 16, 48000, 0);
+	if (!ok) printf("FAILED block/VADPCM ring reuse\n");
+	return ok;
+}
+
 // End state of "ring closed and reinited, configure skipped": uuid and wave
 // pointer still say this waveform, but unit_bytes is 0. Replay must restore it.
 static bool test_mixer_stale_unit_bytes(void)
@@ -3464,6 +3500,7 @@ int main(void)
     printf("Streamed mono PCM tests\n");
     fflush(stdout);
     sv_init();
+    total++; if (!test_mixer_block_vadpcm_reuse()) failed++;
     // Below the sample rate: step < 1 makes the inclusive window one unit
     // larger than the position advance, which is what used to overrun the
     // samplebuffer margin. Odd starts exercise the 8-bit ring parity path.


### PR DESCRIPTION
Fix an assertion when reusing sample buffers across codecs by configuring  the waveform and unit size together. Includes a regression test for PCM/VADPCM transitions.