### PR TITLE
toolchain: apply the VR4300 mulmul fix using the gcc specs

### DIFF
--- a/tools/build-toolchain.sh
+++ b/tools/build-toolchain.sh
@@ -478,9 +478,12 @@ new file mode 100644
 index 00000000000..92fab2d41cd
 --- /dev/null
 +++ b/gcc/config/mips/n64.h
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,13 @@
 +#undef DRIVER_SELF_SPECS
 +#define DRIVER_SELF_SPECS \
++	/* Enable the mulmul fix for the VR4300 */ \
++	"%{march=vr4300:%{!mno-fix4300:%{!mfix4300:-mfix4300}}}", \
++														\
 +	/* Make -mabi=eabi imply 32-bit longs */			\
 +	"%{mabi=eabi:%{!mlong*:-mlong32}}"                              \
 +									\


### PR DESCRIPTION
With there now being multiple commercial games built using libdragon shipping, which absolutely should work on all revisions of N64 consoles, the topic of the lacking mulmul fix and the possible consequences of that has come up a few times now. So here's a PR to enable it.

This modifies the GCC specs used by the toolchain to enable `-mfix4300` by default when compiling for the VR4300. This should enable the mulmul fix globally, including for libgcc and newlib, and of course anything built with the toolchain.

The specs line is formatted such that the user can still opt out with `-mno-fix4300` if they know they're building for a N64 without the mulmul bug or an iQue or something. That double check *might* be unnecessary (it passes both ' -mno-fix4300` and `-mfix4300` if you don't check for the negative option), but better safe then sorry I think.

`n64.mk` does not need to be modified since the option is implicitly on by default.